### PR TITLE
Java SE Bootstrapping API

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -31,6 +31,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <microprofile.config.version>1.3</microprofile.config.version>
     </properties>
 
     <organization>
@@ -267,6 +268,12 @@
             <groupId>javax</groupId>
             <artifactId>javaee-api</artifactId>
             <version>7.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+            <version>${microprofile.config.version}</version>
         </dependency>
     </dependencies>
 

--- a/examples/src/main/java/jaxrs/examples/bootstrap/BasicJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/BasicJavaSeBootstrapExample.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2018 Markus KARG. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jaxrs.examples.bootstrap;
+
+import java.net.URI;
+
+import javax.ws.rs.JAXRS;
+import javax.ws.rs.JAXRS.Configuration;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.UriBuilder;
+
+/**
+ * Basic Java SE bootstrap example.
+ * <p>
+ * This example demonstrates bootstrapping on Java SE platforms solely using
+ * defaults. It will effectively startup the {@link HelloWorld} application at
+ * the URL {@code http://localhost/} on an implementation-specific default IP
+ * port (e. g. 80, 8080, or something completely different). The actual
+ * configuration needs to be queried after bootstrapping, otherwise callers
+ * would be unaware of the actual chosen port.
+ * </p>
+ *
+ * @author Markus KARG (markus@headcrashing.eu)
+ * @since 2.2
+ */
+public final class BasicJavaSeBootstrapExample {
+
+    /**
+     * Runs this example.
+     *
+     * @param args
+     *            unused command line arguments
+     * @throws InterruptedException
+     *             when process is killed
+     */
+    public static final void main(final String[] args) throws InterruptedException {
+        final Application application = new HelloWorld();
+
+        final JAXRS.Configuration requestedConfiguration = JAXRS.Configuration.builder().build();
+
+        JAXRS.start(application, requestedConfiguration).thenAccept(instance -> {
+            Runtime.getRuntime()
+                    .addShutdownHook(new Thread(() -> instance.stop()
+                            .thenAccept(stopResult -> System.out.printf("Stop result: %s [Native stop result: %s].%n",
+                                    stopResult, stopResult.unwrap(Object.class)))));
+
+            final Configuration actualConfigurarion = instance.configuration();
+            final URI uri = UriBuilder.newInstance().scheme(actualConfigurarion.protocol().toLowerCase())
+                    .host(actualConfigurarion.host()).port(actualConfigurarion.port())
+                    .path(actualConfigurarion.rootPath()).build();
+            System.out.printf("Instance %s running at %s [Native handle: %s].%n", instance, uri,
+                    instance.unwrap(Object.class));
+            System.out.println("Send SIGKILL to shutdown.");
+        });
+
+        Thread.currentThread().join();
+    }
+
+}

--- a/examples/src/main/java/jaxrs/examples/bootstrap/ClientAuthenticationJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/ClientAuthenticationJavaSeBootstrapExample.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2018 Markus KARG. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jaxrs.examples.bootstrap;
+
+import java.net.URI;
+
+import javax.ws.rs.JAXRS;
+import javax.ws.rs.JAXRS.Configuration;
+import javax.ws.rs.JAXRS.Configuration.SSLClientAuthentication;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.UriBuilder;
+
+/**
+ * Java SE Bootstrap Example using TLS Client Authentication.
+ * <p>
+ * This example demonstrates bootstrapping on Java SE platforms using HTTPS with
+ * <em>bidirectional</em> TLS authentication (i. e. only <em>trustworthy</em>
+ * clients may connect). It relies mostly on defaults but explicitly sets the
+ * protocol to HTTPS and mandates TLS client certificate validation. The example
+ * will effectively startup the {@link HelloWorld} application at the URL
+ * {@code https://localhost/} on an implementation-specific default IP port (e.
+ * g. 443, 8443, or someting completely different). The actual configuration
+ * needs to be queried after bootstrapping, otherwise callers would be unaware
+ * of the actual chosen port. If the client's certificate is invalid or cannot
+ * be validated, the server will reject the connection.
+ * </p>
+ * <p>
+ * This example uses some basic <em>external</em> JSSE configuration:
+ * </p>
+ * <ul>
+ * <li>{@code javax.net.ssl.keyStore=~/.keystore} - HTTPS: Path to a keystore
+ * holding an X.509 certificate for {@code CN=localhost}</li>
+ * <li>{@code javax.net.ssl.keyStorePassword=...} - HTTPS: Password of that
+ * keystore</li>
+ * <li>Client Authentication: The default truststore
+ * ({@code $JAVA_HOME/lib/security/cacerts}) must hold the root certificate of
+ * the CA and all intermediate certificates used for signing the client's
+ * certificate.</li>
+ * </ul>
+ * </p>
+ *
+ * @author Markus KARG (markus@headcrashing.eu)
+ * @since 2.2
+ */
+public final class ClientAuthenticationJavaSeBootstrapExample {
+
+    /**
+     * Runs this example.
+     *
+     * @param args
+     *            unused command line arguments
+     * @throws InterruptedException
+     *             when process is killed
+     */
+    public static final void main(final String[] args) throws InterruptedException {
+        final Application application = new HelloWorld();
+
+        final JAXRS.Configuration requestedConfiguration = JAXRS.Configuration.builder().protocol("HTTPS")
+                .sslClientAuthentication(SSLClientAuthentication.MANDATORY).build();
+
+        JAXRS.start(application, requestedConfiguration).thenAccept(instance -> {
+            Runtime.getRuntime()
+                    .addShutdownHook(new Thread(() -> instance.stop()
+                            .thenAccept(stopResult -> System.out.printf("Stop result: %s [Native stop result: %s].%n",
+                                    stopResult, stopResult.unwrap(Object.class)))));
+
+            final Configuration actualConfigurarion = instance.configuration();
+            final URI uri = UriBuilder.newInstance().scheme(actualConfigurarion.protocol().toLowerCase())
+                    .host(actualConfigurarion.host()).port(actualConfigurarion.port())
+                    .path(actualConfigurarion.rootPath()).build();
+            System.out.printf("Instance %s running at %s [Native handle: %s].%n", instance, uri,
+                    instance.unwrap(Object.class));
+            System.out.println("Send SIGKILL to shutdown.");
+        });
+
+        Thread.currentThread().join();
+    }
+
+}

