### PR TITLE
Fixed invalid HTML in API docs

### DIFF
--- a/jaxrs-api/src/main/java/javax/ws/rs/container/AsyncResponse.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/container/AsyncResponse.java
@@ -37,7 +37,6 @@ import java.util.concurrent.TimeUnit;
  * <li>resuming the suspended request processing</li>
  * <li>canceling the suspended request processing</li>
  * </ul>
- * </p>
  * <p>
  * Following example demonstrates the use of the {@code AsyncResponse} for asynchronous
  * HTTP request processing:

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Link.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Link.java
@@ -32,7 +32,7 @@ import javax.xml.namespace.QName;
 /**
  * <p>Class representing hypermedia links. A hypermedia link may include additional
  * parameters beyond its underlying URI. Parameters such as {@code rel} or {@code type}
- * provide additional meta-data. Links in responses can be <emph>followed</emph> by
+ * provide additional meta-data. Links in responses can be <em>followed</em> by
  * creating an {@link javax.ws.rs.client.Invocation.Builder} or a
  * {@link javax.ws.rs.client.WebTarget}.</p>
  *


### PR DESCRIPTION
This pull requests will fix two issues in the API docs which Checkstyle found in the code:

* The API docs of `AsyncResponse` contain a `</p>` without a matching `<p>` element. Browsers will most likely either ignore this or create a matching `<p>` automatically, which will add additional margin.
* The API docs of `Link` contain a `<emph>` element, which doesn't exist in HTML. I replaced this with `<em>` which is most likely the element that the original author had in mind.
