### PR TITLE
Free IP port scan using JAXRS.Configuration.FREE_PORT=0

### DIFF
--- a/jaxrs-api/src/main/java/javax/ws/rs/JAXRS.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/JAXRS.java
@@ -291,6 +291,14 @@ public interface JAXRS {
 
         /**
          * Special value for {@link #PORT} property indicating that the implementation
+         * MUST scan for a free port.
+         *
+         * @since 2.2
+         */
+        static final int FREE_PORT = 0;
+
+        /**
+         * Special value for {@link #PORT} property indicating that the implementation
          * MUST use its default port.
          *
          * @since 2.2


### PR DESCRIPTION
New configuration option `JAXRS.Configuration.FREE_PORT=0` issues scanning for a free port when starting a server using the Java SE Bootstrap API.