--- a/examples/src/main/java/jaxrs/examples/bootstrap/ExplicitJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/ExplicitJavaSeBootstrapExample.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2018 Markus KARG. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jaxrs.examples.bootstrap;
+
+import java.net.URI;
+
+import javax.ws.rs.JAXRS;
+import javax.ws.rs.JAXRS.Configuration;
+import javax.ws.rs.JAXRS.Configuration.SSLClientAuthentication;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.UriBuilder;
+
+/**
+ * Java SE bootstrap example with explicit configuration.
+ * <p>
+ * This example demonstrates bootstrapping on Java SE platforms using hardly no
+ * defaults at all (besides JSSE defaults). It applies parameters passed at the
+ * command line.
+ * </p>
+ * <p>
+ * Depending of the actual parameters passed at the command line (i. e. with
+ * protocol set up {@code HTTPS}), this example might need to have additional
+ * <em>external</em> JSSE configuration:
+ * </p>
+ * <ul>
+ * <li>{@code javax.net.ssl.keyStore=~/.keystore} - HTTPS: Path to a keystore
+ * holding an X.509 certificate for {@code CN=localhost}</li>
+ * <li>{@code javax.net.ssl.keyStorePassword=...} - HTTPS: Password of that
+ * keystore</li>
+ * </ul>
+ *
+ * @author Markus KARG (markus@headcrashing.eu)
+ * @since 2.2
+ */
+public final class ExplicitJavaSeBootstrapExample {
+
+    /**
+     * Runs this example.
+     *
+     * @param args
+     *            configuration to be used in exact this order:
+     *            {@code PROTOCOL HOST PORT ROOT_PATH CLIENT_AUTH} where the
+     *            protocol can be either {@code HTTP} or {@code HTTPS} and the
+     *            client authentication is one of {@code NONE, OPTIONAL, MANDATORY}.
+     * @throws InterruptedException
+     *             when process is killed
+     */
+    public static final void main(final String[] args) throws InterruptedException {
+        final Application application = new HelloWorld();
+
+        final String protocol = args[0];
+        final String host = args[1];
+        final int port = Integer.parseInt(args[2]);
+        final String rootPath = args[3];
+        final SSLClientAuthentication clientAuth = SSLClientAuthentication.valueOf(args[4]);
+
+        final JAXRS.Configuration requestedConfiguration = JAXRS.Configuration.builder().protocol(protocol).host(host)
+                .port(port).rootPath(rootPath).sslClientAuthentication(clientAuth).build();
+
+        JAXRS.start(application, requestedConfiguration).thenAccept(instance -> {
+            Runtime.getRuntime()
+                    .addShutdownHook(new Thread(() -> instance.stop()
+                            .thenAccept(stopResult -> System.out.printf("Stop result: %s [Native stop result: %s].%n",
+                                    stopResult, stopResult.unwrap(Object.class)))));
+
+            final Configuration actualConfigurarion = instance.configuration();
+            final URI uri = UriBuilder.newInstance().scheme(actualConfigurarion.protocol().toLowerCase())
+                    .host(actualConfigurarion.host()).port(actualConfigurarion.port())
+                    .path(actualConfigurarion.rootPath()).build();
+            System.out.printf("Instance %s running at %s [Native handle: %s].%n", instance, uri,
+                    instance.unwrap(Object.class));
+            System.out.println("Send SIGKILL to shutdown.");
+        });
+
+        Thread.currentThread().join();
+    }
+
+}

--- a/examples/src/main/java/jaxrs/examples/bootstrap/ExternalConfigJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/ExternalConfigJavaSeBootstrapExample.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2018 Markus KARG. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jaxrs.examples.bootstrap;
+
+import java.net.URI;
+
+import javax.ws.rs.JAXRS;
+import javax.ws.rs.JAXRS.Configuration;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.UriBuilder;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+
+/**
+ * Java SE bootstrap example utilizing an external configuration system.
+ * <p>
+ * This example demonstrates bootstrapping on Java SE platforms using values
+ * retrieved from an external configuration system plus statically overriden
+ * properties. In particular, this demo first uses Eclipse Microprofile Config
+ * to let the actual implementation retrieve all properties from an external
+ * source of configuration, but then explicitly enforces HTTPS within the
+ * bootstrap code.
+ * </p>
+ * <p>
+ * To actually run this example, an implementation of Eclipse Microprofile
+ * Config has to be added to the classpath, and the configuration options to be
+ * customized have to be provided, e. g. as environment variables:
+ * </p>
+ *
+ * <pre>
+ * export javax.ws.rs.JAXRS.Port=8888;
+ * java -Djavax.ws.rs.JAXRS.Host=127.0.0.1 ExternalConfigJavaSeBootstrapExample;
+ * </pre>
+ * <p>
+ * This example uses some basic <em>external</em> JSSE configuration:
+ * </p>
+ * <ul>
+ * <li>{@code javax.net.ssl.keyStore=~/.keystore} - HTTPS: Path to a keystore
+ * holding an X.509 certificate for {@code CN=localhost}</li>
+ * <li>{@code javax.net.ssl.keyStorePassword=...} - HTTPS: Password of that
+ * keystore</li>
+ * </ul>
+ * <p>
+ * Due to the <em>implicit</em> use of Microprofile Config in the
+ * implementation, this example is <em>not necessarily</em> portable: Support
+ * for external configuration is <em>not mandatory</em>. Implementations could
+ * choose to not implement it, or to support other external configuration
+ * mechanics not mentioned here.
+ * </p>
+ *
+ * @author Markus KARG (markus@headcrashing.eu)
+ * @since 2.2
+ */
+public final class ExternalConfigJavaSeBootstrapExample {
+
+    /**
+     * Runs this example.
+     *
+     * @param args
+     *            unused command line arguments
+     * @throws InterruptedException
+     *             when process is killed
+     */
+    public static final void main(final String[] args) throws InterruptedException {
+        final Application application = new HelloWorld();
+
+        final Config config = ConfigProvider.getConfig();
+
+        final JAXRS.Configuration requestedConfiguration = JAXRS.Configuration.builder().from(config).protocol("HTTPS")
+                .build();
+
+        JAXRS.start(application, requestedConfiguration).thenAccept(instance -> {
+            Runtime.getRuntime()
+                    .addShutdownHook(new Thread(() -> instance.stop()
+                            .thenAccept(stopResult -> System.out.printf("Stop result: %s [Native stop result: %s].%n",
+                                    stopResult, stopResult.unwrap(Object.class)))));
+
+            final Configuration actualConfigurarion = instance.configuration();
+            final URI uri = UriBuilder.newInstance().scheme(actualConfigurarion.protocol().toLowerCase())
+                    .host(actualConfigurarion.host()).port(actualConfigurarion.port())
+                    .path(actualConfigurarion.rootPath()).build();
+            System.out.printf("Instance %s running at %s [Native handle: %s].%n", instance, uri,
+                    instance.unwrap(Object.class));
+            System.out.println("Send SIGKILL to shutdown.");
+        });
+
+        Thread.currentThread().join();
+    }
+
+}

--- a/examples/src/main/java/jaxrs/examples/bootstrap/HelloWorld.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/HelloWorld.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2018 Markus KARG. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jaxrs.examples.bootstrap;
+
+import java.util.Collections;
+import java.util.Set;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Application;
+
+/**
+ * Demo application simply returning the string {@code "Hello, World!"}.
+ *
+ * @author Markus KARG (markus@headcrashing.eu)
+ * @since 2.2
+ */
+@ApplicationPath("helloworld")
+@Path("hello")
+public class HelloWorld extends Application {
+
+    /**
+     * Returns the sole, singleton resource.
+     */
+    @Override
+    public Set<Class<?>> getClasses() {
+        return Collections.singleton(HelloWorld.class);
+    }
+
+    /**
+     * @return {@code "Hello, World!"}
+     */
+    @GET
+    public String sayHello() {
+        return "Hello, World!";
+    }
+
+}

