### PR TITLE
Fix Issue 527: MultivaluedHashMap is not deserializable

### DIFF
--- a/jaxrs-api/src/main/java/javax/ws/rs/core/AbstractMultivaluedMap.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/AbstractMultivaluedMap.java
@@ -16,6 +16,7 @@
 
 package javax.ws.rs.core;
 
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -30,7 +31,7 @@ import java.util.Set;
  * @param <V> the type of mapped values.
  * @author Marek Potociar
  */
-public abstract class AbstractMultivaluedMap<K, V> implements MultivaluedMap<K, V> {
+public abstract class AbstractMultivaluedMap<K, V> implements MultivaluedMap<K, V>, Serializable {
 
     /**
      * Backing store for the [key, multi-value] pairs.

--- a/jaxrs-api/src/test/java/javax/ws/rs/core/MultivaluedHashMapTest.java
+++ b/jaxrs-api/src/test/java/javax/ws/rs/core/MultivaluedHashMapTest.java
@@ -22,10 +22,13 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.*;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 
-public class MultivaluedMapTest {
+public class MultivaluedHashMapTest {
 
     @Before
     public void setUp() throws Exception {
@@ -95,5 +98,24 @@ public class MultivaluedMapTest {
         mvm2.addAll("foo1", "bar2", "bar1");
         assertFalse(mvm1.equalsIgnoreValueOrder(mvm2));
         assertFalse(mvm2.equalsIgnoreValueOrder(mvm1));
+    }
+
+    @Test
+    public void testSerialization() throws IOException, ClassNotFoundException {
+        MultivaluedHashMap<String, String> mvm = new MultivaluedHashMap<String, String>();
+        mvm.addAll("foo1", "bar1", "bar2", "bar1");
+
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream();
+             ObjectOutputStream objOut = new ObjectOutputStream(out)) {
+
+            objOut.writeObject(mvm);
+
+            try (ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+                 ObjectInputStream objIn = new ObjectInputStream(in)) {
+
+                assertEquals(mvm, objIn.readObject());
+            }
+        }
+
     }
 }


### PR DESCRIPTION
- Added Serializable interface to AbstractMultivaluedMap
- Renamed MultivaluedMapTest -> MultivaluedHashMapTest to match tested class

This should fix #527
