### PR TITLE
ClientBuilderListener implementation

### DIFF
--- a/examples/src/main/java/jaxrs/examples/client/builderListener/BasicLoggingClientBuilderListener.java
+++ b/examples/src/main/java/jaxrs/examples/client/builderListener/BasicLoggingClientBuilderListener.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2018 IBM and Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jaxrs.examples.client.builderListener;
+
+import java.io.IOException;
+import java.util.logging.Logger;
+
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.ClientBuilderListener;
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.client.ClientResponseContext;
+import javax.ws.rs.client.ClientResponseFilter;
+
+/**
+ * This class is an example of how to intercept calls to <code>ClientBuilder.newBuilder()</code>.
+ * In order to be discovered, the class needs to be registered to be found by the
+ * <code>ServiceLoader</code>.  In unnamed modules or JVMs not using JPMS, this is accomplished
+ * by creating a file named <code>META-INF/services/javax.ws.rs.client.ClientBuilderListener</code>
+ * in which the contents is the fully qualified class name of the listener implementation class - in
+ * this case, it would be "jaxrs.examples.client.builderListener.BasicLoggingClientBuilderListener".
+ * <p>
+ * If using JPMS, then your module-info.java file would need to contain a clause like this:
+ * <code>
+ * provides javax.ws.rs.client.ClientBuilderListener
+ *     with jaxrs.examples.client.builderListener.BasicLoggingClientBuilderListener;
+ * </code>
+ * </p>
+ * <p>
+ * When some code in the JVM attempts to create a new JAX-RS ClientBuilder, this code would be
+ * executed first, allowing it to register a <code>ClientRequestFilter</code> and
+ * <code>ClientResponseFilter</code> that will log requests and responses, respectively.
+ * </p>
+ *
+ * @author andymc
+ * @since 2.2
+ *
+ */
+public class BasicLoggingClientBuilderListener implements ClientBuilderListener {
+    private static Logger LOG = Logger.getLogger(BasicLoggingClientBuilderListener.class.getName());
+
+    @Override
+    public void onNewBuilder(ClientBuilder builder) {
+        builder.register(new ClientRequestFilter() {
+
+            @Override
+            public void filter(ClientRequestContext reqCtx) throws IOException {
+                LOG.info("Outbound request: " + reqCtx.getUri());
+            }});
+
+        builder.register(new ClientResponseFilter() {
+
+            @Override
+            public void filter(ClientRequestContext reqCtx, ClientResponseContext resCtx) throws IOException {
+                LOG.info("Inbound response: " + resCtx.getStatus());
+            }});
+    }
+
+}

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/ClientBuilder.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/ClientBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,10 @@
 package javax.ws.rs.client;
 
 import java.net.URL;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.security.KeyStore;
+import java.util.ServiceLoader;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -80,6 +83,14 @@ public abstract class ClientBuilder implements Configurable<ClientBuilder> {
                         + delegate.getClass().getClassLoader().getResource(classnameAsResource)
                         + " to " + targetTypeURL);
             }
