### PR TITLE
POM additions requested by OSSRH

### DIFF
--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -25,6 +25,7 @@
     <version>2.1.1</version>
     <packaging>${packaging.type}</packaging>
     <name>javax.ws.rs-api</name>
+    <description>Java API for RESTful Web Services</description>
 
     <url>https://github.com/eclipse-ee4j/jaxrs-api</url>
 

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -34,6 +34,15 @@
         <url>https://www.eclipse.org/org/foundation/</url>
     </organization>
 
+    <developers>
+        <developer>
+            <id>developers</id>
+            <name>JAX-RS API Developers</name>
+            <email>jaxrs-dev@eclipse.org</email>
+            <url>https://github.com/eclipse-ee4j/jaxrs-api/graphs/contributors</url>
+        </developer>
+    </developers>
+
     <issueManagement>
         <system>Github</system>
         <url>https://github.com/eclipse-ee4j/jaxrs-api/issues</url>


### PR DESCRIPTION
This PR provides minimum information requested by OSSRH.

I hope that the automated OSSRH POM check allows generic `<developers>` section. This is not detailed anywhere.