### PR TITLE
First version of .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+dist: trusty
+language: java
+sudo: false
+
+jdk:
+  - oraclejdk8
+  - oraclejdk9
+
+install:
+  - cd $TRAVIS_BUILD_DIR/jaxrs-api
+  - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+  - cd $TRAVIS_BUILD_DIR/examples
+  - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+
+script:
+  - cd $TRAVIS_BUILD_DIR/jaxrs-api
+  - mvn test -B
+  - cd $TRAVIS_BUILD_DIR/examples
+  - mvn test -B

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ---
 
-# JAX-RS API
+# JAX-RS API [![Build Status](https://travis-ci.org/eclipse-ee4j/jaxrs-api.svg?branch=master)](https://travis-ci.org/eclipse-ee4j/jaxrs-api)
 
 This repository contains JAX-RS API source code.
 


### PR DESCRIPTION
The Eclipse Webmaster team has already enabled Travis for our repository.

https://bugs.eclipse.org/bugs/show_bug.cgi?id=533020

This pull request contains a first simple `.travis.yml` file. It will build both the API and the example project with JDK8 and JDK9. I think that's a good start. 

Unfortunately JDK10 isn't available on Travis by default, but there are ways to install it manually during the build. I'll provide a separate pull request for an enhanced setup with more JDK versions in the next days.