+            AccessController.doPrivileged((PrivilegedAction<Void>)
+                () -> {
+                    for(ClientBuilderListener listener : ServiceLoader.load(ClientBuilderListener.class)) {
+                        listener.onNewBuilder((ClientBuilder) delegate);
+                    }
+                    return null;
+                }
+            );
             return (ClientBuilder) delegate;
         } catch (Exception ex) {
             throw new RuntimeException(ex);

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/ClientBuilderListener.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/ClientBuilderListener.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2018 IBM and Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package javax.ws.rs.client;
+
+/**
+ * Implementations of this interface will be notified when new
+ * <code>ClientBuilder</code> instances are being constructed. This will allow
+ * implementations to register providers on the <code>ClientBuilder</code>, and
+ * is intended for global providers.
+ * <p>
+ * For example, an audit logging implementation might want to register a
+ * <code>ClientRequestFilter</code> or <code>ClientResponseFilter</code> to
+ * record an outbound request or response.
+ * <p>
+ * In order for the <code>ClientBuilder</code> to call implementations of this
+ * interface, the implementation must be specified such that a ServiceLoader can
+ * find it - i.e. it must be specified in the
+ * <code>META-INF/services/javax.ws.rs.client.ClientBuilderListener</code> file
+ * in an archive on the current thread's context classloader's class path.
+ * <p>
+ * Note that the <code>onNewBuilder</code> method will be invoked after the
+ * <code>ClientBuilder</code> instance has been constructed, but before it is
+ * returned from the <code>ClientBuilder.newBuilder()</code> method.
+ * This allows the caller to override global providers if they desire.
+ *
+ * @since 2.2
+ * @author Andy McCright
+ */
+public interface ClientBuilderListener {
+
+    void onNewBuilder(ClientBuilder builder);
+}

--- a/jaxrs-api/src/test/java/javax/ws/rs/client/ClientBuilderListenerTest.java
+++ b/jaxrs-api/src/test/java/javax/ws/rs/client/ClientBuilderListenerTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2018 IBM and Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package javax.ws.rs.client;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+/**
+ * {@link javax.ws.rs.client.ClientBuilderListener} unit tests.
+ *
+ * @author Andy McCright
+ * @since 2.2
+ */
+public class ClientBuilderListenerTest {
+
+    @Test
+    public void testClientBuilderListenerPropertiesAreRegistered() {
+        ClientBuilder builder = ClientBuilder.newBuilder();
+        assertEquals("true", builder.getConfiguration()
+                                    .getProperty("org.someThirdParty.isRegistered"));
+    }
+
+    @Test
+    public void testClientBuilderListenerProvidersAreRegistered() {
+        ClientBuilder builder = ClientBuilder.newBuilder();
+        assertTrue(builder.getConfiguration()
+                          .isRegistered(org.someThirdParty.LoggingClientRequestFilter.class));
+    }
+
+    @Test
+    public void testClientBuilderListenerFeaturesAreRegistered() {
+        ClientBuilder builder = ClientBuilder.newBuilder();
+        assertTrue(builder.getConfiguration()
+                          .isEnabled(org.someThirdParty.LoggingFeature.INSTANCE));
+    }
+}

--- a/jaxrs-api/src/test/java/javax/ws/rs/client/ClientBuilderStub.java
+++ b/jaxrs-api/src/test/java/javax/ws/rs/client/ClientBuilderStub.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2018 IBM and Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package javax.ws.rs.client;
+
+import java.security.KeyStore;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Configuration;
+import javax.ws.rs.core.Feature;
+
+/**
+ * {@link javax.ws.rs.client.ClientBuilderListener} unit tests.
+ *
+ * @author Andy McCright
+ * @since 2.2
+ */
+public class ClientBuilderStub extends ClientBuilder {
+
+    ConfigurationStub config = new ConfigurationStub();
+    /* (non-Javadoc)
+    * @see javax.ws.rs.core.Configurable#getConfiguration()
+    */
+    @Override
+    public Configuration getConfiguration() {
+        return config;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.ws.rs.core.Configurable#property(java.lang.String, java.lang.Object)
+     */
+    @Override
+    public ClientBuilder property(String key, Object value) {
+        config.properties.put(key, value);
+        return this;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.ws.rs.core.Configurable#register(java.lang.Class)
+     */
+    @Override
+    public ClientBuilder register(Class<?> clazz) {
+        config.providerClasses.put(clazz, 5000);
+        return this;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.ws.rs.core.Configurable#register(java.lang.Object)
+     */
+    @Override
+    public ClientBuilder register(Object o) {
+        if (o instanceof Feature) {
+            config.features.add((Feature)o);
+        } else {
+            config.providerInstances.put(o, 5000);
+        }
+        return this;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.ws.rs.core.Configurable#register(java.lang.Class, int)
+     */
+    @Override
+    public ClientBuilder register(Class<?> arg0, int arg1) {
+        // unimplemented
+        return this;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.ws.rs.core.Configurable#register(java.lang.Class, java.lang.Class[])
+     */
+    @Override
+    public ClientBuilder register(Class<?> arg0, Class<?>... arg1) {
+        // unimplemented
+        return this;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.ws.rs.core.Configurable#register(java.lang.Class, java.util.Map)
+     */
+    @Override
+    public ClientBuilder register(Class<?> arg0, Map<Class<?>, Integer> arg1) {
+        // unimplemented
+        return this;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.ws.rs.core.Configurable#register(java.lang.Object, int)
+     */
+    @Override
+    public ClientBuilder register(Object arg0, int arg1) {
+        // unimplemented
+        return this;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.ws.rs.core.Configurable#register(java.lang.Object, java.lang.Class[])
+     */
+    @Override
+    public ClientBuilder register(Object arg0, Class<?>... arg1) {
+        // unimplemented
+        return this;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.ws.rs.core.Configurable#register(java.lang.Object, java.util.Map)
+     */
+    @Override
+    public ClientBuilder register(Object arg0, Map<Class<?>, Integer> arg1) {
+        // unimplemented
+        return this;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.ws.rs.client.ClientBuilder#build()
+     */
+    @Override
+    public Client build() {
+        // unimplemented
+        return null;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.ws.rs.client.ClientBuilder#connectTimeout(long, java.util.concurrent.TimeUnit)
+     */
+    @Override
+    public ClientBuilder connectTimeout(long arg0, TimeUnit arg1) {
+        // unimplemented
+        return this;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.ws.rs.client.ClientBuilder#executorService(java.util.concurrent.ExecutorService)
+     */
+    @Override
+    public ClientBuilder executorService(ExecutorService arg0) {
+        // unimplemented
+        return this;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.ws.rs.client.ClientBuilder#hostnameVerifier(javax.net.ssl.HostnameVerifier)
+     */
+    @Override
+    public ClientBuilder hostnameVerifier(HostnameVerifier arg0) {
+        // unimplemented
+        return this;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.ws.rs.client.ClientBuilder#keyStore(java.security.KeyStore, char[])
+     */
+    @Override
+    public ClientBuilder keyStore(KeyStore arg0, char[] arg1) {
+        // unimplemented
+        return this;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.ws.rs.client.ClientBuilder#readTimeout(long, java.util.concurrent.TimeUnit)
+     */
+    @Override
+    public ClientBuilder readTimeout(long arg0, TimeUnit arg1) {
+        // unimplemented
+        return this;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.ws.rs.client.ClientBuilder#scheduledExecutorService(java.util.concurrent.ScheduledExecutorService)
+     */
+    @Override
+    public ClientBuilder scheduledExecutorService(ScheduledExecutorService arg0) {
+        // unimplemented
+        return this;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.ws.rs.client.ClientBuilder#sslContext(javax.net.ssl.SSLContext)
+     */
+    @Override
+    public ClientBuilder sslContext(SSLContext arg0) {
+        // unimplemented
+        return this;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.ws.rs.client.ClientBuilder#trustStore(java.security.KeyStore)
+     */
+    @Override
+    public ClientBuilder trustStore(KeyStore arg0) {
+        // unimplemented
+        return this;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.ws.rs.client.ClientBuilder#withConfig(javax.ws.rs.core.Configuration)
+     */
+    @Override
+    public ClientBuilder withConfig(Configuration arg0) {
+        // unimplemented
+        return this;
+    }
+
+ }

--- a/jaxrs-api/src/test/java/javax/ws/rs/client/ConfigurationStub.java
+++ b/jaxrs-api/src/test/java/javax/ws/rs/client/ConfigurationStub.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2018 IBM and Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package javax.ws.rs.client;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import javax.ws.rs.RuntimeType;
+import javax.ws.rs.core.Configuration;
+import javax.ws.rs.core.Feature;
+
+/**
+ * {@link javax.ws.rs.client.ClientBuilderListener} unit tests.
+ *
+ * @author Andy McCright
+ * @since 2.2
+ */
+public class ConfigurationStub implements Configuration {
+    Map<String,Object> properties = new HashMap<>();
+    Map<Object,Integer> providerInstances = new HashMap<>();
+    Map<Class<?>,Integer> providerClasses = new HashMap<>();
+    Set<Feature> features = new HashSet<>();
+
+    /* (non-Javadoc)
+     * @see javax.ws.rs.core.Configuration#getClasses()
+     */
+    @Override
+    public Set<Class<?>> getClasses() {
+        // unimplemented
+        return null;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.ws.rs.core.Configuration#getContracts(java.lang.Class)
+     */
+    @Override
+    public Map<Class<?>, Integer> getContracts(Class<?> arg0) {
+        // unimplemented
+        return null;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.ws.rs.core.Configuration#getInstances()
+     */
+    @Override
+    public Set<Object> getInstances() {
+        // unimplemented
+        return null;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.ws.rs.core.Configuration#getProperties()
+     */
+    @Override
+    public Map<String, Object> getProperties() {
+        return properties;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.ws.rs.core.Configuration#getProperty(java.lang.String)
+     */
+    @Override
+    public Object getProperty(String key) {
+        return properties.get(key);
+    }
+
+    /* (non-Javadoc)
+     * @see javax.ws.rs.core.Configuration#getPropertyNames()
+     */
+    @Override
+    public Collection<String> getPropertyNames() {
+        return properties.keySet();
+    }
+
+    /* (non-Javadoc)
+     * @see javax.ws.rs.core.Configuration#getRuntimeType()
+     */
+    @Override
+    public RuntimeType getRuntimeType() {
+        return RuntimeType.CLIENT;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.ws.rs.core.Configuration#isEnabled(javax.ws.rs.core.Feature)
+     */
+    @Override
+    public boolean isEnabled(Feature feature) {
+        return features.contains(feature);
+    }
+
+    /* (non-Javadoc)
+     * @see javax.ws.rs.core.Configuration#isEnabled(java.lang.Class)
+     */
+    @Override
+    public boolean isEnabled(Class<? extends Feature> arg0) {
+        // unimplemented
+        return false;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.ws.rs.core.Configuration#isRegistered(java.lang.Object)
+     */
+    @Override
+    public boolean isRegistered(Object instance) {
+        return providerInstances.containsKey(instance);
+    }
+
+    /* (non-Javadoc)
+     * @see javax.ws.rs.core.Configuration#isRegistered(java.lang.Class)
+     */
+    @Override
+    public boolean isRegistered(Class<?> clazz) {
+        return providerClasses.containsKey(clazz);
+    }
+
+}

--- a/jaxrs-api/src/test/java/org/someThirdParty/LoggingClientBuilderListener.java
+++ b/jaxrs-api/src/test/java/org/someThirdParty/LoggingClientBuilderListener.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2018 IBM and Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.someThirdParty;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.ClientBuilderListener;
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.core.Response;
+
+/**
+ * Used for {@link javax.ws.rs.client.ClientBuilderListener} unit tests.
+ *
+ * @author Andy McCright
+ * @since 2.2
+ */
+public class LoggingClientBuilderListener implements ClientBuilderListener {
+
+    @Override
+    public void onNewBuilder(ClientBuilder builder) {
+        builder.property("org.someThirdParty.isRegistered", "true");
+        builder.register(LoggingClientRequestFilter.class);
+        builder.register(LoggingFeature.INSTANCE);
+    }
+}

--- a/jaxrs-api/src/test/java/org/someThirdParty/LoggingClientRequestFilter.java
+++ b/jaxrs-api/src/test/java/org/someThirdParty/LoggingClientRequestFilter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2018 IBM and Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.someThirdParty;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.ClientBuilderListener;
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.core.Response;
+
+/**
+ * Used for {@link javax.ws.rs.client.ClientBuilderListener} unit tests.
+ *
+ * @author Andy McCright
+ * @since 2.2
+ */
+public class LoggingClientRequestFilter implements ClientRequestFilter {
+
+    public final static List<String> REQUESTS = new ArrayList<>();
+
+    @Override
+    public void filter(ClientRequestContext context) throws IOException {
+        REQUESTS.add(context.getUri().toString());
+        context.abortWith(Response.ok().build());
+    }
+}

--- a/jaxrs-api/src/test/java/org/someThirdParty/LoggingFeature.java
+++ b/jaxrs-api/src/test/java/org/someThirdParty/LoggingFeature.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2018 IBM and Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.someThirdParty;
+
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+
+/**
+ * Used for {@link javax.ws.rs.client.ClientBuilderListener} unit tests.
+ *
+ * @author Andy McCright
+ * @since 2.2
+ */
+public class LoggingFeature implements Feature {
+
+    public final static LoggingFeature INSTANCE = new LoggingFeature();
+
+    @Override
+    public boolean configure(FeatureContext context) {
+        // no-op
+        return true;
+    }
+}

--- a/jaxrs-api/src/test/resources/META-INF/services/javax.ws.rs.client.ClientBuilder
+++ b/jaxrs-api/src/test/resources/META-INF/services/javax.ws.rs.client.ClientBuilder
@@ -1,0 +1,1 @@
+javax.ws.rs.client.ClientBuilderStub

--- a/jaxrs-api/src/test/resources/META-INF/services/javax.ws.rs.client.ClientBuilderListener
+++ b/jaxrs-api/src/test/resources/META-INF/services/javax.ws.rs.client.ClientBuilderListener
@@ -1,0 +1,1 @@
+org.someThirdParty.LoggingClientBuilderListener


### PR DESCRIPTION
Creates a new SPI allowing third parties to plug in providers automatically when new ClientBuilders are created.

This follows a similar process that MicroProfile Rest Client uses for "global" registration of providers and properties.  It enables a user to automatically register a features/providers/properties when a new `ClientBuilder` instance is created.  This can be useful for third party products, like OpenTracing, MP Metrics, etc. that may want to register specific providers for JAX-RS Clients but only if that feature is available.

This addresses issue #596. 

Signed-off-by: Andy McCright <j.andrew.mccright@gmail.com>