### PR TITLE
Run Travis build against more JDK versions (in 2.1.1 / EE4J_8)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ sudo: false
 jdk:
   - oraclejdk8
   - oraclejdk9
+  - oraclejdk10
+  - openjdk8
+  - openjdk9
+  - openjdk10
 
 install:
   - cd $TRAVIS_BUILD_DIR/jaxrs-api


### PR DESCRIPTION
Backporting this into the nightly builds of 2.1.1 / EE4J_8

**As we already merged this into master (i. e. 2.2), I will apply a one-day review period only to not slow us down unnecessarily. If you do not want this backport, please immediate reject the PR now!**