### PR TITLE
Publishing nightly builds of branches EE4J_8 / 2.1.1-SNAPSHOT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+dist: trusty
+language: java
+sudo: false
+
+jdk:
+  - oraclejdk8
+  - oraclejdk9
+
+install:
+  - cd $TRAVIS_BUILD_DIR/jaxrs-api
+  - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+  - cd $TRAVIS_BUILD_DIR/examples
+  - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+
+script:
+  - cd $TRAVIS_BUILD_DIR/jaxrs-api
+  - mvn test -B
+  - cd $TRAVIS_BUILD_DIR/examples
+  - mvn test -B

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,30 @@
+pipeline {
+	agent any
+	tools {
+		jdk 'jdk1.8.0-latest'
+		maven 'apache-maven-latest'
+	}
+	environment {
+		MVN = 'mvn -B'
+	}
+	stages {
+		stage('Nightly Build') {
+			when {
+				anyOf {
+					branch 'EE4J_8'
+					branch '2.1.1-SNAPSHOT'
+					branch '2.2-SNAPSHOT'
+				}
+			}
+			steps {
+				dir ('jaxrs-api') {
+					sh "$MVN deploy"
+				}
+				dir ('examples') {
+					sh "$MVN deploy"
+				}
+			}
+		}
+	}
+}
+

--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@
 
 ---
 
-# JAX-RS API
+# JAX-RS API [![Build Status](https://travis-ci.org/eclipse-ee4j/jaxrs-api.svg?branch=master)](https://travis-ci.org/eclipse-ee4j/jaxrs-api)
 
 This repository contains JAX-RS API source code.

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>javax.ws.rs</groupId>
     <artifactId>javax.ws.rs-examples</artifactId>
-    <version>2.2-SNAPSHOT</version>
+    <version>2.1.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>javax.ws.rs-examples</name>
 
@@ -260,7 +260,7 @@
         <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.2-SNAPSHOT</version>
+            <version>2.1.1-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -270,4 +270,17 @@
         </dependency>
     </dependencies>
 
+    <distributionManagement>
+        <repository>
+            <id>repo.eclipse.org</id>
+            <name>JAX-RS API Repository - Releases</name>
+            <url>https://repo.eclipse.org/content/repositories/jax-rs-api-releases/</url>
+        </repository>
+
+        <snapshotRepository>
+            <id>repo.eclipse.org</id>
+            <name>JAX-RS API Repository - Snapshots</name>
+            <url>https://repo.eclipse.org/content/repositories/jax-rs-api-snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
 </project>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -605,4 +605,18 @@
         <spec.version.revision /> <!-- e.g. (Rev a) -->
     </properties>
 
+    <distributionManagement>
+        <repository>
+            <id>repo.eclipse.org</id>
+            <name>JAX-RS API Repository - Releases</name>
+            <url>https://repo.eclipse.org/content/repositories/jax-rs-api-releases/</url>
+        </repository>
+
+        <snapshotRepository>
+            <id>repo.eclipse.org</id>
+            <name>JAX-RS API Repository - Snapshots</name>
+	    <url>https://repo.eclipse.org/content/repositories/jax-rs-api-snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
 </project>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>javax.ws.rs</groupId>
     <artifactId>javax.ws.rs-api</artifactId>
-    <version>2.2-SNAPSHOT</version>
+    <version>2.1.1-SNAPSHOT</version>
     <packaging>${packaging.type}</packaging>
     <name>javax.ws.rs-api</name>
 


### PR DESCRIPTION
**Enabling nightly builds for EE4J_8 / 2.1.1-SNAPSHOT _in preparation of_ a "JAX-RS 2.1 (Jakarta EE branded)" release (currently prepared by @spericas in #638)**

This PR sets up the minimal infrastructure needed for publishing nightly builds of branch 'EE4J_8 / 2.1.1-SNAPSHOT' [plus enables Travis CI for _immediate_ PR-validation].

The nightly build job is performed using the Eclipse Foundation's own infrastructure (i. e. without neither Travis CI nor Maven Central) [but Travis CI is _enabled_ by this PR for _immediate_ PR-validation].

The EF's Jenkins service (Jenkins with multi-branch pipeline, see https://ci.eclipse.org/jaxrs/job/Nightly%20Build) uses a Jenkinsfile, which in turn instructs Maven to publish on the EF's Nexus service. The latter is publicly readable, so nightly builds can be accessed by the broad public easily, either by manual download, or by adding the EF's repo as an additional Maven dependency repo.

Jenkins: https://ci.eclipse.org/jaxrs/

Nexus: https://repo.eclipse.org/content/repositories/jax-rs-api/

This PR provides nightly builds using Jenkins, but intentionally does not provide a full set of cross-platform tests on that infrastructure, but still uses Travis CI, just like the `master` branch.

Signed-off-by: Markus KARG markus@headcrashing.eu