--- a/examples/src/main/java/jaxrs/examples/bootstrap/HttpsJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/HttpsJavaSeBootstrapExample.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2018 Markus KARG. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jaxrs.examples.bootstrap;
+
+import java.net.URI;
+
+import javax.ws.rs.JAXRS;
+import javax.ws.rs.JAXRS.Configuration;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.UriBuilder;
+
+/**
+ * Java SE bootstrap example using HTTPS.
+ * <p>
+ * This example demonstrates bootstrapping on Java SE platforms using HTTPS. It
+ * relies mostly on defaults but explicitly sets the protocol to HTTPS. The
+ * example will effectively startup the {@link HelloWorld} application at the
+ * URL {@code https://localhost/} on an implementation-specific default IP port
+ * (e. g. 443, 8443, or someting completely different). The actual configuration
+ * needs to be queried after bootstrapping, otherwise callers would be unaware
+ * of the actual chosen port.
+ * </p>
+ * <p>
+ * This example uses some basic <em>external</em> JSSE configuration:
+ * </p>
+ * <ul>
+ * <li>{@code javax.net.ssl.keyStore=~/.keystore} - HTTPS: Path to a keystore
+ * holding an X.509 certificate for {@code CN=localhost}</li>
+ * <li>{@code javax.net.ssl.keyStorePassword=...} - HTTPS: Password of that
+ * keystore</li>
+ * </ul>
+ * </p>
+ *
+ * @author Markus KARG (markus@headcrashing.eu)
+ * @since 2.2
+ */
+public final class HttpsJavaSeBootstrapExample {
+
+    /**
+     * Runs this example.
+     *
+     * @param args
+     *            unused command line arguments
+     * @throws InterruptedException
+     *             when process is killed
+     */
+    public static final void main(final String[] args) throws InterruptedException {
+        final Application application = new HelloWorld();
+
+        final JAXRS.Configuration requestedConfiguration = JAXRS.Configuration.builder().protocol("HTTPS").build();
+
+        JAXRS.start(application, requestedConfiguration).thenAccept(instance -> {
+            Runtime.getRuntime()
+                    .addShutdownHook(new Thread(() -> instance.stop()
+                            .thenAccept(stopResult -> System.out.printf("Stop result: %s [Native stop result: %s].%n",
+                                    stopResult, stopResult.unwrap(Object.class)))));
+
+            final Configuration actualConfigurarion = instance.configuration();
+            final URI uri = UriBuilder.newInstance().scheme(actualConfigurarion.protocol().toLowerCase())
+                    .host(actualConfigurarion.host()).port(actualConfigurarion.port())
+                    .path(actualConfigurarion.rootPath()).build();
+            System.out.printf("Instance %s running at %s [Native handle: %s].%n", instance, uri,
+                    instance.unwrap(Object.class));
+            System.out.println("Send SIGKILL to shutdown.");
+        });
+
+        Thread.currentThread().join();
+    }
+
+}

--- a/examples/src/main/java/jaxrs/examples/bootstrap/NativeJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/NativeJavaSeBootstrapExample.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2018 Markus KARG. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jaxrs.examples.bootstrap;
+
+import java.net.URI;
+
+import javax.ws.rs.JAXRS;
+import javax.ws.rs.JAXRS.Configuration;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.UriBuilder;
+
+/**
+ * Java SE bootstrap example demonstrating the use of native properties.
+ * <p>
+ * This example demonstrates bootstrapping on Java SE platforms with native
+ * properties, in particular by explicitly selecting the Grizzly2 backend in
+ * Jersey. It will effectively startup the {@link HelloWorld} application at the
+ * URL {@code http://localhost:80/}, i. e. the Grizzly2 backend selects exactly
+ * port 80 as this is its default IP port. The actual configuration needs to be
+ * queried after bootstrapping, otherwise callers would be unaware of the actual
+ * chosen port, as Grizzly2's default behavior is not publicly documented.
+ * </p>
+ * <p>
+ * This is a native example, hence it only works with Jersey, and in particular
+ * only with its Grizzly2 backend. To actually run this demo, the following
+ * libraries have to be found on the classpath:
+ * </p>
+ * <ul>
+ * <li>jersey-server</li>
+ * <li>jersey-container-grizzly2-http</li>
+ * </ul>
+ *
+ * @author Markus KARG (markus@headcrashing.eu)
+ * @since 2.2
+ */
+public final class NativeJavaSeBootstrapExample {
+
+    /**
+     * Runs this example.
+     *
+     * @param args
+     *            unused command line arguments
+     * @throws InterruptedException
+     *             when process is killed
+     * @throws ClassNotFoundException
+     *             when Jersey's Grizzly backend is not on the classpath
+     */
+    public static final void main(final String[] args) throws InterruptedException, ClassNotFoundException {
+        final Application application = new HelloWorld();
+
+        final JAXRS.Configuration requestedConfiguration = JAXRS.Configuration.builder()
+                .property("jersey.config.server.httpServerClass",
+                        Class.forName("org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServer"))
+                .build();
+
+        JAXRS.start(application, requestedConfiguration).thenAccept(instance -> {
+            Runtime.getRuntime()
+                    .addShutdownHook(new Thread(() -> instance.stop()
+                            .thenAccept(stopResult -> System.out.printf("Stop result: %s [Native stop result: %s].%n",
+                                    stopResult, stopResult.unwrap(Object.class)))));
+
+            final Configuration actualConfigurarion = instance.configuration();
+            final URI uri = UriBuilder.newInstance().scheme(actualConfigurarion.protocol().toLowerCase())
+                    .host(actualConfigurarion.host()).port(actualConfigurarion.port())
+                    .path(actualConfigurarion.rootPath()).build();
+            System.out.printf("Instance %s running at %s [Native handle: %s].%n", instance, uri,
+                    instance.unwrap(Object.class));
+            System.out.println("Send SIGKILL to shutdown.");
+        });
+
+        Thread.currentThread().join();
+    }
+
+}

--- a/examples/src/main/java/jaxrs/examples/bootstrap/PropertyProviderJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/PropertyProviderJavaSeBootstrapExample.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2018 Markus KARG. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jaxrs.examples.bootstrap;
+
+import java.net.URI;
+
+import javax.ws.rs.JAXRS;
+import javax.ws.rs.JAXRS.Configuration;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.UriBuilder;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+
+/**
+ * Java SE bootstrap example utilizing a property provider.
+ * <p>
+ * This example demonstrates bootstrapping on Java SE platforms using values
+ * explicitly bulk-loaded from a property provider plus statically overridden
+ * properties. In particular, this demo first uses Eclipse Microprofile Config
+ * as a property provider for all properties supported by the implementation,
+ * but then explicitly enforces HTTPS within the bootstrap code.
+ * </p>
+ * <p>
+ * To actually run this example, an implementation of Eclipse Microprofile
+ * Config has to be added to the classpath, and the configuration options to be
+ * customized have to be provided, e. g. as environment variables:
+ * </p>
+ *
+ * <pre>
+ * export javax.ws.rs.JAXRS.Port=8888;
+ * java -Djavax.ws.rs.JAXRS.Host=127.0.0.1 PropertyProviderJavaSeBootstrapExample;
+ * </pre>
+ * <p>
+ * Thanks to the <em>explicit</em> use of Microprofile Config in the
+ * application, this example is completely portable.
+ * </p>
+ * <p>
+ * This example uses some basic <em>external</em> JSSE configuration:
+ * </p>
+ * <ul>
+ * <li>{@code javax.net.ssl.keyStore=~/.keystore} - HTTPS: Path to a keystore
+ * holding an X.509 certificate for {@code CN=localhost}</li>
+ * <li>{@code javax.net.ssl.keyStorePassword=...} - HTTPS: Password of that
+ * keystore</li>
+ * </ul>
+ *
+ * @author Markus KARG (markus@headcrashing.eu)
+ * @since 2.2
+ */
+public final class PropertyProviderJavaSeBootstrapExample {
+
+    /**
+     * Runs this example.
+     *
+     * @param args
+     *            unused command line arguments
+     * @throws InterruptedException
+     *             when process is killed
+     */
+    public static final void main(final String[] args) throws InterruptedException {
+        final Application application = new HelloWorld();
+
+        final Config config = ConfigProvider.getConfig();
+
+        final JAXRS.Configuration requestedConfiguration = JAXRS.Configuration.builder().from(config::getOptionalValue)
+                .protocol("HTTPS").build();
+
+        JAXRS.start(application, requestedConfiguration).thenAccept(instance -> {
+            Runtime.getRuntime()
+                    .addShutdownHook(new Thread(() -> instance.stop()
+                            .thenAccept(stopResult -> System.out.printf("Stop result: %s [Native stop result: %s].%n",
+                                    stopResult, stopResult.unwrap(Object.class)))));
+
+            final Configuration actualConfigurarion = instance.configuration();
+            final URI uri = UriBuilder.newInstance().scheme(actualConfigurarion.protocol().toLowerCase())
+                    .host(actualConfigurarion.host()).port(actualConfigurarion.port())
+                    .path(actualConfigurarion.rootPath()).build();
+            System.out.printf("Instance %s running at %s [Native handle: %s].%n", instance, uri,
+                    instance.unwrap(Object.class));
+            System.out.println("Send SIGKILL to shutdown.");
+        });
+
+        Thread.currentThread().join();
+    }
+
+}

