### PR TITLE
Add uses clauses to module-info.java

### DIFF
--- a/jaxrs-api/src/main/java/module-info.java
+++ b/jaxrs-api/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -27,4 +27,7 @@ module java.ws.rs {
     exports javax.ws.rs.ext;
     exports javax.ws.rs.sse;
 
+    uses javax.ws.rs.client.ClientBuilder;
+    uses javax.ws.rs.ext.RuntimeDelegate;
+    uses javax.ws.rs.sse.SseEventSource.Builder;
 }


### PR DESCRIPTION
This is required for implementors with JPMS to implement the
ClientBuilder, RuntimeDelegate, and SseEventSource.Builder.

This resolves issue #661.

Due to JPMS unit testing issues described in Pull Request #658 [comment](https://github.com/eclipse-ee4j/jaxrs-api/pull/658#issuecomment-422459421), I don't have any unit tests for this.  However, I was able to test this using a basic Java application on Java 10 with a module-info.java like this:

```
module andymc.jaxrs.stubs {
	requires java.ws.rs;
	
	provides javax.ws.rs.client.ClientBuilder
		with io.andymc.jaxrs.stubs.ClientBuilderStub;
	provides javax.ws.rs.ext.RuntimeDelegate
		with io.andymc.jaxrs.stubs.RuntimeDelegateStub;
	provides javax.ws.rs.sse.SseEventSource.Builder
		with io.andymc.jaxrs.stubs.SseEventSourceBuilderStub;
} 
```

and a main method like this:
```
public class Main {
	public static void main(String[] args) throws Throwable {
		ClientBuilder clientBuilder = ClientBuilder.newBuilder();
		if (clientBuilder != null && clientBuilder instanceof ClientBuilderStub) {
			System.out.println("Loaded ClientBuilderStub - SUCCESS");
		}
		
		RuntimeDelegate runtimeDelegate = RuntimeDelegate.getInstance();
		if (runtimeDelegate != null && runtimeDelegate instanceof RuntimeDelegateStub) {
			System.out.println("Loaded RuntimeDelegateStub - SUCCESS");
		}
		
		// note that SseEventSourceBuilderStub.target(...) will print text similar to above
		SseEventSource.target(null); 
	}
}
```

Prior to this change, the output looks like:
```
Exception in thread "main" java.lang.RuntimeException: java.lang.ClassNotFoundException: org.glassfish.jersey.client.JerseyClientBuilder
	at java.ws.rs/javax.ws.rs.client.ClientBuilder.newBuilder(ClientBuilder.java:85)
	at andymc.jaxrs.stubs/io.andymc.jaxrs.stubs.Main.main(Main.java:12)
Caused by: java.lang.ClassNotFoundException: org.glassfish.jersey.client.JerseyClientBuilder
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:582)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:190)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:499)
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:291)
	at java.ws.rs/javax.ws.rs.client.FactoryFinder.newInstance(FactoryFinder.java:87)
	at java.ws.rs/javax.ws.rs.client.FactoryFinder.find(FactoryFinder.java:185)
	at java.ws.rs/javax.ws.rs.client.ClientBuilder.newBuilder(ClientBuilder.java:69)
	... 1 more
```

This fails because the JAX-RS API module does not have the `uses` clause, so the `FactoryFinder`/`ServiceLoader` cannot load the `ClientBuilderStub` class in my module, so then the `FactoryFinder` falls back to the Jersey impl which also is not on the classpath.

After applying this fix, the test runs successfully - here is the output:
```
Loaded ClientBuilderStub - SUCCESS
Loaded RuntimeDelegateStub - SUCCESS
Loaded SseEventSourceBuilderStub and invoked it - SUCCESS
```

When I try the same code using an unnamed module (no module-info.java file - instead, it has three `META-INF/services` files: `javax.ws.rs.client.ClientBuilder`, `javax.ws.rs.ext.RuntimeDelegate`, and `javax.ws.rs.sse.SseEventSource$Builder`), the test also passes:
```
Loaded ClientBuilderStub - SUCCESS
Loaded RuntimeDelegateStub - SUCCESS
Loaded SseEventSourceBuilderStub and invoked it - SUCCESS
``` 

Signed-off-by: Andy McCright <j.andrew.mccright@gmail.com>