### PR TITLE
Fixed broken HTML in FormParam API docs (#589)

### DIFF
--- a/jaxrs-api/src/main/java/javax/ws/rs/FormParam.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/FormParam.java
@@ -35,11 +35,11 @@ import java.lang.annotation.Target;
  * <li>Be a primitive type</li>
  * <li>Have a constructor that accepts a single {@code String} argument</li>
  * <li>Have a static method named {@code valueOf} or {@code fromString}
- * that accepts a single</li>
+ * that accepts a single {@code String} argument (see, for example,
+ * {@link Integer#valueOf(String)})</li>
  * <li>Have a registered implementation of {@link javax.ws.rs.ext.ParamConverterProvider}
  * JAX-RS extension SPI that returns a {@link javax.ws.rs.ext.ParamConverter}
  * instance capable of a "from string" conversion for the type.</li>
- * {@code String} argument (see, for example, {@link Integer#valueOf(String)})</li>
  * <li>Be {@code List<T>}, {@code Set<T>} or
  * {@code SortedSet<T>}, where {@code T} satisfies 2, 3 or 4 above.
  * The resulting collection is read-only.</li>


### PR DESCRIPTION
The pull request fixes the broken API docs of `@FormParam` as described in #589. It simply moves the second part of the sentence one line up and removes the redundant `</li>` element.

PS: I'm not sure if this is something for the `2.1.1-SNAPSHOT`. But as we also need it in `2.2-SNAPSHOT` we could cherry-pick it to the `2.1.1-SNAPSHOT` branch if required.