### PR TITLE
Updated Checkstyle and improved configuration (#587)

### DIFF
--- a/etc/config/checkstyle.xml
+++ b/etc/config/checkstyle.xml
@@ -135,7 +135,7 @@
         <!-- Checks for Size Violations.                    -->
         <!-- See http://checkstyle.sf.net/config_sizes.html -->
         <module name="LineLength">
-            <property name="max" value="120"/>
+            <property name="max" value="160"/>
             <property name="ignorePattern" value="@version|@see|@todo|TODO"/>
         </module>
         <module name="MethodLength"/>
@@ -163,7 +163,7 @@
                 LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS, MINUS_ASSIGN, MOD,
                 MOD_ASSIGN, NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION, SL,
                 SLIST, SL_ASSIGN, SR, SR_ASSIGN, STAR, STAR_ASSIGN,
-                TYPE_EXTENSION_AND, GENERIC_START, GENERIC_END" /> <!-- RCURLY removed -->
+                TYPE_EXTENSION_AND" /> <!-- RCURLY removed -->
         </module>
 
 
@@ -201,9 +201,6 @@
             <property name="ignoreHashCodeMethod" value="true"/>
         </module-->
         <module name="MissingSwitchDefault"/>
-        <module name="RedundantThrows">
-            <property name="allowUnchecked" value="true"/>
-        </module>
         <module name="SimplifyBooleanExpression"/>
         <module name="SimplifyBooleanReturn"/>
 
@@ -224,7 +221,6 @@
         <!-- Miscellaneous other checks.                   -->
         <!-- See http://checkstyle.sf.net/config_misc.html -->
         <module name="ArrayTypeStyle"/>
-        <module name="FinalParameters"/>
         <module name="TodoComment"/>
         <module name="UpperEll"/>
     </module>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -496,11 +496,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>2.12.1</version>
+                    <version>3.0.0</version>
                     <configuration>
                         <outputDirectory>${project.build.directory}/checkstyle</outputDirectory>
                         <outputFile>${project.build.directory}/checkstyle/checkstyle-result.xml</outputFile>
                         <configLocation>${basedir}/../etc/config/checkstyle.xml</configLocation>
+                        <excludes>**/module-info.java</excludes>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
This pull requests addresses the problem described in #587. Merging this pull request will reduce the number of Checkstyle violations from 984 to 88.

The pull request contains the following changes:

* Updated of the `maven-checkstyle-plugin` to the latest version
* Ignore `module-info.java`, because it breaks the analysis for some reason.
* Increased the maximum allows line length to 160.
* Don't enforce whitespaces around `<` and `>` tokens, as this would fail even for simple generics usage like `List<String>`.
* Deleted `RedundantThrows` check which was removed from Checkstyle (see https://github.com/checkstyle/checkstyle/issues/473).
* Don't enforce all method parameters to be `final`.

Please let me know if you have any objections regarding these changes.

There are 3 other error categories which cause about 90% of the remaining violations. But I think we should discuss them in #587 to decide whether to remove the check or to adjust the source code. 