--- a/examples/src/main/java/jaxrs/examples/bootstrap/TlsJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/TlsJavaSeBootstrapExample.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2018 Markus KARG. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jaxrs.examples.bootstrap;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.ws.rs.JAXRS;
+import javax.ws.rs.JAXRS.Configuration;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.UriBuilder;
+
+/**
+ * Java SE bootstrap example using TLS customization.
+ * <p>
+ * This example demonstrates bootstrapping on Java SE platforms using HTTPS with
+ * TLS 1.2 and a <em>particular</em> keystore. It explicitly sets the protocol
+ * to {@code HTTPS} using port 443 and provides a {@link SSLContext} customized
+ * to TLS v1.2 using a provided keystore file. The example will effectively
+ * startup the {@link HelloWorld} application at the URL
+ * {@code https://localhost:443/}.
+ * </p>
+ *
+ * @author Markus KARG (markus@headcrashing.eu)
+ * @since 2.2
+ */
+public final class TlsJavaSeBootstrapExample {
+
+    /**
+     * Runs this example.
+     *
+     * @param args
+     *            KEYSTORE_PATH KEYSTORE_PASSWORD
+     * @throws GeneralSecurityException
+     *             in case JSSE fails
+     * @throws IOException
+     *             in case file access fails
+     * @throws InterruptedException
+     *             when process is killed
+     */
+    public static final void main(final String[] args)
+            throws GeneralSecurityException, IOException, InterruptedException {
+        final Application application = new HelloWorld();
+
+        final Path keyStorePath = Paths.get(args[0]);
+        final char[] passphrase = args[1].toCharArray();
+
+        final KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        keyStore.load(Files.newInputStream(keyStorePath), passphrase);
+        final KeyManagerFactory keyManagerFactory = KeyManagerFactory
+                .getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        keyManagerFactory.init(keyStore, passphrase);
+        final SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
+        sslContext.init(keyManagerFactory.getKeyManagers(), null, null);
+
+        final JAXRS.Configuration requestedConfiguration = JAXRS.Configuration.builder().protocol("HTTPS")
+                .sslContext(sslContext).build();
+
+        JAXRS.start(application, requestedConfiguration).thenAccept(instance -> {
+            Runtime.getRuntime()
+                    .addShutdownHook(new Thread(() -> instance.stop()
+                            .thenAccept(stopResult -> System.out.printf("Stop result: %s [Native stop result: %s].%n",
+                                    stopResult, stopResult.unwrap(Object.class)))));
+
+            final Configuration actualConfigurarion = instance.configuration();
+            final URI uri = UriBuilder.newInstance().scheme(actualConfigurarion.protocol().toLowerCase())
+                    .host(actualConfigurarion.host()).port(actualConfigurarion.port())
+                    .path(actualConfigurarion.rootPath()).build();
+            System.out.printf("Instance %s running at %s [Native handle: %s].%n", instance, uri,
+                    instance.unwrap(Object.class));
+            System.out.println("Send SIGKILL to shutdown.");
+        });
+
+        Thread.currentThread().join();
+    }
+
+}

--- a/examples/src/main/java/jaxrs/examples/bootstrap/package-info.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/package-info.java
@@ -1,0 +1,29 @@
+/**
+ * Java SE bootstrap examples.
+ *
+ * <ul>
+ * <li>{@link BasicJavaSeBootstrapExample} - Basic example solely using
+ * defaults</li>
+ * <li>{@link ExplicitJavaSeBootstrapExample} - Explicit configuration instead
+ * of defaults</li>
+ * <li>{@link HttpsJavaSeBootstrapExample} - HTTPS instead of HTTP</li>
+ * <li>{@link TlsJavaSeBootstrapExample} - TLS customization</li>
+ * <li>{@link ClientAuthenticationJavaSeBootstrapExample} - HTTPS with
+ * <em>bidirectional</em> authentication</li>
+ * <li>{@link NativeJavaSeBootstrapExample} - Custom (non-portable) properties
+ * (using Jersey's Grizzly2 backend)</li>
+ * <li>{@link PropertyProviderJavaSeBootstrapExample} - Bulk-loading
+ * configuration using a property provider (using Microprofile Config
+ * <em>explicitly</em>, hence in a non-optional, portable way)
+ * <li>{@link ExternalConfigJavaSeBootstrapExample} - Bulk-loading configuration
+ * from external configuration mechanics (using Microprofile Config
+ * <em>implicitly</em>, hence in an optional, <em>not necessarily</em> portable
+ * way)
+ * </ul>
+ *
+ *
+ * @author Markus KARG (markus@headcrashing.eu)
+ * @since 2.2
+ * @see javax.ws.rs.JAXRS;
+ */
+package jaxrs.examples.bootstrap;

