### PR TITLE
Cleanup EntityTag.equals() / hashcode() (#426)

### DIFF
--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -585,6 +585,12 @@
             <version>4.11</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.16.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/EntityTag.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/EntityTag.java
@@ -18,6 +18,7 @@ package javax.ws.rs.core;
 
 import javax.ws.rs.ext.RuntimeDelegate;
 import javax.ws.rs.ext.RuntimeDelegate.HeaderDelegate;
+import java.util.Objects;
 
 /**
  * An abstraction for the value of a HTTP Entity Tag, used as the value
@@ -99,17 +100,12 @@ public class EntityTag {
      */
     @Override
     public boolean equals(final Object obj) {
-        if (obj == null) {
-            return false;
-        }
         if (!(obj instanceof EntityTag)) {
             return false;
         }
+        
         EntityTag other = (EntityTag) obj;
-        if (value.equals(other.getValue()) && weak == other.isWeak()) {
-            return true;
-        }
-        return false;
+        return Objects.equals(value, other.getValue()) && weak == other.isWeak();
     }
 
     /**
@@ -119,10 +115,7 @@ public class EntityTag {
      */
     @Override
     public int hashCode() {
-        int hash = 3;
-        hash = 17 * hash + (this.value != null ? this.value.hashCode() : 0);
-        hash = 17 * hash + (this.weak ? 1 : 0);
-        return hash;
+        return Objects.hash(this.value, this.weak);
     }
 
     /**

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/EntityTag.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/EntityTag.java
@@ -103,7 +103,7 @@ public class EntityTag {
             return false;
         }
         if (!(obj instanceof EntityTag)) {
-            return super.equals(obj);
+            return false;
         }
         EntityTag other = (EntityTag) obj;
         if (value.equals(other.getValue()) && weak == other.isWeak()) {

--- a/jaxrs-api/src/test/java/javax/ws/rs/core/EntityTagTest.java
+++ b/jaxrs-api/src/test/java/javax/ws/rs/core/EntityTagTest.java
@@ -1,0 +1,74 @@
+package javax.ws.rs.core;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
+
+import javax.ws.rs.ext.RuntimeDelegate;
+
+public class EntityTagTest {
+
+
+    @Before
+    public void setUp() {
+        RuntimeDelegate.setInstance(mock(RuntimeDelegate.class));
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        RuntimeDelegate.setInstance(null);
+    }
+
+    @Test
+    public void shouldBeEqualToTheSameInstance() {
+        EntityTag entityTag = new EntityTag("value", true);
+
+        assertThat(entityTag, equalTo(entityTag));
+        assertThat(entityTag.hashCode(), equalTo(entityTag.hashCode()));
+    }
+
+    @Test
+    public void shouldBeEqualsForSameFieldValues() {
+        EntityTag entityTag = new EntityTag("value", true);
+        EntityTag entityTagWithSameValues = new EntityTag("value", true);
+        assertThat(entityTag, equalTo(entityTagWithSameValues));
+        assertThat(entityTag.hashCode(), equalTo(entityTagWithSameValues.hashCode()));
+    }
+
+    @Test
+    public void shouldNotBeEqualIfValueFieldDiffers() {
+        EntityTag entityTag = new EntityTag("value", true);
+        EntityTag entityTagWithDifferentValue = new EntityTag("differentValue", true);
+
+        assertThat(entityTag, not(equalTo(entityTagWithDifferentValue)));
+        assertThat(entityTag.hashCode(), not(equalTo(entityTagWithDifferentValue.hashCode())));
+    }
+
+    @Test
+    public void shouldNotBeEqualIfWeekSettingDiffers() {
+        EntityTag entityTag = new EntityTag("value", true);
+        EntityTag entityTagWithDifferentWeakSetting = new EntityTag("value", false);
+
+        assertThat(entityTag, not(equalTo(entityTagWithDifferentWeakSetting)));
+        assertThat(entityTag.hashCode(), not(equalTo(entityTagWithDifferentWeakSetting.hashCode())));
+    }
+
+    @Test
+    public void shouldNeverEqualsNull() {
+        EntityTag entityTag = new EntityTag("value", true);
+
+        assertThat(entityTag, not(equalTo(null)));
+    }
+
+    @Test
+    public void shouldNotBeEqualToObjectFromDifferentClass() {
+        EntityTag entityTag = new EntityTag("value", true);
+
+        assertThat(entityTag, not(equalTo(new Object())));
+    }
+}


### PR DESCRIPTION
This PR fixes issue #426 and simplifies equals/hashcode in EntityTag.

As correctly stated in the ticket the call to super.equals() can never return true, since the super is a simple instance comparison.

I have also used the Objects.equals()/hash() methods to simplify the code.

I am not particulary happy with the test since it has the side effect of initializing the EntityType.HEADER_DELEGATE to null. But I do not see any way around this as long as the HEADER_DELEGATE field is is initialized on class initialization. Perhaps this field should be "inlined" in the toString() method (but I am not sure on the performance implications of this)

The test rule could later be extended to add more functionality (if needed in other tests)