### PR TITLE
public UriBuilder.newInstance()

### DIFF
--- a/jaxrs-api/src/main/java/javax/ws/rs/core/UriBuilder.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/UriBuilder.java
@@ -67,8 +67,9 @@ public abstract class UriBuilder {
      * Creates a new instance of UriBuilder.
      *
      * @return a new instance of UriBuilder.
+     * @since 2.2
      */
-    protected static UriBuilder newInstance() {
+    public static UriBuilder newInstance() {
         return RuntimeDelegate.getInstance().createUriBuilder();
     }
 


### PR DESCRIPTION
# Intention
Allowing application programmers to use `UriBuilder` created *from scratch*, i. e. prividing *all* parts separately *without* having a valid URI/template to start with.

# Justification
There are situations where it just comes handy to construct URIs from scratch using a builder pattern, i. e. not using valid URI as a starting point. One example is when one wants to format a pretty-printed URI string from the distinct parts provided to the new `JAXRS.Configuration` builder for informational use (like the examples do) or inside of an implementation (like Jersey does). The Javadocs of `UriBuilder` already says `...for building URIs from their components` but this never was true: Until now one couldn't build *from components* but always had to build from a *valid* URI/template and then *modify* components.

# Side Effects
Virtually none, as all code had been there before, but just was `protected`. In case the provided parts are not sufficient to finally form a valid URI, the terminal `build()`'s Javadocs already mandate to throw `UriBuilderException`.