### PR TITLE
Preparation for Release 2.1.1

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>javax.ws.rs</groupId>
     <artifactId>javax.ws.rs-examples</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.1.1</version>
     <packaging>jar</packaging>
     <name>javax.ws.rs-examples</name>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -260,7 +260,7 @@
         <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.1.1-SNAPSHOT</version>
+            <version>2.1.1</version>
         </dependency>
 
         <dependency>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>javax.ws.rs</groupId>
     <artifactId>javax.ws.rs-api</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.1.1</version>
     <packaging>${packaging.type}</packaging>
     <name>javax.ws.rs-api</name>
 

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -20,19 +20,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>net.java</groupId>
-        <artifactId>jvnet-parent</artifactId>
-        <version>5</version>
-    </parent>
-
     <groupId>javax.ws.rs</groupId>
     <artifactId>javax.ws.rs-api</artifactId>
     <version>2.1.1</version>
     <packaging>${packaging.type}</packaging>
     <name>javax.ws.rs-api</name>
 
-    <url>https://github.com/jax-rs/api</url>
+    <url>https://github.com/eclipse-ee4j/jaxrs-api</url>
 
     <organization>
         <name>Eclipse Foundation</name>
@@ -41,13 +35,13 @@
 
     <issueManagement>
         <system>Github</system>
-        <url>https://github.com/jax-rs/api/issues</url>
+        <url>https://github.com/eclipse-ee4j/jaxrs-api/issues</url>
     </issueManagement>
 
     <mailingLists>
         <mailingList>
-            <name>JAX-RS Discussion Group </name>
-            <archive>jaxrs-spec@javaee.groups.io</archive>
+            <name>JAX-RS Developer Discussions</name>
+            <archive>jaxrs-dev@eclipse.org</archive>
         </mailingList>
     </mailingLists>
 
@@ -65,24 +59,10 @@
     </licenses>
 
     <scm>
-        <connection>scm:git:https://github.com/jax-rs/api.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com:jax-rs/api.git</developerConnection>
-        <url>https://github.com/jax-rs/api</url>
+        <connection>scm:git:https://github.com/eclipse-ee4j/jaxrs-api</connection>
+        <url>https://github.com/eclipse-ee4j/jaxrs-api</url>
         <tag>HEAD</tag>
     </scm>
-
-    <developers>
-        <developer>
-            <email>santiago.pericasgeertsen@oracle.com</email>
-            <id>Santiago</id>
-            <name>Santiago Pericas-Geertsen</name>
-            <organization>Oracle</organization>
-            <roles>
-                <role>JAX-RS Spec Lead</role>
-            </roles>
-            <timezone>EST</timezone>
-        </developer>
-    </developers>
 
     <profiles>
         <profile>
@@ -247,7 +227,6 @@
                 </pluginManagement>
             </build>
         </profile>
-
         <profile>
             <id>jdk8-</id>
             <activation>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -35,8 +35,8 @@
     <url>https://github.com/jax-rs/api</url>
 
     <organization>
-        <name>Oracle Corporation</name>
-        <url>http://www.oracle.com/</url>
+        <name>Eclipse Foundation</name>
+        <url>https://www.eclipse.org/org/foundation/</url>
     </organization>
 
     <issueManagement>

--- a/jaxrs-api/src/main/java/javax/ws/rs/FormParam.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/FormParam.java
@@ -35,11 +35,11 @@ import java.lang.annotation.Target;
  * <li>Be a primitive type</li>
  * <li>Have a constructor that accepts a single {@code String} argument</li>
  * <li>Have a static method named {@code valueOf} or {@code fromString}
