### PR TITLE
Minor improvements to pom.xml

### DIFF
--- a/jaxrs-api/.gitignore
+++ b/jaxrs-api/.gitignore
@@ -1,0 +1,1 @@
+.checkstyle

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -164,7 +164,7 @@
                                 and/or its affiliates. All Rights Reserved.
                                 ]]>
                             </bottom>
-                            <additionalparam>-Xdoclint:none</additionalparam>
+                            <doclint>none</doclint>
                             <!--javaApiLinks>
                                 <property>
                                     <name>api_1.3</name>
@@ -222,13 +222,13 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.5</version>
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <!-- This plugin generates the buildNumber property used in maven-bundle-plugin -->
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>buildnumber-maven-plugin</artifactId>
-                    <version>1.3</version>
+                    <version>1.4</version>
                     <configuration>
                         <format>{0,date,MM/dd/yyyy hh:mm aa}</format>
                         <items>
@@ -313,7 +313,7 @@
                                 and/or its affiliates. All Rights Reserved.
                             ]]>
                         </bottom>
-                        <additionalparam>-Xdoclint:none</additionalparam>
+                        <doclint>none</doclint>
                         <!--javaApiLinks>
                             <property>
                                 <name>api_1.3</name>
@@ -347,7 +347,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>2.3</version>
+                    <version>3.0.1</version>
                     <executions>
                         <execution>
                             <id>attach-sources</id>
@@ -359,7 +359,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.8.1</version>
+                    <version>2.8.2</version>
                     <configuration>
                         <retryFailedDeploymentCount>10</retryFailedDeploymentCount>
                     </configuration>
@@ -395,7 +395,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-jxr-plugin</artifactId>
-                    <version>2.3</version>
+                    <version>2.5</version>
                     <executions>
                         <execution>
                             <goals>
@@ -502,9 +502,9 @@
         <apidocs.title>JAX-RS ${spec.version} API Specification ${spec.version.revision}</apidocs.title>
         <java.version>1.8</java.version>
 
-        <maven.bundle.plugin.version>3.3.0</maven.bundle.plugin.version>
-        <maven.compiler.plugin.version>3.6.1</maven.compiler.plugin.version>
-        <maven.javadoc.plugin.version>2.10.4</maven.javadoc.plugin.version>
+        <maven.bundle.plugin.version>3.5.0</maven.bundle.plugin.version>
+        <maven.compiler.plugin.version>3.7.0</maven.compiler.plugin.version>
+        <maven.javadoc.plugin.version>3.0.0</maven.javadoc.plugin.version>
 
         <last.final.spec.version>2.1</last.final.spec.version>
         <milestone.number>01</milestone.number>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -29,8 +29,8 @@
     <url>https://github.com/eclipse-ee4j/jaxrs-api</url>
 
     <organization>
-        <name>Oracle Corporation</name>
-        <url>http://www.oracle.com/</url>
+        <name>Eclipse Foundation</name>
+        <url>https://www.eclipse.org/org/foundation/</url>
     </organization>
 
     <issueManagement>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -101,7 +101,6 @@
                 <pluginManagement>
                     <plugins>
                         <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-compiler-plugin</artifactId>
                             <version>${maven.compiler.plugin.version}</version>
                             <executions>
@@ -155,7 +154,6 @@
                     <plugin>
                         <!-- TODO: overriding paren pom (profile jvnet-release) - we should find nicer way -->
                         <!-- 1.8- javadoc cannot handle module-info -->
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <version>${maven.javadoc.plugin.version}</version>
                         <configuration combine.self="override">
@@ -202,7 +200,6 @@
                 <pluginManagement>
                     <plugins>
                         <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-compiler-plugin</artifactId>
                             <version>${maven.compiler.plugin.version}</version>
                             <configuration>
@@ -224,7 +221,6 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>2.5</version>
                 </plugin>
@@ -307,7 +303,6 @@
                     </executions>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>${maven.javadoc.plugin.version}</version>
                     <configuration>
@@ -351,7 +346,6 @@
                     </executions>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
                     <version>2.3</version>
                     <executions>
@@ -364,7 +358,6 @@
                     </executions>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
                     <version>2.8.1</version>
                     <configuration>
@@ -372,7 +365,6 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
                     <version>2.5.3</version>
                     <!--
@@ -402,7 +394,6 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jxr-plugin</artifactId>
                     <version>2.3</version>
                     <executions>
@@ -415,7 +406,6 @@
                     </executions>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
                     <version>3.0.0</version>
                     <configuration>
@@ -465,11 +455,9 @@
                 <artifactId>spec-version-maven-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
             </plugin>
             <plugin>
@@ -477,19 +465,15 @@
                 <artifactId>buildnumber-maven-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jxr-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
             <plugin>


### PR DESCRIPTION
With this PR I'd like to propose some minor improvements to the pom.xml file:

- Getting rid of `groupId` lines wherevery possible, following a Maven best-practice: Using CoC for default group IDs.
- Correcting the `organization` element, which now says "Eclipse Foundation" not "Oracle" anymore.
- Bumping versions of Maven plugins to catch up with months to years of bug fixes.