### PR TITLE
Fixed: Building on JDK9 using maven-surefire-plugin:2.21.0

### DIFF
--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -134,7 +134,7 @@
                         <plugin>
                             <artifactId>maven-surefire-plugin</artifactId>
                             <configuration>
-                                <argLine>--add-modules java.xml.bind</argLine>
+                                <argLine>--add-modules java.xml.bind --add-opens java.ws.rs/javax.ws.rs.core=java.xml.bind</argLine>
                             </configuration>
                         </plugin>
                     </plugins>


### PR DESCRIPTION
Fixes the following problem when building JDK9 using maven-surefire-plugin:2.21.0+:

```
[ERROR] testSerializationOfJaxbLink(javax.ws.rs.core.JaxbLinkTest)  Time elapsed: 0.296 s  <<< ERROR!
java.lang.reflect.InaccessibleObjectException: Unable to make void javax.ws.rs.core.Link$JaxbLink.setParams(java.util.Map) accessible: module java.ws.rs does not "opens javax.ws.rs.core" to module java.xml.bind
        at java.ws.rs/javax.ws.rs.core.JaxbLinkTest.testSerializationOfJaxbLink(JaxbLinkTest.java:47)
```