--- a/jaxrs-api/src/main/java/javax/ws/rs/JAXRS.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/JAXRS.java
@@ -1,0 +1,697 @@
+/*
+ * Copyright (c) 2018 Markus KARG. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package javax.ws.rs;
+
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import java.util.function.BiFunction;
+
+import javax.net.ssl.SSLContext;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.ext.RuntimeDelegate;
+
+/**
+ * Bootstrap class used to startup a JAX-RS application in Java SE environments.
+ * <p>
+ * The {@code JAXRS} class is available in a Jakarta EE container environment as
+ * well; however, support for the Java SE bootstrapping APIs is <em>not
+ * required</em> in container environments.
+ * </p>
+ * <p>
+ * In a Java SE environment an application is getting started by the following
+ * command using default configuration values (i. e. mounting application at
+ * {@code http://localhost:80/} <em>or a different port</em> (there is <em>no
+ * particular default port</em> mandated by this specification). As the JAX-RS
+ * implementation is free to choose any port by default, the caller will not
+ * know the actual port unless explicitly checking the actual configuration of
+ * the instance started:
+ * </p>
+ *
+ * <pre>
+ * Application app = new MyApplication();
+ * JAXRS.Configuration config = JAXRS.Configuration.builder().build();
+ * JAXRS.start(app, config).thenAccept(instance -&gt; instance.configuration().port());
+ * </pre>
+ *
+ * <p>
+ * Running instances can be instructed to stop serving the application:
+ * </p>
+ *
+ * <pre>
+ * JAXRS.start(app, config).thenAccept(instance -&gt; { ... instance.stop(); } );
+ * </pre>
+ *
+ * <p>
+ * A shutdown callback can be registered which will get invoked once the
+ * implementation stops serving the application:
+ * </p>
+ *
+ * <pre>
+ * instance.stop().thenAccept(stopResult -&gt; ...));
+ * </pre>
+ *
+ * {@code stopResult} is not further defined but solely acts as a wrapper around
+ * a native result provided by the particular JAX-RS implementation. Portable
+ * applications should not assume any particular data type or value.
+ *
+ * <p>
+ * Protocol, host address, port and root path can be overridden explicitly. As
+ * the JAX-RS implementation is bound to that values, no querying of the actual
+ * configuration is needed in that case:
+ * </p>
+ *
+ * <pre>
+ * JAXRS.Configuration.builder().protocol("HTTPS").host("0.0.0.0").port(8443).rootPath("api").build();
+ * </pre>
+ *
+ * <p>
+ * TLS can be configured by explicitly passing a customized {@link SSLContext}:
+ * </p>
+ *
+ * <pre>
+ * SSLContext tls = SSLContext.getInstance("TLSv1.2");
+ * // ...further initialize context here (see JSSE API)...
+ * JAXRS.Configuration.builder().protocol("HTTPS").sslContext(tls).build();
+ * </pre>
+ *
+ * <p>
+ * In case of HTTPS, client authentication can be enforced to ensure that only
+ * <em>trustworthy</em> clients can connect:
+ * </p>
+ *
+ * <pre>
+ * JAXRS.Configuration.builder().protocol("HTTPS").sslClientAuthentication(SSLClientAuthentication.MANDATORY).build();
+ * </pre>
+ *
+ * <p>
+ * Implementations are free to support more use cases by native properties,
+ * which effectively render the application non-portable:
+ * </p>
+ *
+ * <pre>
+ * JAXRS.Configuration.builder().property("productname.foo", "bar").build()
+ * </pre>
+ *
+ * <p>
+ * Bulk-loading allows to attach configuration storages easily without the need
+ * to write down all properties to be transferred. Hence, even properties
+ * unknown to the application author will get channeled into the implementation.
+ * This can be done both, explicitly (hence portable) and implicitly (hence
+ * <em>not necessarily</em> portable as no particular configuration mechanics
+ * are required to be supported by compliant implementations):
+ * </p>
+ *
+ * <pre>
+ * // Explicit use of particular configuration mechanics is portable
+ * JAXRS.Configuration.builder().from((name, type) -&gt; externalConfigurationSystem.getValue(name, type)).build();
+ *
+ * // Implicitly relying on the support of particular configuration mechanics by
+ * // the actual JAX-RS implementation is not necessarily portable
+ * JAXRS.Configuration.builder().from(externalConfigurationSystem).build();
+ * </pre>
+ *
+ * @author Markus KARG (markus@headcrashing.eu)
+ * @since 2.2
+ */
+public interface JAXRS {
+
+    /**
+     * Starts the provided application using the specified configuration.
+     *
+     * <p>
+     * This method is intended to be used in Java SE environments only. The outcome
+     * of invocations in Jakarta EE container environments is undefined.
+     * </p>
+     *
+     * @param application
+     *            The application to start up.
+     * @param configuration
+     *            Provides information needed for bootstrapping the application.
+     * @return {@code CompletionStage} (possibly asynchronously) producing handle of
+     *         the running application {@link JAXRS.Instance instance}.
+     * @see Configuration
+     * @since 2.2
+     */
+    static CompletionStage<Instance> start(final Application application, final Configuration configuration) {
+        return RuntimeDelegate.getInstance().bootstrap(application, configuration);
+    }
+
+    /**
+     * Provides information needed by the JAX-RS implementation for bootstrapping an
+     * application.
+     * <p>
+     * The configuration essentially consists of a set of parameters. While the set
+     * of actually effective keys is product specific, the key constants defined by
+     * the {@link JAXRS.Configuration} interface MUST be effective on all compliant
+     * products. Any unknown key MUST be silently ignored.
+     * </p>
+     *
+     * @author Markus KARG (markus@headcrashing.eu)
+     * @since 2.2
+     */
+    public static interface Configuration {
+
+        /**
+         * Configuration key for the protocol an application is bound to.
+         * <p>
+         * A compliant implementation at least MUST accept the strings {@code "HTTP"}
+         * and {@code "HTTPS"} if these protocols are supported.
+         * </p>
+         * <p>
+         * The default value is {@code "HTTP"}.
+         * </p>
+         *
+         * @since 2.2
+         */
+        static final String PROTOCOL = "javax.ws.rs.JAXRS.Protocol";
+
+        /**
+         * Configuration key for the hostname or IP address an application is bound to.
+         * <p>
+         * A compliant implementation at least MUST accept string values bearing
+         * hostnames, IP4 address text representations, and IP6 address text
+         * representations. If a hostname string, the special IP4 address string
+         * {@code "0.0.0.0"} or {@code "::"} for IP6 is provided, the application MUST
+         * be bound to <em>all</em> IP addresses assigned to that hostname. If the
+         * hostname string is {@code "localhost"} the application MUST be bound to the
+         * local host's loopback adapter <em>only</em>.
+         * </p>
+         * <p>
+         * The default value is {@code "localhost"}.
+         * </p>
+         *
+         * @since 2.2
+         */
+        static final String HOST = "javax.ws.rs.JAXRS.Host";
+
+        /**
+         * Configuration key for the TCP port an application is bound to.
+         *
+         * <p>
+         * A compliant implementation MUST accept {@code java.lang.Integer} values.
+         * </p>
+         * <p>
+         * There is no default <em>port</em> mandated by this specification, but the
+         * default <em>value</em> of this property is {@link #DEFAULT_PORT} (i. e.
+         * <code>-1</code>). A compliant implementation MUST use its own default
+         * <em>port</em> when the <em>value</em> <code>-1</code> is provided, and MAY
+         * apply (but is not obligated to) auto-selection and range-scanning algorithms.
+         * </p>
+         *
+         * @since 2.2
+         */
+        static final String PORT = "javax.ws.rs.JAXRS.Port";
+
+        /**
+         * Configuration key for the root path an application is bound to.
+         * <p>
+         * The default value is {@code "/"}.
+         * </p>
+         *
+         * @since 2.2
+         */
+        static final String ROOT_PATH = "javax.ws.rs.JAXRS.RootPath";
+
+        /**
+         * Configuration key for the secure socket configuration to be used.
+         * <p>
+         * The default value is {@link SSLContext#getDefault()}.
+         * </p>
+         *
+         * @since 2.2
+         */
+        static final String SSL_CONTEXT = "javax.ws.rs.JAXRS.SSLContext";
+
+        /**
+         * Configuration key for the secure socket client authentication policy.
+         *
+         * <p>
+         * A compliant implementation MUST accept {@link SSLClientAuthentication} enums.
+         * </p>
+         * <p>
+         * The default value is {@code SSLClientAuthentication#NONE}.
+         * </p>
+         *
+         * @since 2.2
+         */
+        static final String SSL_CLIENT_AUTHENTICATION = "javax.ws.rs.JAXRS.SSLClientAuthentication";
+
+        /**
+         * Secure socket client authentication policy
+         *
+         * <p>
+         * This policy is used in secure socket handshake to control whether the server
+         * <em>requests</em> client authentication, and whether <em>successful</em>
+         * client authentication is <em>mandatory</em> (i. e. connection attempt will
+         * fail for invalid clients).
+         * </p>
+         *
+         * @author Markus KARG (markus@headcrashing.eu)
+         * @since 2.2
+         */
+        public enum SSLClientAuthentication {
+
+            /**
+             * Server will <em>not request</em> client authentication.
+             *
+             * @since 2.2
+             */
+            NONE,
+
+            /**
+             * Client authentication is performed, but invalid clients are
+             * <em>accepted</em>.
+             *
+             * @since 2.2
+             */
+            OPTIONAL,
+
+            /**
+             * Client authentication is performed, and invalid clients are
+             * <em>rejected</em>.
+             *
+             * @since 2.2
+             */
+            MANDATORY
+        }
+
+        /**
+         * Special value for {@link #PORT} property indicating that the implementation
+         * MUST use its default port.
+         *
+         * @since 2.2
+         */
+        static final int DEFAULT_PORT = -1;
+
+        /**
+         * Returns the value of the property with the given name, or {@code null} if
+         * there is no property of that name.
+         *
+         * @param name
+         *            a {@code String} specifying the name of the property.
+         * @return an {@code Object} containing the value of the property, or
+         *         {@code null} if no property exists matching the given name.
+         * @since 2.2
+         */
+        Object property(String name);
+
+        /**
+         * Convenience method to get the {@code protocol} to be used.
+         * <p>
+         * Same as if calling {@link #property(String) (String) property(PROTOCOL)}.
+         * </p>
+         *
+         * @return protocol to be used (e. g. {@code "HTTP")}.
+         * @throws ClassCastException
+         *             if protocol is not a {@link String}.
+         * @see JAXRS.Configuration#PROTOCOL
+         * @since 2.2
+         */
+        default String protocol() {
+            return (String) property(PROTOCOL);
+        }
+
+        /**
+         * Convenience method to get the {@code host} to be used.
+         * <p>
+         * Same as if calling {@link #property(String) (String) property(HOST)}.
+         * </p>
+         *
+         * @return host name or IP address to be used (e. g. {@code "localhost"} or
+         *         {@code "0.0.0.0"}).
+         * @throws ClassCastException
+         *             if host is not a {@link String}.
+         * @see JAXRS.Configuration#HOST
+         * @since 2.2
+         */
+        default String host() {
+            return (String) property(HOST);
+        }
+
+        /**
+         * Convenience method to get the actually used {@code port}.
+         * <p>
+         * Same as if calling {@link #property(String) (int) property(PORT)}.
+         * </p>
+         * <p>
+         * If the port was <em>not explicitly</em> given, this will return the port
+         * chosen implicitly by the JAX-RS implementation.
+         * </p>
+         *
+         * @return port number <em>actually</em> used (e. g. {@code 8080}).
+         * @throws ClassCastException
+         *             if port is not an {@code Integer}.
+         * @see JAXRS.Configuration#PORT
+         * @since 2.2
+         */
+        default int port() {
+            return (int) property(PORT);
+        }
+
+        /**
+         * Convenience method to get the {@code rootPath} to be used.
+         * <p>
+         * Same as if calling {@link #property(String) (String) property(ROOT_PATH)}.
+         * </p>
+         *
+         * @return root path to be used, e. g. {@code "/"}.
+         * @throws ClassCastException
+         *             if root path is not a {@link String}.
+         * @see JAXRS.Configuration#ROOT_PATH
+         * @since 2.2
+         */
+        default String rootPath() {
+            return (String) property(ROOT_PATH);
+        }
+
+        /**
+         * Convenience method to get the {@code sslContext} to be used.
+         * <p>
+         * Same as if calling {@link #property(String) (SSLContext)
+         * property(SSL_CONTEXT)}.
+         * </p>
+         *
+         * @return root path to be used, e. g. {@code "/"}.
+         * @throws ClassCastException
+         *             if sslContext is not a {@link SSLContext}.
+         * @see JAXRS.Configuration#SSL_CONTEXT
+         * @since 2.2
+         */
+        default SSLContext sslContext() {
+            return (SSLContext) property(SSL_CONTEXT);
+        }
+
+        /**
+         * Convenience method to get the secure socket client authentication policy.
+         * <p>
+         * Same as if calling {@link #property(String) (SSLClientAuthentication)
+         * property(SSL_CLIENT_AUTHENTICATION)}.
+         * </p>
+         *
+         * @return client authentication mode, e. g. {@code NONE}.
+         * @throws ClassCastException
+         *             if sslClientAuthentication is not a
+         *             {@link SSLClientAuthentication}.
+         * @see JAXRS.Configuration#SSL_CLIENT_AUTHENTICATION
+         * @since 2.2
+         */
+        default SSLClientAuthentication sslClientAuthentication() {
+            return (SSLClientAuthentication) property(SSL_CLIENT_AUTHENTICATION);
+        }
+
+        /**
+         * Creates a new bootstrap configuration builder instance.
+         *
+         * @return {@link Builder} for bootstrap configuration.
+         * @since 2.2
+         */
+        static Builder builder() {
+            return RuntimeDelegate.getInstance().createConfigurationBuilder();
+        };
+
+        /**
+         * Builder for bootstrap {@link Configuration}.
+         *
+         * @author Markus KARG (markus@headcrashing.eu)
+         * @since 2.2
+         */
+        static interface Builder {
+
+            /**
+             * Builds a bootstrap configuration instance from the provided property values.
+             *
+             * @return {@link Configuration} built from provided property values.
+             * @since 2.2
+             */
+            Configuration build();
+
+            /**
+             * Sets the property {@code name} to the provided {@code value}.
+             * <p>
+             * This method does not check the validity, type or syntax of the provided
+             * value.
+             * </p>
+             *
+             * @param name
+             *            name of the parameter to set.
+             * @param value
+             *            value to set, or {@code null} to use the default value.
+             * @return the updated builder.
+             * @since 2.2
+             */
+            Builder property(String name, Object value);
+
+            /**
+             * Convenience method to set the {@code protocol} to be used.
+             * <p>
+             * Same as if calling {@link #property(String, Object) property(PROTOCOL,
+             * value)}.
+             * </p>
+             *
+             * @param protocol
+             *            protocol parameter of this configuration, or {@code null} to use
+             *            the default value.
+             * @return the updated builder.
+             * @see JAXRS.Configuration#PROTOCOL
+             * @since 2.2
+             */
+            default Builder protocol(String protocol) {
+                return property(PROTOCOL, protocol);
+            }
+
+            /**
+             * Convenience method to set the {@code host} to be used.
+             * <p>
+             * Same as if calling {@link #property(String, Object) property(HOST, value)}.
+             * </p>
+             *
+             * @param host
+             *            host parameter (IP address or hostname) of this configuration, or
+             *            {@code null} to use the default value.
+             * @return the updated builder.
+             * @see JAXRS.Configuration#HOST
+             * @since 2.2
+             */
+            default Builder host(String host) {
+                return property(HOST, host);
+            }
+
+            /**
+             * Convenience method to set the {@code port} to be used.
+             * <p>
+             * Same as if calling {@link #property(String, Object) property(PORT, value)}.
+             * </p>
+             *
+             * @param port
+             *            port parameter of this configuration, or {@code null} to use the
+             *            default value.
+             * @return the updated builder.
+             * @see JAXRS.Configuration#PORT
+             * @since 2.2
+             */
+            default Builder port(Integer port) {
+                return property(PORT, port);
+            }
+
+            /**
+             * Convenience method to set the {@code rootPath} to be used.
+             * <p>
+             * Same as if calling {@link #property(String, Object) property(ROOT_PATH,
+             * value)}.
+             * </p>
+             *
+             * @param rootPath
+             *            rootPath parameter of this configuration, or {@code null} to use
+             *            the default value.
+             * @return the updated builder.
+             * @see JAXRS.Configuration#ROOT_PATH
+             * @since 2.2
+             */
+            default Builder rootPath(String rootPath) {
+                return property(ROOT_PATH, rootPath);
+            }
+
+            /**
+             * Convenience method to set the {@code sslContext} to be used.
+             * <p>
+             * Same as if calling {@link #property(String, Object) property(SSL_CONTEXT,
+             * value)}.
+             * </p>
+             *
+             * @param sslContext
+             *            sslContext parameter of this configuration, or {@code null} to use
+             *            the default value.
+             * @return the updated builder.
+             * @see JAXRS.Configuration#SSL_CONTEXT
+             * @since 2.2
+             */
+            default Builder sslContext(SSLContext sslContext) {
+                return property(SSL_CONTEXT, sslContext);
+            }
+
+            /**
+             * Convenience method to set SSL client authentication policy.
+             * <p>
+             * Same as if calling {@link #property(String, Object)
+             * property(SSL_CLIENT_AUTHENTICATION, value)}.
+             * </p>
+             *
+             * @param sslClientAuthentication
+             *            SSL client authentication mode of this configuration
+             * @return the updated builder.
+             * @see JAXRS.Configuration#SSL_CLIENT_AUTHENTICATION
+             * @since 2.2
+             */
+            default Builder sslClientAuthentication(SSLClientAuthentication sslClientAuthentication) {
+                return property(SSL_CLIENT_AUTHENTICATION, sslClientAuthentication);
+            }
+
+            /**
+             * Convenience method for bulk-loading configuration from a property supplier.
+             * <p>
+             * Implementations ask the passed provider function for the actual values of all
+             * their supported properties, before returning from this configuration method.
+             * For each single request the implementation provides the name of the property
+             * and the expected data type of the value. If no such property exists (i. e.
+             * either the name is unknown or misspelled, or the type does not exactly
+             * match), the {@link Optional} is {@link Optional#empty() empty}.
+             * </p>
+             *
+             * @param <T>
+             *            Type of the requested property value.
+             * @param propertiesProvider
+             *            Retrieval function of externally managed properties. MUST NOT
+             *            return {@code null}.
+             * @return the updated builder.
+             * @since 2.2
+             */
+            <T> Builder from(BiFunction<String, Class<T>, Optional<T>> propertiesProvider);
+
+            /**
+             * Optional convenience method to bulk-load external configuration.
+             * <p>
+             * Implementations are free to support any external configuration mechanics, or
+             * none at all. It is completely up to the implementation what set of properties
+             * is effectively loaded from the provided external configuration, possibly none
+             * at all.
+             * </p>
+             * <p>
+             * If the passed external configuration mechanics is unsupported, this method
+             * MUST simply do nothing.
+             * </p>
+             * <p>
+             * Portable applications should not call this method, as the outcome is
+             * completely implementation-specific.
+             * </p>
+             *
+             * @param externalConfig
+             *            source of externally managed properties
+             * @return the updated builder.
+             * @since 2.2
+             */
+            default Builder from(Object externalConfig) {
+                return this;
+            }
+
+        }
+    }
+
+    /**
+     * Handle of the running application instance.
+     *
+     * @author Markus KARG (markus@headcrashing.eu)
+     * @since 2.2
+     */
+    public interface Instance {
+
+        /**
+         * Provides access to the configuration <em>actually</em> used by the
+         * implementation used to create this instance.
+         * <p>
+         * This may, or may not, be the same instance passed to
+         * {@link JAXRS#start(Application, Configuration)}, not even an equal instance,
+         * as implementations MAY create a new intance and MUST update at least the
+         * {@code PORT} property with the actually used value. Portable applications
+         * should not make any assumptions but always explicitly read the actual values
+         * from the configuration returned from this method.
+         * </p>
+         *
+         * @return The configuration actually used to create this instance.
+         * @since 2.2
+         */
+        public Configuration configuration();
+
+        /**
+         * Initiate immediate shutdown of running application instance.
+         *
+         * @return {@code CompletionStage} asynchronously shutting down this application
+         *         instance.
+         * @since 2.2
+         */
+        public CompletionStage<StopResult> stop();
+
+        /**
+         * Result of stopping the application instance.
+         *
+         * @author Markus KARG (markus@headcrashing.eu)
+         * @since 2.2
+         */
+        public interface StopResult {
+
+            /**
+             * Provides access to the wrapped native shutdown result.
+             * <p>
+             * Implementations may, or may not, have native shutdown results. Portable
+             * applications should not invoke this method, as the outcome is undefined.
+             * </p>
+             *
+             * @param <T>
+             *            Requested type of the native result to return.
+             * @param nativeClass
+             *            Requested type of the native result to return.
+             * @return Native result of shutting down the running application instance or
+             *         {@code null} if the implementation has no native result.
+             * @throws ClassCastException
+             *             if the result is not {@code null} or is not assignable to the
+             *             type {@code T}.
+             * @since 2.2
+             */
+            public <T> T unwrap(Class<T> nativeClass);
+        }
+
+        /**
+         * Provides access to the wrapped native handle of the application instance.
+         * <p>
+         * Implementations may, or may not, have native handles. Portable applications
+         * should not invoke this method, as the outcome is undefined.
+         * </p>
+         *
+         * @param <T>
+         *            Requested type of the native handle to return.
+         * @param nativeClass
+         *            Requested type of the native handle to return.
+         * @return Native handle of the running application instance or {@code null} if
+         *         the implementation has no native handle.
+         * @throws ClassCastException
+         *             if the handle is not {@code null} and is not assignable to the
+         *             type {@code T}.
+         * @since 2.2
+         */
+        public <T> T unwrap(Class<T> nativeClass);
+    }
+
+}

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/RuntimeDelegate.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/RuntimeDelegate.java
@@ -18,7 +18,10 @@ package javax.ws.rs.ext;
 
 import java.lang.reflect.ReflectPermission;
 import java.net.URL;
