### PR TITLE
Add mockito test dependency (2.16)

### DIFF
--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -585,6 +585,12 @@
             <version>4.11</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.16.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <properties>


### PR DESCRIPTION
Since adding a new dependency is probably a change that should be discussed on its own I have created this PR instead of adding the dependency as part of #593.

I think by now mock testing is a standard in using testing, so we should use mock testing. Especially since we are only creating an API, mocking the implementation part will help in a lot of cases.