### PR TITLE
JAX-RS 2.1.2 (Bug fixes ontop JAX-RS 2.1.1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,11 @@ jdk:
   - oraclejdk8
   - oraclejdk9
   - oraclejdk10
+  - oraclejdk11
   - openjdk8
   - openjdk9
   - openjdk10
+  - openjdk11
 
 install:
   - cd $TRAVIS_BUILD_DIR/jaxrs-api

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>jakarta.ws.rs</groupId>
     <artifactId>jakarta.ws.rs-examples</artifactId>
-    <version>2.1.2-SNAPSHOT</version>
+    <version>2.1.2</version>
     <packaging>jar</packaging>
     <name>jakarta.ws.rs-examples</name>
 
@@ -260,7 +260,7 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>2.1.2-SNAPSHOT</version>
+            <version>2.1.2</version>
         </dependency>
 
         <dependency>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>jakarta.ws.rs</groupId>
     <artifactId>jakarta.ws.rs-examples</artifactId>
-    <version>2.1.1</version>
+    <version>2.1.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>jakarta.ws.rs-examples</name>
 
@@ -260,7 +260,7 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>2.1.1</version>
+            <version>2.1.2-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -258,8 +258,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <version>2.1.1</version>
         </dependency>
 

--- a/jaxrs-api/.gitignore
+++ b/jaxrs-api/.gitignore
@@ -1,0 +1,1 @@
+.checkstyle

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -261,7 +261,7 @@
                                 and/or its affiliates. All Rights Reserved.
                                 ]]>
                             </bottom>
-                            <additionalparam>-Xdoclint:none</additionalparam>
+                            <doclint>none</doclint>
                             <!--javaApiLinks>
                                 <property>
                                     <name>api_1.3</name>
@@ -321,13 +321,13 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.5</version>
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <!-- This plugin generates the buildNumber property used in maven-bundle-plugin -->
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>buildnumber-maven-plugin</artifactId>
-                    <version>1.3</version>
+                    <version>1.4</version>
                     <configuration>
                         <format>{0,date,MM/dd/yyyy hh:mm aa}</format>
                         <items>
@@ -414,7 +414,7 @@
                                 and/or its affiliates. All Rights Reserved.
                             ]]>
                         </bottom>
-                        <additionalparam>-Xdoclint:none</additionalparam>
+                        <doclint>none</doclint>
                         <!--javaApiLinks>
                             <property>
                                 <name>api_1.3</name>
@@ -449,7 +449,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>2.3</version>
+                    <version>3.0.1</version>
                     <executions>
                         <execution>
                             <id>attach-sources</id>
@@ -462,7 +462,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.8.1</version>
+                    <version>2.8.2</version>
                     <configuration>
                         <retryFailedDeploymentCount>10</retryFailedDeploymentCount>
                     </configuration>
@@ -500,7 +500,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jxr-plugin</artifactId>
-                    <version>2.3</version>
+                    <version>2.5</version>
                     <executions>
                         <execution>
                             <goals>
@@ -607,9 +607,9 @@
         <apidocs.title>JAX-RS ${spec.version} API Specification ${spec.version.revision}</apidocs.title>
         <java.version>1.8</java.version>
 
-        <maven.bundle.plugin.version>3.3.0</maven.bundle.plugin.version>
-        <maven.compiler.plugin.version>3.6.1</maven.compiler.plugin.version>
-        <maven.javadoc.plugin.version>2.10.4</maven.javadoc.plugin.version>
+        <maven.bundle.plugin.version>3.5.0</maven.bundle.plugin.version>
+        <maven.compiler.plugin.version>3.7.0</maven.compiler.plugin.version>
+        <maven.javadoc.plugin.version>3.0.0</maven.javadoc.plugin.version>
 
         <last.final.spec.version>2.1</last.final.spec.version>
         <milestone.number>01</milestone.number>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>jakarta.ws.rs</groupId>
     <artifactId>jakarta.ws.rs-api</artifactId>
-    <version>2.1.1</version>
+    <version>2.1.2-SNAPSHOT</version>
     <packaging>${packaging.type}</packaging>
     <name>javax.ws.rs-api</name>
     <description>Java API for RESTful Web Services</description>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -230,7 +230,7 @@
                         <plugin>
                             <artifactId>maven-surefire-plugin</artifactId>
                             <configuration>
-                                <argLine>--add-modules java.xml.bind</argLine>
+                                <argLine>--add-modules java.xml.bind --add-opens java.ws.rs/javax.ws.rs.core=java.xml.bind</argLine>
                             </configuration>
                         </plugin>
                     </plugins>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>jakarta.ws.rs</groupId>
     <artifactId>jakarta.ws.rs-api</artifactId>
-    <version>2.1.2-SNAPSHOT</version>
+    <version>2.1.2</version>
     <packaging>bundle</packaging>
     <name>javax.ws.rs-api</name>
     <description>Java API for RESTful Web Services</description>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -23,7 +23,7 @@
     <groupId>jakarta.ws.rs</groupId>
     <artifactId>jakarta.ws.rs-api</artifactId>
     <version>2.1.2-SNAPSHOT</version>
