### PR TITLE
Clarify that Feature supports auto-discovery via @Provider (#583)

### DIFF
--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Feature.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Feature.java
@@ -29,6 +29,12 @@ package javax.ws.rs.core;
  * for the facility or conceptual domain it represents, such as registering additional contract providers,
  * including nested features and/or specifying domain-specific properties.
  * </p>
+ * <p>
+ * Features implementing this interface MAY be annotated with the {@link javax.ws.rs.ext.Provider &#64;Provider}
+ * annotation in order to be discovered by the JAX-RS runtime when scanning for resources and providers.
+ * Please note that this will only work for server side features. Features for the JAX-RS client must
+ * be registered programmatically.
+ * </p>
  *
  * @author Marek Potociar
  * @since 2.0


### PR DESCRIPTION
This pull requests adds a clarification to the API docs of the `Feature` provider interface which describes that auto-discovery via `@Provider` is supported for server side features.

Please see #583 for the corresponding discussion.

As this pull request isn't a API change and has been discussed before, the review period will be one week.
 