### PR TITLE
Static packaging type 'bundle' instead of property

### DIFF
--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -134,7 +134,7 @@
                         <plugin>
                             <artifactId>maven-surefire-plugin</artifactId>
                             <configuration>
-                                <argLine>--add-modules java.xml.bind</argLine>
+                                <argLine>--add-modules java.xml.bind --add-opens java.ws.rs/javax.ws.rs.core=java.xml.bind</argLine>
                             </configuration>
                         </plugin>
                     </plugins>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -23,7 +23,7 @@
     <groupId>javax.ws.rs</groupId>
     <artifactId>javax.ws.rs-api</artifactId>
     <version>2.2-SNAPSHOT</version>
-    <packaging>${packaging.type}</packaging>
+    <packaging>bundle</packaging>
     <name>javax.ws.rs-api</name>
 
     <url>https://github.com/eclipse-ee4j/jaxrs-api</url>
@@ -93,10 +93,6 @@
             <activation>
                 <jdk>[9,)</jdk>
             </activation>
-            <properties>
-                <!-- TODO: maven-bundle-plugin doesn't understand module-info yet. -->
-                <packaging.type>jar</packaging.type>
-            </properties>
             <build>
                 <pluginManagement>
                     <plugins>
@@ -146,9 +142,6 @@
             <activation>
                 <jdk>(,9)</jdk>
             </activation>
-            <properties>
-                <packaging.type>bundle</packaging.type>
-            </properties>
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
Currently used maven-bundle-plugin 3.5.0 seems to work fine with module-info, so apparently there is no more need for separate packaging types on JDK 8- vs. JDK 9+.

Closing #627 