### PR TITLE
Updated Checkstyle (#587)

### DIFF
--- a/etc/config/checkstyle.xml
+++ b/etc/config/checkstyle.xml
@@ -201,9 +201,6 @@
             <property name="ignoreHashCodeMethod" value="true"/>
         </module-->
         <module name="MissingSwitchDefault"/>
-        <module name="RedundantThrows">
-            <property name="allowUnchecked" value="true"/>
-        </module>
         <module name="SimplifyBooleanExpression"/>
         <module name="SimplifyBooleanReturn"/>
 

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -496,11 +496,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>2.12.1</version>
+                    <version>3.0.0</version>
                     <configuration>
                         <outputDirectory>${project.build.directory}/checkstyle</outputDirectory>
                         <outputFile>${project.build.directory}/checkstyle/checkstyle-result.xml</outputFile>
                         <configLocation>${basedir}/../etc/config/checkstyle.xml</configLocation>
+                        <excludes>**/module-info.java</excludes>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
This pull request is a first step to address #587 and a subset of #588. It contains just the update of the Checkstyle Maven plugin. 

Beside updating the plugin version, this pull request also:

* Ignores `module-info.java`, because Checkstyle completely fails while parsing it.
* Removes the `RedundantThrows` rule, which has been removed from Checkstyle (see checkstyle/checkstyle#473)

Further adjustments of the Checkstyle configuration will be provided in separate pull requests.