### PR TITLE
Deprecating branch 2.1.1-SNAPSHOT in favor of EE4J_8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+dist: trusty
+language: java
+sudo: false
+
+jdk:
+  - oraclejdk8
+  - oraclejdk9
+
+install:
+  - cd $TRAVIS_BUILD_DIR/jaxrs-api
+  - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+  - cd $TRAVIS_BUILD_DIR/examples
+  - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+
+script:
+  - cd $TRAVIS_BUILD_DIR/jaxrs-api
+  - mvn test -B
+  - cd $TRAVIS_BUILD_DIR/examples
+  - mvn test -B

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,30 @@
+pipeline {
+	agent any
+	tools {
+		jdk 'jdk1.8.0-latest'
+		maven 'apache-maven-latest'
+	}
+	environment {
+		MVN = 'mvn -B'
+	}
+	stages {
+		stage('Nightly Build') {
+			when {
+				anyOf {
+					branch 'EE4J_8'
+					branch '2.1.1-SNAPSHOT'
+					branch '2.2-SNAPSHOT'
+				}
+			}
+			steps {
+				dir ('jaxrs-api') {
+					sh "$MVN deploy"
+				}
+				dir ('examples') {
+					sh "$MVN deploy"
+				}
+			}
+		}
+	}
+}
+

--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@
 
 ---
 
-# JAX-RS API
+# JAX-RS API [![Build Status](https://travis-ci.org/eclipse-ee4j/jaxrs-api.svg?branch=master)](https://travis-ci.org/eclipse-ee4j/jaxrs-api)
 
 This repository contains JAX-RS API source code.

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>javax.ws.rs</groupId>
     <artifactId>javax.ws.rs-examples</artifactId>
-    <version>2.2-SNAPSHOT</version>
+    <version>2.1.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>javax.ws.rs-examples</name>
 
@@ -260,7 +260,7 @@
         <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.2-SNAPSHOT</version>
+            <version>2.1.1-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -270,4 +270,17 @@
         </dependency>
     </dependencies>
 
+    <distributionManagement>
+        <repository>
+            <id>repo.eclipse.org</id>
+            <name>JAX-RS API Repository - Releases</name>
+            <url>https://repo.eclipse.org/content/repositories/jax-rs-api-releases/</url>
+        </repository>
+
+        <snapshotRepository>
+            <id>repo.eclipse.org</id>
+            <name>JAX-RS API Repository - Snapshots</name>
+            <url>https://repo.eclipse.org/content/repositories/jax-rs-api-snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
 </project>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -605,4 +605,18 @@
         <spec.version.revision /> <!-- e.g. (Rev a) -->
     </properties>
 
+    <distributionManagement>
+        <repository>
+            <id>repo.eclipse.org</id>
+            <name>JAX-RS API Repository - Releases</name>
+            <url>https://repo.eclipse.org/content/repositories/jax-rs-api-releases/</url>
+        </repository>
+
+        <snapshotRepository>
+            <id>repo.eclipse.org</id>
+            <name>JAX-RS API Repository - Snapshots</name>
+	    <url>https://repo.eclipse.org/content/repositories/jax-rs-api-snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
 </project>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>javax.ws.rs</groupId>
     <artifactId>javax.ws.rs-api</artifactId>
-    <version>2.2-SNAPSHOT</version>
+    <version>2.1.1-SNAPSHOT</version>
     <packaging>${packaging.type}</packaging>
     <name>javax.ws.rs-api</name>
 


### PR DESCRIPTION
# Aim
Deprecate branch 2.1.1-SNAPSHOT in favor of EE4J_8. 2.1.1-SNAPSHOT will be removed once this merge happened. EE4J_8 will be the new collection of _any_ bug fixes (not only _critical_ ones) from now on.

# Approval
Please re-approve this PR, even if you already approved on the mailing list.

# Shortened Review Period
As this PR does not imply any API of JavaDoc changes, I will apply a shortened review period of only five days.