### PR TITLE
ClientFilter need @Provider only for discovery

### DIFF
--- a/jaxrs-api/src/main/java/javax/ws/rs/client/ClientRequestFilter.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/ClientRequestFilter.java
@@ -22,8 +22,8 @@ import java.io.IOException;
  * An extension interface implemented by client request filters.
  *
  * Filters implementing this interface MUST be annotated with
- * {@link javax.ws.rs.ext.Provider &#64;Provider}. This type of filters is supported
- * only as part of the Client API.
+ * {@link javax.ws.rs.ext.Provider &#64;Provider} to be discovered by the JAX-RS
+ * runtime. This type of filters is supported only as part of the Client API.
  *
  * @author Marek Potociar
  * @author Santiago Pericas-Geertsen

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/ClientResponseFilter.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/ClientResponseFilter.java
@@ -22,8 +22,8 @@ import java.io.IOException;
  * An extension interface implemented by client response filters.
  *
  * Filters implementing this interface MUST be annotated with
- * {@link javax.ws.rs.ext.Provider &#64;Provider}. This type of filters is supported
- * only as part of the Client API.
+ * {@link javax.ws.rs.ext.Provider &#64;Provider} to be discovered by the JAX-RS
+ * runtime. This type of filters is supported only as part of the Client API.
  *
  * @author Marek Potociar
  * @author Santiago Pericas-Geertsen


### PR DESCRIPTION
According to JAX-RS 2.2 specification, `@Provider` MUST be set on Filters and Interceptors (this includes ClientFilter) _only_ for discovery.

Signed-off-by: Markus KARG <markus@headcrashing.eu>