+import java.util.concurrent.CompletionStage;
 
+import javax.ws.rs.JAXRS;
+import javax.ws.rs.JAXRS.Instance;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Link;
 import javax.ws.rs.core.Response.ResponseBuilder;
@@ -246,4 +249,32 @@ public abstract class RuntimeDelegate {
      * @see javax.ws.rs.core.Link.Builder
      */
     public abstract Link.Builder createLinkBuilder();
+
+    /**
+     * Create a new instance of a {@link javax.ws.rs.JAXRS.Configuration.Builder}.
+     * <p>
+     * <em>This method is not intended to be invoked by applications. Call
+     * {@link JAXRS.Configuration#builder()} instead.</em>
+     * </p>
+     *
+     * @return new {@code JAXRS.Configuration.Builder} instance.
+     * @see JAXRS.Configuration.Builder
+     */
+    public abstract JAXRS.Configuration.Builder createConfigurationBuilder();
+
+    /**
+     * Perform startup of the application in Java SE environments.
+     * <p>
+     * <em>This method is not intended to be invoked by applications. Call
+     * {@link JAXRS#start(Application, Configuration)} instead.</em>
+     * </p>
+     *
+     * @param application
+     *            The application to start up.
+     * @param configuration
+     *            The bootstrap configuration.
+     * @return {@code CompletionStage} asynchronously producing handle of the
+     *         running application {@link JAXRS.Instance instance}.
+     */
+    public abstract CompletionStage<Instance> bootstrap(Application application, JAXRS.Configuration configuration);
 }