- * that accepts a single</li>
+ * that accepts a single {@code String} argument (see, for example,
+ * {@link Integer#valueOf(String)})</li>
  * <li>Have a registered implementation of {@link javax.ws.rs.ext.ParamConverterProvider}
  * JAX-RS extension SPI that returns a {@link javax.ws.rs.ext.ParamConverter}
  * instance capable of a "from string" conversion for the type.</li>
- * {@code String} argument (see, for example, {@link Integer#valueOf(String)})</li>
  * <li>Be {@code List<T>}, {@code Set<T>} or
  * {@code SortedSet<T>}, where {@code T} satisfies 2, 3 or 4 above.
  * The resulting collection is read-only.</li>

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/ClientRequestFilter.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/ClientRequestFilter.java
@@ -22,8 +22,8 @@ import java.io.IOException;
  * An extension interface implemented by client request filters.
  *
  * Filters implementing this interface MUST be annotated with
- * {@link javax.ws.rs.ext.Provider &#64;Provider}. This type of filters is supported
- * only as part of the Client API.
+ * {@link javax.ws.rs.ext.Provider &#64;Provider} to be discovered by the JAX-RS
+ * runtime. This type of filters is supported only as part of the Client API.
  *
  * @author Marek Potociar
  * @author Santiago Pericas-Geertsen

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/ClientResponseFilter.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/ClientResponseFilter.java
@@ -22,8 +22,8 @@ import java.io.IOException;
  * An extension interface implemented by client response filters.
  *
  * Filters implementing this interface MUST be annotated with
- * {@link javax.ws.rs.ext.Provider &#64;Provider}. This type of filters is supported
- * only as part of the Client API.
+ * {@link javax.ws.rs.ext.Provider &#64;Provider} to be discovered by the JAX-RS
+ * runtime. This type of filters is supported only as part of the Client API.
  *
  * @author Marek Potociar
  * @author Santiago Pericas-Geertsen

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/ClientResponseFilter.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/ClientResponseFilter.java
@@ -35,7 +35,7 @@ public interface ClientResponseFilter {
     /**
      * Filter method called after a response has been provided for a request
      * (either by a {@link ClientRequestFilter request filter} or when the
-     * HTTP invocation returns.
+     * HTTP invocation returns).
      *
      * Filters in the filter chain are ordered according to their {@code javax.annotation.Priority}
      * class-level annotation value.

--- a/jaxrs-api/src/main/java/javax/ws/rs/container/AsyncResponse.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/container/AsyncResponse.java
@@ -37,7 +37,6 @@ import java.util.concurrent.TimeUnit;
  * <li>resuming the suspended request processing</li>
  * <li>canceling the suspended request processing</li>
  * </ul>
- * </p>
  * <p>
  * Following example demonstrates the use of the {@code AsyncResponse} for asynchronous
  * HTTP request processing:

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Feature.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Feature.java
@@ -29,6 +29,12 @@ package javax.ws.rs.core;
  * for the facility or conceptual domain it represents, such as registering additional contract providers,
  * including nested features and/or specifying domain-specific properties.
  * </p>
+ * <p>
+ * Features implementing this interface MAY be annotated with the {@link javax.ws.rs.ext.Provider &#64;Provider}
+ * annotation in order to be discovered by the JAX-RS runtime when scanning for resources and providers.
+ * Please note that this will only work for server side features. Features for the JAX-RS client must
+ * be registered programmatically.
+ * </p>
  *
  * @author Marek Potociar
  * @since 2.0

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Link.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Link.java
@@ -32,7 +32,7 @@ import javax.xml.namespace.QName;
 /**
  * <p>Class representing hypermedia links. A hypermedia link may include additional
  * parameters beyond its underlying URI. Parameters such as {@code rel} or {@code type}
- * provide additional meta-data. Links in responses can be <emph>followed</emph> by
+ * provide additional meta-data. Links in responses can be <em>followed</em> by
  * creating an {@link javax.ws.rs.client.Invocation.Builder} or a
  * {@link javax.ws.rs.client.WebTarget}.</p>
  *


### PR DESCRIPTION
This PR includes a number of fixes cherry picked from the master branch that are simply clarifications to the 2.1 Javadoc. This should be the last PR in preparation for the 2.1.1 release. Oracle will provide TCK results for the final bits using the RI (Jersey) --TCKs also include signature tests that will confirm no changes were to the API in 2.1.1 compared to 2.1.