### PR TITLE
Using EE4J parent POM

### DIFF
--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -24,14 +24,36 @@
     <artifactId>javax.ws.rs-api</artifactId>
     <version>2.2-SNAPSHOT</version>
     <packaging>bundle</packaging>
+
+    <parent>
+        <groupId>org.eclipse.ee4j</groupId>
+        <artifactId>project</artifactId>
+        <version>1.0</version>
+    </parent>
+
     <name>javax.ws.rs-api</name>
+    <description>JAX-RS: Java API for RESTful Web Services (JAX-RS) is a Java programming language API spec that provides support in creating web services according to the Representational State Transfer (REST) architectural pattern.</description>
+    <inceptionYear>2007</inceptionYear>
 
     <url>https://github.com/eclipse-ee4j/jaxrs-api</url>
 
-    <organization>
-        <name>Eclipse Foundation</name>
-        <url>https://www.eclipse.org/org/foundation/</url>
-    </organization>
+    <developers>
+        <developer>
+           <id>mkarg</id>
+           <name>Markus KARG</name>
+           <email>markus@headcrashing.eu</email>
+           <url>http://www.headcrashing.eu</url>
+           <organization>Head Crashing Informatics</organization>
+           <organizationUrl>http://www.headcrashing.eu</organizationUrl>
+           <roles>
+               <role>Committer</role>
+           </roles>
+           <timezone>Europe/Berlin</timezone>
+           <properties>
+               <picUrl>https://avatars0.githubusercontent.com/u/1701815</picUrl>
+           </properties>
+        </developer>
+    </developers>
 
     <issueManagement>
         <system>Github</system>
@@ -44,19 +66,6 @@
             <archive>jaxrs-dev@eclipse.org</archive>
         </mailingList>
     </mailingLists>
-
-    <licenses>
-        <license>
-            <name>EPL 2.0</name>
-            <url>http://www.eclipse.org/legal/epl-2.0</url>
-            <distribution>repo</distribution>
-        </license>
-        <license>
-            <name>GPL2 w/ CPE</name>
-            <url>https://www.gnu.org/software/classpath/license.html</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
 
     <scm>
         <connection>scm:git:https://github.com/eclipse-ee4j/jaxrs-api</connection>


### PR DESCRIPTION
The PMC proposed that EE4J subprojects use their recently published parent POM (https://github.com/eclipse-ee4j/ee4j).

It is up to the JAX-RS API committers to decide whether we adopt it or not.

According to the [official POM reference](https://maven.apache.org/pom.html), I added the following to our POM to override the seetings inherited from the EE4J parent POM:
* `description` - copied from Eclipse Project for JAX-RS [project page](https://projects.eclipse.org/projects/ee4j.jaxrs).
* `inceptionYear` - @bshannon I hope 2008 is correct for JAX-RS 1.0?
* `developers` - currently only containing myself according to the best practice mentioned in the official POM reference (quote: _A good rule of thumb is, if the person **should not be contacted** about the project, they need **not** be listed here._). Feel free to send a PR containing a `developer` entry for yourself _if you want to be contacted by users_ from now on. I assume particularly @chkal and @spericas would like to be mentioned here, but I leave it open to them to send PRs containing the exact form they want their personal developer entry look like. Note: This is not a hall of fame. This is all about whom to contact for questions.