--- a/jaxrs-api/src/test/java/javax/ws/rs/JAXRSTest.java
+++ b/jaxrs-api/src/test/java/javax/ws/rs/JAXRSTest.java
@@ -1,0 +1,199 @@
+package javax.ws.rs;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.util.concurrent.CompletionStage;
+
+import javax.net.ssl.SSLContext;
+import javax.ws.rs.JAXRS.Configuration;
+import javax.ws.rs.JAXRS.Configuration.SSLClientAuthentication;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.ext.RuntimeDelegate;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link JAXRS}
+ *
+ * @author Markus KARG (markus@headcrashing.eu)
+ * @since 2.2
+ */
+public final class JAXRSTest {
+
+    /**
+     * Installs a new {@code RuntimeDelegate} mock before each test case, as some
+     * test cases need to find a pristine <em>installed</em> RuntimeDelegate.
+     */
+    @Before
+    public final void setUp() {
+        RuntimeDelegate.setInstance(mock(RuntimeDelegate.class));
+    }
+
+    /**
+     * Uninstalls the {@code RuntimeDelegate} mock after each test case to be sure
+     * that the <em>next</em> test case does not use a possibly cluttered instance.
+     */
+    @After
+    public final void tearDown() {
+        RuntimeDelegate.setInstance(null);
+    }
+
+    /**
+     * Assert that {@link JAXRS#start(Application, Configuration)} will delegate to
+     * {@link RuntimeDelegate#bootstrap(Application, Configuration)}.
+     *
+     * @since 2.2
+     */
+    @Test
+    public final void shouldDelegateApplicationStartupToRuntimeDelegate() {
+        // given
+        final Application application = mock(Application.class);
+        final Configuration configuration = mock(Configuration.class);
+        @SuppressWarnings("unchecked")
+        final CompletionStage<JAXRS.Instance> nativeCompletionStage = mock(CompletionStage.class);
+        given(RuntimeDelegate.getInstance().bootstrap(application, configuration)).willReturn(nativeCompletionStage);
+
+        // when
+        final CompletionStage<JAXRS.Instance> actualCompletionStage = JAXRS.start(application, configuration);
+
+        // then
+        assertThat(actualCompletionStage, is(sameInstance(nativeCompletionStage)));
+    }
+
+    /**
+     * Assert that {@link JAXRS.Configuration#builder()} will delegate to
+     * {@link RuntimeDelegate#createConfigurationBuilder()}.
+     *
+     * @since 2.2
+     */
+    @Test
+    public final void shouldDelegateConfigurationBuilderCreationToRuntimeDelegate() {
+        // given
+        final JAXRS.Configuration.Builder nativeConfigurationBuilder = mock(JAXRS.Configuration.Builder.class);
+        given(RuntimeDelegate.getInstance().createConfigurationBuilder()).willReturn(nativeConfigurationBuilder);
+
+        // when
+        final JAXRS.Configuration.Builder actualConfigurationBuilder = JAXRS.Configuration.builder();
+
+        // then
+        assertThat(actualConfigurationBuilder, is(sameInstance(nativeConfigurationBuilder)));
+    }
+
+    /**
+     * Assert that {@code Configuration.Builder}'s
+     * {@code from(external configuration)} bulk-loading method simply returns
+     * {@code this}, but does nothing else, as it is a no-op implementation.
+     *
+     * @since 2.2
+     */
+    @Test
+    public final void shouldReturnSameConfigurationBuilderInstanceWhenLoadingExternalConfiguration() {
+        // given
+        final JAXRS.Configuration.Builder previousConfigurationBuilder = spy(JAXRS.Configuration.Builder.class);
+        final Object someExternalConfiguration = mock(Object.class);
+
+        // when
+        final JAXRS.Configuration.Builder currentConfigurationBuilder = previousConfigurationBuilder
+                .from(someExternalConfiguration);
+
+        // then
+        assertThat(currentConfigurationBuilder, is(sameInstance(previousConfigurationBuilder)));
+        verify(previousConfigurationBuilder).from(someExternalConfiguration);
+        verifyNoMoreInteractions(previousConfigurationBuilder);
+    }
+
+    /**
+     * Assert that {@code Configuration.Builder}'s convenience methods delegate to
+     * its generic {@code property(name, value)} method using the <em>right</em>
+     * property name.
+     *
+     * @since 2.2
+     */
+    @Test
+    public final void shouldPushCorrespondingPropertiesIntoConfigurationBuilder() {
+        // given
+        final String someProtocolValue = mockString();
+        final String someHostValue = mockString();
+        final int somePortValue = mockInt();
+        final String someRootPathValue = mockString();
+        final SSLContext someSSLContextValue = mock(SSLContext.class);
+        final SSLClientAuthentication someSSLClientAuthenticationValue = SSLClientAuthentication.MANDATORY;
+        final JAXRS.Configuration.Builder configurationBuilder = spy(JAXRS.Configuration.Builder.class);
+
+        // when
+        configurationBuilder.protocol(someProtocolValue);
+        configurationBuilder.host(someHostValue);
+        configurationBuilder.port(somePortValue);
+        configurationBuilder.rootPath(someRootPathValue);
+        configurationBuilder.sslContext(someSSLContextValue);
+        configurationBuilder.sslClientAuthentication(someSSLClientAuthenticationValue);
+
+        // then
+        verify(configurationBuilder).property(JAXRS.Configuration.PROTOCOL, someProtocolValue);
+        verify(configurationBuilder).property(JAXRS.Configuration.HOST, someHostValue);
+        verify(configurationBuilder).property(JAXRS.Configuration.PORT, somePortValue);
+        verify(configurationBuilder).property(JAXRS.Configuration.ROOT_PATH, someRootPathValue);
+        verify(configurationBuilder).property(JAXRS.Configuration.SSL_CONTEXT, someSSLContextValue);
+        verify(configurationBuilder).property(JAXRS.Configuration.SSL_CLIENT_AUTHENTICATION,
+                someSSLClientAuthenticationValue);
+    }
+
+    /**
+     * Assert that {@code Configuration}'s convenience methods delegate to its
+     * generic {@code property(name)} method using the <em>right</em> property name.
+     *
+     * @since 2.2
+     */
+    @Test
+    public final void shouldPullCorrespondingPropertiesFromConfiguration() {
+        // given
+        final String someProtocolValue = mockString();
+        final String someHostValue = mockString();
+        final int somePortValue = mockInt();
+        final String someRootPathValue = mockString();
+        final SSLContext someSSLContextValue = mock(SSLContext.class);
+        final SSLClientAuthentication someSSLClientAuthenticationValue = SSLClientAuthentication.MANDATORY;
+        final JAXRS.Configuration configuration = spy(JAXRS.Configuration.class);
+        given(configuration.property(JAXRS.Configuration.PROTOCOL)).willReturn(someProtocolValue);
+        given(configuration.property(JAXRS.Configuration.HOST)).willReturn(someHostValue);
+        given(configuration.property(JAXRS.Configuration.PORT)).willReturn(somePortValue);
+        given(configuration.property(JAXRS.Configuration.ROOT_PATH)).willReturn(someRootPathValue);
+        given(configuration.property(JAXRS.Configuration.SSL_CONTEXT)).willReturn(someSSLContextValue);
+        given(configuration.property(JAXRS.Configuration.SSL_CLIENT_AUTHENTICATION))
+                .willReturn(someSSLClientAuthenticationValue);
+
+        // when
+        final String actualProtocolValue = configuration.protocol();
+        final String actualHostValue = configuration.host();
+        final int actualPortValue = configuration.port();
+        final String actualRootPathValue = configuration.rootPath();
+        final SSLContext actualSSLContextValue = configuration.sslContext();
+        final SSLClientAuthentication actualSSLClientAuthenticationValue = configuration.sslClientAuthentication();
+
+        // then
+        assertThat(actualProtocolValue, is(sameInstance(someProtocolValue)));
+        assertThat(actualHostValue, is(sameInstance(someHostValue)));
+        assertThat(actualPortValue, is(somePortValue));
+        assertThat(actualRootPathValue, is(sameInstance(someRootPathValue)));
+        assertThat(actualSSLContextValue, is(sameInstance(someSSLContextValue)));
+        assertThat(actualSSLClientAuthenticationValue, is(sameInstance(someSSLClientAuthenticationValue)));
+    }
+
+    private static String mockString() {
+        return Integer.toString(mockInt());
+    }
+
+    private static int mockInt() {
+        return (int) Math.round(Integer.MAX_VALUE * Math.random());
+    }
+
+}

