### PR TITLE
Release Process: GPG Signing & OSSRH Nexus Staging

### DIFF
--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -140,6 +140,17 @@
                         <artifactId>maven-release-plugin</artifactId>
                     </plugin>
                     <plugin>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sign-release</id>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-deploy-plugin</artifactId>
                         <configuration>
@@ -149,6 +160,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <extensions>true</extensions>
                         <executions>
                             <execution>
                                 <id>default-deploy</id>
@@ -159,12 +171,27 @@
                             </execution>
                         </executions>
                         <configuration>
-                            <serverId>jvnet-nexus-staging</serverId>
-                            <nexusUrl>https://maven.java.net/</nexusUrl>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
                         </configuration>
                     </plugin>
                 </plugins>
             </build>
+
+            <distributionManagement>
+                <repository>
+                    <id>ossrh</id>
+                    <name>Sonatype Nexus Releases</name>
+                    <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+                </repository>
+
+                <snapshotRepository>
+                    <id>ossrh</id>
+                    <name>Sonatype Nexus Snapshots</name>
+                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+                </snapshotRepository>
+            </distributionManagement>
         </profile>
         <profile>
             <id>jdk9+</id>


### PR DESCRIPTION
**This PR implements the needed changes ontop of branch `EE4J_8` to release JAX-RS 2.1.1 using OSSRH.**

When performing `mvn deploy -P release` the following happens:
* Signs artifacts using GPG.
* Publishes to OSSRH (either snapshot repo or staging repo for publication on The Central Repository).

Usage for publishing a release on The Central Repository:
* Step 1: *Manually* perform a release (i. e. create a PR containing the version change and let the committers review it). *I abstain from the Maven Release plugin as it brings us no measurable benefit in this particular project, does not fit in the EF's typical "committers have to vote" policy, and it won't work due to our branch protection.*
* Step 2: Start the "[Publish Release](https://ci.eclipse.org/jaxrs/job/Publish%20Release/)" job on EF's Jenkins.
* Step 3: If the EF / PMC agrees with the release, the EF admins have to manually promote the stated release on OSSRH.

Note:
* There is no dry-run, as this is not needed: Releases end up in a staging area anyways. There is no *automatic* release, as the EF's rules enforce that the EF / PMC agrees to the release.

**Zero Review Period: In exception to our two-weeks review period, this branch gets merged *immediately* once two committers +1'ed it. The reason is that the project manager needs this branch immediately to continue with the release process.**