### PR TITLE
Run Travis build against more JDK versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ sudo: false
 jdk:
   - oraclejdk8
   - oraclejdk9
+  - oraclejdk10
+  - openjdk8
+  - openjdk9
+  - openjdk10
 
 install:
   - cd $TRAVIS_BUILD_DIR/jaxrs-api


### PR DESCRIPTION
Although we will most likely use the Jenkins instance provided by the Eclipse Foundation in the future, we could update our Travis configuration to run the build about all relevant JDKs. Travis recently introduced support for more JDK versions, so I modified the config accordingly.

Please note that while testing the new configuration, I discovered that the build currently does NOT work with the EA versions of JDK11. I'll create a separate issue for that.