### PR TITLE
Clarify which components are returned from Configuration#getClasses()

### DIFF
--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Configuration.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Configuration.java
@@ -153,9 +153,10 @@ public interface Configuration {
     public Map<Class<?>, Integer> getContracts(Class<?> componentClass);
 
     /**
-     * Get the immutable set of registered JAX-RS component (such as provider or
+     * Get the immutable set of registered JAX-RS component (such as provider, root resource or
      * {@link Feature feature}) classes to be instantiated, injected and utilized in the scope
-     * of the configurable instance.
+     * of the configurable instance. In contrast to {@link Application#getClasses()} this method
+     * returns a complete runtime view and therefore also includes auto-discovered components.
      * <p>
      * For each component type, there can be only a single class-based or instance-based registration
      * present in the configuration context at any given time.


### PR DESCRIPTION
This pull requests clarifies which classes are returned from `Configuration.getClasses()`. Especially it states that the resulting set will include root resource classes and that the result of this method will return a complete runtime view which includes auto-detected components.

Please see #565 for the corresponding discussion.

As this pull request isn't an API change and has been discussed before, the review period will be one week. Feel free to comment if you prefer a two week period.