-    <packaging>${packaging.type}</packaging>
+    <packaging>bundle</packaging>
     <name>javax.ws.rs-api</name>
     <description>Java API for RESTful Web Services</description>
 
@@ -188,10 +188,6 @@
             <activation>
                 <jdk>[9,)</jdk>
             </activation>
-            <properties>
-                <!-- TODO: maven-bundle-plugin doesn't understand module-info yet. -->
-                <packaging.type>jar</packaging.type>
-            </properties>
             <build>
                 <pluginManagement>
                     <plugins>
@@ -242,9 +238,6 @@
             <activation>
                 <jdk>(,9)</jdk>
             </activation>
-            <properties>
-                <packaging.type>bundle</packaging.type>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -184,9 +184,78 @@
             </distributionManagement>
         </profile>
         <profile>
-            <id>jdk9+</id>
+            <id>jdk11+</id>
             <activation>
-                <jdk>[9,)</jdk>
+                <jdk>[11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                    <version>${jaxb.api.version}</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>javax.activation</groupId>
+                    <artifactId>javax.activation-api</artifactId>
+                    <version>${activation.api.version}</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.glassfish.jaxb</groupId>
+                    <artifactId>jaxb-runtime</artifactId>
+                    <version>${jaxb.impl.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <artifactId>maven-compiler-plugin</artifactId>
+                            <version>${maven.compiler.plugin.version}</version>
+                            <executions>
+                                <execution>
+                                    <id>default-compile</id>
+                                    <configuration>
+                                        <!-- compile everything to ensure module-info contains right entries -->
+                                        <release>9</release>
+                                    </configuration>
+                                </execution>
+                                <execution>
+                                    <id>base-compile</id>
+                                    <goals>
+                                        <goal>compile</goal>
+                                    </goals>
+                                    <!-- recompile everything for target VM except the module-info.java -->
+                                    <configuration>
+                                        <excludes>
+                                            <exclude>module-info.java</exclude>
+                                        </excludes>
+                                        <source>${java.version}</source>
+                                        <target>${java.version}</target>
+                                    </configuration>
+                                </execution>
+                            </executions>
+                            <configuration>
+                                <source>${java.version}</source>
+                                <target>${java.version}</target>
+                            </configuration>
+                        </plugin>
+                        <plugin>
+                            <artifactId>maven-surefire-plugin</artifactId>
+                            <configuration>
+                                <argLine>--add-opens java.ws.rs/javax.ws.rs.core=java.xml.bind</argLine>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+        <profile>
+            <id>jdk9-jdk10</id>
+            <activation>
+                <jdk>[9,11)</jdk>
             </activation>
             <build>
                 <pluginManagement>
@@ -594,6 +663,12 @@
             <version>4.11</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.22.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <properties>
@@ -613,6 +688,10 @@
         <skip.release.tests>false</skip.release.tests>
         <spec.version>${last.final.spec.version}</spec.version>
         <spec.version.revision /> <!-- e.g. (Rev a) -->
+
+        <jaxb.api.version>2.3.0</jaxb.api.version>
+        <jaxb.impl.version>2.3.0.1</jaxb.impl.version>
+        <activation.api.version>1.2.0</activation.api.version>
     </properties>
 
     <distributionManagement>

--- a/jaxrs-api/src/main/java/module-info.java
+++ b/jaxrs-api/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -27,4 +27,7 @@ module java.ws.rs {
     exports javax.ws.rs.ext;
     exports javax.ws.rs.sse;
 
+    uses javax.ws.rs.client.ClientBuilder;
+    uses javax.ws.rs.ext.RuntimeDelegate;
+    uses javax.ws.rs.sse.SseEventSource.Builder;
 }


### PR DESCRIPTION
This is a proposal to cherry-pick *more* "non-essential" bug fixes from `master` to `EE4J_8` in the form another service release: JAX-RS 2.1.2.

*There had been several voices saying that these bug fixes are wanted in 2.1.2, so it is **up to the committers** to decide whether we actually cherry-pick them or not.*

While technically there are several commits contained, effectively what they produce simply spoken is:
* Will build fine on JDK11 (several commits needed for that, as Maven plugins are failing in EE4J_8)
* JPMS module declaration corrected
* Examples reference Jakarta EE instead of Java EE (existing bug in current EE4J_8 branch)

*As this is only a service release, and as the actual API is not touched we can just push to OSSRH without the need of another review by EMO / PMC. Having said that, I propose we do informally announce our proposal to the PMC.*

**Counter Proposal: If this PR fails the review, I will simply republish `EE4J_8` *as-is*, i. e. in the form of JAX-RS 2.1.1 with changed Maven Coordinates.**

**As the release has to be published before October 22nd, I hereby announce a shortened review period of just five days. This means, I will release EE4J_8 either with or with without this PR next week to match the deadline!**