### PR TITLE
Adjusted Checkstyle's WhitespaceAround rule for generics (#587)

### DIFF
--- a/etc/config/checkstyle.xml
+++ b/etc/config/checkstyle.xml
@@ -163,7 +163,7 @@
                 LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS, MINUS_ASSIGN, MOD,
                 MOD_ASSIGN, NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION, SL,
                 SLIST, SL_ASSIGN, SR, SR_ASSIGN, STAR, STAR_ASSIGN,
-                TYPE_EXTENSION_AND, GENERIC_START, GENERIC_END" /> <!-- RCURLY removed -->
+                TYPE_EXTENSION_AND" /> <!-- RCURLY removed -->
         </module>
 
 


### PR DESCRIPTION
Currently Checkstyle reports 2516 (!) violations in the source code. The number increased dramatically after updating Checkstyle as part of #595.

A majority of the violations is caused by the `WhitespaceAround` rule, which is currently configured to enforce whitespaces around `<` and `>`. Therefore, this rule is violated for all generic declarations like `List<String>`.

This pull requests updates the Checkstyle configuration to not check for whitespaces around `<` and `>` anymore, which reduces the total number of violations to 674.