--- a/jaxrs-api/src/test/java/javax/ws/rs/core/RuntimeDelegateStub.java
+++ b/jaxrs-api/src/test/java/javax/ws/rs/core/RuntimeDelegateStub.java
@@ -16,6 +16,11 @@
 
 package javax.ws.rs.core;
 
+import java.util.concurrent.CompletionStage;
+
+import javax.ws.rs.JAXRS;
+import javax.ws.rs.JAXRS.Configuration;
+import javax.ws.rs.JAXRS.Instance;
 import javax.ws.rs.core.Link.Builder;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Variant.VariantListBuilder;
@@ -51,5 +56,15 @@ public class RuntimeDelegateStub extends RuntimeDelegate {
     @Override
     public Builder createLinkBuilder() {
         return null;
+    }
+
+    @Override
+    public Configuration.Builder createConfigurationBuilder() {
+	return null;
+    }
+
+    @Override
+    public CompletionStage<Instance> bootstrap(final Application application, final JAXRS.Configuration configuration) {
+	return null;
     }
 }


### PR DESCRIPTION
This PR implements a vendor-neutral way to bootstrap JAX-RS applications in pure Java SE environments (i. e. making the application self-contained, without being powered by an application server product). It just provides a common API for starting up the application and runtime, but does not make any contstraints about supported features or technology.

Signed-off-by: Markus KARG <markus@headcrashing.eu>