### PR TITLE
Enabling JDK 8 Doclint Checks (#623)

### DIFF
--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -164,7 +164,6 @@
                                 and/or its affiliates. All Rights Reserved.
                                 ]]>
                             </bottom>
-                            <doclint>none</doclint>
                             <!--javaApiLinks>
                                 <property>
                                     <name>api_1.3</name>
@@ -313,7 +312,6 @@
                                 and/or its affiliates. All Rights Reserved.
                             ]]>
                         </bottom>
-                        <doclint>none</doclint>
                         <!--javaApiLinks>
                             <property>
                                 <name>api_1.3</name>

--- a/jaxrs-api/src/main/java/javax/ws/rs/ApplicationPath.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ApplicationPath.java
@@ -51,6 +51,8 @@ public @interface ApplicationPath {
      * Note that percent encoded values are allowed in the value, an
      * implementation will recognize such values and will not double
      * encode the '%' character.</p>
+     * 
+     * @return base URI.
      */
     String value();
 }

--- a/jaxrs-api/src/main/java/javax/ws/rs/ApplicationPath.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ApplicationPath.java
@@ -47,7 +47,7 @@ public @interface ApplicationPath {
      *
      * <p>The supplied value is automatically percent
      * encoded to conform to the {@code path} production of
-     * {@link <a href="http://tools.ietf.org/html/rfc3986#section-3.3">RFC 3986 section 3.3</a>}.
+     * <a href="http://tools.ietf.org/html/rfc3986#section-3.3">RFC 3986 section 3.3</a>.
      * Note that percent encoded values are allowed in the value, an
      * implementation will recognize such values and will not double
      * encode the '%' character.</p>

--- a/jaxrs-api/src/main/java/javax/ws/rs/BeanParam.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/BeanParam.java
@@ -32,9 +32,8 @@ import java.lang.annotation.Target;
  * annotation. For the POJO classes same instantiation and injection rules apply as in case of instantiation
  * and injection of request-scoped root resource classes.
  * </p>
- * <p>
  * For example:
- * <pre>
+ * <PRE>
  * public class MyBean {
  *   &#64;FormParam("myData")
  *   private String data;
@@ -56,8 +55,7 @@ import java.lang.annotation.Target;
  *
  *   ...
  * }
- * </pre>
- * </p>
+ * </PRE>
  * <p>
  * Because injection occurs at object creation time, use of this annotation on resource
  * class fields and bean properties is only supported for the default per-request resource

--- a/jaxrs-api/src/main/java/javax/ws/rs/ConstrainedTo.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ConstrainedTo.java
@@ -76,6 +76,8 @@ public @interface ConstrainedTo {
 
     /**
      * Define the {@link RuntimeType constraint type} to be placed on a JAX-RS provider.
+     * 
+     * @return applicable run-time context.
      */
     RuntimeType value();
 }

--- a/jaxrs-api/src/main/java/javax/ws/rs/Consumes.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/Consumes.java
@@ -53,6 +53,8 @@ public @interface Consumes {
      * </pre>
      * Use of the comma-separated form allows definition of a common string constant
      * for use on multiple targets.
+     * 
+     * @return media types to accept.
      */
     String[] value() default "*/*";
 }

--- a/jaxrs-api/src/main/java/javax/ws/rs/CookieParam.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/CookieParam.java
@@ -66,6 +66,8 @@ public @interface CookieParam {
      * Defines the name of the HTTP cookie whose value will be used
      * to initialize the value of the annotated method argument, class field or
      * bean property.
+     * 
+     * @return HTTP cookie name.
      */
     String value();
 }

--- a/jaxrs-api/src/main/java/javax/ws/rs/DefaultValue.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/DefaultValue.java
@@ -62,6 +62,8 @@ public @interface DefaultValue {
 
     /**
      * The specified default value.
+     *
+     * @return default value.
      */
     String value();
 }

--- a/jaxrs-api/src/main/java/javax/ws/rs/FormParam.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/FormParam.java
@@ -71,6 +71,8 @@ public @interface FormParam {
      * will not be decoded and will instead be treated as literal text. E.g. if
      * the parameter name is "a b" then the value of the annotation is "a b",
      * <i>not</i> "a+b" or "a%20b".
+     * 
+     * @return form parameter name.
      */
     String value();
 }

--- a/jaxrs-api/src/main/java/javax/ws/rs/HeaderParam.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/HeaderParam.java
@@ -68,6 +68,8 @@ public @interface HeaderParam {
      * Defines the name of the HTTP header whose value will be used
      * to initialize the value of the annotated method argument, class field or
      * bean property. Case insensitive.
+     * 
+     * @return HTTP header name.
      */
     String value();
 }

--- a/jaxrs-api/src/main/java/javax/ws/rs/HttpMethod.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/HttpMethod.java
@@ -78,6 +78,8 @@ public @interface HttpMethod {
 
     /**
      * Specifies the name of a HTTP method. E.g. "GET".
+     * 
+     * @return HTTP method name.
      */
     String value();
 }

--- a/jaxrs-api/src/main/java/javax/ws/rs/MatrixParam.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/MatrixParam.java
@@ -81,6 +81,8 @@ public @interface MatrixParam {
      * literals within the value will not be decoded and will instead be
      * treated as literal text. E.g. if the parameter name is "a b" then the
      * value of the annotation is "a b", <i>not</i> "a+b" or "a%20b".
+     * 
+     * @return URI matrix parameter name.
      */
     String value();
 }

--- a/jaxrs-api/src/main/java/javax/ws/rs/NameBinding.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/NameBinding.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
 /**
  * Meta-annotation used to create name binding annotations for filters
  * and interceptors.
- * <p>
+ *
  * Name binding via annotations is only supported as part of the Server API.
  * In name binding, a <i>name-binding</i> annotation is first defined using the
  * {@code @NameBinding} meta-annotation:
@@ -77,7 +77,6 @@ import java.lang.annotation.Target;
  *      ...
  *  }
  * </pre>
- * </p>
  *
  * @author Santiago Pericas-Geertsen
  * @author Marek Potociar

--- a/jaxrs-api/src/main/java/javax/ws/rs/Path.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/Path.java
@@ -102,6 +102,8 @@ public @interface Path {
      * Note that percent encoded values are allowed in the literal part of the
      * value, an implementation will recognize such values and will not double
      * encode the '%' character.</p>
+     * 
+     * @return URI template.
      */
     String value();
 }

