### PR TITLE
Publishing nightly builds of master branch (#634)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,26 @@
+pipeline {
+	agent any
+	tools {
+		jdk 'jdk1.8.0-latest'
+		maven 'apache-maven-latest'
+	}
+	environment {
+		MVN = 'mvn -B'
+	}
+	stages {
+		stage('Nightly Build') {
+			when {
+				branch 'master'
+			}
+			steps {
+				dir ('jaxrs-api') {
+					sh "$MVN deploy"
+				}
+				dir ('examples') {
+					sh "$MVN deploy"
+				}
+			}
+		}
+	}
+}
+

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -270,4 +270,17 @@
         </dependency>
     </dependencies>
 
+    <distributionManagement>
+        <repository>
+            <id>repo.eclipse.org</id>
+            <name>JAX-RS API Repository - Releases</name>
+            <url>https://repo.eclipse.org/content/repositories/jax-rs-api-releases/</url>
+        </repository>
+
+        <snapshotRepository>
+            <id>repo.eclipse.org</id>
+            <name>JAX-RS API Repository - Snapshots</name>
+            <url>https://repo.eclipse.org/content/repositories/jax-rs-api-snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
 </project>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -508,4 +508,18 @@
         <spec.version.revision /> <!-- e.g. (Rev a) -->
     </properties>
 
+    <distributionManagement>
+        <repository>
+            <id>repo.eclipse.org</id>
+            <name>JAX-RS API Repository - Releases</name>
+            <url>https://repo.eclipse.org/content/repositories/jax-rs-api-releases/</url>
+        </repository>
+
+        <snapshotRepository>
+            <id>repo.eclipse.org</id>
+            <name>JAX-RS API Repository - Snapshots</name>
+	    <url>https://repo.eclipse.org/content/repositories/jax-rs-api-snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
 </project>


### PR DESCRIPTION
This PR sets up the minimal infrastructure needed for publishing nightly builds of branch 'master'.

The job is performed using the Eclipse Foundation's own infrastructure (i. e. without neither Travis CI nor Maven Central).

The EF's Jenkins service (Jenkins with multi-branch pipeline, see https://ci.eclipse.org/jaxrs/job/Nightly%20Build) uses a Jenkinsfile, which in turn instructs Maven to publish on the EF's Nexus service. The latter is publicly readable, so nightly builds can be accessed by the broad public easily, either by manual download, or by adding the EF's repo as an additional Maven dependency repo.

Jenkins: https://ci.eclipse.org/jaxrs/

Nexus: https://repo.eclipse.org/content/repositories/jax-rs-api/

_This PR solely provides nightly builds, but intentionally does not provide a full set of cross-platform tests, as this is to be performed by Travis CI still._

closes eclipse-ee4j/jaxrs-api#634

Signed-off-by: Markus KARG <markus@headcrashing.eu>