--- a/jaxrs-api/src/main/java/javax/ws/rs/Path.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/Path.java
@@ -77,7 +77,7 @@ public @interface Path {
      * name = (ALPHA / DIGIT / "_")*(ALPHA / DIGIT / "." / "_" / "-" ) ; \w[\w\.-]*
      * regex = *( nonbrace / "{" *nonbrace "}" ) ; where nonbrace is any char other than "{" and "}"</pre>
      *
-     * <p>See {@link <a href="http://tools.ietf.org/html/rfc5234">RFC 5234</a>}
+     * <p>See <a href="http://tools.ietf.org/html/rfc5234">RFC 5234</a>
      * for a description of the syntax used above and the expansions of
      * {@code WSP}, {@code ALPHA} and {@code DIGIT}. In the above {@code name}
      * is the template parameter name and the optional {@code regex} specifies
@@ -88,17 +88,17 @@ public @interface Path {
      * will not escape literal characters in regex automatically, therefore any
      * literals in {@code regex} should be escaped by the author according to
      * the rules of
-     * {@link <a href="http://tools.ietf.org/html/rfc3986#section-3.3">RFC 3986 section 3.3</a>}.
+     * <a href="http://tools.ietf.org/html/rfc3986#section-3.3">RFC 3986 section 3.3</a>.
      * Caution is recommended in the use of {@code regex}, incorrect use can
      * lead to a template parameter matching unexpected URI paths. See
-     * {@link <a href="http://download.oracle.com/javase/6/docs/api/java/util/regex/Pattern.html">Pattern</a>}
+     * <a href="http://download.oracle.com/javase/6/docs/api/java/util/regex/Pattern.html">Pattern</a>
      * for further information on the syntax of regular expressions.
      * Values of template parameters may be extracted using {@link PathParam}.</p>
      *
      * <p>The literal part of the supplied value (those characters
      * that are not part of a template parameter) is automatically percent
      * encoded to conform to the {@code path} production of
-     * {@link <a href="http://tools.ietf.org/html/rfc3986#section-3.3">RFC 3986 section 3.3</a>}.
+     * <a href="http://tools.ietf.org/html/rfc3986#section-3.3">RFC 3986 section 3.3</a>.
      * Note that percent encoded values are allowed in the literal part of the
      * value, an implementation will recognize such values and will not double
      * encode the '%' character.</p>

--- a/jaxrs-api/src/main/java/javax/ws/rs/PathParam.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/PathParam.java
@@ -87,6 +87,8 @@ public @interface PathParam {
      * <p>E.g. a class annotated with: {@code @Path("widgets/{id}")}
      * can have methods annotated whose arguments are annotated
      * with {@code @PathParam("id")}.
+     * 
+     * @return resource URI template parameter name.
      */
     String value();
 }

--- a/jaxrs-api/src/main/java/javax/ws/rs/ProcessingException.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ProcessingException.java
@@ -64,9 +64,10 @@ public class ProcessingException extends RuntimeException {
     }
 
     /**
+     * <p>
      * Constructs a new JAX-RS runtime processing exception with the specified detail
      * message and cause.
-     * <p/>
+     * </p>
      * Note that the detail message associated with {@code cause} is <i>not</i>
      * automatically incorporated in this runtime exception's detail message.
      *

--- a/jaxrs-api/src/main/java/javax/ws/rs/Produces.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/Produces.java
@@ -58,6 +58,8 @@ public @interface Produces {
      * </pre>
      * Use of the comma-separated form allows definition of a common string constant
      * for use on multiple targets.
+     * 
+     * @return media types to accept.
      */
     String[] value() default "*/*";
 }

--- a/jaxrs-api/src/main/java/javax/ws/rs/QueryParam.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/QueryParam.java
@@ -74,6 +74,8 @@ public @interface QueryParam {
      * literals within the value will not be decoded and will instead be
      * treated as literal text. E.g. if the parameter name is "a b" then the
      * value of the annotation is "a b", <i>not</i> "a+b" or "a%20b".
+     * 
+     * @return HTTP query parameter name.
      */
     String value();
 }

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/Client.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/Client.java
@@ -25,9 +25,10 @@ import javax.ws.rs.core.Link;
 import javax.ws.rs.core.UriBuilder;
 
 /**
+ * <p>
  * Client is the main entry point to the fluent API used to build and execute client
  * requests in order to consume responses returned.
- * <p/>
+ * </p>
  * Clients are heavy-weight objects that manage the client-side communication
  * infrastructure. Initialization as well as disposal of a {@code Client} instance
  * may be a rather expensive operation. It is therefore advised to construct only
@@ -42,11 +43,12 @@ import javax.ws.rs.core.UriBuilder;
 public interface Client extends Configurable<Client>, AutoCloseable {
 
     /**
+     * <p>
      * Close client instance and all it's associated resources. Subsequent calls
      * have no effect and are ignored. Once the client is closed, invoking any
      * other method on the client instance would result in an {@link IllegalStateException}
      * being thrown.
-     * <p/>
+     * </p>
      * Calling this method effectively invalidates all {@link WebTarget resource targets}
      * produced by the client instance. Invoking any method on such targets once the client
      * is closed would result in an {@link IllegalStateException} being thrown.

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/Invocation.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/Invocation.java
@@ -82,7 +82,7 @@ public interface Invocation {
      *   WebTarget resourceTarget = client.target("http://examples.jaxrs.com/");
      *
      *   // Build and invoke the get request asynchronously in a single step
-     *   Future<String> response = resourceTarget.request("text/plain")
+     *   Future&lt;String&gt; response = resourceTarget.request("text/plain")
      *           .header("Foo", "bar").async().get(String.class);
      * </pre>
      */

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/Invocation.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/Invocation.java
@@ -279,6 +279,7 @@ public interface Invocation {
          * This method is an extension point for JAX-RS implementations to support other types
          * representing asynchronous computations.
          *
+         * @param <T> generic invoker type.
          * @param clazz {@link RxInvoker} subclass.
          * @return reactive invoker instance.
          * @throws IllegalStateException when provider for given class is not registered.

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/ResponseProcessingException.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/ResponseProcessingException.java
@@ -53,9 +53,9 @@ public class ResponseProcessingException extends ProcessingException {
     }
 
     /**
-     * Constructs a new JAX-RS runtime response processing exception with the specified detail
+     * <p>Constructs a new JAX-RS runtime response processing exception with the specified detail
      * message and cause.
-     * <p/>
+     * </p>
      * Note that the detail message associated with {@code cause} is <i>not</i>
      * automatically incorporated in this runtime exception's detail message.
      *

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/package-info.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/package-info.java
@@ -16,7 +16,7 @@
 
 /**
  * <h1>The JAX-RS client API</h1>
- *
+ * <p>
  * The JAX-RS client API is a Java based API used to access Web resources.
  * It is not restricted to resources implemented using JAX-RS.
  * It provides a higher-level abstraction compared to a {@link java.net.HttpURLConnection
@@ -24,7 +24,7 @@
  * providers, in order to enable concise and efficient implementation of
  * reusable client-side solutions that leverage existing and well
  * established client-side implementations of HTTP-based communication.
- * <p />
+ * </p>
  * The JAX-RS Client API encapsulates the Uniform Interface Constraint &ndash;
  * a key constraint of the REST architectural style &ndash; and associated data
  * elements as client-side Java artifacts and supports a pluggable architecture
@@ -96,9 +96,9 @@
  *       .queryParam("card", "111122223333").queryParam("pin", "9876")
  *       .request().buildPost(text("50.0")));
  *
- *   Collection<Invocation> invs = Arrays.asList(inv1, inv2);
+ *   Collection&lt;Invocation&gt; invs = Arrays.asList(inv1, inv2);
  *   // Executed by the submitter
- *   Collection<Response> ress = Collections.transform(invs, new F<Invocation, Response>() {
+ *   Collection&lt;Response&gt; ress = Collections.transform(invs, new F&lt;Invocation, Response&gt;() {
  *      public Response apply(Invocation inv) {return inv.invoke(); }
  *   });
  * </pre>

--- a/jaxrs-api/src/main/java/javax/ws/rs/container/AsyncResponse.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/container/AsyncResponse.java
@@ -279,12 +279,12 @@ public interface AsyncResponse {
      * The time-out handler will be invoked when the suspend period of this
      * asynchronous response times out. The job of the time-out handler is to
      * resolve the time-out situation by either
+     * </p>
      * <ul>
      * <li>resuming the suspended response</li>
      * <li>cancelling the suspended response</li>
      * <li>extending the suspend period by setting a new suspend time-out</li>
      * </ul>
-     * </p>
      * <p>
      * Note that in case the response is suspended {@link #NO_TIMEOUT indefinitely},
      * the time-out handler may never be invoked.

--- a/jaxrs-api/src/main/java/javax/ws/rs/container/Suspended.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/container/Suspended.java
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeUnit;
  * as a custom {@link TimeoutHandler timeout handler} can be specified programmatically
  * using the {@link AsyncResponse#setTimeout(long, TimeUnit)} and
  * {@link AsyncResponse#setTimeoutHandler(TimeoutHandler)} methods. For example:
- * <p/>
+ * </p>
  * <pre>
  *  &#64;Stateless
  *  &#64;Path("/")

--- a/jaxrs-api/src/main/java/javax/ws/rs/container/TimeoutHandler.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/container/TimeoutHandler.java
@@ -31,6 +31,7 @@ package javax.ws.rs.container;
  * <p>
  * In case of a suspend time-out event, a custom time-out handler takes typically one
  * of the following actions:
+ * </p>
  * <ul>
  * <li>Resumes the suspended asynchronous response using a {@link AsyncResponse#resume(Object)
  * custom response} or a {@link AsyncResponse#resume(Throwable) custom exception}</li>
@@ -40,6 +41,7 @@ package javax.ws.rs.container;
  * {@link AsyncResponse#setTimeout(long, java.util.concurrent.TimeUnit)
  * setting a new suspend time-out}</li>
  * </ul>
+ * <p>
  * If the registered time-out handler does not take any of the actions above, the
  * default time-out event processing continues and the response is resumed with
  * a generated {@code WebApplicationException} containing the HTTP 503 status code.
@@ -87,13 +89,13 @@ public interface TimeoutHandler {
      * {@link javax.ws.rs.container.AsyncResponse} API documentation).
      * <p>
      * A custom time-out handler may decide to either
+     * </p>
      * <ul>
      * <li>resume the suspended response using one of it's {@code resume(...)} methods,</li>
      * <li>cancel the suspended response using one of it's {@code cancel(...)} methods, or</li>
      * <li>extend the suspend period by {@link AsyncResponse#setTimeout(long, java.util.concurrent.TimeUnit)
      * setting a new suspend time-out}</li>
      * </ul>
-     * </p>
      * In case the time-out handler does not take any of the actions mentioned above,
      * a default time-out strategy is executed by the JAX-RS runtime.
      *

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/AbstractMultivaluedMap.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/AbstractMultivaluedMap.java
@@ -55,9 +55,9 @@ public abstract class AbstractMultivaluedMap<K, V> implements MultivaluedMap<K, 
     }
 
     /**
-     * Set the value for the key to be a one item list consisting of the supplied
+     * <p>Set the value for the key to be a one item list consisting of the supplied
      * value. Any existing values will be replaced.
-     * <p />
+     * </p>
      * NOTE: This implementation ignores {@code null} values; A supplied value
      * of {@code null} is ignored and not added to the purged value list.
      * As a result of such operation, empty value list would  be registered for
@@ -81,8 +81,8 @@ public abstract class AbstractMultivaluedMap<K, V> implements MultivaluedMap<K, 
     }
 
     /**
-     * Define the behavior for adding a {@code null} values to the value list.
-     * <p />
+     * <p>Define the behavior for adding a {@code null} values to the value list.
+     * </p>
      * Default implementation is a no-op, i.e. the {@code null} values are ignored.
      * Overriding implementations may modify this behavior by providing their
      * own definitions of this method.
@@ -96,9 +96,9 @@ public abstract class AbstractMultivaluedMap<K, V> implements MultivaluedMap<K, 
     }
 
     /**
-     * Define the behavior for adding a {@code null} values to the first position
+     * <p>Define the behavior for adding a {@code null} values to the first position
      * in the value list.
-     * <p />
+     * </p>
      * Default implementation is a no-op, i.e. the {@code null} values are ignored.
      * Overriding implementations may modify this behavior by providing their
      * own definitions of this method.
@@ -112,8 +112,8 @@ public abstract class AbstractMultivaluedMap<K, V> implements MultivaluedMap<K, 
     }
 
     /**
-     * Add a value to the current list of values for the supplied key.
-     * <p />
+     * <p>Add a value to the current list of values for the supplied key.
+     * </p>
      * NOTE: This implementation ignores {@code null} values; A supplied value
      * of {@code null} is ignored and not added to the value list. Overriding
      * implementations may modify this behavior by redefining the
@@ -134,11 +134,11 @@ public abstract class AbstractMultivaluedMap<K, V> implements MultivaluedMap<K, 
     }
 
     /**
-     * Add multiple values to the current list of values for the supplied key. If
+     * <p>Add multiple values to the current list of values for the supplied key. If
      * the supplied array of new values is empty, method returns immediately.
      * Method throws a {@code NullPointerException} if the supplied array of values
      * is {@code null}.
-     * <p />
+     * </p>
      * NOTE: This implementation ignores {@code null} values; Any of the supplied values
      * of {@code null} is ignored and not added to the value list. Overriding
      * implementations may modify this behavior by redefining the
@@ -169,11 +169,11 @@ public abstract class AbstractMultivaluedMap<K, V> implements MultivaluedMap<K, 
     }
 
     /**
-     * Add all the values from the supplied value list to the current list of
+     * <p>Add all the values from the supplied value list to the current list of
      * values for the supplied key. If the supplied value list is empty, method
      * returns immediately. Method throws a {@code NullPointerException} if the
      * supplied array of values is {@code null}.
-     * <p />
+     * </p>
      * NOTE: This implementation ignores {@code null} values; Any {@code null} value
      * in the supplied value list is ignored and not added to the value list. Overriding
      * implementations may modify this behavior by redefining the
@@ -214,9 +214,9 @@ public abstract class AbstractMultivaluedMap<K, V> implements MultivaluedMap<K, 
     }
 
     /**
-     * Add a value to the first position in the current list of values for the
+     * <p>Add a value to the first position in the current list of values for the
      * supplied key.
-     * <p />
+     * </p>
      * NOTE: This implementation ignores {@code null} values; A supplied value
      * of {@code null} is ignored and not added to the purged value list. Overriding
      * implementations may modify this behavior by redefining the
@@ -237,9 +237,9 @@ public abstract class AbstractMultivaluedMap<K, V> implements MultivaluedMap<K, 
     }
 
     /**
-     * Return a non-null list of values for a given key. The returned list may be
+     * <p>Return a non-null list of values for a given key. The returned list may be
      * empty.
-     * <p />
+     * </p>
      * If there is no entry for the key in the map, a new empty {@link List}
      * instance is created, registered within the map to hold the values of
      * the key and returned from the method.
@@ -264,9 +264,9 @@ public abstract class AbstractMultivaluedMap<K, V> implements MultivaluedMap<K, 
 
     /**
      * {@inheritDoc }
-     * <p />
+     * <p>
      * This implementation delegates the method call to to the the underlying
-     * [key, multi-value] store.
+     * [key, multi-value] store.</p>
      *
      * @return a hash code value for the underlying [key, multi-value] store.
      */
@@ -277,9 +277,9 @@ public abstract class AbstractMultivaluedMap<K, V> implements MultivaluedMap<K, 
 
     /**
      * {@inheritDoc }
-     * <p />
+     * <p>
      * This implementation delegates the method call to to the the underlying
-     * [key, multi-value] store.
+     * [key, multi-value] store.</p>
      *
      * @return {@code true} if the specified object is equal to the underlying
      *         [key, multi-value] store, {@code false} otherwise.

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Configurable.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Configurable.java
@@ -58,11 +58,11 @@ import java.util.Map;
  * </p>
  * <p>
  * For example:
+ * </p>
  * <pre>
  * config.register(HtmlDocumentReader.class);
  * config.register(new HtmlDocumentWriter(writerConfig));
  * </pre>
- * </p>
  * <p>
  * In some situations a JAX-RS component class or instance may implement multiple
  * provider contracts recognized by a JAX-RS implementation (e.g. filter, interceptor or entity provider).
@@ -71,6 +71,7 @@ import java.util.Map;
  * </p>
  * <p>
  * For example:
+ * </p>
  * <pre>
  * &#64;Priority(ENTITY_CODER)
  * public class GzipInterceptor
@@ -82,7 +83,6 @@ import java.util.Map;
  * // as well as a WriterInterceptor
  * config.register(GzipInterceptor.class);
  * </pre>
- * </p>
  * <p>
  * There are however situations when the default registration of a JAX-RS component to all the
  * recognized provider contracts is not desirable. In such cases users may use other versions of the
@@ -92,6 +92,7 @@ import java.util.Map;
  * </p>
  * <p>
  * For example:
+ * </p>
  * <pre>
  * &#64;Priority(USER)
  * public class ClientLoggingFilter
@@ -110,7 +111,6 @@ import java.util.Map;
  * // and both of it's provider contracts
  * config.register(GzipInterceptor.class, 6500);
  * </pre>
- * </p>
  * <p>
  * As a general rule, for each JAX-RS component class there can be at most one registration
  * &mdash; class-based or instance-based &mdash; configured at any given moment. Implementations
@@ -120,6 +120,7 @@ import java.util.Map;
  * </p>
  * <p>
  * For example:
+ * </p>
  * <pre>
  * config.register(GzipInterceptor.class, WriterInterceptor.class);
  * config.register(GzipInterceptor.class);       // Rejected by runtime.
@@ -131,7 +132,6 @@ import java.util.Map;
  * config.register(ClientLoggingFilter.class,
  *                 ClientResponseFilter.class);  // Rejected by runtime.
  * </pre>
- * </p>
  *
  * @author Marek Potociar
  * @since 2.0

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Configurable.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Configurable.java
@@ -132,7 +132,8 @@ import java.util.Map;
  * config.register(ClientLoggingFilter.class,
  *                 ClientResponseFilter.class);  // Rejected by runtime.
  * </pre>
- *
+ * 
+ * @param <C> generic configurable Java type
  * @author Marek Potociar
  * @since 2.0
  */

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Configuration.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Configuration.java
@@ -145,6 +145,7 @@ public interface Configuration {
      * For component classes that are not configured in this configuration context the method returns
      * an empty {@code Map}. Method does not return {@code null}.
      *
+     * @param componentClass a component class for which to get contracts.
      * @return map of extension contracts and their priorities for which the component class
      *         is registered.
      *         May return an empty map in case the component has not been registered for any

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/GenericEntity.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/GenericEntity.java
@@ -58,9 +58,9 @@ import java.lang.reflect.Type;
  * <pre>Method method = ...;
  * GenericEntity&lt;Object&gt; entity = new GenericEntity&lt;Object&gt;(
  *    method.invoke(...), method.getGenericReturnType());
- * Response response = Response.ok(entity).build();</pre></li>
+ * Response response = Response.ok(entity).build();</pre>
  * <p>The above obtains the generic type from the return type of the method,
- * the raw type is the class of entity.</p>
+ * the raw type is the class of entity.</p></li>
  * </ol>
  *
  * @param <T> response entity instance type

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/HttpHeaders.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/HttpHeaders.java
@@ -45,8 +45,8 @@ public interface HttpHeaders {
     public List<String> getRequestHeader(String name);
 
     /**
-     * Get a HTTP header as a single string value.
-     * <p/>
+     * <p>Get a HTTP header as a single string value.
+     * </p>
      * Each single header value is converted to String using a
      * {@link javax.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one is available
      * via {@link javax.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)}
@@ -76,8 +76,8 @@ public interface HttpHeaders {
     public MultivaluedMap<String, String> getRequestHeaders();
 
     /**
-     * Get a list of media types that are acceptable for the response.
-     * <p/>
+     * <p>Get a list of media types that are acceptable for the response.
+     * </p>
      * If no acceptable media types are specified, a read-only list containing
      * a single {@link javax.ws.rs.core.MediaType#WILDCARD_TYPE wildcard media type}
      * instance is returned.
@@ -90,8 +90,8 @@ public interface HttpHeaders {
     public List<MediaType> getAcceptableMediaTypes();
 
     /**
-     * Get a list of languages that are acceptable for the response.
-     * <p/>
+     * <p>Get a list of languages that are acceptable for the response.
+     * </p>
      * If no acceptable languages are specified, a read-only list containing
      * a single wildcard {@link java.util.Locale} instance (with language field
      * set to "{@code *}") is returned.
@@ -148,127 +148,127 @@ public interface HttpHeaders {
     public int getLength();
 
     /**
-     * See {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.1">HTTP/1.1 documentation</a>}.
+     * See <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.1">HTTP/1.1 documentation</a>.
      */
     public static final String ACCEPT = "Accept";
     /**
-     * See {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.2">HTTP/1.1 documentation</a>}.
+     * See <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.2">HTTP/1.1 documentation</a>.
      */
     public static final String ACCEPT_CHARSET = "Accept-Charset";
     /**
-     * See {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.3">HTTP/1.1 documentation</a>}.
+     * See <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.3">HTTP/1.1 documentation</a>.
      */
     public static final String ACCEPT_ENCODING = "Accept-Encoding";
     /**
-     * See {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.4">HTTP/1.1 documentation</a>}.
+     * See <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.4">HTTP/1.1 documentation</a>.
      */
     public static final String ACCEPT_LANGUAGE = "Accept-Language";
     /**
-     * See {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.7">HTTP/1.1 documentation</a>}.
+     * See <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.7">HTTP/1.1 documentation</a>.
      */
     public static final String ALLOW = "Allow";
     /**
-     * See {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.8">HTTP/1.1 documentation</a>}.
+     * See <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.8">HTTP/1.1 documentation</a>.
      */
     public static final String AUTHORIZATION = "Authorization";
     /**
-     * See {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9">HTTP/1.1 documentation</a>}.
+     * See <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9">HTTP/1.1 documentation</a>.
      */
     public static final String CACHE_CONTROL = "Cache-Control";
     /**
-     * See {@link <a href="http://tools.ietf.org/html/rfc2183">IETF RFC-2183</a>}.
+     * See <a href="http://tools.ietf.org/html/rfc2183">IETF RFC-2183</a>.
      */
     public static final String CONTENT_DISPOSITION = "Content-Disposition";
     /**
-     * See {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11">HTTP/1.1 documentation</a>}.
+     * See <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11">HTTP/1.1 documentation</a>.
      */
     public static final String CONTENT_ENCODING = "Content-Encoding";
     /**
-     * See {@link <a href="http://tools.ietf.org/html/rfc2392">IETF RFC-2392</a>}.
+     * See <a href="http://tools.ietf.org/html/rfc2392">IETF RFC-2392</a>.
      */
     public static final String CONTENT_ID = "Content-ID";
     /**
-     * See {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.12">HTTP/1.1 documentation</a>}.
+     * See <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.12">HTTP/1.1 documentation</a>.
      */
     public static final String CONTENT_LANGUAGE = "Content-Language";
     /**
-     * See {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13">HTTP/1.1 documentation</a>}.
+     * See <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13">HTTP/1.1 documentation</a>.
      */
     public static final String CONTENT_LENGTH = "Content-Length";
     /**
-     * See {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.14">HTTP/1.1 documentation</a>}.
+     * See <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.14">HTTP/1.1 documentation</a>.
      */
     public static final String CONTENT_LOCATION = "Content-Location";
     /**
-     * See {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17">HTTP/1.1 documentation</a>}.
+     * See <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17">HTTP/1.1 documentation</a>.
      */
     public static final String CONTENT_TYPE = "Content-Type";
     /**
-     * See {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.18">HTTP/1.1 documentation</a>}.
+     * See <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.18">HTTP/1.1 documentation</a>.
      */
     public static final String DATE = "Date";
     /**
-     * See {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.19">HTTP/1.1 documentation</a>}.
+     * See <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.19">HTTP/1.1 documentation</a>.
      */
     public static final String ETAG = "ETag";
     /**
-     * See {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.21">HTTP/1.1 documentation</a>}.
+     * See <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.21">HTTP/1.1 documentation</a>.
      */
     public static final String EXPIRES = "Expires";
     /**
-     * See {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.23">HTTP/1.1 documentation</a>}.
+     * See <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.23">HTTP/1.1 documentation</a>.
      */
     public static final String HOST = "Host";
     /**
-     * See {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.24">HTTP/1.1 documentation</a>}.
+     * See <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.24">HTTP/1.1 documentation</a>.
      */
     public static final String IF_MATCH = "If-Match";
     /**
-     * See {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.25">HTTP/1.1 documentation</a>}.
+     * See <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.25">HTTP/1.1 documentation</a>.
      */
     public static final String IF_MODIFIED_SINCE = "If-Modified-Since";
     /**
-     * See {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.26">HTTP/1.1 documentation</a>}.
+     * See <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.26">HTTP/1.1 documentation</a>.
      */
     public static final String IF_NONE_MATCH = "If-None-Match";
     /**
-     * See {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.28">HTTP/1.1 documentation</a>}.
+     * See <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.28">HTTP/1.1 documentation</a>.
      */
     public static final String IF_UNMODIFIED_SINCE = "If-Unmodified-Since";
     /**
-     * See {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.29">HTTP/1.1 documentation</a>}.
+     * See <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.29">HTTP/1.1 documentation</a>.
      */
     public static final String LAST_MODIFIED = "Last-Modified";
     /**
-     * See {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.30">HTTP/1.1 documentation</a>}.
+     * See <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.30">HTTP/1.1 documentation</a>.
      */
     public static final String LOCATION = "Location";
     /**
-     * See {@link <a href="http://tools.ietf.org/html/rfc5988#page-6">Web Linking (IETF RFC-5988) documentation</a>}.
+     * See <a href="http://tools.ietf.org/html/rfc5988#page-6">Web Linking (IETF RFC-5988) documentation</a>.
      */
     public static final String LINK = "Link";
     /**
-     * See {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.37">HTTP/1.1 documentation</a>}.
+     * See <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.37">HTTP/1.1 documentation</a>.
      */
     public static final String RETRY_AFTER = "Retry-After";
     /**
-     * See {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.43">HTTP/1.1 documentation</a>}.
+     * See <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.43">HTTP/1.1 documentation</a>.
      */
     public static final String USER_AGENT = "User-Agent";
     /**
-     * See {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.44">HTTP/1.1 documentation</a>}.
+     * See <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.44">HTTP/1.1 documentation</a>.
      */
     public static final String VARY = "Vary";
     /**
-     * See {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.47">HTTP/1.1 documentation</a>}.
+     * See <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.47">HTTP/1.1 documentation</a>.
      */
     public static final String WWW_AUTHENTICATE = "WWW-Authenticate";
     /**
-     * See {@link <a href="http://www.ietf.org/rfc/rfc2109.txt">IETF RFC 2109</a>}.
+     * See <a href="http://www.ietf.org/rfc/rfc2109.txt">IETF RFC 2109</a>.
      */
     public static final String COOKIE = "Cookie";
     /**
-     * See {@link <a href="http://www.ietf.org/rfc/rfc2109.txt">IETF RFC 2109</a>}.
+     * See <a href="http://www.ietf.org/rfc/rfc2109.txt">IETF RFC 2109</a>.
      */
     public static final String SET_COOKIE = "Set-Cookie";
     /**

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Link.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Link.java
@@ -123,7 +123,7 @@ public abstract class Link {
      * All link params are serialized as link-param="value" where value
      * is a quoted-string. For example,
      *
-     * <http://foo.bar/employee/john>; title="employee"; rel="manager friend"
+     * &lt;http://foo.bar/employee/john&gt;; title="employee"; rel="manager friend"
      *
      * @return string link header representation for this link.
      */
@@ -133,7 +133,7 @@ public abstract class Link {
     /**
      * Simple parser to convert link header string representations into a link.
      * <pre>
-     * link ::= '<' uri '>' (';' link-param)*
+     * link ::= '&lt;' uri 'gt;' (';' link-param)*
      * link-param ::= name '=' quoted-string
      * </pre>
      *
@@ -276,7 +276,7 @@ public abstract class Link {
          * Initialize builder using another link represented as a string. Uses
          * simple parser to convert string representation into a link.
          * <pre>
-         * link ::= '<' uri '>' (';' link-param)*
+         * link ::= '&lt;' uri 'gt;' (';' link-param)*
          * link-param ::= name '=' quoted-string
          * </pre>
          *

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/MediaType.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/MediaType.java
@@ -335,12 +335,12 @@ public class MediaType {
     }
 
     /**
-     * Compares {@code obj} to this media type to see if they are the same by comparing
+     * <p>Compares {@code obj} to this media type to see if they are the same by comparing
      * type, subtype and parameters. Note that the case-sensitivity of parameter
      * values is dependent on the semantics of the parameter name, see
-     * {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.7">HTTP/1.1</a>}.
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.7">HTTP/1.1</a>.
      * This method assumes that values are case-sensitive.
-     * <p/>
+     * </p>
      * Note that the {@code equals(...)} implementation does not perform
      * a class equality check ({@code this.getClass() == obj.getClass()}). Therefore
      * any class that extends from {@code MediaType} class and needs to override
@@ -366,8 +366,8 @@ public class MediaType {
     }
 
     /**
-     * Generate a hash code from the type, subtype and parameters.
-     * <p/>
+     * <p>Generate a hash code from the type, subtype and parameters.
+     * </p>
      * Note that the {@link #equals(java.lang.Object)} implementation does not perform
      * a class equality check ({@code this.getClass() == obj.getClass()}). Therefore
      * any class that extends from {@code MediaType} class and needs to override

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/MultivaluedHashMap.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/MultivaluedHashMap.java
@@ -26,15 +26,15 @@ import java.util.Map;
 /**
  * A hash table based implementation of {@link MultivaluedMap} interface.
  *
- * This implementation provides all of the optional map operations. This class
+ * <p>This implementation provides all of the optional map operations. This class
  * makes no guarantees as to the order of the map; in particular, it does not
  * guarantee that the order will remain constant over time. The implementation
  * permits {@code null} key. By default the implementation does also permit
  * {@code null} values, but ignores them. This behavior can be customized
  * by overriding the protected {@link #addNull(List) addNull(...)} and
  * {@link #addFirstNull(List) addFirstNull(...)} methods.
- * <p />
- * This implementation provides constant-time performance for the basic
+ * </p>
+ * <p>This implementation provides constant-time performance for the basic
  * operations (<tt>get</tt> and <tt>put</tt>), assuming the hash function
  * disperses the elements properly among the buckets. Iteration over
  * collection views requires time proportional to the "capacity" of the
@@ -42,8 +42,8 @@ import java.util.Map;
  * of key-value mappings).  Thus, it's very important not to set the initial
  * capacity too high (or the load factor too low) if iteration performance is
  * important.
- * <p />
- * An instance of <tt>MultivaluedHashMap</tt> has two parameters that affect its
+ * </p>
+ * <p>An instance of <tt>MultivaluedHashMap</tt> has two parameters that affect its
  * performance: <i>initial capacity</i> and <i>load factor</i>. The <i>capacity</i>
  * is the number of buckets in the hash table, and the initial capacity is simply
  * the capacity at the time the hash table is created. The <i>load factor</i> is
@@ -52,8 +52,8 @@ import java.util.Map;
  * the product of the load factor and the current capacity, the hash table is
  * <i>rehashed</i> (that is, internal data structures are rebuilt) so that the
  * hash table has approximately twice the number of buckets.
- * <p />
- * As a general rule, the default load factor (.75) offers a good tradeoff
+ * </p>
+ * <p>As a general rule, the default load factor (.75) offers a good tradeoff
  * between time and space costs. Higher values decrease the space overhead
  * but increase the lookup cost (reflected in most of the operations of the
  * <tt>HashMap</tt> class, including <tt>get</tt> and <tt>put</tt>). The
@@ -62,13 +62,13 @@ import java.util.Map;
  * number of rehash operations. If the initial capacity is greater
  * than the maximum number of entries divided by the load factor, no
  * rehash operations will ever occur.
- * <p />
- * If many mappings are to be stored in a <tt>MultivaluedHashMap</tt> instance,
+ * </p>
+ * <p>If many mappings are to be stored in a <tt>MultivaluedHashMap</tt> instance,
  * creating it with a sufficiently large capacity will allow the mappings to
  * be stored more efficiently than letting it perform automatic rehashing as
  * needed to grow the table.
- * <p />
- * <strong>Note that this implementation is not guaranteed to be synchronized.</strong>
+ * </p>
+ * <p><strong>Note that this implementation is not guaranteed to be synchronized.</strong>
  * If multiple threads access a hash map concurrently, and at least one of
  * the threads modifies the map structurally, it <i>must</i> be
  * synchronized externally. (A structural modification is any operation
@@ -76,15 +76,15 @@ import java.util.Map;
  * associated with a key that an instance already contains is not a
  * structural modification.) This is typically accomplished by
  * synchronizing on some object that naturally encapsulates the map.
- * <p />
- * The iterators returned by all of this class's "collection view methods"
+ * </p>
+ * <p>The iterators returned by all of this class's "collection view methods"
  * are <i>fail-fast</i>: if the map is structurally modified at any time after
  * the iterator is created, in any way except through the iterator's own
  * <tt>remove</tt> method, the iterator will throw a {@link ConcurrentModificationException}.
  * Thus, in the face of concurrent modification, the iterator fails quickly and
  * cleanly, rather than risking arbitrary, non-deterministic behavior at an
  * undetermined time in the future.
- * <p />
+ * </p>
  * Note that the fail-fast behavior of an iterator cannot be guaranteed
  * as it is, generally speaking, impossible to make any hard guarantees in the
  * presence of unsynchronized concurrent modification. Fail-fast iterators

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Request.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Request.java
@@ -123,11 +123,11 @@ public interface Request {
 
     /**
      * Evaluate request preconditions for a resource that does not currently
-     * exist. The primary use of this method is to support the {@link <a
+     * exist. The primary use of this method is to support the <a
      * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.24">
-     * If-Match: *</a>} and {@link <a
+     * If-Match: *</a> and <a
      * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.26">
-     * If-None-Match: *</a>} preconditions.
+     * If-None-Match: *</a> preconditions.
      *
      * <p>Note that both preconditions {@code If-None-Match: *} and
      * <code>If-None-Match: <i>something</i></code> will always be considered to

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Response.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Response.java
@@ -909,14 +909,14 @@ public abstract class Response implements AutoCloseable {
         }
 
         /**
-         * Set the response entity in the builder.
-         * <p />
-         * Any Java type instance for a response entity, that is supported by the
+         * <p>Set the response entity in the builder.
+         * </p>
+         * <p>Any Java type instance for a response entity, that is supported by the
          * runtime can be passed. It is the callers responsibility to wrap the
          * actual entity with {@link GenericEntity} if preservation of its generic
          * type is required. Note that the entity can be also set as an
          * {@link java.io.InputStream input stream}.
-         * <p />
+         * </p>
          * A specific entity media type can be set using one of the {@code type(...)}
          * methods.
          *
@@ -929,14 +929,14 @@ public abstract class Response implements AutoCloseable {
         public abstract ResponseBuilder entity(Object entity);
 
         /**
-         * Set the response entity in the builder.
-         * <p />
-         * Any Java type instance for a response entity, that is supported by the
+         * <p>Set the response entity in the builder.
+         * </p>
+         * <p>Any Java type instance for a response entity, that is supported by the
          * runtime can be passed. It is the callers responsibility to wrap the
          * actual entity with {@link GenericEntity} if preservation of its generic
          * type is required. Note that the entity can be also set as an
          * {@link java.io.InputStream input stream}.
-         * <p />
+         * </p>
          * A specific entity media type can be set using one of the {@code type(...)}
          * methods.
          *
@@ -1054,8 +1054,8 @@ public abstract class Response implements AutoCloseable {
         public abstract ResponseBuilder type(String type);
 
         /**
-         * Set message entity representation metadata.
-         * <p/>
+         * <p>Set message entity representation metadata.
+         * </p>
          * Equivalent to setting the values of content type, content language,
          * and content encoding separately using the values of the variant properties.
          *
@@ -1128,8 +1128,8 @@ public abstract class Response implements AutoCloseable {
         public abstract ResponseBuilder tag(EntityTag tag);
 
         /**
-         * Set a strong response entity tag.
-         * <p/>
+         * <p>Set a strong response entity tag.
+         * </p>
          * This is a shortcut for <code>tag(new EntityTag(<i>value</i>))</code>.
          *
          * @param tag the string content of a strong entity tag. The JAX-RS
@@ -1234,210 +1234,210 @@ public abstract class Response implements AutoCloseable {
 
     /**
      * Commonly used status codes defined by HTTP, see
-     * {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10">HTTP/1.1 documentation</a>}
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10">HTTP/1.1 documentation</a>
      * for the complete list. Additional status codes can be added by applications
      * by creating an implementation of {@link StatusType}.
      */
     public enum Status implements StatusType {
 
         /**
-         * 200 OK, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.1">HTTP/1.1 documentation</a>}.
+         * 200 OK, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.1">HTTP/1.1 documentation</a>.
          */
         OK(200, "OK"),
         /**
-         * 201 Created, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.2">HTTP/1.1 documentation</a>}.
+         * 201 Created, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.2">HTTP/1.1 documentation</a>.
          */
         CREATED(201, "Created"),
         /**
-         * 202 Accepted, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.3">HTTP/1.1 documentation</a>}.
+         * 202 Accepted, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.3">HTTP/1.1 documentation</a>.
          */
         ACCEPTED(202, "Accepted"),
         /**
-         * 204 No Content, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5">HTTP/1.1 documentation</a>}.
+         * 204 No Content, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5">HTTP/1.1 documentation</a>.
          */
         NO_CONTENT(204, "No Content"),
         /**
-         * 205 Reset Content, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.6">HTTP/1.1 documentation</a>}.
+         * 205 Reset Content, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.6">HTTP/1.1 documentation</a>.
          *
          * @since 2.0
          */
         RESET_CONTENT(205, "Reset Content"),
         /**
-         * 206 Reset Content, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.7">HTTP/1.1 documentation</a>}.
+         * 206 Reset Content, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.7">HTTP/1.1 documentation</a>.
          *
          * @since 2.0
          */
         PARTIAL_CONTENT(206, "Partial Content"),
         /**
-         * 301 Moved Permanently, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.2">HTTP/1.1 documentation</a>}.
+         * 301 Moved Permanently, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.2">HTTP/1.1 documentation</a>.
          */
         MOVED_PERMANENTLY(301, "Moved Permanently"),
         /**
-         * 302 Found, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.3">HTTP/1.1 documentation</a>}.
+         * 302 Found, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.3">HTTP/1.1 documentation</a>.
          *
          * @since 2.0
          */
         FOUND(302, "Found"),
         /**
-         * 303 See Other, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.4">HTTP/1.1 documentation</a>}.
+         * 303 See Other, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.4">HTTP/1.1 documentation</a>.
          */
         SEE_OTHER(303, "See Other"),
         /**
-         * 304 Not Modified, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.5">HTTP/1.1 documentation</a>}.
+         * 304 Not Modified, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.5">HTTP/1.1 documentation</a>.
          */
         NOT_MODIFIED(304, "Not Modified"),
         /**
-         * 305 Use Proxy, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.6">HTTP/1.1 documentation</a>}.
+         * 305 Use Proxy, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.6">HTTP/1.1 documentation</a>.
          *
          * @since 2.0
          */
         USE_PROXY(305, "Use Proxy"),
         /**
-         * 307 Temporary Redirect, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.8">HTTP/1.1 documentation</a>}.
+         * 307 Temporary Redirect, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.8">HTTP/1.1 documentation</a>.
          */
         TEMPORARY_REDIRECT(307, "Temporary Redirect"),
         /**
-         * 400 Bad Request, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1">HTTP/1.1 documentation</a>}.
+         * 400 Bad Request, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1">HTTP/1.1 documentation</a>.
          */
         BAD_REQUEST(400, "Bad Request"),
         /**
-         * 401 Unauthorized, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2">HTTP/1.1 documentation</a>}.
+         * 401 Unauthorized, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2">HTTP/1.1 documentation</a>.
          */
         UNAUTHORIZED(401, "Unauthorized"),
         /**
-         * 402 Payment Required, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.3">HTTP/1.1 documentation</a>}.
+         * 402 Payment Required, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.3">HTTP/1.1 documentation</a>.
          *
          * @since 2.0
          */
         PAYMENT_REQUIRED(402, "Payment Required"),
         /**
-         * 403 Forbidden, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4">HTTP/1.1 documentation</a>}.
+         * 403 Forbidden, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4">HTTP/1.1 documentation</a>.
          */
         FORBIDDEN(403, "Forbidden"),
         /**
-         * 404 Not Found, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.5">HTTP/1.1 documentation</a>}.
+         * 404 Not Found, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.5">HTTP/1.1 documentation</a>.
          */
         NOT_FOUND(404, "Not Found"),
         /**
-         * 405 Method Not Allowed, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.6">HTTP/1.1 documentation</a>}.
+         * 405 Method Not Allowed, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.6">HTTP/1.1 documentation</a>.
          *
          * @since 2.0
          */
         METHOD_NOT_ALLOWED(405, "Method Not Allowed"),
         /**
-         * 406 Not Acceptable, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.7">HTTP/1.1 documentation</a>}.
+         * 406 Not Acceptable, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.7">HTTP/1.1 documentation</a>.
          */
         NOT_ACCEPTABLE(406, "Not Acceptable"),
         /**
-         * 407 Proxy Authentication Required, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.8">HTTP/1.1 documentation</a>}.
+         * 407 Proxy Authentication Required, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.8">HTTP/1.1 documentation</a>.
          *
          * @since 2.0
          */
         PROXY_AUTHENTICATION_REQUIRED(407, "Proxy Authentication Required"),
         /**
-         * 408 Request Timeout, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.9">HTTP/1.1 documentation</a>}.
+         * 408 Request Timeout, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.9">HTTP/1.1 documentation</a>.
          *
          * @since 2.0
          */
         REQUEST_TIMEOUT(408, "Request Timeout"),
         /**
-         * 409 Conflict, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.10">HTTP/1.1 documentation</a>}.
+         * 409 Conflict, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.10">HTTP/1.1 documentation</a>.
          */
         CONFLICT(409, "Conflict"),
         /**
-         * 410 Gone, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.11">HTTP/1.1 documentation</a>}.
+         * 410 Gone, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.11">HTTP/1.1 documentation</a>.
          */
         GONE(410, "Gone"),
         /**
-         * 411 Length Required, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.12">HTTP/1.1 documentation</a>}.
+         * 411 Length Required, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.12">HTTP/1.1 documentation</a>.
          *
          * @since 2.0
          */
         LENGTH_REQUIRED(411, "Length Required"),
         /**
-         * 412 Precondition Failed, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.13">HTTP/1.1 documentation</a>}.
+         * 412 Precondition Failed, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.13">HTTP/1.1 documentation</a>.
          */
         PRECONDITION_FAILED(412, "Precondition Failed"),
         /**
-         * 413 Request Entity Too Large, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.14">HTTP/1.1 documentation</a>}.
+         * 413 Request Entity Too Large, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.14">HTTP/1.1 documentation</a>.
          *
          * @since 2.0
          */
         REQUEST_ENTITY_TOO_LARGE(413, "Request Entity Too Large"),
         /**
-         * 414 Request-URI Too Long, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.15">HTTP/1.1 documentation</a>}.
+         * 414 Request-URI Too Long, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.15">HTTP/1.1 documentation</a>.
          *
          * @since 2.0
          */
         REQUEST_URI_TOO_LONG(414, "Request-URI Too Long"),
         /**
-         * 415 Unsupported Media Type, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.16">HTTP/1.1 documentation</a>}.
+         * 415 Unsupported Media Type, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.16">HTTP/1.1 documentation</a>.
          */
         UNSUPPORTED_MEDIA_TYPE(415, "Unsupported Media Type"),
         /**
-         * 416 Requested Range Not Satisfiable, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.17">HTTP/1.1 documentation</a>}.
+         * 416 Requested Range Not Satisfiable, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.17">HTTP/1.1 documentation</a>.
          *
          * @since 2.0
          */
         REQUESTED_RANGE_NOT_SATISFIABLE(416, "Requested Range Not Satisfiable"),
         /**
-         * 417 Expectation Failed, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.18">HTTP/1.1 documentation</a>}.
+         * 417 Expectation Failed, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.18">HTTP/1.1 documentation</a>.
          *
          * @since 2.0
          */
         EXPECTATION_FAILED(417, "Expectation Failed"),
         /**
-         * 428 Precondition required, see {@link <a href="https://tools.ietf.org/html/rfc6585#section-3">RFC 6585: Additional HTTP Status Codes</a>}.
+         * 428 Precondition required, see <a href="https://tools.ietf.org/html/rfc6585#section-3">RFC 6585: Additional HTTP Status Codes</a>.
          *
          * @since 2.1
          */
         PRECONDITION_REQUIRED(428, "Precondition Required"),
         /**
-         * 429 Too Many Requests, see {@link <a href="https://tools.ietf.org/html/rfc6585#section-4">RFC 6585: Additional HTTP Status Codes</a>}.
+         * 429 Too Many Requests, see <a href="https://tools.ietf.org/html/rfc6585#section-4">RFC 6585: Additional HTTP Status Codes</a>.
          *
          * @since 2.1
          */
         TOO_MANY_REQUESTS(429, "Too Many Requests"),
         /**
-         * 431 Request Header Fields Too Large, see {@link <a href="https://tools.ietf.org/html/rfc6585#section-5">RFC 6585: Additional HTTP Status Codes</a>}.
+         * 431 Request Header Fields Too Large, see <a href="https://tools.ietf.org/html/rfc6585#section-5">RFC 6585: Additional HTTP Status Codes</a>.
          *
          * @since 2.1
          */
         REQUEST_HEADER_FIELDS_TOO_LARGE(431, "Request Header Fields Too Large"),
         /**
-         * 500 Internal Server Error, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1">HTTP/1.1 documentation</a>}.
+         * 500 Internal Server Error, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1">HTTP/1.1 documentation</a>.
          */
         INTERNAL_SERVER_ERROR(500, "Internal Server Error"),
         /**
-         * 501 Not Implemented, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.2">HTTP/1.1 documentation</a>}.
+         * 501 Not Implemented, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.2">HTTP/1.1 documentation</a>.
          *
          * @since 2.0
          */
         NOT_IMPLEMENTED(501, "Not Implemented"),
         /**
-         * 502 Bad Gateway, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.3">HTTP/1.1 documentation</a>}.
+         * 502 Bad Gateway, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.3">HTTP/1.1 documentation</a>.
          *
          * @since 2.0
          */
         BAD_GATEWAY(502, "Bad Gateway"),
         /**
-         * 503 Service Unavailable, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4">HTTP/1.1 documentation</a>}.
+         * 503 Service Unavailable, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4">HTTP/1.1 documentation</a>.
          */
         SERVICE_UNAVAILABLE(503, "Service Unavailable"),
         /**
-         * 504 Gateway Timeout, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.5">HTTP/1.1 documentation</a>}.
+         * 504 Gateway Timeout, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.5">HTTP/1.1 documentation</a>.
          *
          * @since 2.0
          */
         GATEWAY_TIMEOUT(504, "Gateway Timeout"),
         /**
-         * 505 HTTP Version Not Supported, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.6">HTTP/1.1 documentation</a>}.
+         * 505 HTTP Version Not Supported, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.6">HTTP/1.1 documentation</a>.
          *
          * @since 2.0
          */
         HTTP_VERSION_NOT_SUPPORTED(505, "HTTP Version Not Supported"),
         /**
-         * 511 Network Authentication Required, see {@link <a href="https://tools.ietf.org/html/rfc6585#section-6">RFC 6585: Additional HTTP Status Codes</a>}.
+         * 511 Network Authentication Required, see <a href="https://tools.ietf.org/html/rfc6585#section-6">RFC 6585: Additional HTTP Status Codes</a>.
          *
          * @since 2.1
          */

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/UriInfo.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/UriInfo.java
@@ -232,7 +232,7 @@ public interface UriInfo {
      * the method is called from are:</p>
      *
      * <table border="1">
-     * <caption></caption>
+     * <caption>Matched URIs from requests</caption>
      * <tr>
      * <th>Request</th>
      * <th>Called from</th>
@@ -309,7 +309,7 @@ public interface UriInfo {
      * the method is called from are:</p>
      *
      * <table border="1">
-     * <caption></caption>
+     * <caption>Matched resources from requests</caption>
      * <tr>
      * <th>Request</th>
      * <th>Called from</th>

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/UriInfo.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/UriInfo.java
@@ -232,6 +232,7 @@ public interface UriInfo {
      * the method is called from are:</p>
      *
      * <table border="1">
+     * <caption></caption>
      * <tr>
      * <th>Request</th>
      * <th>Called from</th>
@@ -308,6 +309,7 @@ public interface UriInfo {
      * the method is called from are:</p>
      *
      * <table border="1">
+     * <caption></caption>
      * <tr>
      * <th>Request</th>
      * <th>Called from</th>
@@ -349,7 +351,7 @@ public interface UriInfo {
     public URI resolve(URI uri);
 
     /**
-     * <p>Relativize a URI with respect to the current request URI. Relativization
+     * Relativize a URI with respect to the current request URI. Relativization
      * works as follows:
      * <ol>
      * <li>If the URI to relativize is already relative, it is first resolved using
@@ -358,17 +360,16 @@ public interface UriInfo {
      * URI. If the two URIs do not share a prefix, the URI computed in
      * step 1 is returned.</li>
      * </ol>
-     * </p>
      *
      * <p>Examples (for base URI {@code http://example.com:8080/app/root/}):
-     * <br/>
-     * <br/><b>Request URI:</b> <tt>http://example.com:8080/app/root/a/b/c/resource.html</tt>
-     * <br/><b>Supplied URI:</b> <tt>a/b/c/d/file.txt</tt>
-     * <br/><b>Returned URI:</b> <tt>d/file.txt</tt>
-     * <br/>
-     * <br/><b>Request URI:</b> <tt>http://example.com:8080/app/root/a/b/c/resource.html</tt>
-     * <br/><b>Supplied URI:</b> <tt>http://example2.com:9090/app2/root2/a/d/file.txt</tt>
-     * <br/><b>Returned URI:</b> <tt>http://example2.com:9090/app2/root2/a/d/file.txt</tt>
+     * <br>
+     * <br><b>Request URI:</b> <tt>http://example.com:8080/app/root/a/b/c/resource.html</tt>
+     * <br><b>Supplied URI:</b> <tt>a/b/c/d/file.txt</tt>
+     * <br><b>Returned URI:</b> <tt>d/file.txt</tt>
+     * <br>
+     * <br><b>Request URI:</b> <tt>http://example.com:8080/app/root/a/b/c/resource.html</tt>
+     * <br><b>Supplied URI:</b> <tt>http://example2.com:9090/app2/root2/a/d/file.txt</tt>
+     * <br><b>Returned URI:</b> <tt>http://example2.com:9090/app2/root2/a/d/file.txt</tt>
      * </p>
      *
      * <p>In the second example, the supplied URI is returned given that it is absolute

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Variant.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Variant.java
@@ -305,7 +305,7 @@ public class Variant {
          * then a variant will be generated for each possible combination. E.g.
          * in the following {@code list} would have five (4 + 1) members:
          * </p>
-         * <pre>List<Variant> list = VariantListBuilder.newInstance()
+         * <pre>List&lt;Variant&gt; list = VariantListBuilder.newInstance()
          *         .languages(Locale.ENGLISH, Locale.FRENCH).encodings("zip", "identity").add()
          *         .languages(Locale.GERMAN).mediaTypes(MediaType.TEXT_PLAIN_TYPE).add()
          *         .build()</pre>
@@ -314,7 +314,7 @@ public class Variant {
          * the build method is called. E.g. the resulting list produced in the example above
          * would be identical to the list produced by the following code:
          * </p>
-         * <pre>List<Variant> list = VariantListBuilder.newInstance()
+         * <pre>List&lt;Variant&gt; list = VariantListBuilder.newInstance()
          *         .languages(Locale.ENGLISH, Locale.FRENCH).encodings("zip", "identity").add()
          *         .languages(Locale.GERMAN).mediaTypes(MediaType.TEXT_PLAIN_TYPE)
          *         .build()</pre>

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/Providers.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/Providers.java
@@ -43,7 +43,7 @@ public interface Providers {
      * {@code type} is assignable to the generic type of the reader, and
      * eliminating those that do not match.
      * The list of matching readers is then ordered with those with the best
-     * matching values of {@link javax.ws.rs.Consumes} (x/y > x&#47;* > *&#47;*)
+     * matching values of {@link javax.ws.rs.Consumes} (x/y &gt; x&#47;* &gt; *&#47;*)
      * sorted first. Finally, the
      * {@link MessageBodyReader#isReadable(Class, Type, Annotation[], MediaType)}
      * method is called on each reader in order using the supplied criteria and
@@ -75,7 +75,7 @@ public interface Providers {
      * {@code type} is assignable to the generic type of the reader, and
      * eliminating those that do not match.
      * The list of matching writers is then ordered with those with the best
-     * matching values of {@link javax.ws.rs.Produces} (x/y > x&#47;* > *&#47;*)
+     * matching values of {@link javax.ws.rs.Produces} (x/y &gt; x&#47;* &gt; *&#47;*)
      * sorted first. Finally, the
      * {@link MessageBodyWriter#isWriteable(Class, Type, Annotation[], MediaType)}
      * method is called on each writer in order using the supplied criteria and
@@ -119,7 +119,7 @@ public interface Providers {
      * eliminating those that do not match. If only one resolver matches the
      * criteria then it is returned. If more than one resolver matches then the
      * list of matching resolvers is ordered with those with the best
-     * matching values of {@link javax.ws.rs.Produces} (x/y > x&#47;* > *&#47;*)
+     * matching values of {@link javax.ws.rs.Produces} (x/y &gt; x&#47;* &gt; *&#47;*)
      * sorted first. A proxy is returned that delegates calls to
      * {@link ContextResolver#getContext(java.lang.Class)} to each matching context
      * resolver in order and returns the first non-null value it obtains or null

--- a/jaxrs-api/src/main/java/javax/ws/rs/sse/InboundSseEvent.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/sse/InboundSseEvent.java
@@ -47,6 +47,7 @@ public interface InboundSseEvent extends SseEvent {
     /**
      * Read event data as a given Java type.
      *
+     * @param <T> generic event data type
      * @param type Java type to be used for event data de-serialization.
      * @return event data de-serialized as an instance of a given type.
      * @throws javax.ws.rs.ProcessingException when provided type can't be read. The thrown exception wraps the original cause.
@@ -56,6 +57,7 @@ public interface InboundSseEvent extends SseEvent {
     /**
      * Read event data as a given generic type.
      *
+     * @param <T> generic event data type
      * @param type generic type to be used for event data de-serialization.
      * @return event data de-serialized as an instance of a given type.
      * @throws javax.ws.rs.ProcessingException when provided type can't be read. The thrown exception wraps the original cause.
@@ -65,6 +67,7 @@ public interface InboundSseEvent extends SseEvent {
     /**
      * Read event data as a given Java type.
      *
+     * @param <T> generic event data type
      * @param messageType Java type to be used for event data de-serialization.
      * @param mediaType   {@link MediaType media type} to be used for event data de-serialization.
      * @return event data de-serialized as an instance of a given type.
@@ -75,6 +78,7 @@ public interface InboundSseEvent extends SseEvent {
     /**
      * Read event data as a given generic type.
      *
+     * @param <T> generic event data type
      * @param type      generic type to be used for event data de-serialization.
      * @param mediaType {@link MediaType media type} to be used for event data de-serialization.
      * @return event data de-serialized as an instance of a given type.

--- a/jaxrs-api/src/main/java/javax/ws/rs/sse/SseEventSource.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/sse/SseEventSource.java
@@ -34,7 +34,7 @@ import javax.ws.rs.client.WebTarget;
  * Once a {@link SseEventSource} is created, it can be used to {@link #open open a connection}
  * to the associated {@link WebTarget web target}. After establishing the connection, the event source starts
  * processing any incoming inbound events. Whenever a new event is received, an
- * {@link Consumer#accept(Object) Consumer<InboundSseEvent>#accept(InboundSseEvent)} method is invoked on any registered event consumers.
+ * {@link Consumer#accept(Object) Consumer&lt;InboundSseEvent&gt;#accept(InboundSseEvent)} method is invoked on any registered event consumers.
  * <h3>Reconnect support</h3>
  * <p>
  * The {@code SseEventSource} supports automated recuperation from a connection loss, including


### PR DESCRIPTION
Improves quality of API JavaDocs by enabling JDK 8 doclint checks and fixing all WARNINGs and ERRORs (see issue #623).