### PR TITLE
Formatting according to recommended EE4J code conventions

### DIFF
--- a/etc/config/checkstyle.xml
+++ b/etc/config/checkstyle.xml
@@ -135,7 +135,7 @@
         <!-- Checks for Size Violations.                    -->
         <!-- See http://checkstyle.sf.net/config_sizes.html -->
         <module name="LineLength">
-            <property name="max" value="120"/>
+            <property name="max" value="160"/>
             <property name="ignorePattern" value="@version|@see|@todo|TODO"/>
         </module>
         <module name="MethodLength"/>

--- a/examples/src/main/java/jaxrs/examples/async/LongRunningAsyncOperationResource.java
+++ b/examples/src/main/java/jaxrs/examples/async/LongRunningAsyncOperationResource.java
@@ -92,7 +92,7 @@ public class LongRunningAsyncOperationResource {
     @GET
     @Path("asyncTimeoutOverride")
     public void overriddenTimeoutAsync(@QueryParam("timeOut") Long timeOut, @QueryParam("timeUnit") TimeUnit timeUnit,
-                                       @Suspended final AsyncResponse ar) {
+            @Suspended final AsyncResponse ar) {
         if (timeOut != null && timeUnit != null) {
             ar.setTimeout(timeOut, timeUnit);
         } else {

--- a/examples/src/main/java/jaxrs/examples/bootstrap/BasicJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/BasicJavaSeBootstrapExample.java
@@ -26,12 +26,10 @@ import javax.ws.rs.core.UriBuilder;
 /**
  * Basic Java SE bootstrap example.
  * <p>
- * This example demonstrates bootstrapping on Java SE platforms solely using
- * defaults. It will effectively startup the {@link HelloWorld} application at
- * the URL {@code http://localhost/} on an implementation-specific default IP
- * port (e. g. 80, 8080, or something completely different). The actual
- * configuration needs to be queried after bootstrapping, otherwise callers
- * would be unaware of the actual chosen port.
+ * This example demonstrates bootstrapping on Java SE platforms solely using defaults. It will effectively startup the
+ * {@link HelloWorld} application at the URL {@code http://localhost/} on an implementation-specific default IP port (e.
+ * g. 80, 8080, or something completely different). The actual configuration needs to be queried after bootstrapping,
+ * otherwise callers would be unaware of the actual chosen port.
  * </p>
  *
  * @author Markus KARG (markus@headcrashing.eu)
@@ -42,10 +40,8 @@ public final class BasicJavaSeBootstrapExample {
     /**
      * Runs this example.
      *
-     * @param args
-     *            unused command line arguments
-     * @throws InterruptedException
-     *             when process is killed
+     * @param args unused command line arguments
+     * @throws InterruptedException when process is killed
      */
     public static final void main(final String[] args) throws InterruptedException {
         final Application application = new HelloWorld();

--- a/examples/src/main/java/jaxrs/examples/bootstrap/ClientAuthenticationJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/ClientAuthenticationJavaSeBootstrapExample.java
@@ -27,29 +27,23 @@ import javax.ws.rs.core.UriBuilder;
 /**
  * Java SE Bootstrap Example using TLS Client Authentication.
  * <p>
- * This example demonstrates bootstrapping on Java SE platforms using HTTPS with
- * <em>bidirectional</em> TLS authentication (i. e. only <em>trustworthy</em>
- * clients may connect). It relies mostly on defaults but explicitly sets the
- * protocol to HTTPS and mandates TLS client certificate validation. The example
- * will effectively startup the {@link HelloWorld} application at the URL
- * {@code https://localhost/} on an implementation-specific default IP port (e.
- * g. 443, 8443, or someting completely different). The actual configuration
- * needs to be queried after bootstrapping, otherwise callers would be unaware
- * of the actual chosen port. If the client's certificate is invalid or cannot
- * be validated, the server will reject the connection.
+ * This example demonstrates bootstrapping on Java SE platforms using HTTPS with <em>bidirectional</em> TLS
+ * authentication (i. e. only <em>trustworthy</em> clients may connect). It relies mostly on defaults but explicitly
+ * sets the protocol to HTTPS and mandates TLS client certificate validation. The example will effectively startup the
+ * {@link HelloWorld} application at the URL {@code https://localhost/} on an implementation-specific default IP port
+ * (e. g. 443, 8443, or someting completely different). The actual configuration needs to be queried after
+ * bootstrapping, otherwise callers would be unaware of the actual chosen port. If the client's certificate is invalid
+ * or cannot be validated, the server will reject the connection.
  * </p>
  * <p>
  * This example uses some basic <em>external</em> JSSE configuration:
  * </p>
  * <ul>
- * <li>{@code javax.net.ssl.keyStore=~/.keystore} - HTTPS: Path to a keystore
- * holding an X.509 certificate for {@code CN=localhost}</li>
- * <li>{@code javax.net.ssl.keyStorePassword=...} - HTTPS: Password of that
- * keystore</li>
- * <li>Client Authentication: The default truststore
- * ({@code $JAVA_HOME/lib/security/cacerts}) must hold the root certificate of
- * the CA and all intermediate certificates used for signing the client's
- * certificate.</li>
+ * <li>{@code javax.net.ssl.keyStore=~/.keystore} - HTTPS: Path to a keystore holding an X.509 certificate for
+ * {@code CN=localhost}</li>
+ * <li>{@code javax.net.ssl.keyStorePassword=...} - HTTPS: Password of that keystore</li>
+ * <li>Client Authentication: The default truststore ({@code $JAVA_HOME/lib/security/cacerts}) must hold the root
+ * certificate of the CA and all intermediate certificates used for signing the client's certificate.</li>
  * </ul>
  * </p>
  *
@@ -61,10 +55,8 @@ public final class ClientAuthenticationJavaSeBootstrapExample {
     /**
      * Runs this example.
      *
-     * @param args
-     *            unused command line arguments
-     * @throws InterruptedException
-     *             when process is killed
+     * @param args unused command line arguments
+     * @throws InterruptedException when process is killed
      */
     public static final void main(final String[] args) throws InterruptedException {
         final Application application = new HelloWorld();

--- a/examples/src/main/java/jaxrs/examples/bootstrap/ExplicitJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/ExplicitJavaSeBootstrapExample.java
@@ -27,20 +27,17 @@ import javax.ws.rs.core.UriBuilder;
 /**
  * Java SE bootstrap example with explicit configuration.
  * <p>
- * This example demonstrates bootstrapping on Java SE platforms using hardly no
- * defaults at all (besides JSSE defaults). It applies parameters passed at the
- * command line.
+ * This example demonstrates bootstrapping on Java SE platforms using hardly no defaults at all (besides JSSE defaults).
+ * It applies parameters passed at the command line.
  * </p>
  * <p>
- * Depending of the actual parameters passed at the command line (i. e. with
- * protocol set up {@code HTTPS}), this example might need to have additional
- * <em>external</em> JSSE configuration:
+ * Depending of the actual parameters passed at the command line (i. e. with protocol set up {@code HTTPS}), this
+ * example might need to have additional <em>external</em> JSSE configuration:
  * </p>
  * <ul>
- * <li>{@code javax.net.ssl.keyStore=~/.keystore} - HTTPS: Path to a keystore
- * holding an X.509 certificate for {@code CN=localhost}</li>
- * <li>{@code javax.net.ssl.keyStorePassword=...} - HTTPS: Password of that
- * keystore</li>
+ * <li>{@code javax.net.ssl.keyStore=~/.keystore} - HTTPS: Path to a keystore holding an X.509 certificate for
+ * {@code CN=localhost}</li>
+ * <li>{@code javax.net.ssl.keyStorePassword=...} - HTTPS: Password of that keystore</li>
  * </ul>
  *
  * @author Markus KARG (markus@headcrashing.eu)
@@ -51,13 +48,10 @@ public final class ExplicitJavaSeBootstrapExample {
     /**
      * Runs this example.
      *
-     * @param args
-     *            configuration to be used in exact this order:
-     *            {@code PROTOCOL HOST PORT ROOT_PATH CLIENT_AUTH} where the
-     *            protocol can be either {@code HTTP} or {@code HTTPS} and the
-     *            client authentication is one of {@code NONE, OPTIONAL, MANDATORY}.
-     * @throws InterruptedException
-     *             when process is killed
+     * @param args configuration to be used in exact this order: {@code PROTOCOL HOST PORT ROOT_PATH CLIENT_AUTH} where the
+     * protocol can be either {@code HTTP} or {@code HTTPS} and the client authentication is one of
+     * {@code NONE, OPTIONAL, MANDATORY}.
+     * @throws InterruptedException when process is killed
      */
     public static final void main(final String[] args) throws InterruptedException {
         final Application application = new HelloWorld();

--- a/examples/src/main/java/jaxrs/examples/bootstrap/ExternalConfigJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/ExternalConfigJavaSeBootstrapExample.java
@@ -29,17 +29,14 @@ import org.eclipse.microprofile.config.ConfigProvider;
 /**
  * Java SE bootstrap example utilizing an external configuration system.
  * <p>
- * This example demonstrates bootstrapping on Java SE platforms using values
- * retrieved from an external configuration system plus statically overriden
- * properties. In particular, this demo first uses Eclipse Microprofile Config
- * to let the actual implementation retrieve all properties from an external
- * source of configuration, but then explicitly enforces HTTPS within the
- * bootstrap code.
+ * This example demonstrates bootstrapping on Java SE platforms using values retrieved from an external configuration
+ * system plus statically overriden properties. In particular, this demo first uses Eclipse Microprofile Config to let
+ * the actual implementation retrieve all properties from an external source of configuration, but then explicitly
+ * enforces HTTPS within the bootstrap code.
  * </p>
  * <p>
- * To actually run this example, an implementation of Eclipse Microprofile
- * Config has to be added to the classpath, and the configuration options to be
- * customized have to be provided, e. g. as environment variables:
+ * To actually run this example, an implementation of Eclipse Microprofile Config has to be added to the classpath, and
+ * the configuration options to be customized have to be provided, e. g. as environment variables:
  * </p>
  *
  * <pre>
@@ -50,17 +47,14 @@ import org.eclipse.microprofile.config.ConfigProvider;
  * This example uses some basic <em>external</em> JSSE configuration:
  * </p>
  * <ul>
- * <li>{@code javax.net.ssl.keyStore=~/.keystore} - HTTPS: Path to a keystore
- * holding an X.509 certificate for {@code CN=localhost}</li>
- * <li>{@code javax.net.ssl.keyStorePassword=...} - HTTPS: Password of that
- * keystore</li>
+ * <li>{@code javax.net.ssl.keyStore=~/.keystore} - HTTPS: Path to a keystore holding an X.509 certificate for
+ * {@code CN=localhost}</li>
+ * <li>{@code javax.net.ssl.keyStorePassword=...} - HTTPS: Password of that keystore</li>
  * </ul>
  * <p>
- * Due to the <em>implicit</em> use of Microprofile Config in the
- * implementation, this example is <em>not necessarily</em> portable: Support
- * for external configuration is <em>not mandatory</em>. Implementations could
- * choose to not implement it, or to support other external configuration
- * mechanics not mentioned here.
+ * Due to the <em>implicit</em> use of Microprofile Config in the implementation, this example is <em>not
+ * necessarily</em> portable: Support for external configuration is <em>not mandatory</em>. Implementations could choose
+ * to not implement it, or to support other external configuration mechanics not mentioned here.
  * </p>
  *
  * @author Markus KARG (markus@headcrashing.eu)
@@ -71,10 +65,8 @@ public final class ExternalConfigJavaSeBootstrapExample {
     /**
      * Runs this example.
      *
-     * @param args
-     *            unused command line arguments
-     * @throws InterruptedException
-     *             when process is killed
+     * @param args unused command line arguments
+     * @throws InterruptedException when process is killed
      */
     public static final void main(final String[] args) throws InterruptedException {
         final Application application = new HelloWorld();

--- a/examples/src/main/java/jaxrs/examples/bootstrap/HttpsJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/HttpsJavaSeBootstrapExample.java
@@ -26,22 +26,19 @@ import javax.ws.rs.core.UriBuilder;
 /**
  * Java SE bootstrap example using HTTPS.
  * <p>
- * This example demonstrates bootstrapping on Java SE platforms using HTTPS. It
- * relies mostly on defaults but explicitly sets the protocol to HTTPS. The
- * example will effectively startup the {@link HelloWorld} application at the
- * URL {@code https://localhost/} on an implementation-specific default IP port
- * (e. g. 443, 8443, or someting completely different). The actual configuration
- * needs to be queried after bootstrapping, otherwise callers would be unaware
- * of the actual chosen port.
+ * This example demonstrates bootstrapping on Java SE platforms using HTTPS. It relies mostly on defaults but explicitly
+ * sets the protocol to HTTPS. The example will effectively startup the {@link HelloWorld} application at the URL
+ * {@code https://localhost/} on an implementation-specific default IP port (e. g. 443, 8443, or someting completely
+ * different). The actual configuration needs to be queried after bootstrapping, otherwise callers would be unaware of
+ * the actual chosen port.
  * </p>
  * <p>
  * This example uses some basic <em>external</em> JSSE configuration:
  * </p>
  * <ul>
- * <li>{@code javax.net.ssl.keyStore=~/.keystore} - HTTPS: Path to a keystore
- * holding an X.509 certificate for {@code CN=localhost}</li>
- * <li>{@code javax.net.ssl.keyStorePassword=...} - HTTPS: Password of that
- * keystore</li>
+ * <li>{@code javax.net.ssl.keyStore=~/.keystore} - HTTPS: Path to a keystore holding an X.509 certificate for
+ * {@code CN=localhost}</li>
+ * <li>{@code javax.net.ssl.keyStorePassword=...} - HTTPS: Password of that keystore</li>
  * </ul>
  * </p>
  *
@@ -53,10 +50,8 @@ public final class HttpsJavaSeBootstrapExample {
     /**
      * Runs this example.
      *
-     * @param args
-     *            unused command line arguments
-     * @throws InterruptedException
-     *             when process is killed
+     * @param args unused command line arguments
+     * @throws InterruptedException when process is killed
      */
     public static final void main(final String[] args) throws InterruptedException {
         final Application application = new HelloWorld();

--- a/examples/src/main/java/jaxrs/examples/bootstrap/NativeJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/NativeJavaSeBootstrapExample.java
@@ -26,18 +26,15 @@ import javax.ws.rs.core.UriBuilder;
 /**
  * Java SE bootstrap example demonstrating the use of native properties.
  * <p>
- * This example demonstrates bootstrapping on Java SE platforms with native
- * properties, in particular by explicitly selecting the Grizzly2 backend in
- * Jersey. It will effectively startup the {@link HelloWorld} application at the
- * URL {@code http://localhost:80/}, i. e. the Grizzly2 backend selects exactly
- * port 80 as this is its default IP port. The actual configuration needs to be
- * queried after bootstrapping, otherwise callers would be unaware of the actual
- * chosen port, as Grizzly2's default behavior is not publicly documented.
+ * This example demonstrates bootstrapping on Java SE platforms with native properties, in particular by explicitly
+ * selecting the Grizzly2 backend in Jersey. It will effectively startup the {@link HelloWorld} application at the URL
+ * {@code http://localhost:80/}, i. e. the Grizzly2 backend selects exactly port 80 as this is its default IP port. The
+ * actual configuration needs to be queried after bootstrapping, otherwise callers would be unaware of the actual chosen
+ * port, as Grizzly2's default behavior is not publicly documented.
  * </p>
  * <p>
- * This is a native example, hence it only works with Jersey, and in particular
- * only with its Grizzly2 backend. To actually run this demo, the following
- * libraries have to be found on the classpath:
+ * This is a native example, hence it only works with Jersey, and in particular only with its Grizzly2 backend. To
+ * actually run this demo, the following libraries have to be found on the classpath:
  * </p>
  * <ul>
  * <li>jersey-server</li>
@@ -52,12 +49,9 @@ public final class NativeJavaSeBootstrapExample {
     /**
      * Runs this example.
      *
-     * @param args
-     *            unused command line arguments
-     * @throws InterruptedException
-     *             when process is killed
-     * @throws ClassNotFoundException
-     *             when Jersey's Grizzly backend is not on the classpath
+     * @param args unused command line arguments
+     * @throws InterruptedException when process is killed
+     * @throws ClassNotFoundException when Jersey's Grizzly backend is not on the classpath
      */
     public static final void main(final String[] args) throws InterruptedException, ClassNotFoundException {
         final Application application = new HelloWorld();

--- a/examples/src/main/java/jaxrs/examples/bootstrap/PropertyProviderJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/PropertyProviderJavaSeBootstrapExample.java
@@ -29,16 +29,14 @@ import org.eclipse.microprofile.config.ConfigProvider;
 /**
  * Java SE bootstrap example utilizing a property provider.
  * <p>
- * This example demonstrates bootstrapping on Java SE platforms using values
- * explicitly bulk-loaded from a property provider plus statically overridden
- * properties. In particular, this demo first uses Eclipse Microprofile Config
- * as a property provider for all properties supported by the implementation,
- * but then explicitly enforces HTTPS within the bootstrap code.
+ * This example demonstrates bootstrapping on Java SE platforms using values explicitly bulk-loaded from a property
+ * provider plus statically overridden properties. In particular, this demo first uses Eclipse Microprofile Config as a
+ * property provider for all properties supported by the implementation, but then explicitly enforces HTTPS within the
+ * bootstrap code.
  * </p>
  * <p>
- * To actually run this example, an implementation of Eclipse Microprofile
- * Config has to be added to the classpath, and the configuration options to be
- * customized have to be provided, e. g. as environment variables:
+ * To actually run this example, an implementation of Eclipse Microprofile Config has to be added to the classpath, and
+ * the configuration options to be customized have to be provided, e. g. as environment variables:
  * </p>
  *
  * <pre>
@@ -46,17 +44,15 @@ import org.eclipse.microprofile.config.ConfigProvider;
  * java -Djavax.ws.rs.JAXRS.Host=127.0.0.1 PropertyProviderJavaSeBootstrapExample;
  * </pre>
  * <p>
- * Thanks to the <em>explicit</em> use of Microprofile Config in the
- * application, this example is completely portable.
+ * Thanks to the <em>explicit</em> use of Microprofile Config in the application, this example is completely portable.
  * </p>
  * <p>
  * This example uses some basic <em>external</em> JSSE configuration:
  * </p>
  * <ul>
- * <li>{@code javax.net.ssl.keyStore=~/.keystore} - HTTPS: Path to a keystore
- * holding an X.509 certificate for {@code CN=localhost}</li>
- * <li>{@code javax.net.ssl.keyStorePassword=...} - HTTPS: Password of that
- * keystore</li>
+ * <li>{@code javax.net.ssl.keyStore=~/.keystore} - HTTPS: Path to a keystore holding an X.509 certificate for
+ * {@code CN=localhost}</li>
+ * <li>{@code javax.net.ssl.keyStorePassword=...} - HTTPS: Password of that keystore</li>
  * </ul>
  *
  * @author Markus KARG (markus@headcrashing.eu)
@@ -67,10 +63,8 @@ public final class PropertyProviderJavaSeBootstrapExample {
     /**
      * Runs this example.
      *
-     * @param args
-     *            unused command line arguments
-     * @throws InterruptedException
-     *             when process is killed
+     * @param args unused command line arguments
+     * @throws InterruptedException when process is killed
      */
     public static final void main(final String[] args) throws InterruptedException {
         final Application application = new HelloWorld();

--- a/examples/src/main/java/jaxrs/examples/bootstrap/TlsJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/TlsJavaSeBootstrapExample.java
@@ -34,12 +34,10 @@ import javax.ws.rs.core.UriBuilder;
 /**
  * Java SE bootstrap example using TLS customization.
  * <p>
- * This example demonstrates bootstrapping on Java SE platforms using HTTPS with
- * TLS 1.2 and a <em>particular</em> keystore. It explicitly sets the protocol
- * to {@code HTTPS} using port 443 and provides a {@link SSLContext} customized
- * to TLS v1.2 using a provided keystore file. The example will effectively
- * startup the {@link HelloWorld} application at the URL
- * {@code https://localhost:443/}.
+ * This example demonstrates bootstrapping on Java SE platforms using HTTPS with TLS 1.2 and a <em>particular</em>
+ * keystore. It explicitly sets the protocol to {@code HTTPS} using port 443 and provides a {@link SSLContext}
+ * customized to TLS v1.2 using a provided keystore file. The example will effectively startup the {@link HelloWorld}
+ * application at the URL {@code https://localhost:443/}.
  * </p>
  *
  * @author Markus KARG (markus@headcrashing.eu)
@@ -50,14 +48,10 @@ public final class TlsJavaSeBootstrapExample {
     /**
      * Runs this example.
      *
-     * @param args
-     *            KEYSTORE_PATH KEYSTORE_PASSWORD
-     * @throws GeneralSecurityException
-     *             in case JSSE fails
-     * @throws IOException
-     *             in case file access fails
-     * @throws InterruptedException
-     *             when process is killed
+     * @param args KEYSTORE_PATH KEYSTORE_PASSWORD
+     * @throws GeneralSecurityException in case JSSE fails
+     * @throws IOException in case file access fails
+     * @throws InterruptedException when process is killed
      */
     public static final void main(final String[] args)
             throws GeneralSecurityException, IOException, InterruptedException {

--- a/examples/src/main/java/jaxrs/examples/bootstrap/package-info.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/package-info.java
@@ -2,23 +2,16 @@
  * Java SE bootstrap examples.
  *
  * <ul>
- * <li>{@link BasicJavaSeBootstrapExample} - Basic example solely using
- * defaults</li>
- * <li>{@link ExplicitJavaSeBootstrapExample} - Explicit configuration instead
- * of defaults</li>
+ * <li>{@link BasicJavaSeBootstrapExample} - Basic example solely using defaults</li>
+ * <li>{@link ExplicitJavaSeBootstrapExample} - Explicit configuration instead of defaults</li>
  * <li>{@link HttpsJavaSeBootstrapExample} - HTTPS instead of HTTP</li>
  * <li>{@link TlsJavaSeBootstrapExample} - TLS customization</li>
- * <li>{@link ClientAuthenticationJavaSeBootstrapExample} - HTTPS with
- * <em>bidirectional</em> authentication</li>
- * <li>{@link NativeJavaSeBootstrapExample} - Custom (non-portable) properties
- * (using Jersey's Grizzly2 backend)</li>
- * <li>{@link PropertyProviderJavaSeBootstrapExample} - Bulk-loading
- * configuration using a property provider (using Microprofile Config
- * <em>explicitly</em>, hence in a non-optional, portable way)
- * <li>{@link ExternalConfigJavaSeBootstrapExample} - Bulk-loading configuration
- * from external configuration mechanics (using Microprofile Config
- * <em>implicitly</em>, hence in an optional, <em>not necessarily</em> portable
- * way)
+ * <li>{@link ClientAuthenticationJavaSeBootstrapExample} - HTTPS with <em>bidirectional</em> authentication</li>
+ * <li>{@link NativeJavaSeBootstrapExample} - Custom (non-portable) properties (using Jersey's Grizzly2 backend)</li>
+ * <li>{@link PropertyProviderJavaSeBootstrapExample} - Bulk-loading configuration using a property provider (using
+ * Microprofile Config <em>explicitly</em>, hence in a non-optional, portable way)
+ * <li>{@link ExternalConfigJavaSeBootstrapExample} - Bulk-loading configuration from external configuration mechanics
+ * (using Microprofile Config <em>implicitly</em>, hence in an optional, <em>not necessarily</em> portable way)
  * </ul>
  *
  *

--- a/examples/src/main/java/jaxrs/examples/client/BasicExamples.java
+++ b/examples/src/main/java/jaxrs/examples/client/BasicExamples.java
@@ -92,7 +92,7 @@ public class BasicExamples {
     public void creatingResourceAndSubResourceUris() {
         // Target( http://jaxrs.examples.org/jaxrsApplication/customers/ )
         WebTarget customersUri = ClientBuilder.newClient()
-                                              .target("http://jaxrs.examples.org/jaxrsApplication/customers");
+                .target("http://jaxrs.examples.org/jaxrsApplication/customers");
         // Target( http://jaxrs.examples.org/jaxrsApplication/customers/{id}/ )
         WebTarget anyCustomerUri = customersUri.path("{id}");
         // Target( http://jaxrs.examples.org/jaxrsApplication/customers/123/ )
@@ -105,19 +105,17 @@ public class BasicExamples {
         final Client client = ClientBuilder.newClient();
 
         Response response = client.target("http://jaxrs.examples.org/jaxrsApplication/customers")
-                                  .request(MediaType.APPLICATION_XML).header("Foo", "Bar").get();
+                .request(MediaType.APPLICATION_XML).header("Foo", "Bar").get();
         assert response.getStatus() == 200;
     }
 
     public void autoCloseableResponse() {
         final Client client = ClientBuilder.newClient();
 
-        try (Response response =
-                     client.target("http://jaxrs.examples.org/jaxrsApplication/customers")
-                           .request(MediaType.APPLICATION_XML)
-                           .header("Foo", "Bar")
-                           .get();
-        ) {
+        try (Response response = client.target("http://jaxrs.examples.org/jaxrsApplication/customers")
+                .request(MediaType.APPLICATION_XML)
+                .header("Foo", "Bar")
+                .get();) {
             assert response.getStatus() == 200;
         }
     }
@@ -126,8 +124,8 @@ public class BasicExamples {
         final SSLContext sslContext = null;
         // ...initialize SSL context...
         final Client client = ClientBuilder.newBuilder()
-                                           .sslContext(sslContext)
-                                           .build();
+                .sslContext(sslContext)
+                .build();
 
         assert client != null;
     }
@@ -146,7 +144,7 @@ public class BasicExamples {
         Response response;
 
         final WebTarget customersUri = ClientBuilder.newClient()
-                                                    .target("http://jaxrs.examples.org/jaxrsApplication/customers");
+                .target("http://jaxrs.examples.org/jaxrsApplication/customers");
 
         response = customersUri.path("{id}").resolveTemplate("id", 123).request().get();
         customer = response.readEntity(Customer.class);
@@ -158,22 +156,22 @@ public class BasicExamples {
 
     public void typedResponse() {
         Customer customer = ClientBuilder.newClient()
-                                         .target("http://jaxrs.examples.org/jaxrsApplication/customers/{id}")
-                                         .resolveTemplate("id", 123).request().get(Customer.class);
+                .target("http://jaxrs.examples.org/jaxrsApplication/customers/{id}")
+                .resolveTemplate("id", 123).request().get(Customer.class);
         assert customer != null;
     }
 
     public void typedGenericResponse() {
         List<Customer> customers = ClientBuilder.newClient()
-                                                .target("http://jaxrs.examples.org/jaxrsApplication/customers")
-                                                .request().get(new GenericType<List<Customer>>() {
+                .target("http://jaxrs.examples.org/jaxrsApplication/customers")
+                .request().get(new GenericType<List<Customer>>() {
                 });
         assert customers != null;
     }
 
     public void responseUsingSubResourceClient() {
         WebTarget customersUri = ClientBuilder.newClient()
-                                              .target("http://jaxrs.examples.org/jaxrsApplication/customers");
+                .target("http://jaxrs.examples.org/jaxrsApplication/customers");
         WebTarget customer = customersUri.path("{id}");
 
         // Create a customer
@@ -194,8 +192,8 @@ public class BasicExamples {
 
     public void asyncResponse() throws Exception {
         Future<Response> future = ClientBuilder.newClient()
-                                               .target("http://jaxrs.examples.org/jaxrsApplication/customers/{id}")
-                                               .resolveTemplate("id", 123).request().async().get();
+                .target("http://jaxrs.examples.org/jaxrsApplication/customers/{id}")
+                .resolveTemplate("id", 123).request().async().get();
 
         Response response = future.get();
         Customer customer = response.readEntity(Customer.class);
@@ -204,8 +202,8 @@ public class BasicExamples {
 
     public void typedAsyncResponse() throws Exception {
         Future<Customer> customer = ClientBuilder.newClient()
-                                                 .target("http://jaxrs.examples.org/jaxrsApplication/customers/{id}")
-                                                 .resolveTemplate("id", 123).request().async().get(Customer.class);
+                .target("http://jaxrs.examples.org/jaxrsApplication/customers/{id}")
+                .resolveTemplate("id", 123).request().async().get(Customer.class);
         assert customer.get() != null;
     }
 
@@ -247,7 +245,7 @@ public class BasicExamples {
 
         // invoke a request in background
         Future<Customer> handle = anyCustomerUri.resolveTemplate("id", 123) // Target
-                                                .request().async().get(new InvocationCallback<Customer>() {
+                .request().async().get(new InvocationCallback<Customer>() {
                     @Override
                     public void completed(Customer customer) {
                         // do something
@@ -262,22 +260,22 @@ public class BasicExamples {
 
         // invoke another request in background
         anyCustomerUri.resolveTemplate("id", 456) // Target
-                      .request().async().get(new InvocationCallback<Response>() {
+                .request().async().get(new InvocationCallback<Response>() {
 
-            @Override
-            public void completed(Response customer) {
-                // do something
-            }
+                    @Override
+                    public void completed(Response customer) {
+                        // do something
+                    }
 
-            @Override
-            public void failed(Throwable throwable) {
-                // do something
-            }
-        });
+                    @Override
+                    public void failed(Throwable throwable) {
+                        // do something
+                    }
+                });
 
         // invoke one more request using newClient
         Future<Response> response = anyCustomerUri.resolveTemplate("id", 789)
-                                                  .request().cookie(new Cookie("fooName", "XYZ")).async().get();
+                .request().cookie(new Cookie("fooName", "XYZ")).async().get();
         assert response.get() != null;
     }
 
@@ -301,7 +299,6 @@ public class BasicExamples {
         client.target("http://examples.jaxrs.com/").request().buildPut(text("Hi")).invoke();
         client.target("http://examples.jaxrs.com/").request("text/plain").buildGet().submit();
 
-
         client.target("http://examples.jaxrs.com/").path("123").request("text/plain").get();
         client.target("http://examples.jaxrs.com/").path("123").request("text/plain").async().get();
         client.target("http://examples.jaxrs.com/").path("123").request("text/plain").buildGet().invoke();
@@ -313,23 +310,23 @@ public class BasicExamples {
         client.target("http://examples.jaxrs.com/").path("123").request("text/plain").buildGet().submit();
 
         client.target("http://examples.jaxrs.com/").path("123").request("text/plain")
-              .header("custom-name", "custom_value").get();
+                .header("custom-name", "custom_value").get();
         client.target("http://examples.jaxrs.com/").path("123").request("text/plain")
-              .header("custom-name", "custom_value").async().get();
+                .header("custom-name", "custom_value").async().get();
         client.target("http://examples.jaxrs.com/").path("123").request("text/plain")
-              .header("custom-name", "custom_value").buildGet().invoke();
+                .header("custom-name", "custom_value").buildGet().invoke();
         client.target("http://examples.jaxrs.com/").path("123").request("text/plain")
-              .header("custom-name", "custom_value").buildGet().submit();
+                .header("custom-name", "custom_value").buildGet().submit();
 
         // POSTing Forms
         client.target("http://examples.jaxrs.com/").path("123").request(MediaType.APPLICATION_JSON)
-              .post(form(new Form("param1", "a").param("param2", "b")));
+                .post(form(new Form("param1", "a").param("param2", "b")));
 
         MultivaluedMap<String, String> formData = new MultivaluedHashMap<String, String>();
         formData.add("param1", "a");
         formData.add("param2", "b");
         client.target("http://examples.jaxrs.com/").path("123").request(MediaType.APPLICATION_JSON)
-              .post(form(formData));
+                .post(form(formData));
 
         // Configuration
         TestFeature testFeature = new TestFeature();
@@ -342,12 +339,12 @@ public class BasicExamples {
     public void invocationFlexibility() {
         // For users who really need it...
         Invocation i = ClientBuilder.newClient()
-                                    .target("http://examples.jaxrs.com/greeting")
-                                    .request("text/plain")
-                                    .header("custom-name", "custom_value")
-                                    .buildPut(text("Hi"));
+                .target("http://examples.jaxrs.com/greeting")
+                .request("text/plain")
+                .header("custom-name", "custom_value")
+                .buildPut(text("Hi"));
 
-        i.invoke();                                              // Ok, now I can send the updated request
+        i.invoke(); // Ok, now I can send the updated request
     }
 
     public static class MyProvider implements ReaderInterceptor, WriterInterceptor, ContainerRequestFilter {
@@ -359,7 +356,7 @@ public class BasicExamples {
 
         @Override
         public Object aroundReadFrom(ReaderInterceptorContext context) throws IOException, WebApplicationException {
-            return null;  // TODO: implement method.
+            return null; // TODO: implement method.
         }
 
         @Override
@@ -382,9 +379,9 @@ public class BasicExamples {
         ScheduledExecutorService scheduledExecutorService = Executors.newScheduledThreadPool(256);
 
         Client client = ClientBuilder.newBuilder()
-                                     .executorService(executorService)
-                                     .scheduledExecutorService(scheduledExecutorService)
-                                     .build();
+                .executorService(executorService)
+                .scheduledExecutorService(scheduledExecutorService)
+                .build();
     }
 
     public void responseStatus20() {
@@ -393,10 +390,13 @@ public class BasicExamples {
         Response response = client.target("https://github.com/jax-rs/").request().get();
 
         switch (response.getStatus()) {
-            case 200: return;
-            case 201: return;
-            case 404: return;
-            case 500:
+        case 200:
+            return;
+        case 201:
+            return;
+        case 404:
+            return;
+        case 500:
         }
     }
 
@@ -406,10 +406,13 @@ public class BasicExamples {
         Response response = client.target("https://github.com/jax-rs/").request().get();
 
         switch (response.getStatusInfo().toEnum()) {
-            case OK: return;
-            case CREATED: return;
-            case NOT_FOUND: return;
-            case INTERNAL_SERVER_ERROR:
+        case OK:
+            return;
+        case CREATED:
+            return;
+        case NOT_FOUND:
+            return;
+        case INTERNAL_SERVER_ERROR:
         }
     }
 }

--- a/examples/src/main/java/jaxrs/examples/client/cache/CacheEntryLocator.java
+++ b/examples/src/main/java/jaxrs/examples/client/cache/CacheEntryLocator.java
@@ -42,8 +42,7 @@ public class CacheEntryLocator implements ClientRequestFilter {
             CacheEntry cacheEntry = cache.get(request.getUri().toString());
 
             if (cacheEntry != null) {
-                Response.ResponseBuilder responseBuilder =
-                        Response.status(cacheEntry.getStatus()).entity(new ByteArrayInputStream(cacheEntry.getBody()));
+                Response.ResponseBuilder responseBuilder = Response.status(cacheEntry.getStatus()).entity(new ByteArrayInputStream(cacheEntry.getBody()));
 
                 for (Map.Entry<String, List<String>> mapEntry : cacheEntry.getHeaders().entrySet()) {
                     for (String value : mapEntry.getValue()) {

--- a/examples/src/main/java/jaxrs/examples/client/custom/ThrottledClient.java
+++ b/examples/src/main/java/jaxrs/examples/client/custom/ThrottledClient.java
@@ -33,7 +33,7 @@ import javax.net.ssl.SSLContext;
  */
 public final class ThrottledClient implements Client {
 
-    @SuppressWarnings({"FieldCanBeLocal", "UnusedDeclaration", "MismatchedQueryAndUpdateOfCollection"})
+    @SuppressWarnings({ "FieldCanBeLocal", "UnusedDeclaration", "MismatchedQueryAndUpdateOfCollection" })
     private final BlockingQueue<ClientRequestContext> requestQueue;
 
     public ThrottledClient() {

--- a/examples/src/main/java/jaxrs/examples/client/validator/ValidatorExample.java
+++ b/examples/src/main/java/jaxrs/examples/client/validator/ValidatorExample.java
@@ -22,7 +22,7 @@ import javax.validation.Payload;
 
 public class ValidatorExample {
 
-    @java.lang.annotation.Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+    @java.lang.annotation.Target({ ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
     @Retention(RetentionPolicy.RUNTIME)
     @Constraint(validatedBy = EmailValidator.class)
     public @interface Email {

--- a/examples/src/main/java/jaxrs/examples/filter/compression/Gzipped.java
+++ b/examples/src/main/java/jaxrs/examples/filter/compression/Gzipped.java
@@ -21,7 +21,7 @@ import javax.ws.rs.NameBinding;
  * @author Santiago Pericas-Geertsen
  */
 @NameBinding
-@Target({ElementType.TYPE, ElementType.METHOD})
+@Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(value = RetentionPolicy.RUNTIME)
 public @interface Gzipped {
 }

--- a/examples/src/main/java/jaxrs/examples/filter/logging/DynamicLoggingFilterFeature.java
+++ b/examples/src/main/java/jaxrs/examples/filter/logging/DynamicLoggingFilterFeature.java
@@ -17,9 +17,8 @@ import javax.ws.rs.core.FeatureContext;
 import javax.ws.rs.ext.Provider;
 
 /**
- * Dynamic feature for a enabling a logging request/response post-matching filter
- * that dynamically decides to bind the logging filter only to GET processing
- * resource methods on all subclasses of {@link MyResourceClass} and the
+ * Dynamic feature for a enabling a logging request/response post-matching filter that dynamically decides to bind the
+ * logging filter only to GET processing resource methods on all subclasses of {@link MyResourceClass} and the
  * {@code MyResourceClass} itself.
  *
  * @author Santiago Pericas-Geertsen

--- a/examples/src/main/java/jaxrs/examples/filter/logging/Logged.java
+++ b/examples/src/main/java/jaxrs/examples/filter/logging/Logged.java
@@ -21,7 +21,7 @@ import javax.ws.rs.NameBinding;
  * @author Santiago Pericas-Geertsen
  */
 @NameBinding
-@Target({ElementType.TYPE, ElementType.METHOD})
+@Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(value = RetentionPolicy.RUNTIME)
 public @interface Logged {
 }

--- a/examples/src/main/java/jaxrs/examples/link/LinkExamples.java
+++ b/examples/src/main/java/jaxrs/examples/link/LinkExamples.java
@@ -48,8 +48,7 @@ public class LinkExamples {
     }
 
     /**
-     * 1-step process: Build Response and add a link directly to it
-     * using either a String or a URI.
+     * 1-step process: Build Response and add a link directly to it using either a String or a URI.
      *
      * @return response.
      * @throws URISyntaxException
@@ -57,7 +56,7 @@ public class LinkExamples {
     public Response example3() throws URISyntaxException {
         Response r;
         r = Response.ok().link("http://foo.bar/employee/john", "manager").build();
-        r = Response.ok().link(new URI("http://foo.bar/employee/john"),"manager").build();
+        r = Response.ok().link(new URI("http://foo.bar/employee/john"), "manager").build();
         return r;
     }
 }

--- a/examples/src/main/java/jaxrs/examples/link/ResourceExample.java
+++ b/examples/src/main/java/jaxrs/examples/link/ResourceExample.java
@@ -34,7 +34,7 @@ public class ResourceExample {
     private UriInfo uriInfo;
 
     @GET
-    @Produces({"application/xml", "application/json"})
+    @Produces({ "application/xml", "application/json" })
     public MyModel getIt() {
         Link self = Link.fromMethod(getClass(), "getIt").baseUri(uriInfo.getBaseUri())
                 .rel("self").buildRelativized(uriInfo.getRequestUri());

--- a/examples/src/main/java/jaxrs/examples/link/clusterservice/Cluster.java
+++ b/examples/src/main/java/jaxrs/examples/link/clusterservice/Cluster.java
@@ -23,7 +23,9 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlRootElement
 public class Cluster {
 
-    public enum Status {OFFLINE, ONLINE};
+    public enum Status {
+        OFFLINE, ONLINE
+    };
 
     private String name;
 

--- a/examples/src/main/java/jaxrs/examples/link/clusterservice/ClusterResource.java
+++ b/examples/src/main/java/jaxrs/examples/link/clusterservice/ClusterResource.java
@@ -37,14 +37,14 @@ public class ClusterResource {
     private Cluster cluster = Model.getCluster();
 
     @GET
-    @Produces({"application/json"})
+    @Produces({ "application/json" })
     public Response self() {
         return Response.ok(cluster).links(getTransitionalLinks()).build();
     }
 
     @POST
     @Path("onliner")
-    @Produces({"application/json"})
+    @Produces({ "application/json" })
     public Response onliner() {
         cluster.setStatus(Status.ONLINE);
         return Response.ok(cluster).links(getTransitionalLinks()).build();
@@ -52,7 +52,7 @@ public class ClusterResource {
 
     @POST
     @Path("offliner")
-    @Produces({"application/json"})
+    @Produces({ "application/json" })
     public Response offliner() {
         cluster.setStatus(Status.OFFLINE);
         return Response.ok(cluster).links(getTransitionalLinks()).build();
@@ -66,8 +66,7 @@ public class ClusterResource {
         Link onliner = Link.fromMethod(getClass(), "onliner").baseUri(baseUri).rel("onliner").buildRelativized(uri);
         Link offliner = Link.fromMethod(getClass(), "offliner").baseUri(baseUri).rel("offliner").buildRelativized(uri);
 
-        return cluster.getStatus() == Status.ONLINE ?
-                new Link[]{self, item, offliner} : new Link[]{self, item, onliner};
+        return cluster.getStatus() == Status.ONLINE ? new Link[] { self, item, offliner } : new Link[] { self, item, onliner };
     }
 
 }

--- a/examples/src/main/java/jaxrs/examples/link/clusterservice/Machine.java
+++ b/examples/src/main/java/jaxrs/examples/link/clusterservice/Machine.java
@@ -20,7 +20,9 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlRootElement
 public class Machine {
 
-    public enum Status {STOPPED, STARTED, SUSPENDED}
+    public enum Status {
+        STOPPED, STARTED, SUSPENDED
+    }
 
     ;
 

--- a/examples/src/main/java/jaxrs/examples/link/clusterservice/MachineResource.java
+++ b/examples/src/main/java/jaxrs/examples/link/clusterservice/MachineResource.java
@@ -39,7 +39,7 @@ public class MachineResource {
     private Machine machine;
 
     @GET
-    @Produces({"application/json"})
+    @Produces({ "application/json" })
     public Response self(@PathParam("name") String name) {
         machine = getMachine(name);
         return Response.ok(machine).links(getTransitionalLinks()).build();
@@ -47,7 +47,7 @@ public class MachineResource {
 
     @POST
     @Path("starter")
-    @Produces({"application/json"})
+    @Produces({ "application/json" })
     public Response starter(@PathParam("name") String name) {
         machine = getMachine(name);
         machine.setStatus(Status.STARTED);
@@ -56,7 +56,7 @@ public class MachineResource {
 
     @POST
     @Path("stopper")
-    @Produces({"application/json"})
+    @Produces({ "application/json" })
     public Response stopper(@PathParam("name") String name) {
         machine = getMachine(name);
         machine.setStatus(Status.STOPPED);
@@ -65,7 +65,7 @@ public class MachineResource {
 
     @POST
     @Path("suspender")
-    @Produces({"application/json"})
+    @Produces({ "application/json" })
     public Response suspender(@PathParam("name") String name) {
         machine = getMachine(name);
         machine.setStatus(Status.SUSPENDED);
@@ -95,14 +95,14 @@ public class MachineResource {
                 .rel("suspender").buildRelativized(uri, name);
 
         switch (machine.getStatus()) {
-            case STOPPED:
-                return new Link[]{self, starter};
-            case STARTED:
-                return new Link[]{self, stopper, suspender};
-            case SUSPENDED:
-                return new Link[]{self, starter};
-            default:
-                throw new IllegalStateException();
+        case STOPPED:
+            return new Link[] { self, starter };
+        case STARTED:
+            return new Link[] { self, stopper, suspender };
+        case SUSPENDED:
+            return new Link[] { self, starter };
+        default:
+            throw new IllegalStateException();
         }
     }
 }

--- a/examples/src/main/java/jaxrs/examples/rc/FruitsResource.java
+++ b/examples/src/main/java/jaxrs/examples/rc/FruitsResource.java
@@ -41,7 +41,7 @@ public class FruitsResource {
         private String fruitName;
         private final String taste;
 
-        public TasteResource( String taste) {
+        public TasteResource(String taste) {
             this.taste = taste;
         }
 

--- a/examples/src/main/java/jaxrs/examples/sse/ItemStoreResource.java
+++ b/examples/src/main/java/jaxrs/examples/sse/ItemStoreResource.java
@@ -61,8 +61,7 @@ public class ItemStoreResource {
         this.sse = sse;
         this.broadcaster = sse.newBroadcaster();
 
-        broadcaster.onError((subscriber, e) ->
-                LOGGER.log(Level.WARNING, "An exception has been thrown while broadcasting to an event output.", e));
+        broadcaster.onError((subscriber, e) -> LOGGER.log(Level.WARNING, "An exception has been thrown while broadcasting to an event output.", e));
 
         broadcaster.onClose(subscriber -> LOGGER.log(Level.INFO, "SSE event output has been closed."));
     }
@@ -92,10 +91,8 @@ public class ItemStoreResource {
      * <ul>
      * <li><b>disconnect</b> - disconnect all registered event streams.</li>
      * <li><b>reconnect now</b> - enable client reconnecting.</li>
-     * <li><b>reconnect &lt;seconds&gt;</b> - disable client reconnecting.
-     * Reconnecting clients will receive a HTTP 503 response with
-     * {@value javax.ws.rs.core.HttpHeaders#RETRY_AFTER} set to the amount of
-     * milliseconds specified.</li>
+     * <li><b>reconnect &lt;seconds&gt;</b> - disable client reconnecting. Reconnecting clients will receive a HTTP 503
+     * response with {@value javax.ws.rs.core.HttpHeaders#RETRY_AFTER} set to the amount of milliseconds specified.</li>
      * </ul>
      *
      * @param command command to be processed.
@@ -128,11 +125,11 @@ public class ItemStoreResource {
     /**
      * Connect or re-connect to SSE event stream.
      *
-     * @param lastEventId Value of custom SSE HTTP <tt>{@value javax.ws.rs.core.HttpHeaders#LAST_EVENT_ID_HEADER}</tt> header.
-     *                    Defaults to {@code -1} if not set.
+     * @param lastEventId Value of custom SSE HTTP <tt>{@value javax.ws.rs.core.HttpHeaders#LAST_EVENT_ID_HEADER}</tt>
+     * header. Defaults to {@code -1} if not set.
      * @param serverSink new SSE server sink stream representing the (re-)established SSE client connection.
      * @throws InternalServerErrorException in case replaying missed events to the reconnected output stream fails.
-     * @throws ServiceUnavailableException  in case the reconnect delay is set to a positive value.
+     * @throws ServiceUnavailableException in case the reconnect delay is set to a positive value.
      */
     @GET
     @Path("events")
@@ -211,7 +208,7 @@ public class ItemStoreResource {
 
     private OutboundSseEvent createItemEvent(final int eventId, final String name) {
         Logger.getLogger(ItemStoreResource.class.getName())
-              .info("Creating event id [" + eventId + "] name [" + name + "]");
+                .info("Creating event id [" + eventId + "] name [" + name + "]");
         return sse.newEventBuilder().id("" + eventId).data(String.class, name).build();
     }
 }

--- a/examples/src/main/java/jaxrs/examples/sse/ServerSentEventsResource.java
+++ b/examples/src/main/java/jaxrs/examples/sse/ServerSentEventsResource.java
@@ -80,12 +80,12 @@ public class ServerSentEventsResource {
     @Path("domains/{id}")
     @Produces(MediaType.SERVER_SENT_EVENTS)
     public void startDomain(@PathParam("id") final String id,
-                            @Context SseEventSink eventSink) {
+            @Context SseEventSink eventSink) {
 
         executorService.submit(() -> {
             try {
                 eventSink.send(sse.newEventBuilder().name("domain-progress")
-                                  .data(String.class, "starting domain " + id + " ...").build());
+                        .data(String.class, "starting domain " + id + " ...").build());
                 Thread.sleep(200);
                 eventSink.send(sse.newEvent("domain-progress", "50%"));
                 Thread.sleep(200);

--- a/examples/src/main/java/jaxrs/examples/sse/SseClient.java
+++ b/examples/src/main/java/jaxrs/examples/sse/SseClient.java
@@ -32,9 +32,8 @@ public class SseClient {
 
         // EventSource#register(Consumer<InboundSseEvent>)
         // consumes all events, writes then on standard out (System.out::println)
-        try (final SseEventSource eventSource =
-                     SseEventSource.target(target)
-                                   .build()) {
+        try (final SseEventSource eventSource = SseEventSource.target(target)
+                .build()) {
 
             eventSource.register(System.out::println);
             eventSource.open();

--- a/jaxrs-api/src/main/java/javax/ws/rs/ApplicationPath.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ApplicationPath.java
@@ -23,12 +23,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Identifies the application path that serves as the base URI
- * for all resource URIs provided by {@link javax.ws.rs.Path}. May only be
- * applied to a subclass of {@link javax.ws.rs.core.Application}.
+ * Identifies the application path that serves as the base URI for all resource URIs provided by
+ * {@link javax.ws.rs.Path}. May only be applied to a subclass of {@link javax.ws.rs.core.Application}.
  *
- * <p>When published in a Servlet container, the value of the application path
- * may be overridden using a servlet-mapping element in the web.xml.</p>
+ * <p>
+ * When published in a Servlet container, the value of the application path may be overridden using a servlet-mapping
+ * element in the web.xml.
+ * </p>
  *
  * @author Paul Sandoz
  * @author Marc Hadley
@@ -37,21 +38,20 @@ import java.lang.annotation.Target;
  * @since 1.1
  */
 @Documented
-@Target({ElementType.TYPE})
+@Target({ ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ApplicationPath {
 
     /**
-     * Defines the base URI for all resource URIs. A trailing '/' character will
-     * be automatically appended if one is not present.
+     * Defines the base URI for all resource URIs. A trailing '/' character will be automatically appended if one is not
+     * present.
      *
-     * <p>The supplied value is automatically percent
-     * encoded to conform to the {@code path} production of
-     * <a href="http://tools.ietf.org/html/rfc3986#section-3.3">RFC 3986 section 3.3</a>.
-     * Note that percent encoded values are allowed in the value, an
-     * implementation will recognize such values and will not double
-     * encode the '%' character.</p>
-     * 
+     * <p>
+     * The supplied value is automatically percent encoded to conform to the {@code path} production of
+     * <a href="http://tools.ietf.org/html/rfc3986#section-3.3">RFC 3986 section 3.3</a>. Note that percent encoded values
+     * are allowed in the value, an implementation will recognize such values and will not double encode the '%' character.
+     * </p>
+     *
      * @return base URI.
      */
     String value();

--- a/jaxrs-api/src/main/java/javax/ws/rs/BadRequestException.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/BadRequestException.java
@@ -19,8 +19,7 @@ package javax.ws.rs;
 import javax.ws.rs.core.Response;
 
 /**
- * A runtime exception indicating a {@link javax.ws.rs.core.Response.Status#BAD_REQUEST
- * bad client request}.
+ * A runtime exception indicating a {@link javax.ws.rs.core.Response.Status#BAD_REQUEST bad client request}.
  *
  * @author Sergey Beryozkin
  * @author Marek Potociar
@@ -40,8 +39,7 @@ public class BadRequestException extends ClientErrorException {
     /**
      * Construct a new bad client request exception.
      *
-     * @param message the detail message (which is saved for later retrieval
-     *                by the {@link #getMessage()} method).
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
      */
     public BadRequestException(final String message) {
         super(message, Response.Status.BAD_REQUEST);
@@ -51,8 +49,7 @@ public class BadRequestException extends ClientErrorException {
      * Construct a new bad client request exception.
      *
      * @param response error response.
-     * @throws IllegalArgumentException in case the status code set in the response
-     *                                  is not HTTP {@code 400}.
+     * @throws IllegalArgumentException in case the status code set in the response is not HTTP {@code 400}.
      */
     public BadRequestException(final Response response) {
         super(validate(response, Response.Status.BAD_REQUEST));
@@ -61,11 +58,9 @@ public class BadRequestException extends ClientErrorException {
     /**
      * Construct a new bad client request exception.
      *
-     * @param message  the detail message (which is saved for later retrieval
-     *                 by the {@link #getMessage()} method).
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
      * @param response error response.
-     * @throws IllegalArgumentException in case the status code set in the response
-     *                                  is not HTTP {@code 400}.
+     * @throws IllegalArgumentException in case the status code set in the response is not HTTP {@code 400}.
      */
     public BadRequestException(final String message, final Response response) {
         super(message, validate(response, Response.Status.BAD_REQUEST));
@@ -83,9 +78,8 @@ public class BadRequestException extends ClientErrorException {
     /**
      * Construct a new bad client request exception.
      *
-     * @param message the detail message (which is saved for later retrieval
-     *                by the {@link #getMessage()} method).
-     * @param cause   the underlying cause of the exception.
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param cause the underlying cause of the exception.
      */
     public BadRequestException(final String message, final Throwable cause) {
         super(message, Response.Status.BAD_REQUEST, cause);
@@ -95,9 +89,8 @@ public class BadRequestException extends ClientErrorException {
      * Construct a new bad client request exception.
      *
      * @param response error response.
-     * @param cause    the underlying cause of the exception.
-     * @throws IllegalArgumentException in case the status code set in the response
-     *                                  is not HTTP {@code 400}.
+     * @param cause the underlying cause of the exception.
+     * @throws IllegalArgumentException in case the status code set in the response is not HTTP {@code 400}.
      */
     public BadRequestException(final Response response, final Throwable cause) {
         super(validate(response, Response.Status.BAD_REQUEST), cause);
@@ -106,12 +99,10 @@ public class BadRequestException extends ClientErrorException {
     /**
      * Construct a new bad client request exception.
      *
-     * @param message  the detail message (which is saved for later retrieval
-     *                 by the {@link #getMessage()} method).
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
      * @param response error response.
-     * @param cause    the underlying cause of the exception.
-     * @throws IllegalArgumentException in case the status code set in the response
-     *                                  is not HTTP {@code 400}.
+     * @param cause the underlying cause of the exception.
+     * @throws IllegalArgumentException in case the status code set in the response is not HTTP {@code 400}.
      */
     public BadRequestException(final String message, final Response response, final Throwable cause) {
         super(message, validate(response, Response.Status.BAD_REQUEST), cause);

--- a/jaxrs-api/src/main/java/javax/ws/rs/BeanParam.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/BeanParam.java
@@ -23,16 +23,16 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * The annotation that may be used to inject custom JAX-RS "parameter aggregator" value object
- * into a resource class field, property or resource method parameter.
+ * The annotation that may be used to inject custom JAX-RS "parameter aggregator" value object into a resource class
+ * field, property or resource method parameter.
  * <p>
- * The JAX-RS runtime will instantiate the object and inject all it's fields and properties annotated
- * with either one of the {@code @XxxParam} annotation ({@link PathParam &#64;PathParam},
- * {@link FormParam &#64;FormParam} ...) or the {@link javax.ws.rs.core.Context &#64;Context}
- * annotation. For the POJO classes same instantiation and injection rules apply as in case of instantiation
- * and injection of request-scoped root resource classes.
+ * The JAX-RS runtime will instantiate the object and inject all it's fields and properties annotated with either one of
+ * the {@code @XxxParam} annotation ({@link PathParam &#64;PathParam}, {@link FormParam &#64;FormParam} ...) or the
+ * {@link javax.ws.rs.core.Context &#64;Context} annotation. For the POJO classes same instantiation and injection rules
+ * apply as in case of instantiation and injection of request-scoped root resource classes.
  * </p>
  * For example:
+ *
  * <PRE>
  * public class MyBean {
  *   &#64;FormParam("myData")
@@ -57,16 +57,15 @@ import java.lang.annotation.Target;
  * }
  * </PRE>
  * <p>
- * Because injection occurs at object creation time, use of this annotation on resource
- * class fields and bean properties is only supported for the default per-request resource
- * class lifecycle. Resource classes using other lifecycles should only use this annotation
- * on resource method parameters.
+ * Because injection occurs at object creation time, use of this annotation on resource class fields and bean properties
+ * is only supported for the default per-request resource class lifecycle. Resource classes using other lifecycles
+ * should only use this annotation on resource method parameters.
  * </p>
  *
  * @author Marek Potociar
  * @since 2.0
  */
-@Target({ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD})
+@Target({ ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface BeanParam {

--- a/jaxrs-api/src/main/java/javax/ws/rs/ClientErrorException.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ClientErrorException.java
@@ -19,8 +19,7 @@ package javax.ws.rs;
 import javax.ws.rs.core.Response;
 
 /**
- * A base runtime application exception indicating a client request error
- * (HTTP {@code 4xx} status codes).
+ * A base runtime application exception indicating a client request error (HTTP {@code 4xx} status codes).
  *
  * @author Marek Potociar
  * @since 2.0
@@ -34,23 +33,19 @@ public class ClientErrorException extends WebApplicationException {
      *
      * @param status client error status. Must be a {@code 4xx} status code.
      * @throws IllegalArgumentException in case the status code is {@code null} or is not from
-     *                                  {@link javax.ws.rs.core.Response.Status.Family#CLIENT_ERROR} status code
-     *                                  family.
+     * {@link javax.ws.rs.core.Response.Status.Family#CLIENT_ERROR} status code family.
      */
     public ClientErrorException(final Response.Status status) {
         super((Throwable) null, validate(Response.status(status).build(), Response.Status.Family.CLIENT_ERROR));
     }
 
-
     /**
      * Construct a new client error exception.
      *
-     * @param message the detail message (which is saved for later retrieval
-     *                by the {@link #getMessage()} method).
-     * @param status  client error status. Must be a {@code 4xx} status code.
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param status client error status. Must be a {@code 4xx} status code.
      * @throws IllegalArgumentException in case the status code is {@code null} or is not from
-     *                                  {@link javax.ws.rs.core.Response.Status.Family#CLIENT_ERROR} status code
-     *                                  family.
+     * {@link javax.ws.rs.core.Response.Status.Family#CLIENT_ERROR} status code family.
      */
     public ClientErrorException(final String message, final Response.Status status) {
         super(message, null, validate(Response.status(status).build(), Response.Status.Family.CLIENT_ERROR));
@@ -60,9 +55,8 @@ public class ClientErrorException extends WebApplicationException {
      * Construct a new client error exception.
      *
      * @param status client error status. Must be a {@code 4xx} status code.
-     * @throws IllegalArgumentException in case the status code is not a valid HTTP status code or
-     *                                  if it is not from the {@link javax.ws.rs.core.Response.Status.Family#CLIENT_ERROR}
-     *                                  status code family.
+     * @throws IllegalArgumentException in case the status code is not a valid HTTP status code or if it is not from the
+     * {@link javax.ws.rs.core.Response.Status.Family#CLIENT_ERROR} status code family.
      */
     public ClientErrorException(final int status) {
         super((Throwable) null, validate(Response.status(status).build(), Response.Status.Family.CLIENT_ERROR));
@@ -71,12 +65,10 @@ public class ClientErrorException extends WebApplicationException {
     /**
      * Construct a new client error exception.
      *
-     * @param message the detail message (which is saved for later retrieval
-     *                by the {@link #getMessage()} method).
-     * @param status  client error status. Must be a {@code 4xx} status code.
-     * @throws IllegalArgumentException in case the status code is not a valid HTTP status code or
-     *                                  if it is not from the {@link javax.ws.rs.core.Response.Status.Family#CLIENT_ERROR}
-     *                                  status code family.
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param status client error status. Must be a {@code 4xx} status code.
+     * @throws IllegalArgumentException in case the status code is not a valid HTTP status code or if it is not from the
+     * {@link javax.ws.rs.core.Response.Status.Family#CLIENT_ERROR} status code family.
      */
     public ClientErrorException(final String message, final int status) {
         super(message, null, validate(Response.status(status).build(), Response.Status.Family.CLIENT_ERROR));
@@ -85,10 +77,9 @@ public class ClientErrorException extends WebApplicationException {
     /**
      * Construct a new client error exception.
      *
-     * @param response client error response. Must have a status code set to a {@code 4xx}
-     *                 status code.
+     * @param response client error response. Must have a status code set to a {@code 4xx} status code.
      * @throws IllegalArgumentException in case the response status code is not from the
-     *                                  {@link javax.ws.rs.core.Response.Status.Family#CLIENT_ERROR} status code family.
+     * {@link javax.ws.rs.core.Response.Status.Family#CLIENT_ERROR} status code family.
      */
     public ClientErrorException(final Response response) {
         super((Throwable) null, validate(response, Response.Status.Family.CLIENT_ERROR));
@@ -97,12 +88,10 @@ public class ClientErrorException extends WebApplicationException {
     /**
      * Construct a new client error exception.
      *
-     * @param message  the detail message (which is saved for later retrieval
-     *                 by the {@link #getMessage()} method).
-     * @param response client error response. Must have a status code set to a {@code 4xx}
-     *                 status code.
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param response client error response. Must have a status code set to a {@code 4xx} status code.
      * @throws IllegalArgumentException in case the response status code is not from the
-     *                                  {@link javax.ws.rs.core.Response.Status.Family#CLIENT_ERROR} status code family.
+     * {@link javax.ws.rs.core.Response.Status.Family#CLIENT_ERROR} status code family.
      */
     public ClientErrorException(final String message, final Response response) {
         super(message, null, validate(response, Response.Status.Family.CLIENT_ERROR));
@@ -112,10 +101,9 @@ public class ClientErrorException extends WebApplicationException {
      * Construct a new client error exception.
      *
      * @param status client error status. Must be a {@code 4xx} status code.
-     * @param cause  the underlying cause of the exception.
+     * @param cause the underlying cause of the exception.
      * @throws IllegalArgumentException in case the status code is {@code null} or is not from
-     *                                  {@link javax.ws.rs.core.Response.Status.Family#CLIENT_ERROR} status code
-     *                                  family.
+     * {@link javax.ws.rs.core.Response.Status.Family#CLIENT_ERROR} status code family.
      */
     public ClientErrorException(final Response.Status status, final Throwable cause) {
         super(cause, validate(Response.status(status).build(), Response.Status.Family.CLIENT_ERROR));
@@ -124,13 +112,11 @@ public class ClientErrorException extends WebApplicationException {
     /**
      * Construct a new client error exception.
      *
-     * @param message the detail message (which is saved for later retrieval
-     *                by the {@link #getMessage()} method).
-     * @param status  client error status. Must be a {@code 4xx} status code.
-     * @param cause   the underlying cause of the exception.
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param status client error status. Must be a {@code 4xx} status code.
+     * @param cause the underlying cause of the exception.
      * @throws IllegalArgumentException in case the status code is {@code null} or is not from
-     *                                  {@link javax.ws.rs.core.Response.Status.Family#CLIENT_ERROR} status code
-     *                                  family.
+     * {@link javax.ws.rs.core.Response.Status.Family#CLIENT_ERROR} status code family.
      */
     public ClientErrorException(final String message, final Response.Status status, final Throwable cause) {
         super(message, cause, validate(Response.status(status).build(), Response.Status.Family.CLIENT_ERROR));
@@ -140,10 +126,9 @@ public class ClientErrorException extends WebApplicationException {
      * Construct a new client error exception.
      *
      * @param status client error status. Must be a {@code 4xx} status code.
-     * @param cause  the underlying cause of the exception.
-     * @throws IllegalArgumentException in case the status code is not a valid HTTP status code or
-     *                                  if it is not from the {@link javax.ws.rs.core.Response.Status.Family#CLIENT_ERROR}
-     *                                  status code family.
+     * @param cause the underlying cause of the exception.
+     * @throws IllegalArgumentException in case the status code is not a valid HTTP status code or if it is not from the
+     * {@link javax.ws.rs.core.Response.Status.Family#CLIENT_ERROR} status code family.
      */
     public ClientErrorException(final int status, final Throwable cause) {
         super(cause, validate(Response.status(status).build(), Response.Status.Family.CLIENT_ERROR));
@@ -152,13 +137,11 @@ public class ClientErrorException extends WebApplicationException {
     /**
      * Construct a new client error exception.
      *
-     * @param message the detail message (which is saved for later retrieval
-     *                by the {@link #getMessage()} method).
-     * @param status  client error status. Must be a {@code 4xx} status code.
-     * @param cause   the underlying cause of the exception.
-     * @throws IllegalArgumentException in case the status code is not a valid HTTP status code or
-     *                                  if it is not from the {@link javax.ws.rs.core.Response.Status.Family#CLIENT_ERROR}
-     *                                  status code family.
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param status client error status. Must be a {@code 4xx} status code.
+     * @param cause the underlying cause of the exception.
+     * @throws IllegalArgumentException in case the status code is not a valid HTTP status code or if it is not from the
+     * {@link javax.ws.rs.core.Response.Status.Family#CLIENT_ERROR} status code family.
      */
     public ClientErrorException(final String message, final int status, final Throwable cause) {
         super(message, cause, validate(Response.status(status).build(), Response.Status.Family.CLIENT_ERROR));
@@ -167,11 +150,10 @@ public class ClientErrorException extends WebApplicationException {
     /**
      * Construct a new client error exception.
      *
-     * @param response client error response. Must have a status code set to a {@code 4xx}
-     *                 status code.
-     * @param cause    the underlying cause of the exception.
+     * @param response client error response. Must have a status code set to a {@code 4xx} status code.
+     * @param cause the underlying cause of the exception.
      * @throws IllegalArgumentException in case the response status code is not from the
-     *                                  {@link javax.ws.rs.core.Response.Status.Family#CLIENT_ERROR} status code family.
+     * {@link javax.ws.rs.core.Response.Status.Family#CLIENT_ERROR} status code family.
      */
     public ClientErrorException(final Response response, final Throwable cause) {
         super(cause, validate(response, Response.Status.Family.CLIENT_ERROR));
@@ -180,13 +162,11 @@ public class ClientErrorException extends WebApplicationException {
     /**
      * Construct a new client error exception.
      *
-     * @param message  the detail message (which is saved for later retrieval
-     *                 by the {@link #getMessage()} method).
-     * @param response client error response. Must have a status code set to a {@code 4xx}
-     *                 status code.
-     * @param cause    the underlying cause of the exception.
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param response client error response. Must have a status code set to a {@code 4xx} status code.
+     * @param cause the underlying cause of the exception.
      * @throws IllegalArgumentException in case the response status code is not from the
-     *                                  {@link javax.ws.rs.core.Response.Status.Family#CLIENT_ERROR} status code family.
+     * {@link javax.ws.rs.core.Response.Status.Family#CLIENT_ERROR} status code family.
      */
     public ClientErrorException(final String message, final Response response, final Throwable cause) {
         super(message, cause, validate(response, Response.Status.Family.CLIENT_ERROR));

--- a/jaxrs-api/src/main/java/javax/ws/rs/ConstrainedTo.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ConstrainedTo.java
@@ -23,15 +23,14 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Indicates the run-time context in which an annotated JAX-RS provider
- * is applicable. If a {@code @ConstrainedTo} annotation is not
- * present on a JAX-RS provider type declaration, the declared provider
- * may be used in any run-time context. If such a annotation is present,
- * the JAX-RS runtime will enforce the specified usage restriction.
+ * Indicates the run-time context in which an annotated JAX-RS provider is applicable. If a {@code @ConstrainedTo}
+ * annotation is not present on a JAX-RS provider type declaration, the declared provider may be used in any run-time
+ * context. If such a annotation is present, the JAX-RS runtime will enforce the specified usage restriction.
  * <p>
- * The following example illustrates restricting a {@link javax.ws.rs.ext.MessageBodyReader}
- * provider implementation to run only as part of a {@link RuntimeType#CLIENT JAX-RS client run-time}:
+ * The following example illustrates restricting a {@link javax.ws.rs.ext.MessageBodyReader} provider implementation to
+ * run only as part of a {@link RuntimeType#CLIENT JAX-RS client run-time}:
  * </p>
+ *
  * <pre>
  *  &#064;ConstrainedTo(RuntimeType.CLIENT)
  *  public class MyReader implements MessageBodyReader {
@@ -39,9 +38,10 @@ import java.lang.annotation.Target;
  *  }
  * </pre>
  * <p>
- * The following example illustrates restricting a {@link javax.ws.rs.ext.WriterInterceptor}
- * provider implementation to run only as part of a {@link RuntimeType#SERVER JAX-RS server run-time}:
+ * The following example illustrates restricting a {@link javax.ws.rs.ext.WriterInterceptor} provider implementation to
+ * run only as part of a {@link RuntimeType#SERVER JAX-RS server run-time}:
  * </p>
+ *
  * <pre>
  *  &#064;ConstrainedTo(RuntimeType.SERVER)
  *  public class MyWriterInterceptor implements WriterInterceptor {
@@ -49,15 +49,15 @@ import java.lang.annotation.Target;
  *  }
  * </pre>
  * <p>
- * It is a configuration error to constraint a JAX-RS provider implementation to
- * a run-time context in which the provider cannot be applied. In such case a JAX-RS
- * runtime SHOULD inform a user about the issue and ignore the provider implementation in further
- * processing.
+ * It is a configuration error to constraint a JAX-RS provider implementation to a run-time context in which the
+ * provider cannot be applied. In such case a JAX-RS runtime SHOULD inform a user about the issue and ignore the
+ * provider implementation in further processing.
  * </p>
  * <p>
- * For example, the following restriction of a {@link javax.ws.rs.client.ClientRequestFilter}
- * to run only as part of a JAX-RS server run-time would be considered invalid:
+ * For example, the following restriction of a {@link javax.ws.rs.client.ClientRequestFilter} to run only as part of a
+ * JAX-RS server run-time would be considered invalid:
  * </p>
+ *
  * <pre>
  *  // reported as invalid and ignored by JAX-RS runtime
  *  &#064;ConstrainedTo(RuntimeType.SERVER)
@@ -76,9 +76,8 @@ public @interface ConstrainedTo {
 
     /**
      * Define the {@link RuntimeType constraint type} to be placed on a JAX-RS provider.
-     * 
+     *
      * @return applicable run-time context.
      */
     RuntimeType value();
 }
-

--- a/jaxrs-api/src/main/java/javax/ws/rs/Consumes.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/Consumes.java
@@ -24,14 +24,11 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Defines the media types that the methods of a resource class or
- * {@link javax.ws.rs.ext.MessageBodyReader} can accept. If
- * not specified, a container will assume that any media type is acceptable.
- * Method level annotations override a class level annotation. A container
- * is responsible for ensuring that the method invoked is capable of consuming
- * the media type of the HTTP request entity body. If no such method is
- * available the container must respond with a HTTP "415 Unsupported Media Type"
- * as specified by RFC 2616.
+ * Defines the media types that the methods of a resource class or {@link javax.ws.rs.ext.MessageBodyReader} can accept.
+ * If not specified, a container will assume that any media type is acceptable. Method level annotations override a
+ * class level annotation. A container is responsible for ensuring that the method invoked is capable of consuming the
+ * media type of the HTTP request entity body. If no such method is available the container must respond with a HTTP
+ * "415 Unsupported Media Type" as specified by RFC 2616.
  *
  * @author Paul Sandoz
  * @author Marc Hadley
@@ -39,21 +36,21 @@ import java.lang.annotation.Target;
  * @since 1.0
  */
 @Inherited
-@Target({ElementType.TYPE, ElementType.METHOD})
+@Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface Consumes {
 
     /**
-     * A list of media types. Each entry may specify a single type or consist
-     * of a comma separated list of types, with any leading or trailing white-spaces
-     * in a single type entry being ignored. For example:
+     * A list of media types. Each entry may specify a single type or consist of a comma separated list of types, with any
+     * leading or trailing white-spaces in a single type entry being ignored. For example:
+     *
      * <pre>
-     *  {"image/jpeg, image/gif ", " image/png"}
+     * { "image/jpeg, image/gif ", " image/png" }
      * </pre>
-     * Use of the comma-separated form allows definition of a common string constant
-     * for use on multiple targets.
-     * 
+     *
+     * Use of the comma-separated form allows definition of a common string constant for use on multiple targets.
+     *
      * @return media types to accept.
      */
     String[] value() default "*/*";

--- a/jaxrs-api/src/main/java/javax/ws/rs/CookieParam.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/CookieParam.java
@@ -23,32 +23,27 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Binds the value of a HTTP cookie to a resource method parameter,
- * resource class field, or resource class bean property.
- * A default value can be specified using the {@link DefaultValue}
- * annotation.
+ * Binds the value of a HTTP cookie to a resource method parameter, resource class field, or resource class bean
+ * property. A default value can be specified using the {@link DefaultValue} annotation.
  *
- * The type {@code T} of the annotated parameter, field or property must
- * either:
+ * The type {@code T} of the annotated parameter, field or property must either:
  * <ol>
  * <li>Be a primitive type</li>
  * <li>Be {@link javax.ws.rs.core.Cookie}</li>
  * <li>Have a constructor that accepts a single String argument</li>
- * <li>Have a static method named {@code valueOf} or {@code fromString}
- * that accepts a single String argument (see, for example, {@link Integer#valueOf(String)})</li>
- * <li>Have a registered implementation of {@link javax.ws.rs.ext.ParamConverterProvider}
- * JAX-RS extension SPI that returns a {@link javax.ws.rs.ext.ParamConverter}
- * instance capable of a "from string" conversion for the type.</li>
- * <li>Be {@code List<T>}, {@code Set<T>} or
- * {@code SortedSet<T>}, where {@code T} satisfies 2, 3, 4 or 5 above.
- * The resulting collection is read-only.</li>
+ * <li>Have a static method named {@code valueOf} or {@code fromString} that accepts a single String argument (see, for
+ * example, {@link Integer#valueOf(String)})</li>
+ * <li>Have a registered implementation of {@link javax.ws.rs.ext.ParamConverterProvider} JAX-RS extension SPI that
+ * returns a {@link javax.ws.rs.ext.ParamConverter} instance capable of a "from string" conversion for the type.</li>
+ * <li>Be {@code List<T>}, {@code Set<T>} or {@code SortedSet<T>}, where {@code T} satisfies 2, 3, 4 or 5 above. The
+ * resulting collection is read-only.</li>
  * </ol>
  *
- * <p>Because injection occurs at object creation time, use of this annotation
- * on resource class fields and bean properties is only supported for the
- * default per-request resource class lifecycle. Resource classes using
- * other lifecycles should only use this annotation on resource method
- * parameters.</p>
+ * <p>
+ * Because injection occurs at object creation time, use of this annotation on resource class fields and bean properties
+ * is only supported for the default per-request resource class lifecycle. Resource classes using other lifecycles
+ * should only use this annotation on resource method parameters.
+ * </p>
  *
  * @author Paul Sandoz
  * @author Marc Hadley
@@ -57,16 +52,15 @@ import java.lang.annotation.Target;
  * @see javax.ws.rs.core.HttpHeaders#getCookies
  * @since 1.0
  */
-@Target({ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD})
+@Target({ ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface CookieParam {
 
     /**
-     * Defines the name of the HTTP cookie whose value will be used
-     * to initialize the value of the annotated method argument, class field or
-     * bean property.
-     * 
+     * Defines the name of the HTTP cookie whose value will be used to initialize the value of the annotated method
+     * argument, class field or bean property.
+     *
      * @return HTTP cookie name.
      */
     String value();

--- a/jaxrs-api/src/main/java/javax/ws/rs/DELETE.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/DELETE.java
@@ -30,7 +30,7 @@ import java.lang.annotation.Target;
  * @see HttpMethod
  * @since 1.0
  */
-@Target({ElementType.METHOD})
+@Target({ ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @HttpMethod(HttpMethod.DELETE)
 @Documented

--- a/jaxrs-api/src/main/java/javax/ws/rs/DefaultValue.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/DefaultValue.java
@@ -23,26 +23,19 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Defines the default value of request meta-data that is bound using one of the
- * following annotations:
- * {@link javax.ws.rs.PathParam},
- * {@link javax.ws.rs.QueryParam},
- * {@link javax.ws.rs.MatrixParam},
- * {@link javax.ws.rs.CookieParam},
- * {@link javax.ws.rs.FormParam},
- * or {@link javax.ws.rs.HeaderParam}.
- * The default value is used if the corresponding meta-data is not present in the
- * request.
+ * Defines the default value of request meta-data that is bound using one of the following annotations:
+ * {@link javax.ws.rs.PathParam}, {@link javax.ws.rs.QueryParam}, {@link javax.ws.rs.MatrixParam},
+ * {@link javax.ws.rs.CookieParam}, {@link javax.ws.rs.FormParam}, or {@link javax.ws.rs.HeaderParam}. The default value
+ * is used if the corresponding meta-data is not present in the request.
  * <p>
- * If the type of the annotated parameter is {@link java.util.List},
- * {@link java.util.Set} or {@link java.util.SortedSet} then the resulting collection
- * will have a single entry mapped from the supplied default value.
+ * If the type of the annotated parameter is {@link java.util.List}, {@link java.util.Set} or
+ * {@link java.util.SortedSet} then the resulting collection will have a single entry mapped from the supplied default
+ * value.
  * </p>
  * <p>
- * If this annotation is not used and the corresponding meta-data is not
- * present in the request, the value will be an empty collection for
- * {@code List}, {@code Set} or {@code SortedSet}, {@code null} for
- * other object types, and the Java-defined default for primitive types.
+ * If this annotation is not used and the corresponding meta-data is not present in the request, the value will be an
+ * empty collection for {@code List}, {@code Set} or {@code SortedSet}, {@code null} for other object types, and the
+ * Java-defined default for primitive types.
  * </p>
  *
  * @author Paul Sandoz
@@ -55,7 +48,7 @@ import java.lang.annotation.Target;
  * @see CookieParam
  * @since 1.0
  */
-@Target({ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD})
+@Target({ ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface DefaultValue {

--- a/jaxrs-api/src/main/java/javax/ws/rs/Encoded.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/Encoded.java
@@ -23,11 +23,9 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Disables automatic decoding of parameter values bound using {@link QueryParam},
- * {@link PathParam}, {@link FormParam} or {@link MatrixParam}.
- * Using this annotation on a method will disable decoding for all parameters.
- * Using this annotation on a class will disable decoding for all parameters of
- * all methods.
+ * Disables automatic decoding of parameter values bound using {@link QueryParam}, {@link PathParam}, {@link FormParam}
+ * or {@link MatrixParam}. Using this annotation on a method will disable decoding for all parameters. Using this
+ * annotation on a class will disable decoding for all parameters of all methods.
  *
  * @author Paul Sandoz
  * @author Marc Hadley
@@ -37,7 +35,7 @@ import java.lang.annotation.Target;
  * @see FormParam
  * @since 1.0
  */
-@Target({ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD, ElementType.CONSTRUCTOR, ElementType.TYPE})
+@Target({ ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD, ElementType.CONSTRUCTOR, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface Encoded {

--- a/jaxrs-api/src/main/java/javax/ws/rs/ForbiddenException.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ForbiddenException.java
@@ -19,9 +19,8 @@ package javax.ws.rs;
 import javax.ws.rs.core.Response;
 
 /**
- * A runtime exception indicating that an access to a resource requested by
- * a client has been {@link javax.ws.rs.core.Response.Status#FORBIDDEN forbidden}
- * by the server.
+ * A runtime exception indicating that an access to a resource requested by a client has been
+ * {@link javax.ws.rs.core.Response.Status#FORBIDDEN forbidden} by the server.
  *
  * @author Marek Potociar
  * @since 2.0
@@ -40,8 +39,7 @@ public class ForbiddenException extends ClientErrorException {
     /**
      * Construct a new "forbidden" exception.
      *
-     * @param message the detail message (which is saved for later retrieval
-     *                by the {@link #getMessage()} method).
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
      */
     public ForbiddenException(final String message) {
         super(message, Response.Status.FORBIDDEN);
@@ -51,8 +49,7 @@ public class ForbiddenException extends ClientErrorException {
      * Construct a new "forbidden" exception.
      *
      * @param response error response.
-     * @throws IllegalArgumentException in case the status code set in the response
-     *                                  is not HTTP {@code 403}.
+     * @throws IllegalArgumentException in case the status code set in the response is not HTTP {@code 403}.
      */
     public ForbiddenException(final Response response) {
         super(validate(response, Response.Status.FORBIDDEN));
@@ -61,11 +58,9 @@ public class ForbiddenException extends ClientErrorException {
     /**
      * Construct a new "forbidden" exception.
      *
-     * @param message  the detail message (which is saved for later retrieval
-     *                 by the {@link #getMessage()} method).
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
      * @param response error response.
-     * @throws IllegalArgumentException in case the status code set in the response
-     *                                  is not HTTP {@code 403}.
+     * @throws IllegalArgumentException in case the status code set in the response is not HTTP {@code 403}.
      */
     public ForbiddenException(final String message, final Response response) {
         super(message, validate(response, Response.Status.FORBIDDEN));
@@ -83,9 +78,8 @@ public class ForbiddenException extends ClientErrorException {
     /**
      * Construct a new "forbidden" exception.
      *
-     * @param message the detail message (which is saved for later retrieval
-     *                by the {@link #getMessage()} method).
-     * @param cause   the underlying cause of the exception.
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param cause the underlying cause of the exception.
      */
     public ForbiddenException(final String message, final Throwable cause) {
         super(message, Response.Status.FORBIDDEN, cause);
@@ -95,9 +89,8 @@ public class ForbiddenException extends ClientErrorException {
      * Construct a new "forbidden" exception.
      *
      * @param response error response.
-     * @param cause    the underlying cause of the exception.
-     * @throws IllegalArgumentException in case the status code set in the response
-     *                                  is not HTTP {@code 403}.
+     * @param cause the underlying cause of the exception.
+     * @throws IllegalArgumentException in case the status code set in the response is not HTTP {@code 403}.
      */
     public ForbiddenException(final Response response, final Throwable cause) {
         super(validate(response, Response.Status.FORBIDDEN), cause);
@@ -106,12 +99,10 @@ public class ForbiddenException extends ClientErrorException {
     /**
      * Construct a new "forbidden" exception.
      *
-     * @param message  the detail message (which is saved for later retrieval
-     *                 by the {@link #getMessage()} method).
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
      * @param response error response.
-     * @param cause    the underlying cause of the exception.
-     * @throws IllegalArgumentException in case the status code set in the response
-     *                                  is not HTTP {@code 403}.
+     * @param cause the underlying cause of the exception.
+     * @throws IllegalArgumentException in case the status code set in the response is not HTTP {@code 403}.
      */
     public ForbiddenException(final String message, final Response response, final Throwable cause) {
         super(message, validate(response, Response.Status.FORBIDDEN), cause);

--- a/jaxrs-api/src/main/java/javax/ws/rs/FormParam.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/FormParam.java
@@ -23,35 +23,32 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Binds the value(s) of a form parameter contained within a request entity body
- * to a resource method parameter. Values are URL decoded unless this is
- * disabled using the {@link Encoded} annotation. A default value can be
- * specified using the {@link DefaultValue} annotation.
- * If the request entity body is absent or is an unsupported media type, the
+ * Binds the value(s) of a form parameter contained within a request entity body to a resource method parameter. Values
+ * are URL decoded unless this is disabled using the {@link Encoded} annotation. A default value can be specified using
+ * the {@link DefaultValue} annotation. If the request entity body is absent or is an unsupported media type, the
  * default value is used.
  *
  * The type {@code T} of the annotated parameter must either:
  * <ol>
  * <li>Be a primitive type</li>
  * <li>Have a constructor that accepts a single {@code String} argument</li>
- * <li>Have a static method named {@code valueOf} or {@code fromString}
- * that accepts a single {@code String} argument (see, for example,
- * {@link Integer#valueOf(String)})</li>
- * <li>Have a registered implementation of {@link javax.ws.rs.ext.ParamConverterProvider}
- * JAX-RS extension SPI that returns a {@link javax.ws.rs.ext.ParamConverter}
- * instance capable of a "from string" conversion for the type.</li>
- * <li>Be {@code List<T>}, {@code Set<T>} or
- * {@code SortedSet<T>}, where {@code T} satisfies 2, 3 or 4 above.
- * The resulting collection is read-only.</li>
+ * <li>Have a static method named {@code valueOf} or {@code fromString} that accepts a single {@code String} argument
+ * (see, for example, {@link Integer#valueOf(String)})</li>
+ * <li>Have a registered implementation of {@link javax.ws.rs.ext.ParamConverterProvider} JAX-RS extension SPI that
+ * returns a {@link javax.ws.rs.ext.ParamConverter} instance capable of a "from string" conversion for the type.</li>
+ * <li>Be {@code List<T>}, {@code Set<T>} or {@code SortedSet<T>}, where {@code T} satisfies 2, 3 or 4 above. The
+ * resulting collection is read-only.</li>
  * </ol>
  *
- * <p>If the type is not one of the collection types listed in 5 above and the
- * form parameter is represented by multiple values then the first value (lexically)
- * of the parameter is used.</p>
+ * <p>
+ * If the type is not one of the collection types listed in 5 above and the form parameter is represented by multiple
+ * values then the first value (lexically) of the parameter is used.
+ * </p>
  *
- * <p>Note that, whilst the annotation target permits use on fields and methods,
- * this annotation is only required to be supported on resource method
- * parameters.</p>
+ * <p>
+ * Note that, whilst the annotation target permits use on fields and methods, this annotation is only required to be
+ * supported on resource method parameters.
+ * </p>
  *
  * @author Paul Sandoz
  * @author Marc Hadley
@@ -59,19 +56,17 @@ import java.lang.annotation.Target;
  * @see Encoded
  * @since 1.0
  */
-@Target({ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD})
+@Target({ ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface FormParam {
 
     /**
-     * Defines the name of the form parameter whose value will be used
-     * to initialize the value of the annotated method argument. The name is
-     * specified in decoded form, any percent encoded literals within the value
-     * will not be decoded and will instead be treated as literal text. E.g. if
-     * the parameter name is "a b" then the value of the annotation is "a b",
-     * <i>not</i> "a+b" or "a%20b".
-     * 
+     * Defines the name of the form parameter whose value will be used to initialize the value of the annotated method
+     * argument. The name is specified in decoded form, any percent encoded literals within the value will not be decoded
+     * and will instead be treated as literal text. E.g. if the parameter name is "a b" then the value of the annotation is
+     * "a b", <i>not</i> "a+b" or "a%20b".
+     *
      * @return form parameter name.
      */
     String value();

--- a/jaxrs-api/src/main/java/javax/ws/rs/GET.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/GET.java
@@ -30,7 +30,7 @@ import java.lang.annotation.Target;
  * @see HttpMethod
  * @since 1.0
  */
-@Target({ElementType.METHOD})
+@Target({ ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @HttpMethod(HttpMethod.GET)
 @Documented

--- a/jaxrs-api/src/main/java/javax/ws/rs/HEAD.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/HEAD.java
@@ -30,7 +30,7 @@ import java.lang.annotation.Target;
  * @see HttpMethod
  * @since 1.0
  */
-@Target({ElementType.METHOD})
+@Target({ ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @HttpMethod(HttpMethod.HEAD)
 @Documented

--- a/jaxrs-api/src/main/java/javax/ws/rs/HeaderParam.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/HeaderParam.java
@@ -23,35 +23,31 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Binds the value(s) of a HTTP header to a resource method parameter,
- * resource class field, or resource class bean property. A default value
- * can be specified using the {@link DefaultValue} annotation.
+ * Binds the value(s) of a HTTP header to a resource method parameter, resource class field, or resource class bean
+ * property. A default value can be specified using the {@link DefaultValue} annotation.
  *
- * The type {@code T} of the annotated parameter, field or property
- * must either:
+ * The type {@code T} of the annotated parameter, field or property must either:
  * <ol>
  * <li>Be a primitive type</li>
  * <li>Have a constructor that accepts a single {@code String} argument</li>
- * <li>Have a static method named {@code valueOf} or {@code fromString}
- * that accepts a single
- * {@code String} argument (see, for example, {@link Integer#valueOf(String)})</li>
- * <li>Have a registered implementation of {@link javax.ws.rs.ext.ParamConverterProvider}
- * JAX-RS extension SPI that returns a {@link javax.ws.rs.ext.ParamConverter}
- * instance capable of a "from string" conversion for the type.</li>
- * <li>Be {@code List<T>}, {@code Set<T>} or
- * {@code SortedSet<T>}, where {@code T} satisfies 2, 3 or 4 above.
- * The resulting collection is read-only.</li>
+ * <li>Have a static method named {@code valueOf} or {@code fromString} that accepts a single {@code String} argument
+ * (see, for example, {@link Integer#valueOf(String)})</li>
+ * <li>Have a registered implementation of {@link javax.ws.rs.ext.ParamConverterProvider} JAX-RS extension SPI that
+ * returns a {@link javax.ws.rs.ext.ParamConverter} instance capable of a "from string" conversion for the type.</li>
+ * <li>Be {@code List<T>}, {@code Set<T>} or {@code SortedSet<T>}, where {@code T} satisfies 2, 3 or 4 above. The
+ * resulting collection is read-only.</li>
  * </ol>
  *
- * <p>If the type is not one of the collection types listed in 5 above and the
- * header parameter is represented by multiple values then the first value (lexically)
- * of the parameter is used.</p>
+ * <p>
+ * If the type is not one of the collection types listed in 5 above and the header parameter is represented by multiple
+ * values then the first value (lexically) of the parameter is used.
+ * </p>
  *
- * <p>Because injection occurs at object creation time, use of this annotation
- * on resource class fields and bean properties is only supported for the
- * default per-request resource class lifecycle. Resource classes using
- * other lifecycles should only use this annotation on resource method
- * parameters.</p>
+ * <p>
+ * Because injection occurs at object creation time, use of this annotation on resource class fields and bean properties
+ * is only supported for the default per-request resource class lifecycle. Resource classes using other lifecycles
+ * should only use this annotation on resource method parameters.
+ * </p>
  *
  * @author Paul Sandoz
  * @author Marc Hadley
@@ -59,16 +55,15 @@ import java.lang.annotation.Target;
  * @see javax.ws.rs.core.HttpHeaders
  * @since 1.0
  */
-@Target({ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD})
+@Target({ ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface HeaderParam {
 
     /**
-     * Defines the name of the HTTP header whose value will be used
-     * to initialize the value of the annotated method argument, class field or
-     * bean property. Case insensitive.
-     * 
+     * Defines the name of the HTTP header whose value will be used to initialize the value of the annotated method
+     * argument, class field or bean property. Case insensitive.
+     *
      * @return HTTP header name.
      */
     String value();

--- a/jaxrs-api/src/main/java/javax/ws/rs/HttpMethod.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/HttpMethod.java
@@ -23,11 +23,9 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Associates the name of a HTTP method with an annotation. A Java method annotated
- * with a runtime annotation that is itself annotated with this annotation will
- * be used to handle HTTP requests of the indicated HTTP method. It is an error
- * for a method to be annotated with more than one annotation that is annotated
- * with {@code HttpMethod}.
+ * Associates the name of a HTTP method with an annotation. A Java method annotated with a runtime annotation that is
+ * itself annotated with this annotation will be used to handle HTTP requests of the indicated HTTP method. It is an
+ * error for a method to be annotated with more than one annotation that is annotated with {@code HttpMethod}.
  *
  * @author Paul Sandoz
  * @author Marc Hadley
@@ -40,7 +38,7 @@ import java.lang.annotation.Target;
  * @see OPTIONS
  * @since 1.0
  */
-@Target({ElementType.ANNOTATION_TYPE})
+@Target({ ElementType.ANNOTATION_TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface HttpMethod {
@@ -78,7 +76,7 @@ public @interface HttpMethod {
 
     /**
      * Specifies the name of a HTTP method. E.g. "GET".
-     * 
+     *
      * @return HTTP method name.
      */
     String value();

--- a/jaxrs-api/src/main/java/javax/ws/rs/InternalServerErrorException.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/InternalServerErrorException.java
@@ -19,8 +19,8 @@ package javax.ws.rs;
 import javax.ws.rs.core.Response;
 
 /**
- * A runtime exception indicating an {@link javax.ws.rs.core.Response.Status#INTERNAL_SERVER_ERROR
- * internal server error}.
+ * A runtime exception indicating an {@link javax.ws.rs.core.Response.Status#INTERNAL_SERVER_ERROR internal server
+ * error}.
  *
  * @author Sergey Beryozkin
  * @author Marek Potociar
@@ -40,8 +40,7 @@ public class InternalServerErrorException extends ServerErrorException {
     /**
      * Construct a new internal server error exception.
      *
-     * @param message the detail message (which is saved for later retrieval
-     *                by the {@link #getMessage()} method).
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
      */
     public InternalServerErrorException(final String message) {
         super(message, Response.Status.INTERNAL_SERVER_ERROR);
@@ -51,8 +50,7 @@ public class InternalServerErrorException extends ServerErrorException {
      * Construct a new internal server error exception.
      *
      * @param response internal server error response.
-     * @throws IllegalArgumentException in case the status code set in the response
-     *                                  is not HTTP {@code 500}.
+     * @throws IllegalArgumentException in case the status code set in the response is not HTTP {@code 500}.
      */
     public InternalServerErrorException(final Response response) {
         super(validate(response, Response.Status.INTERNAL_SERVER_ERROR));
@@ -61,11 +59,9 @@ public class InternalServerErrorException extends ServerErrorException {
     /**
      * Construct a new internal server error exception.
      *
-     * @param message  the detail message (which is saved for later retrieval
-     *                 by the {@link #getMessage()} method).
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
      * @param response internal server error response.
-     * @throws IllegalArgumentException in case the status code set in the response
-     *                                  is not HTTP {@code 500}.
+     * @throws IllegalArgumentException in case the status code set in the response is not HTTP {@code 500}.
      */
     public InternalServerErrorException(final String message, final Response response) {
         super(message, validate(response, Response.Status.INTERNAL_SERVER_ERROR));
@@ -83,9 +79,8 @@ public class InternalServerErrorException extends ServerErrorException {
     /**
      * Construct a new internal server error exception.
      *
-     * @param message the detail message (which is saved for later retrieval
-     *                by the {@link #getMessage()} method).
-     * @param cause   the underlying cause of the exception.
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param cause the underlying cause of the exception.
      */
     public InternalServerErrorException(final String message, final Throwable cause) {
         super(message, Response.Status.INTERNAL_SERVER_ERROR, cause);
@@ -95,9 +90,8 @@ public class InternalServerErrorException extends ServerErrorException {
      * Construct a new internal server error exception.
      *
      * @param response internal server error response.
-     * @param cause    the underlying cause of the exception.
-     * @throws IllegalArgumentException in case the status code set in the response
-     *                                  is not HTTP {@code 500}.
+     * @param cause the underlying cause of the exception.
+     * @throws IllegalArgumentException in case the status code set in the response is not HTTP {@code 500}.
      */
     public InternalServerErrorException(final Response response, final Throwable cause) {
         super(validate(response, Response.Status.INTERNAL_SERVER_ERROR), cause);
@@ -106,12 +100,10 @@ public class InternalServerErrorException extends ServerErrorException {
     /**
      * Construct a new internal server error exception.
      *
-     * @param message  the detail message (which is saved for later retrieval
-     *                 by the {@link #getMessage()} method).
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
      * @param response internal server error response.
-     * @param cause    the underlying cause of the exception.
-     * @throws IllegalArgumentException in case the status code set in the response
-     *                                  is not HTTP {@code 500}.
+     * @param cause the underlying cause of the exception.
+     * @throws IllegalArgumentException in case the status code set in the response is not HTTP {@code 500}.
      */
     public InternalServerErrorException(final String message, final Response response, final Throwable cause) {
         super(message, validate(response, Response.Status.INTERNAL_SERVER_ERROR), cause);

--- a/jaxrs-api/src/main/java/javax/ws/rs/JAXRS.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/JAXRS.java
@@ -27,18 +27,15 @@ import javax.ws.rs.ext.RuntimeDelegate;
 /**
  * Bootstrap class used to startup a JAX-RS application in Java SE environments.
  * <p>
- * The {@code JAXRS} class is available in a Jakarta EE container environment as
- * well; however, support for the Java SE bootstrapping APIs is <em>not
- * required</em> in container environments.
+ * The {@code JAXRS} class is available in a Jakarta EE container environment as well; however, support for the Java SE
+ * bootstrapping APIs is <em>not required</em> in container environments.
  * </p>
  * <p>
- * In a Java SE environment an application is getting started by the following
- * command using default configuration values (i. e. mounting application at
- * {@code http://localhost:80/} <em>or a different port</em> (there is <em>no
- * particular default port</em> mandated by this specification). As the JAX-RS
- * implementation is free to choose any port by default, the caller will not
- * know the actual port unless explicitly checking the actual configuration of
- * the instance started:
+ * In a Java SE environment an application is getting started by the following command using default configuration
+ * values (i. e. mounting application at {@code http://localhost:80/} <em>or a different port</em> (there is <em>no
+ * particular default port</em> mandated by this specification). As the JAX-RS implementation is free to choose any port
+ * by default, the caller will not know the actual port unless explicitly checking the actual configuration of the
+ * instance started:
  * </p>
  *
  * <pre>
@@ -56,22 +53,19 @@ import javax.ws.rs.ext.RuntimeDelegate;
  * </pre>
  *
  * <p>
- * A shutdown callback can be registered which will get invoked once the
- * implementation stops serving the application:
+ * A shutdown callback can be registered which will get invoked once the implementation stops serving the application:
  * </p>
  *
  * <pre>
  * instance.stop().thenAccept(stopResult -&gt; ...));
  * </pre>
  *
- * {@code stopResult} is not further defined but solely acts as a wrapper around
- * a native result provided by the particular JAX-RS implementation. Portable
- * applications should not assume any particular data type or value.
+ * {@code stopResult} is not further defined but solely acts as a wrapper around a native result provided by the
+ * particular JAX-RS implementation. Portable applications should not assume any particular data type or value.
  *
  * <p>
- * Protocol, host address, port and root path can be overridden explicitly. As
- * the JAX-RS implementation is bound to that values, no querying of the actual
- * configuration is needed in that case:
+ * Protocol, host address, port and root path can be overridden explicitly. As the JAX-RS implementation is bound to
+ * that values, no querying of the actual configuration is needed in that case:
  * </p>
  *
  * <pre>
@@ -89,8 +83,7 @@ import javax.ws.rs.ext.RuntimeDelegate;
  * </pre>
  *
  * <p>
- * In case of HTTPS, client authentication can be enforced to ensure that only
- * <em>trustworthy</em> clients can connect:
+ * In case of HTTPS, client authentication can be enforced to ensure that only <em>trustworthy</em> clients can connect:
  * </p>
  *
  * <pre>
@@ -98,8 +91,8 @@ import javax.ws.rs.ext.RuntimeDelegate;
  * </pre>
  *
  * <p>
- * Implementations are free to support more use cases by native properties,
- * which effectively render the application non-portable:
+ * Implementations are free to support more use cases by native properties, which effectively render the application
+ * non-portable:
  * </p>
  *
  * <pre>
@@ -107,12 +100,10 @@ import javax.ws.rs.ext.RuntimeDelegate;
  * </pre>
  *
  * <p>
- * Bulk-loading allows to attach configuration storages easily without the need
- * to write down all properties to be transferred. Hence, even properties
- * unknown to the application author will get channeled into the implementation.
- * This can be done both, explicitly (hence portable) and implicitly (hence
- * <em>not necessarily</em> portable as no particular configuration mechanics
- * are required to be supported by compliant implementations):
+ * Bulk-loading allows to attach configuration storages easily without the need to write down all properties to be
+ * transferred. Hence, even properties unknown to the application author will get channeled into the implementation.
+ * This can be done both, explicitly (hence portable) and implicitly (hence <em>not necessarily</em> portable as no
+ * particular configuration mechanics are required to be supported by compliant implementations):
  * </p>
  *
  * <pre>
@@ -133,16 +124,14 @@ public interface JAXRS {
      * Starts the provided application using the specified configuration.
      *
      * <p>
-     * This method is intended to be used in Java SE environments only. The outcome
-     * of invocations in Jakarta EE container environments is undefined.
+     * This method is intended to be used in Java SE environments only. The outcome of invocations in Jakarta EE container
+     * environments is undefined.
      * </p>
      *
-     * @param application
-     *            The application to start up.
-     * @param configuration
-     *            Provides information needed for bootstrapping the application.
-     * @return {@code CompletionStage} (possibly asynchronously) producing handle of
-     *         the running application {@link JAXRS.Instance instance}.
+     * @param application The application to start up.
+     * @param configuration Provides information needed for bootstrapping the application.
+     * @return {@code CompletionStage} (possibly asynchronously) producing handle of the running application
+     * {@link JAXRS.Instance instance}.
      * @see Configuration
      * @since 2.2
      */
@@ -151,12 +140,10 @@ public interface JAXRS {
     }
 
     /**
-     * Provides information needed by the JAX-RS implementation for bootstrapping an
-     * application.
+     * Provides information needed by the JAX-RS implementation for bootstrapping an application.
      * <p>
-     * The configuration essentially consists of a set of parameters. While the set
-     * of actually effective keys is product specific, the key constants defined by
-     * the {@link JAXRS.Configuration} interface MUST be effective on all compliant
+     * The configuration essentially consists of a set of parameters. While the set of actually effective keys is product
+     * specific, the key constants defined by the {@link JAXRS.Configuration} interface MUST be effective on all compliant
      * products. Any unknown key MUST be silently ignored.
      * </p>
      *
@@ -168,8 +155,8 @@ public interface JAXRS {
         /**
          * Configuration key for the protocol an application is bound to.
          * <p>
-         * A compliant implementation at least MUST accept the strings {@code "HTTP"}
-         * and {@code "HTTPS"} if these protocols are supported.
+         * A compliant implementation at least MUST accept the strings {@code "HTTP"} and {@code "HTTPS"} if these protocols are
+         * supported.
          * </p>
          * <p>
          * The default value is {@code "HTTP"}.
@@ -182,13 +169,11 @@ public interface JAXRS {
         /**
          * Configuration key for the hostname or IP address an application is bound to.
          * <p>
-         * A compliant implementation at least MUST accept string values bearing
-         * hostnames, IP4 address text representations, and IP6 address text
-         * representations. If a hostname string, the special IP4 address string
-         * {@code "0.0.0.0"} or {@code "::"} for IP6 is provided, the application MUST
-         * be bound to <em>all</em> IP addresses assigned to that hostname. If the
-         * hostname string is {@code "localhost"} the application MUST be bound to the
-         * local host's loopback adapter <em>only</em>.
+         * A compliant implementation at least MUST accept string values bearing hostnames, IP4 address text representations,
+         * and IP6 address text representations. If a hostname string, the special IP4 address string {@code "0.0.0.0"} or
+         * {@code "::"} for IP6 is provided, the application MUST be bound to <em>all</em> IP addresses assigned to that
+         * hostname. If the hostname string is {@code "localhost"} the application MUST be bound to the local host's loopback
+         * adapter <em>only</em>.
          * </p>
          * <p>
          * The default value is {@code "localhost"}.
@@ -205,11 +190,10 @@ public interface JAXRS {
          * A compliant implementation MUST accept {@code java.lang.Integer} values.
          * </p>
          * <p>
-         * There is no default <em>port</em> mandated by this specification, but the
-         * default <em>value</em> of this property is {@link #DEFAULT_PORT} (i. e.
-         * <code>-1</code>). A compliant implementation MUST use its own default
-         * <em>port</em> when the <em>value</em> <code>-1</code> is provided, and MAY
-         * apply (but is not obligated to) auto-selection and range-scanning algorithms.
+         * There is no default <em>port</em> mandated by this specification, but the default <em>value</em> of this property is
+         * {@link #DEFAULT_PORT} (i. e. <code>-1</code>). A compliant implementation MUST use its own default <em>port</em> when
+         * the <em>value</em> <code>-1</code> is provided, and MAY apply (but is not obligated to) auto-selection and
+         * range-scanning algorithms.
          * </p>
          *
          * @since 2.2
@@ -254,10 +238,9 @@ public interface JAXRS {
          * Secure socket client authentication policy
          *
          * <p>
-         * This policy is used in secure socket handshake to control whether the server
-         * <em>requests</em> client authentication, and whether <em>successful</em>
-         * client authentication is <em>mandatory</em> (i. e. connection attempt will
-         * fail for invalid clients).
+         * This policy is used in secure socket handshake to control whether the server <em>requests</em> client authentication,
+         * and whether <em>successful</em> client authentication is <em>mandatory</em> (i. e. connection attempt will fail for
+         * invalid clients).
          * </p>
          *
          * @author Markus KARG (markus@headcrashing.eu)
@@ -273,16 +256,14 @@ public interface JAXRS {
             NONE,
 
             /**
-             * Client authentication is performed, but invalid clients are
-             * <em>accepted</em>.
+             * Client authentication is performed, but invalid clients are <em>accepted</em>.
              *
              * @since 2.2
              */
             OPTIONAL,
 
             /**
-             * Client authentication is performed, and invalid clients are
-             * <em>rejected</em>.
+             * Client authentication is performed, and invalid clients are <em>rejected</em>.
              *
              * @since 2.2
              */
@@ -290,29 +271,25 @@ public interface JAXRS {
         }
 
         /**
-         * Special value for {@link #PORT} property indicating that the implementation
-         * MUST scan for a free port.
+         * Special value for {@link #PORT} property indicating that the implementation MUST scan for a free port.
          *
          * @since 2.2
          */
         static final int FREE_PORT = 0;
 
         /**
-         * Special value for {@link #PORT} property indicating that the implementation
-         * MUST use its default port.
+         * Special value for {@link #PORT} property indicating that the implementation MUST use its default port.
          *
          * @since 2.2
          */
         static final int DEFAULT_PORT = -1;
 
         /**
-         * Returns the value of the property with the given name, or {@code null} if
-         * there is no property of that name.
+         * Returns the value of the property with the given name, or {@code null} if there is no property of that name.
          *
-         * @param name
-         *            a {@code String} specifying the name of the property.
-         * @return an {@code Object} containing the value of the property, or
-         *         {@code null} if no property exists matching the given name.
+         * @param name a {@code String} specifying the name of the property.
+         * @return an {@code Object} containing the value of the property, or {@code null} if no property exists matching the
+         * given name.
          * @since 2.2
          */
         Object property(String name);
@@ -324,8 +301,7 @@ public interface JAXRS {
          * </p>
          *
          * @return protocol to be used (e. g. {@code "HTTP")}.
-         * @throws ClassCastException
-         *             if protocol is not a {@link String}.
+         * @throws ClassCastException if protocol is not a {@link String}.
          * @see JAXRS.Configuration#PROTOCOL
          * @since 2.2
          */
@@ -339,10 +315,8 @@ public interface JAXRS {
          * Same as if calling {@link #property(String) (String) property(HOST)}.
          * </p>
          *
-         * @return host name or IP address to be used (e. g. {@code "localhost"} or
-         *         {@code "0.0.0.0"}).
-         * @throws ClassCastException
-         *             if host is not a {@link String}.
+         * @return host name or IP address to be used (e. g. {@code "localhost"} or {@code "0.0.0.0"}).
+         * @throws ClassCastException if host is not a {@link String}.
          * @see JAXRS.Configuration#HOST
          * @since 2.2
          */
@@ -356,13 +330,12 @@ public interface JAXRS {
          * Same as if calling {@link #property(String) (int) property(PORT)}.
          * </p>
          * <p>
-         * If the port was <em>not explicitly</em> given, this will return the port
-         * chosen implicitly by the JAX-RS implementation.
+         * If the port was <em>not explicitly</em> given, this will return the port chosen implicitly by the JAX-RS
+         * implementation.
          * </p>
          *
          * @return port number <em>actually</em> used (e. g. {@code 8080}).
-         * @throws ClassCastException
-         *             if port is not an {@code Integer}.
+         * @throws ClassCastException if port is not an {@code Integer}.
          * @see JAXRS.Configuration#PORT
          * @since 2.2
          */
@@ -377,8 +350,7 @@ public interface JAXRS {
          * </p>
          *
          * @return root path to be used, e. g. {@code "/"}.
-         * @throws ClassCastException
-         *             if root path is not a {@link String}.
+         * @throws ClassCastException if root path is not a {@link String}.
          * @see JAXRS.Configuration#ROOT_PATH
          * @since 2.2
          */
@@ -389,13 +361,11 @@ public interface JAXRS {
         /**
          * Convenience method to get the {@code sslContext} to be used.
          * <p>
-         * Same as if calling {@link #property(String) (SSLContext)
-         * property(SSL_CONTEXT)}.
+         * Same as if calling {@link #property(String) (SSLContext) property(SSL_CONTEXT)}.
          * </p>
          *
          * @return root path to be used, e. g. {@code "/"}.
-         * @throws ClassCastException
-         *             if sslContext is not a {@link SSLContext}.
+         * @throws ClassCastException if sslContext is not a {@link SSLContext}.
          * @see JAXRS.Configuration#SSL_CONTEXT
          * @since 2.2
          */
@@ -406,14 +376,11 @@ public interface JAXRS {
         /**
          * Convenience method to get the secure socket client authentication policy.
          * <p>
-         * Same as if calling {@link #property(String) (SSLClientAuthentication)
-         * property(SSL_CLIENT_AUTHENTICATION)}.
+         * Same as if calling {@link #property(String) (SSLClientAuthentication) property(SSL_CLIENT_AUTHENTICATION)}.
          * </p>
          *
          * @return client authentication mode, e. g. {@code NONE}.
-         * @throws ClassCastException
-         *             if sslClientAuthentication is not a
-         *             {@link SSLClientAuthentication}.
+         * @throws ClassCastException if sslClientAuthentication is not a {@link SSLClientAuthentication}.
          * @see JAXRS.Configuration#SSL_CLIENT_AUTHENTICATION
          * @since 2.2
          */
@@ -450,14 +417,11 @@ public interface JAXRS {
             /**
              * Sets the property {@code name} to the provided {@code value}.
              * <p>
-             * This method does not check the validity, type or syntax of the provided
-             * value.
+             * This method does not check the validity, type or syntax of the provided value.
              * </p>
              *
-             * @param name
-             *            name of the parameter to set.
-             * @param value
-             *            value to set, or {@code null} to use the default value.
+             * @param name name of the parameter to set.
+             * @param value value to set, or {@code null} to use the default value.
              * @return the updated builder.
              * @since 2.2
              */
@@ -466,13 +430,10 @@ public interface JAXRS {
             /**
              * Convenience method to set the {@code protocol} to be used.
              * <p>
-             * Same as if calling {@link #property(String, Object) property(PROTOCOL,
-             * value)}.
+             * Same as if calling {@link #property(String, Object) property(PROTOCOL, value)}.
              * </p>
              *
-             * @param protocol
-             *            protocol parameter of this configuration, or {@code null} to use
-             *            the default value.
+             * @param protocol protocol parameter of this configuration, or {@code null} to use the default value.
              * @return the updated builder.
              * @see JAXRS.Configuration#PROTOCOL
              * @since 2.2
@@ -487,9 +448,7 @@ public interface JAXRS {
              * Same as if calling {@link #property(String, Object) property(HOST, value)}.
              * </p>
              *
-             * @param host
-             *            host parameter (IP address or hostname) of this configuration, or
-             *            {@code null} to use the default value.
+             * @param host host parameter (IP address or hostname) of this configuration, or {@code null} to use the default value.
              * @return the updated builder.
              * @see JAXRS.Configuration#HOST
              * @since 2.2
@@ -504,9 +463,7 @@ public interface JAXRS {
              * Same as if calling {@link #property(String, Object) property(PORT, value)}.
              * </p>
              *
-             * @param port
-             *            port parameter of this configuration, or {@code null} to use the
-             *            default value.
+             * @param port port parameter of this configuration, or {@code null} to use the default value.
              * @return the updated builder.
              * @see JAXRS.Configuration#PORT
              * @since 2.2
@@ -518,13 +475,10 @@ public interface JAXRS {
             /**
              * Convenience method to set the {@code rootPath} to be used.
              * <p>
-             * Same as if calling {@link #property(String, Object) property(ROOT_PATH,
-             * value)}.
+             * Same as if calling {@link #property(String, Object) property(ROOT_PATH, value)}.
              * </p>
              *
-             * @param rootPath
-             *            rootPath parameter of this configuration, or {@code null} to use
-             *            the default value.
+             * @param rootPath rootPath parameter of this configuration, or {@code null} to use the default value.
              * @return the updated builder.
              * @see JAXRS.Configuration#ROOT_PATH
              * @since 2.2
@@ -536,13 +490,10 @@ public interface JAXRS {
             /**
              * Convenience method to set the {@code sslContext} to be used.
              * <p>
-             * Same as if calling {@link #property(String, Object) property(SSL_CONTEXT,
-             * value)}.
+             * Same as if calling {@link #property(String, Object) property(SSL_CONTEXT, value)}.
              * </p>
              *
-             * @param sslContext
-             *            sslContext parameter of this configuration, or {@code null} to use
-             *            the default value.
+             * @param sslContext sslContext parameter of this configuration, or {@code null} to use the default value.
              * @return the updated builder.
              * @see JAXRS.Configuration#SSL_CONTEXT
              * @since 2.2
@@ -554,12 +505,10 @@ public interface JAXRS {
             /**
              * Convenience method to set SSL client authentication policy.
              * <p>
-             * Same as if calling {@link #property(String, Object)
-             * property(SSL_CLIENT_AUTHENTICATION, value)}.
+             * Same as if calling {@link #property(String, Object) property(SSL_CLIENT_AUTHENTICATION, value)}.
              * </p>
              *
-             * @param sslClientAuthentication
-             *            SSL client authentication mode of this configuration
+             * @param sslClientAuthentication SSL client authentication mode of this configuration
              * @return the updated builder.
              * @see JAXRS.Configuration#SSL_CLIENT_AUTHENTICATION
              * @since 2.2
@@ -571,19 +520,14 @@ public interface JAXRS {
             /**
              * Convenience method for bulk-loading configuration from a property supplier.
              * <p>
-             * Implementations ask the passed provider function for the actual values of all
-             * their supported properties, before returning from this configuration method.
-             * For each single request the implementation provides the name of the property
-             * and the expected data type of the value. If no such property exists (i. e.
-             * either the name is unknown or misspelled, or the type does not exactly
-             * match), the {@link Optional} is {@link Optional#empty() empty}.
+             * Implementations ask the passed provider function for the actual values of all their supported properties, before
+             * returning from this configuration method. For each single request the implementation provides the name of the
+             * property and the expected data type of the value. If no such property exists (i. e. either the name is unknown or
+             * misspelled, or the type does not exactly match), the {@link Optional} is {@link Optional#empty() empty}.
              * </p>
              *
-             * @param <T>
-             *            Type of the requested property value.
-             * @param propertiesProvider
-             *            Retrieval function of externally managed properties. MUST NOT
-             *            return {@code null}.
+             * @param <T> Type of the requested property value.
+             * @param propertiesProvider Retrieval function of externally managed properties. MUST NOT return {@code null}.
              * @return the updated builder.
              * @since 2.2
              */
@@ -592,22 +536,18 @@ public interface JAXRS {
             /**
              * Optional convenience method to bulk-load external configuration.
              * <p>
-             * Implementations are free to support any external configuration mechanics, or
-             * none at all. It is completely up to the implementation what set of properties
-             * is effectively loaded from the provided external configuration, possibly none
+             * Implementations are free to support any external configuration mechanics, or none at all. It is completely up to the
+             * implementation what set of properties is effectively loaded from the provided external configuration, possibly none
              * at all.
              * </p>
              * <p>
-             * If the passed external configuration mechanics is unsupported, this method
-             * MUST simply do nothing.
+             * If the passed external configuration mechanics is unsupported, this method MUST simply do nothing.
              * </p>
              * <p>
-             * Portable applications should not call this method, as the outcome is
-             * completely implementation-specific.
+             * Portable applications should not call this method, as the outcome is completely implementation-specific.
              * </p>
              *
-             * @param externalConfig
-             *            source of externally managed properties
+             * @param externalConfig source of externally managed properties
              * @return the updated builder.
              * @since 2.2
              */
@@ -627,15 +567,12 @@ public interface JAXRS {
     public interface Instance {
 
         /**
-         * Provides access to the configuration <em>actually</em> used by the
-         * implementation used to create this instance.
+         * Provides access to the configuration <em>actually</em> used by the implementation used to create this instance.
          * <p>
-         * This may, or may not, be the same instance passed to
-         * {@link JAXRS#start(Application, Configuration)}, not even an equal instance,
-         * as implementations MAY create a new intance and MUST update at least the
-         * {@code PORT} property with the actually used value. Portable applications
-         * should not make any assumptions but always explicitly read the actual values
-         * from the configuration returned from this method.
+         * This may, or may not, be the same instance passed to {@link JAXRS#start(Application, Configuration)}, not even an
+         * equal instance, as implementations MAY create a new intance and MUST update at least the {@code PORT} property with
+         * the actually used value. Portable applications should not make any assumptions but always explicitly read the actual
+         * values from the configuration returned from this method.
          * </p>
          *
          * @return The configuration actually used to create this instance.
@@ -646,8 +583,7 @@ public interface JAXRS {
         /**
          * Initiate immediate shutdown of running application instance.
          *
-         * @return {@code CompletionStage} asynchronously shutting down this application
-         *         instance.
+         * @return {@code CompletionStage} asynchronously shutting down this application instance.
          * @since 2.2
          */
         public CompletionStage<StopResult> stop();
@@ -663,19 +599,15 @@ public interface JAXRS {
             /**
              * Provides access to the wrapped native shutdown result.
              * <p>
-             * Implementations may, or may not, have native shutdown results. Portable
-             * applications should not invoke this method, as the outcome is undefined.
+             * Implementations may, or may not, have native shutdown results. Portable applications should not invoke this method,
+             * as the outcome is undefined.
              * </p>
              *
-             * @param <T>
-             *            Requested type of the native result to return.
-             * @param nativeClass
-             *            Requested type of the native result to return.
-             * @return Native result of shutting down the running application instance or
-             *         {@code null} if the implementation has no native result.
-             * @throws ClassCastException
-             *             if the result is not {@code null} or is not assignable to the
-             *             type {@code T}.
+             * @param <T> Requested type of the native result to return.
+             * @param nativeClass Requested type of the native result to return.
+             * @return Native result of shutting down the running application instance or {@code null} if the implementation has no
+             * native result.
+             * @throws ClassCastException if the result is not {@code null} or is not assignable to the type {@code T}.
              * @since 2.2
              */
             public <T> T unwrap(Class<T> nativeClass);
@@ -684,19 +616,14 @@ public interface JAXRS {
         /**
          * Provides access to the wrapped native handle of the application instance.
          * <p>
-         * Implementations may, or may not, have native handles. Portable applications
-         * should not invoke this method, as the outcome is undefined.
+         * Implementations may, or may not, have native handles. Portable applications should not invoke this method, as the
+         * outcome is undefined.
          * </p>
          *
-         * @param <T>
-         *            Requested type of the native handle to return.
-         * @param nativeClass
-         *            Requested type of the native handle to return.
-         * @return Native handle of the running application instance or {@code null} if
-         *         the implementation has no native handle.
-         * @throws ClassCastException
-         *             if the handle is not {@code null} and is not assignable to the
-         *             type {@code T}.
+         * @param <T> Requested type of the native handle to return.
+         * @param nativeClass Requested type of the native handle to return.
+         * @return Native handle of the running application instance or {@code null} if the implementation has no native handle.
+         * @throws ClassCastException if the handle is not {@code null} and is not assignable to the type {@code T}.
          * @since 2.2
          */
         public <T> T unwrap(Class<T> nativeClass);

--- a/jaxrs-api/src/main/java/javax/ws/rs/MatrixParam.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/MatrixParam.java
@@ -23,44 +23,38 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Binds the value(s) of a URI matrix parameter to a resource method parameter,
- * resource class field, or resource class bean property.
- * Values are URL decoded unless this is disabled using the {@link Encoded}
- * annotation. A default value can be specified using the {@link DefaultValue}
- * annotation.
+ * Binds the value(s) of a URI matrix parameter to a resource method parameter, resource class field, or resource class
+ * bean property. Values are URL decoded unless this is disabled using the {@link Encoded} annotation. A default value
+ * can be specified using the {@link DefaultValue} annotation.
  * <p>
- * Note that the {@code @MatrixParam} {@link #value() annotation value} refers
- * to a name of a matrix parameter that resides in the last matched path segment
- * of the {@link Path}-annotated Java structure that injects the value of the matrix
- * parameter.
+ * Note that the {@code @MatrixParam} {@link #value() annotation value} refers to a name of a matrix parameter that
+ * resides in the last matched path segment of the {@link Path}-annotated Java structure that injects the value of the
+ * matrix parameter.
  * </p>
  * <p>
- * The type {@code T} of the annotated parameter, field or property must
- * either:
+ * The type {@code T} of the annotated parameter, field or property must either:
  * </p>
  * <ol>
  * <li>Be a primitive type</li>
  * <li>Have a constructor that accepts a single {@code String} argument</li>
- * <li>Have a static method named {@code valueOf} or {@code fromString}
- * that accepts a single
- * {@code String} argument (see, for example, {@link Integer#valueOf(String)})</li>
- * <li>Have a registered implementation of {@link javax.ws.rs.ext.ParamConverterProvider}
- * JAX-RS extension SPI that returns a {@link javax.ws.rs.ext.ParamConverter}
- * instance capable of a "from string" conversion for the type.</li>
- * <li>Be {@code List<T>}, {@code Set<T>} or
- * {@code SortedSet<T>}, where {@code T} satisfies 2, 3 or 4 above.
- * The resulting collection is read-only.</li>
+ * <li>Have a static method named {@code valueOf} or {@code fromString} that accepts a single {@code String} argument
+ * (see, for example, {@link Integer#valueOf(String)})</li>
+ * <li>Have a registered implementation of {@link javax.ws.rs.ext.ParamConverterProvider} JAX-RS extension SPI that
+ * returns a {@link javax.ws.rs.ext.ParamConverter} instance capable of a "from string" conversion for the type.</li>
+ * <li>Be {@code List<T>}, {@code Set<T>} or {@code SortedSet<T>}, where {@code T} satisfies 2, 3 or 4 above. The
+ * resulting collection is read-only.</li>
  * </ol>
  *
- * <p>If the type is not one of the collection types listed in 5 above and the
- * matrix parameter is represented by multiple values then the first value (lexically)
- * of the parameter is used.</p>
+ * <p>
+ * If the type is not one of the collection types listed in 5 above and the matrix parameter is represented by multiple
+ * values then the first value (lexically) of the parameter is used.
+ * </p>
  *
- * <p>Because injection occurs at object creation time, use of this annotation
- * on resource class fields and bean properties is only supported for the
- * default per-request resource class lifecycle. Resource classes using
- * other lifecycles should only use this annotation on resource method
- * parameters.</p>
+ * <p>
+ * Because injection occurs at object creation time, use of this annotation on resource class fields and bean properties
+ * is only supported for the default per-request resource class lifecycle. Resource classes using other lifecycles
+ * should only use this annotation on resource method parameters.
+ * </p>
  *
  * @author Paul Sandoz
  * @author Marc Hadley
@@ -69,19 +63,17 @@ import java.lang.annotation.Target;
  * @see <a href="http://www.w3.org/DesignIssues/MatrixURIs.html">Matrix URIs</a>
  * @since 1.0
  */
-@Target({ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD})
+@Target({ ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface MatrixParam {
 
     /**
-     * Defines the name of the URI matrix parameter whose value will be used
-     * to initialize the value of the annotated method argument, class field or
-     * bean property. The name is specified in decoded form, any percent encoded
-     * literals within the value will not be decoded and will instead be
-     * treated as literal text. E.g. if the parameter name is "a b" then the
-     * value of the annotation is "a b", <i>not</i> "a+b" or "a%20b".
-     * 
+     * Defines the name of the URI matrix parameter whose value will be used to initialize the value of the annotated method
+     * argument, class field or bean property. The name is specified in decoded form, any percent encoded literals within
+     * the value will not be decoded and will instead be treated as literal text. E.g. if the parameter name is "a b" then
+     * the value of the annotation is "a b", <i>not</i> "a+b" or "a%20b".
+     *
      * @return URI matrix parameter name.
      */
     String value();

--- a/jaxrs-api/src/main/java/javax/ws/rs/NameBinding.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/NameBinding.java
@@ -23,12 +23,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Meta-annotation used to create name binding annotations for filters
- * and interceptors.
+ * Meta-annotation used to create name binding annotations for filters and interceptors.
  *
- * Name binding via annotations is only supported as part of the Server API.
- * In name binding, a <i>name-binding</i> annotation is first defined using the
- * {@code @NameBinding} meta-annotation:
+ * Name binding via annotations is only supported as part of the Server API. In name binding, a <i>name-binding</i>
+ * annotation is first defined using the {@code @NameBinding} meta-annotation:
  *
  * <pre>
  *  &#64;Target({ ElementType.TYPE, ElementType.METHOD })
@@ -37,9 +35,8 @@ import java.lang.annotation.Target;
  *  <b>public @interface Logged</b> { }
  * </pre>
  *
- * The defined name-binding annotation is then used to decorate a filter or interceptor
- * class (more than one filter or interceptor may be decorated with the same name-binding
- * annotation):
+ * The defined name-binding annotation is then used to decorate a filter or interceptor class (more than one filter or
+ * interceptor may be decorated with the same name-binding annotation):
  *
  * <pre>
  *  <b>&#64;Logged</b>
@@ -49,8 +46,8 @@ import java.lang.annotation.Target;
  *  }
  * </pre>
  *
- * At last, the name-binding annotation is applied to the resource method(s) to which the
- * name-bound JAX-RS provider(s) should be bound to:
+ * At last, the name-binding annotation is applied to the resource method(s) to which the name-bound JAX-RS provider(s)
+ * should be bound to:
  *
  * <pre>
  *  &#64;Path("/")
@@ -65,10 +62,9 @@ import java.lang.annotation.Target;
  *  }
  * </pre>
  *
- * A name-binding annotation may also be attached to a custom JAX-RS
- * {@link javax.ws.rs.core.Application} subclass. In such case a name-bound JAX-RS provider
- * bound by the annotation will be applied to all {@link HttpMethod resource and sub-resource
- * methods} in the JAX-RS application:
+ * A name-binding annotation may also be attached to a custom JAX-RS {@link javax.ws.rs.core.Application} subclass. In
+ * such case a name-bound JAX-RS provider bound by the annotation will be applied to all {@link HttpMethod resource and
+ * sub-resource methods} in the JAX-RS application:
  *
  * <pre>
  *  <b>&#64;Logged</b>

--- a/jaxrs-api/src/main/java/javax/ws/rs/NotAcceptableException.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/NotAcceptableException.java
@@ -19,9 +19,8 @@ package javax.ws.rs;
 import javax.ws.rs.core.Response;
 
 /**
- * A runtime exception indicating that a client request is
- * {@link javax.ws.rs.core.Response.Status#NOT_ACCEPTABLE not acceptable}
- * by the server.
+ * A runtime exception indicating that a client request is {@link javax.ws.rs.core.Response.Status#NOT_ACCEPTABLE not
+ * acceptable} by the server.
  *
  * @author Sergey Beryozkin
  * @author Marek Potociar
@@ -41,8 +40,7 @@ public class NotAcceptableException extends ClientErrorException {
     /**
      * Construct a new "request not acceptable" exception.
      *
-     * @param message the detail message (which is saved for later retrieval
-     *                by the {@link #getMessage()} method).
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
      */
     public NotAcceptableException(final String message) {
         super(message, Response.Status.NOT_ACCEPTABLE);
@@ -52,8 +50,7 @@ public class NotAcceptableException extends ClientErrorException {
      * Construct a new "request not acceptable" exception.
      *
      * @param response error response.
-     * @throws IllegalArgumentException in case the status code set in the response
-     *                                  is not HTTP {@code 406}.
+     * @throws IllegalArgumentException in case the status code set in the response is not HTTP {@code 406}.
      */
     public NotAcceptableException(final Response response) {
         super(validate(response, Response.Status.NOT_ACCEPTABLE));
@@ -62,11 +59,9 @@ public class NotAcceptableException extends ClientErrorException {
     /**
      * Construct a new "request not acceptable" exception.
      *
-     * @param message  the detail message (which is saved for later retrieval
-     *                 by the {@link #getMessage()} method).
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
      * @param response error response.
-     * @throws IllegalArgumentException in case the status code set in the response
-     *                                  is not HTTP {@code 406}.
+     * @throws IllegalArgumentException in case the status code set in the response is not HTTP {@code 406}.
      */
     public NotAcceptableException(final String message, final Response response) {
         super(message, validate(response, Response.Status.NOT_ACCEPTABLE));
@@ -84,9 +79,8 @@ public class NotAcceptableException extends ClientErrorException {
     /**
      * Construct a new "request not acceptable" exception.
      *
-     * @param message the detail message (which is saved for later retrieval
-     *                by the {@link #getMessage()} method).
-     * @param cause   the underlying cause of the exception.
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param cause the underlying cause of the exception.
      */
     public NotAcceptableException(final String message, final Throwable cause) {
         super(message, Response.Status.NOT_ACCEPTABLE, cause);
@@ -96,9 +90,8 @@ public class NotAcceptableException extends ClientErrorException {
      * Construct a new "request not acceptable" exception.
      *
      * @param response error response.
-     * @param cause    the underlying cause of the exception.
-     * @throws IllegalArgumentException in case the status code set in the response
-     *                                  is not HTTP {@code 406}.
+     * @param cause the underlying cause of the exception.
+     * @throws IllegalArgumentException in case the status code set in the response is not HTTP {@code 406}.
      */
     public NotAcceptableException(final Response response, final Throwable cause) {
         super(validate(response, Response.Status.NOT_ACCEPTABLE), cause);
@@ -107,12 +100,10 @@ public class NotAcceptableException extends ClientErrorException {
     /**
      * Construct a new "request not acceptable" exception.
      *
-     * @param message  the detail message (which is saved for later retrieval
-     *                 by the {@link #getMessage()} method).
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
      * @param response error response.
-     * @param cause    the underlying cause of the exception.
-     * @throws IllegalArgumentException in case the status code set in the response
-     *                                  is not HTTP {@code 406}.
+     * @param cause the underlying cause of the exception.
+     * @throws IllegalArgumentException in case the status code set in the response is not HTTP {@code 406}.
      */
     public NotAcceptableException(final String message, final Response response, final Throwable cause) {
         super(message, validate(response, Response.Status.NOT_ACCEPTABLE), cause);

--- a/jaxrs-api/src/main/java/javax/ws/rs/NotAllowedException.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/NotAllowedException.java
@@ -37,7 +37,7 @@ public class NotAllowedException extends ClientErrorException {
     /**
      * Construct a new method not allowed exception.
      *
-     * @param allowed     allowed request method.
+     * @param allowed allowed request method.
      * @param moreAllowed more allowed request methods.
      * @throws NullPointerException in case the allowed method is {@code null}.
      */
@@ -48,9 +48,8 @@ public class NotAllowedException extends ClientErrorException {
     /**
      * Construct a new method not allowed exception.
      *
-     * @param message     the detail message (which is saved for later retrieval
-     *                    by the {@link #getMessage()} method).
-     * @param allowed     allowed request method.
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param allowed allowed request method.
      * @param moreAllowed more allowed request methods.
      * @throws NullPointerException in case the allowed method is {@code null}.
      */
@@ -77,15 +76,13 @@ public class NotAllowedException extends ClientErrorException {
     /**
      * Construct a new method not allowed exception.
      * <p>
-     * Note that this constructor does not validate the presence of HTTP
-     * {@code Allow} header. I.e. it is possible
-     * to use the constructor to create a client-side exception instance
-     * even for an invalid HTTP {@code 405} response content returned from a server.
+     * Note that this constructor does not validate the presence of HTTP {@code Allow} header. I.e. it is possible to use
+     * the constructor to create a client-side exception instance even for an invalid HTTP {@code 405} response content
+     * returned from a server.
      * </p>
      *
      * @param response error response.
-     * @throws IllegalArgumentException in case the status code set in the response
-     *                                  is not HTTP {@code 405}.
+     * @throws IllegalArgumentException in case the status code set in the response is not HTTP {@code 405}.
      */
     public NotAllowedException(final Response response) {
         super(validate(response, Response.Status.METHOD_NOT_ALLOWED));
@@ -94,17 +91,14 @@ public class NotAllowedException extends ClientErrorException {
     /**
      * Construct a new method not allowed exception.
      * <p>
-     * Note that this constructor does not validate the presence of HTTP
-     * {@code Allow} header. I.e. it is possible
-     * to use the constructor to create a client-side exception instance
-     * even for an invalid HTTP {@code 405} response content returned from a server.
+     * Note that this constructor does not validate the presence of HTTP {@code Allow} header. I.e. it is possible to use
+     * the constructor to create a client-side exception instance even for an invalid HTTP {@code 405} response content
+     * returned from a server.
      * </p>
      *
-     * @param message  the detail message (which is saved for later retrieval
-     *                 by the {@link #getMessage()} method).
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
      * @param response error response.
-     * @throws IllegalArgumentException in case the status code set in the response
-     *                                  is not HTTP {@code 405}.
+     * @throws IllegalArgumentException in case the status code set in the response is not HTTP {@code 405}.
      */
     public NotAllowedException(final String message, final Response response) {
         super(message, validate(response, Response.Status.METHOD_NOT_ALLOWED));
@@ -113,7 +107,7 @@ public class NotAllowedException extends ClientErrorException {
     /**
      * Construct a new method not allowed exception.
      *
-     * @param cause          the underlying cause of the exception.
+     * @param cause the underlying cause of the exception.
      * @param allowedMethods allowed request methods.
      * @throws IllegalArgumentException in case the allowed methods varargs are {@code null}.
      */
@@ -124,9 +118,8 @@ public class NotAllowedException extends ClientErrorException {
     /**
      * Construct a new method not allowed exception.
      *
-     * @param message        the detail message (which is saved for later retrieval
-     *                       by the {@link #getMessage()} method).
-     * @param cause          the underlying cause of the exception.
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param cause the underlying cause of the exception.
      * @param allowedMethods allowed request methods.
      * @throws IllegalArgumentException in case the allowed methods varargs are {@code null}.
      */
@@ -138,10 +131,9 @@ public class NotAllowedException extends ClientErrorException {
      * Construct a new method not allowed exception.
      *
      * @param response error response.
-     * @param cause    the underlying cause of the exception.
-     * @throws IllegalArgumentException in case the status code set in the response
-     *                                  is not HTTP {@code 405} or does not contain
-     *                                  an HTTP {@code Allow} header.
+     * @param cause the underlying cause of the exception.
+     * @throws IllegalArgumentException in case the status code set in the response is not HTTP {@code 405} or does not
+     * contain an HTTP {@code Allow} header.
      */
     public NotAllowedException(final Response response, final Throwable cause) {
         super(validateAllow(validate(response, Response.Status.METHOD_NOT_ALLOWED)), cause);
@@ -150,13 +142,11 @@ public class NotAllowedException extends ClientErrorException {
     /**
      * Construct a new method not allowed exception.
      *
-     * @param message  the detail message (which is saved for later retrieval
-     *                 by the {@link #getMessage()} method).
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
      * @param response error response.
-     * @param cause    the underlying cause of the exception.
-     * @throws IllegalArgumentException in case the status code set in the response
-     *                                  is not HTTP {@code 405} or does not contain
-     *                                  an HTTP {@code Allow} header.
+     * @param cause the underlying cause of the exception.
+     * @throws IllegalArgumentException in case the status code set in the response is not HTTP {@code 405} or does not
+     * contain an HTTP {@code Allow} header.
      */
     public NotAllowedException(final String message, final Response response, final Throwable cause) {
         super(message, validateAllow(validate(response, Response.Status.METHOD_NOT_ALLOWED)), cause);

--- a/jaxrs-api/src/main/java/javax/ws/rs/NotAuthorizedException.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/NotAuthorizedException.java
@@ -27,19 +27,12 @@ import java.util.List;
 import javax.ws.rs.core.Response;
 
 /**
- * A runtime exception indicating request authorization failure caused by one of the following
- * scenarios:
+ * A runtime exception indicating request authorization failure caused by one of the following scenarios:
  * <ul>
- * <li>
- * a client did not send the required authorization credentials to access the requested resource,
- * i.e. {@link javax.ws.rs.core.HttpHeaders#AUTHORIZATION Authorization} HTTP header is missing
- * in the request,
- * </li>
- * <li>
- * or - in case the request already contains the HTTP {@code Authorization} header - then
- * the exception indicates that authorization has been refused for the credentials contained
- * in the request header.
- * </li>
+ * <li>a client did not send the required authorization credentials to access the requested resource, i.e.
+ * {@link javax.ws.rs.core.HttpHeaders#AUTHORIZATION Authorization} HTTP header is missing in the request,</li>
+ * <li>or - in case the request already contains the HTTP {@code Authorization} header - then the exception indicates
+ * that authorization has been refused for the credentials contained in the request header.</li>
  * </ul>
  *
  * @author Marek Potociar
@@ -54,10 +47,8 @@ public class NotAuthorizedException extends ClientErrorException {
     /**
      * Construct a new "not authorized" exception.
      *
-     * @param challenge      authorization challenge applicable to the resource requested
-     *                       by the client.
-     * @param moreChallenges additional authorization challenge applicable to the
-     *                       requested resource.
+     * @param challenge authorization challenge applicable to the resource requested by the client.
+     * @param moreChallenges additional authorization challenge applicable to the requested resource.
      * @throws NullPointerException in case the {@code challenge} parameter is {@code null}.
      */
     public NotAuthorizedException(final Object challenge, final Object... moreChallenges) {
@@ -68,12 +59,9 @@ public class NotAuthorizedException extends ClientErrorException {
     /**
      * Construct a new "not authorized" exception.
      *
-     * @param message        the detail message (which is saved for later retrieval
-     *                       by the {@link #getMessage()} method).
-     * @param challenge      authorization challenge applicable to the resource requested
-     *                       by the client.
-     * @param moreChallenges additional authorization challenge applicable to the
-     *                       requested resource.
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param challenge authorization challenge applicable to the resource requested by the client.
+     * @param moreChallenges additional authorization challenge applicable to the requested resource.
      * @throws NullPointerException in case the {@code challenge} parameter is {@code null}.
      */
     public NotAuthorizedException(final String message, final Object challenge, final Object... moreChallenges) {
@@ -85,8 +73,7 @@ public class NotAuthorizedException extends ClientErrorException {
      * Construct a new "not authorized" exception.
      *
      * @param response error response.
-     * @throws IllegalArgumentException in case the status code set in the response
-     *                                  is not HTTP {@code 401}.
+     * @throws IllegalArgumentException in case the status code set in the response is not HTTP {@code 401}.
      */
     public NotAuthorizedException(final Response response) {
         super(validate(response, UNAUTHORIZED));
@@ -95,11 +82,9 @@ public class NotAuthorizedException extends ClientErrorException {
     /**
      * Construct a new "not authorized" exception.
      *
-     * @param message  the detail message (which is saved for later retrieval
-     *                 by the {@link #getMessage()} method).
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
      * @param response error response.
-     * @throws IllegalArgumentException in case the status code set in the response
-     *                                  is not HTTP {@code 401}.
+     * @throws IllegalArgumentException in case the status code set in the response is not HTTP {@code 401}.
      */
     public NotAuthorizedException(final String message, final Response response) {
         super(message, validate(response, UNAUTHORIZED));
@@ -108,10 +93,9 @@ public class NotAuthorizedException extends ClientErrorException {
     /**
      * Construct a new "not authorized" exception.
      *
-     * @param cause          the underlying cause of the exception.
-     * @param challenge      authorization challenge applicable to the requested resource.
-     * @param moreChallenges additional authorization challenge applicable to the
-     *                       requested resource.
+     * @param cause the underlying cause of the exception.
+     * @param challenge authorization challenge applicable to the requested resource.
+     * @param moreChallenges additional authorization challenge applicable to the requested resource.
      */
     public NotAuthorizedException(final Throwable cause, final Object challenge, final Object... moreChallenges) {
         super(createUnauthorizedResponse(challenge, moreChallenges), cause);
@@ -121,12 +105,10 @@ public class NotAuthorizedException extends ClientErrorException {
     /**
      * Construct a new "not authorized" exception.
      *
-     * @param message        the detail message (which is saved for later retrieval
-     *                       by the {@link #getMessage()} method).
-     * @param cause          the underlying cause of the exception.
-     * @param challenge      authorization challenge applicable to the requested resource.
-     * @param moreChallenges additional authorization challenge applicable to the
-     *                       requested resource.
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param cause the underlying cause of the exception.
+     * @param challenge authorization challenge applicable to the requested resource.
+     * @param moreChallenges additional authorization challenge applicable to the requested resource.
      */
     public NotAuthorizedException(final String message, final Throwable cause, final Object challenge, final Object... moreChallenges) {
         super(message, createUnauthorizedResponse(challenge, moreChallenges), cause);
@@ -137,9 +119,8 @@ public class NotAuthorizedException extends ClientErrorException {
      * Construct a new "not authorized" exception.
      *
      * @param response error response.
-     * @param cause    the underlying cause of the exception.
-     * @throws IllegalArgumentException in case the status code set in the response
-     *                                  is not HTTP {@code 401}.
+     * @param cause the underlying cause of the exception.
+     * @throws IllegalArgumentException in case the status code set in the response is not HTTP {@code 401}.
      */
     public NotAuthorizedException(final Response response, final Throwable cause) {
         super(validate(response, UNAUTHORIZED), cause);
@@ -148,23 +129,20 @@ public class NotAuthorizedException extends ClientErrorException {
     /**
      * Construct a new "not authorized" exception.
      *
-     * @param message  the detail message (which is saved for later retrieval
-     *                 by the {@link #getMessage()} method).
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
      * @param response error response.
-     * @param cause    the underlying cause of the exception.
-     * @throws IllegalArgumentException in case the status code set in the response
-     *                                  is not HTTP {@code 401}.
+     * @param cause the underlying cause of the exception.
+     * @throws IllegalArgumentException in case the status code set in the response is not HTTP {@code 401}.
      */
     public NotAuthorizedException(final String message, final Response response, final Throwable cause) {
         super(message, validate(response, UNAUTHORIZED), cause);
     }
 
     /**
-     * Get the list of authorization challenges associated with the exception and
-     * applicable to the resource requested by the client.
+     * Get the list of authorization challenges associated with the exception and applicable to the resource requested by
+     * the client.
      *
-     * @return list of authorization challenges applicable to the resource requested
-     *         by the client.
+     * @return list of authorization challenges applicable to the resource requested by the client.
      */
     public List<Object> getChallenges() {
         if (challenges == null) {

--- a/jaxrs-api/src/main/java/javax/ws/rs/NotFoundException.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/NotFoundException.java
@@ -19,8 +19,8 @@ package javax.ws.rs;
 import javax.ws.rs.core.Response;
 
 /**
- * A runtime exception indicating a resource requested by a client was
- * {@link javax.ws.rs.core.Response.Status#NOT_FOUND not found} on the server.
+ * A runtime exception indicating a resource requested by a client was {@link javax.ws.rs.core.Response.Status#NOT_FOUND
+ * not found} on the server.
  *
  * @author Sergey Beryozkin
  * @author Marek Potociar
@@ -40,8 +40,7 @@ public class NotFoundException extends ClientErrorException {
     /**
      * Construct a new "not found" exception.
      *
-     * @param message the detail message (which is saved for later retrieval
-     *                by the {@link #getMessage()} method).
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
      */
     public NotFoundException(final String message) {
         super(message, Response.Status.NOT_FOUND);
@@ -51,8 +50,7 @@ public class NotFoundException extends ClientErrorException {
      * Construct a new "not found" exception.
      *
      * @param response error response.
-     * @throws IllegalArgumentException in case the status code set in the response
-     *                                  is not HTTP {@code 404}.
+     * @throws IllegalArgumentException in case the status code set in the response is not HTTP {@code 404}.
      */
     public NotFoundException(final Response response) {
         super(validate(response, Response.Status.NOT_FOUND));
@@ -61,11 +59,9 @@ public class NotFoundException extends ClientErrorException {
     /**
      * Construct a new "not found" exception.
      *
-     * @param message  the detail message (which is saved for later retrieval
-     *                 by the {@link #getMessage()} method).
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
      * @param response error response.
-     * @throws IllegalArgumentException in case the status code set in the response
-     *                                  is not HTTP {@code 404}.
+     * @throws IllegalArgumentException in case the status code set in the response is not HTTP {@code 404}.
      */
     public NotFoundException(final String message, final Response response) {
         super(message, validate(response, Response.Status.NOT_FOUND));
@@ -83,9 +79,8 @@ public class NotFoundException extends ClientErrorException {
     /**
      * Construct a new "not found" exception.
      *
-     * @param message the detail message (which is saved for later retrieval
-     *                by the {@link #getMessage()} method).
-     * @param cause   the underlying cause of the exception.
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param cause the underlying cause of the exception.
      */
     public NotFoundException(final String message, final Throwable cause) {
         super(message, Response.Status.NOT_FOUND, cause);
@@ -95,9 +90,8 @@ public class NotFoundException extends ClientErrorException {
      * Construct a new "not found" exception.
      *
      * @param response error response.
-     * @param cause    the underlying cause of the exception.
-     * @throws IllegalArgumentException in case the status code set in the response
-     *                                  is not HTTP {@code 404}.
+     * @param cause the underlying cause of the exception.
+     * @throws IllegalArgumentException in case the status code set in the response is not HTTP {@code 404}.
      */
     public NotFoundException(final Response response, final Throwable cause) {
         super(validate(response, Response.Status.NOT_FOUND), cause);
@@ -106,12 +100,10 @@ public class NotFoundException extends ClientErrorException {
     /**
      * Construct a new "not found" exception.
      *
-     * @param message  the detail message (which is saved for later retrieval
-     *                 by the {@link #getMessage()} method).
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
      * @param response error response.
-     * @param cause    the underlying cause of the exception.
-     * @throws IllegalArgumentException in case the status code set in the response
-     *                                  is not HTTP {@code 404}.
+     * @param cause the underlying cause of the exception.
+     * @throws IllegalArgumentException in case the status code set in the response is not HTTP {@code 404}.
      */
     public NotFoundException(final String message, final Response response, final Throwable cause) {
         super(message, validate(response, Response.Status.NOT_FOUND), cause);

--- a/jaxrs-api/src/main/java/javax/ws/rs/NotSupportedException.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/NotSupportedException.java
@@ -40,8 +40,7 @@ public class NotSupportedException extends ClientErrorException {
     /**
      * Construct a new unsupported media type exception.
      *
-     * @param message the detail message (which is saved for later retrieval
-     *                by the {@link #getMessage()} method).
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
      */
     public NotSupportedException(final String message) {
         super(message, Response.Status.UNSUPPORTED_MEDIA_TYPE);
@@ -51,8 +50,7 @@ public class NotSupportedException extends ClientErrorException {
      * Construct a new unsupported media type exception.
      *
      * @param response error response.
-     * @throws IllegalArgumentException in case the status code set in the response
-     *                                  is not HTTP {@code 415}.
+     * @throws IllegalArgumentException in case the status code set in the response is not HTTP {@code 415}.
      */
     public NotSupportedException(final Response response) {
         super(validate(response, Response.Status.UNSUPPORTED_MEDIA_TYPE));
@@ -61,11 +59,9 @@ public class NotSupportedException extends ClientErrorException {
     /**
      * Construct a new unsupported media type exception.
      *
-     * @param message  the detail message (which is saved for later retrieval
-     *                 by the {@link #getMessage()} method).
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
      * @param response error response.
-     * @throws IllegalArgumentException in case the status code set in the response
-     *                                  is not HTTP {@code 415}.
+     * @throws IllegalArgumentException in case the status code set in the response is not HTTP {@code 415}.
      */
     public NotSupportedException(final String message, final Response response) {
         super(message, validate(response, Response.Status.UNSUPPORTED_MEDIA_TYPE));
@@ -83,9 +79,8 @@ public class NotSupportedException extends ClientErrorException {
     /**
      * Construct a new unsupported media type exception.
      *
-     * @param message the detail message (which is saved for later retrieval
-     *                by the {@link #getMessage()} method).
-     * @param cause   the underlying cause of the exception.
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param cause the underlying cause of the exception.
      */
     public NotSupportedException(final String message, final Throwable cause) {
         super(message, Response.Status.UNSUPPORTED_MEDIA_TYPE, cause);
@@ -95,9 +90,8 @@ public class NotSupportedException extends ClientErrorException {
      * Construct a new unsupported media type exception.
      *
      * @param response error response.
-     * @param cause    the underlying cause of the exception.
-     * @throws IllegalArgumentException in case the status code set in the response
-     *                                  is not HTTP {@code 415}.
+     * @param cause the underlying cause of the exception.
+     * @throws IllegalArgumentException in case the status code set in the response is not HTTP {@code 415}.
      */
     public NotSupportedException(final Response response, final Throwable cause) {
         super(validate(response, Response.Status.UNSUPPORTED_MEDIA_TYPE), cause);
@@ -106,12 +100,10 @@ public class NotSupportedException extends ClientErrorException {
     /**
      * Construct a new unsupported media type exception.
      *
-     * @param message  the detail message (which is saved for later retrieval
-     *                 by the {@link #getMessage()} method).
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
      * @param response error response.
-     * @param cause    the underlying cause of the exception.
-     * @throws IllegalArgumentException in case the status code set in the response
-     *                                  is not HTTP {@code 415}.
+     * @param cause the underlying cause of the exception.
+     * @throws IllegalArgumentException in case the status code set in the response is not HTTP {@code 415}.
      */
     public NotSupportedException(final String message, final Response response, final Throwable cause) {
         super(message, validate(response, Response.Status.UNSUPPORTED_MEDIA_TYPE), cause);

--- a/jaxrs-api/src/main/java/javax/ws/rs/OPTIONS.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/OPTIONS.java
@@ -30,7 +30,7 @@ import java.lang.annotation.Target;
  * @see HttpMethod
  * @since 1.1
  */
-@Target({ElementType.METHOD})
+@Target({ ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @HttpMethod(HttpMethod.OPTIONS)
 @Documented

--- a/jaxrs-api/src/main/java/javax/ws/rs/PATCH.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/PATCH.java
@@ -29,7 +29,7 @@ import java.lang.annotation.Target;
  * @see HttpMethod
  * @since 2.1
  */
-@Target({ElementType.METHOD})
+@Target({ ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @HttpMethod(HttpMethod.PATCH)
 @Documented

--- a/jaxrs-api/src/main/java/javax/ws/rs/POST.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/POST.java
@@ -30,7 +30,7 @@ import java.lang.annotation.Target;
  * @see HttpMethod
  * @since 1.0
  */
-@Target({ElementType.METHOD})
+@Target({ ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @HttpMethod(HttpMethod.POST)
 @Documented

--- a/jaxrs-api/src/main/java/javax/ws/rs/PUT.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/PUT.java
@@ -30,7 +30,7 @@ import java.lang.annotation.Target;
  * @see HttpMethod
  * @since 1.0
  */
-@Target({ElementType.METHOD})
+@Target({ ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @HttpMethod(HttpMethod.PUT)
 @Documented

--- a/jaxrs-api/src/main/java/javax/ws/rs/Path.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/Path.java
@@ -23,37 +23,37 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Identifies the URI path that a resource class or class method will serve
- * requests for.
+ * Identifies the URI path that a resource class or class method will serve requests for.
  *
- * <p>Paths are relative. For an annotated class the base URI is the
- * application path, see {@link ApplicationPath}. For an annotated
- * method the base URI is the
- * effective URI of the containing class. For the purposes of absolutizing a
- * path against the base URI , a leading '/' in a path is
- * ignored and base URIs are treated as if they ended in '/'. E.g.:</p>
+ * <p>
+ * Paths are relative. For an annotated class the base URI is the application path, see {@link ApplicationPath}. For an
+ * annotated method the base URI is the effective URI of the containing class. For the purposes of absolutizing a path
+ * against the base URI , a leading '/' in a path is ignored and base URIs are treated as if they ended in '/'. E.g.:
+ * </p>
  *
- * <pre>&#64;Path("widgets")
+ * <pre>
+ * &#64;Path("widgets")
  * public class WidgetsResource {
  *  &#64;GET
  *  String getList() {...}
  *
  *  &#64;GET &#64;Path("{id}")
  *  String getWidget(&#64;PathParam("id") String id) {...}
- * }</pre>
+ * }
+ * </pre>
  *
- * <p>In the above, if the application path is
- * {@code catalogue} and the application is deployed at
- * {@code http://example.com/}, then {@code GET} requests for
- * {@code http://example.com/catalogue/widgets} will be handled by the
- * {@code getList} method while requests for
- * <code>http://example.com/catalogue/widgets/<i>nnn</i></code> (where
- * <code><i>nnn</i></code> is some value) will be handled by the
- * {@code getWidget} method. The same would apply if the value of either
- * {@code @Path} annotation started with '/'.</p>
+ * <p>
+ * In the above, if the application path is {@code catalogue} and the application is deployed at
+ * {@code http://example.com/}, then {@code GET} requests for {@code http://example.com/catalogue/widgets} will be
+ * handled by the {@code getList} method while requests for <code>http://example.com/catalogue/widgets/<i>nnn</i></code>
+ * (where <code><i>nnn</i></code> is some value) will be handled by the {@code getWidget} method. The same would apply
+ * if the value of either {@code @Path} annotation started with '/'.
+ * </p>
  *
- * <p>Classes and methods may also be annotated with {@link Consumes} and
- * {@link Produces} to filter the requests they will receive.</p>
+ * <p>
+ * Classes and methods may also be annotated with {@link Consumes} and {@link Produces} to filter the requests they will
+ * receive.
+ * </p>
  *
  * @author Paul Sandoz
  * @author Marc Hadley
@@ -62,47 +62,46 @@ import java.lang.annotation.Target;
  * @see PathParam
  * @since 1.0
  */
-@Target({ElementType.TYPE, ElementType.METHOD})
+@Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface Path {
 
     /**
-     * Defines a URI template for the resource class or method, must not
-     * include matrix parameters.
+     * Defines a URI template for the resource class or method, must not include matrix parameters.
      *
-     * <p>Embedded template parameters are allowed and are of the form:</p>
+     * <p>
+     * Embedded template parameters are allowed and are of the form:
+     * </p>
      *
-     * <pre> param = "{" *WSP name *WSP [ ":" *WSP regex *WSP ] "}"
+     * <pre>
+     *  param = "{" *WSP name *WSP [ ":" *WSP regex *WSP ] "}"
      * name = (ALPHA / DIGIT / "_")*(ALPHA / DIGIT / "." / "_" / "-" ) ; \w[\w\.-]*
-     * regex = *( nonbrace / "{" *nonbrace "}" ) ; where nonbrace is any char other than "{" and "}"</pre>
+     * regex = *( nonbrace / "{" *nonbrace "}" ) ; where nonbrace is any char other than "{" and "}"
+     * </pre>
      *
-     * <p>See <a href="http://tools.ietf.org/html/rfc5234">RFC 5234</a>
-     * for a description of the syntax used above and the expansions of
-     * {@code WSP}, {@code ALPHA} and {@code DIGIT}. In the above {@code name}
-     * is the template parameter name and the optional {@code regex} specifies
-     * the contents of the capturing group for the parameter. If {@code regex}
-     * is not supplied then a default value of {@code [^/]+} which terminates at
-     * a path segment boundary, is used. Matching of request URIs to URI
-     * templates is performed against encoded path values and implementations
-     * will not escape literal characters in regex automatically, therefore any
-     * literals in {@code regex} should be escaped by the author according to
-     * the rules of
-     * <a href="http://tools.ietf.org/html/rfc3986#section-3.3">RFC 3986 section 3.3</a>.
-     * Caution is recommended in the use of {@code regex}, incorrect use can
-     * lead to a template parameter matching unexpected URI paths. See
-     * <a href="http://download.oracle.com/javase/6/docs/api/java/util/regex/Pattern.html">Pattern</a>
-     * for further information on the syntax of regular expressions.
-     * Values of template parameters may be extracted using {@link PathParam}.</p>
+     * <p>
+     * See <a href="http://tools.ietf.org/html/rfc5234">RFC 5234</a> for a description of the syntax used above and the
+     * expansions of {@code WSP}, {@code ALPHA} and {@code DIGIT}. In the above {@code name} is the template parameter name
+     * and the optional {@code regex} specifies the contents of the capturing group for the parameter. If {@code regex} is
+     * not supplied then a default value of {@code [^/]+} which terminates at a path segment boundary, is used. Matching of
+     * request URIs to URI templates is performed against encoded path values and implementations will not escape literal
+     * characters in regex automatically, therefore any literals in {@code regex} should be escaped by the author according
+     * to the rules of <a href="http://tools.ietf.org/html/rfc3986#section-3.3">RFC 3986 section 3.3</a>. Caution is
+     * recommended in the use of {@code regex}, incorrect use can lead to a template parameter matching unexpected URI
+     * paths. See <a href="http://download.oracle.com/javase/6/docs/api/java/util/regex/Pattern.html">Pattern</a> for
+     * further information on the syntax of regular expressions. Values of template parameters may be extracted using
+     * {@link PathParam}.
+     * </p>
      *
-     * <p>The literal part of the supplied value (those characters
-     * that are not part of a template parameter) is automatically percent
-     * encoded to conform to the {@code path} production of
-     * <a href="http://tools.ietf.org/html/rfc3986#section-3.3">RFC 3986 section 3.3</a>.
-     * Note that percent encoded values are allowed in the literal part of the
-     * value, an implementation will recognize such values and will not double
-     * encode the '%' character.</p>
-     * 
+     * <p>
+     * The literal part of the supplied value (those characters that are not part of a template parameter) is automatically
+     * percent encoded to conform to the {@code path} production of
+     * <a href="http://tools.ietf.org/html/rfc3986#section-3.3">RFC 3986 section 3.3</a>. Note that percent encoded values
+     * are allowed in the literal part of the value, an implementation will recognize such values and will not double encode
+     * the '%' character.
+     * </p>
+     *
      * @return URI template.
      */
     String value();

--- a/jaxrs-api/src/main/java/javax/ws/rs/PathParam.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/PathParam.java
@@ -23,47 +23,38 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Binds the value of a URI template parameter or a path segment
- * containing the template parameter to a resource method parameter, resource
- * class field, or resource class
- * bean property. The value is URL decoded unless this
- * is disabled using the {@link Encoded &#64;Encoded} annotation.
- * A default value can be specified using the {@link DefaultValue &#64;DefaultValue}
- * annotation.
+ * Binds the value of a URI template parameter or a path segment containing the template parameter to a resource method
+ * parameter, resource class field, or resource class bean property. The value is URL decoded unless this is disabled
+ * using the {@link Encoded &#64;Encoded} annotation. A default value can be specified using the {@link DefaultValue
+ * &#64;DefaultValue} annotation.
  *
  * The type of the annotated parameter, field or property must either:
  * <ul>
- * <li>Be {@link javax.ws.rs.core.PathSegment}, the value will be the final
- * segment of the matching part of the path.
- * See {@link javax.ws.rs.core.UriInfo} for a means of retrieving all request
- * path segments.</li>
- * <li>Be {@code List<javax.ws.rs.core.PathSegment>}, the
- * value will be a list of {@code PathSegment} corresponding to the path
- * segment(s) that matched the named template parameter.
- * See {@link javax.ws.rs.core.UriInfo} for a means of retrieving all request
- * path segments.</li>
+ * <li>Be {@link javax.ws.rs.core.PathSegment}, the value will be the final segment of the matching part of the path.
+ * See {@link javax.ws.rs.core.UriInfo} for a means of retrieving all request path segments.</li>
+ * <li>Be {@code List<javax.ws.rs.core.PathSegment>}, the value will be a list of {@code PathSegment} corresponding to
+ * the path segment(s) that matched the named template parameter. See {@link javax.ws.rs.core.UriInfo} for a means of
+ * retrieving all request path segments.</li>
  * <li>Be a primitive type.</li>
  * <li>Have a constructor that accepts a single String argument.</li>
- * <li>Have a static method named {@code valueOf} or {@code fromString}
- * that accepts a single
- * String argument (see, for example, {@link Integer#valueOf(String)}).</li>
- * <li>Have a registered implementation of {@link javax.ws.rs.ext.ParamConverterProvider}
- * JAX-RS extension SPI that returns a {@link javax.ws.rs.ext.ParamConverter}
- * instance capable of a "from string" conversion for the type.</li>
+ * <li>Have a static method named {@code valueOf} or {@code fromString} that accepts a single String argument (see, for
+ * example, {@link Integer#valueOf(String)}).</li>
+ * <li>Have a registered implementation of {@link javax.ws.rs.ext.ParamConverterProvider} JAX-RS extension SPI that
+ * returns a {@link javax.ws.rs.ext.ParamConverter} instance capable of a "from string" conversion for the type.</li>
  * </ul>
  *
- * <p>The injected value corresponds to the latest use (in terms of scope) of
- * the path parameter. E.g. if a class and a sub-resource method are both
- * annotated with a {@link Path &#64;Path} containing the same URI template
- * parameter, use of {@code @PathParam} on a sub-resource method parameter
- * will bind the value matching URI template parameter in the method's
- * {@code @Path} annotation.</p>
+ * <p>
+ * The injected value corresponds to the latest use (in terms of scope) of the path parameter. E.g. if a class and a
+ * sub-resource method are both annotated with a {@link Path &#64;Path} containing the same URI template parameter, use
+ * of {@code @PathParam} on a sub-resource method parameter will bind the value matching URI template parameter in the
+ * method's {@code @Path} annotation.
+ * </p>
  *
- * <p>Because injection occurs at object creation time, use of this annotation
- * on resource class fields and bean properties is only supported for the
- * default per-request resource class lifecycle. Resource classes using
- * other lifecycles should only use this annotation on resource method
- * parameters.</p>
+ * <p>
+ * Because injection occurs at object creation time, use of this annotation on resource class fields and bean properties
+ * is only supported for the default per-request resource class lifecycle. Resource classes using other lifecycles
+ * should only use this annotation on resource method parameters.
+ * </p>
  *
  * @author Paul Sandoz
  * @author Marc Hadley
@@ -73,21 +64,20 @@ import java.lang.annotation.Target;
  * @see javax.ws.rs.core.UriInfo
  * @since 1.0
  */
-@Target({ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD})
+@Target({ ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface PathParam {
 
     /**
-     * Defines the name of the URI template parameter whose value will be used
-     * to initialize the value of the annotated method parameter, class field or
-     * property. See {@link Path#value()} for a description of the syntax of
-     * template parameters.
+     * Defines the name of the URI template parameter whose value will be used to initialize the value of the annotated
+     * method parameter, class field or property. See {@link Path#value()} for a description of the syntax of template
+     * parameters.
      *
-     * <p>E.g. a class annotated with: {@code @Path("widgets/{id}")}
-     * can have methods annotated whose arguments are annotated
+     * <p>
+     * E.g. a class annotated with: {@code @Path("widgets/{id}")} can have methods annotated whose arguments are annotated
      * with {@code @PathParam("id")}.
-     * 
+     *
      * @return resource URI template parameter name.
      */
     String value();

--- a/jaxrs-api/src/main/java/javax/ws/rs/Priorities.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/Priorities.java
@@ -17,21 +17,19 @@
 package javax.ws.rs;
 
 /**
- * A collection of built-in priority constants for the JAX-RS components that are supposed to be
- * ordered based on their {@code javax.annotation.Priority} class-level annotation value when used
- * or applied by JAX-RS runtime.
+ * A collection of built-in priority constants for the JAX-RS components that are supposed to be ordered based on their
+ * {@code javax.annotation.Priority} class-level annotation value when used or applied by JAX-RS runtime.
  * <p>
- * For example, JAX-RS filters and interceptors are grouped in chains for each of the message
- * processing extension points: Pre, PreMatch, Post as well as ReadFrom and WriteTo.
- * Each of these chains is sorted based on priorities which are represented as integer numbers.
- * All chains, except Post, are sorted in ascending order; the lower the number the higher the priority.
- * The Post filter chain is sorted in descending order to ensure that response filters are executed in
- * <em>reverse order</em>.
+ * For example, JAX-RS filters and interceptors are grouped in chains for each of the message processing extension
+ * points: Pre, PreMatch, Post as well as ReadFrom and WriteTo. Each of these chains is sorted based on priorities which
+ * are represented as integer numbers. All chains, except Post, are sorted in ascending order; the lower the number the
+ * higher the priority. The Post filter chain is sorted in descending order to ensure that response filters are executed
+ * in <em>reverse order</em>.
  * </p>
  * <p>
  * JAX-RS components that belong to the same priority class (same integer value) are executed in an
- * implementation-defined manner. By default, when the {@code @Priority} annotation is absent on a component,
- * for which a priority should be applied, the {@link Priorities#USER} priority value is used.
+ * implementation-defined manner. By default, when the {@code @Priority} annotation is absent on a component, for which
+ * a priority should be applied, the {@link Priorities#USER} priority value is used.
  * </p>
  *
  * @author Marek Potociar (marek.potociar at oracle.com)

--- a/jaxrs-api/src/main/java/javax/ws/rs/ProcessingException.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ProcessingException.java
@@ -19,26 +19,21 @@ package javax.ws.rs;
 /**
  * A base JAX-RS runtime processing exception.
  *
- * The exception of this type is thrown during HTTP request or response processing,
- * to signal a runtime processing failure. Typical classes of failures covered by
- * {@code ProcessingException} include
+ * The exception of this type is thrown during HTTP request or response processing, to signal a runtime processing
+ * failure. Typical classes of failures covered by {@code ProcessingException} include
  * <ul>
  * <li>failures in filter or interceptor chain execution,</li>
- * <li>errors caused by missing message body readers or writers for the particular Java type
- * and media type combinations,</li>
- * <li>propagated {@link java.io.IOException IO exceptions} thrown by
- * entity {@link javax.ws.rs.ext.MessageBodyReader readers} and {@link javax.ws.rs.ext.MessageBodyWriter writers}
- * during entity serialization and de-serialization.</li>
+ * <li>errors caused by missing message body readers or writers for the particular Java type and media type
+ * combinations,</li>
+ * <li>propagated {@link java.io.IOException IO exceptions} thrown by entity {@link javax.ws.rs.ext.MessageBodyReader
+ * readers} and {@link javax.ws.rs.ext.MessageBodyWriter writers} during entity serialization and de-serialization.</li>
  * </ul>
- * as well as any other JAX-RS runtime processing errors.
- * The exception message or nested {@link Throwable}
- * cause SHOULD contain additional information about the reason of the processing
- * failure.
+ * as well as any other JAX-RS runtime processing errors. The exception message or nested {@link Throwable} cause SHOULD
+ * contain additional information about the reason of the processing failure.
  * <p>
- * Note that the exception is used to indicate (internal) JAX-RS processing errors.
- * It is not used to indicate HTTP error response states. A HTTP error response is
- * represented by a {@link javax.ws.rs.WebApplicationException} class or one of it's
- * sub-classes.
+ * Note that the exception is used to indicate (internal) JAX-RS processing errors. It is not used to indicate HTTP
+ * error response states. A HTTP error response is represented by a {@link javax.ws.rs.WebApplicationException} class or
+ * one of it's sub-classes.
  * </p>
  *
  * @author Marek Potociar
@@ -49,15 +44,13 @@ public class ProcessingException extends RuntimeException {
     private static final long serialVersionUID = -4232431597816056514L;
 
     /**
-     * Constructs a new JAX-RS runtime processing exception with the specified cause
-     * and a detail message of {@code (cause==null ? null : cause.toString())}
-     * (which typically contains the class and detail message of {@code cause}).
-     * This constructor is useful for runtime exceptions that are little more
-     * than wrappers for other throwables.
+     * Constructs a new JAX-RS runtime processing exception with the specified cause and a detail message of
+     * {@code (cause==null ? null : cause.toString())} (which typically contains the class and detail message of
+     * {@code cause}). This constructor is useful for runtime exceptions that are little more than wrappers for other
+     * throwables.
      *
-     * @param cause the cause (which is saved for later retrieval by the
-     *              {@link #getCause()} method). (A {@code null} value is permitted,
-     *              and indicates that the cause is nonexistent or unknown.)
+     * @param cause the cause (which is saved for later retrieval by the {@link #getCause()} method). (A {@code null} value
+     * is permitted, and indicates that the cause is nonexistent or unknown.)
      */
     public ProcessingException(final Throwable cause) {
         super(cause);
@@ -65,29 +58,24 @@ public class ProcessingException extends RuntimeException {
 
     /**
      * <p>
-     * Constructs a new JAX-RS runtime processing exception with the specified detail
-     * message and cause.
+     * Constructs a new JAX-RS runtime processing exception with the specified detail message and cause.
      * </p>
-     * Note that the detail message associated with {@code cause} is <i>not</i>
-     * automatically incorporated in this runtime exception's detail message.
+     * Note that the detail message associated with {@code cause} is <i>not</i> automatically incorporated in this runtime
+     * exception's detail message.
      *
-     * @param message the detail message (which is saved for later retrieval
-     *                by the {@link #getMessage()} method).
-     * @param cause   the cause (which is saved for later retrieval by the
-     *                {@link #getCause()} method). (A {@code null} value is permitted,
-     *                and indicates that the cause is nonexistent or unknown.)
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param cause the cause (which is saved for later retrieval by the {@link #getCause()} method). (A {@code null} value
+     * is permitted, and indicates that the cause is nonexistent or unknown.)
      */
     public ProcessingException(final String message, final Throwable cause) {
         super(message, cause);
     }
 
     /**
-     * Constructs a new JAX-RS runtime processing exception with the specified detail
-     * message. The cause is not initialized, and may subsequently be initialized
-     * by a call to {@link #initCause}.
+     * Constructs a new JAX-RS runtime processing exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to {@link #initCause}.
      *
-     * @param message the detail message (which is saved for later retrieval
-     *                by the {@link #getMessage()} method).
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
      */
     public ProcessingException(final String message) {
         super(message);

--- a/jaxrs-api/src/main/java/javax/ws/rs/Produces.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/Produces.java
@@ -24,19 +24,16 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Defines the media type(s) that the methods of a resource class or
- * {@link javax.ws.rs.ext.MessageBodyWriter} can produce.
- * If not specified then a container will assume that any type can be produced.
- * Method level annotations override a class level annotation. A container
- * is responsible for ensuring that the method invoked is capable of producing
- * one of the media types requested in the HTTP request. If no such method is
- * available the container must respond with a HTTP "406 Not Acceptable" as
- * specified by RFC 2616.
+ * Defines the media type(s) that the methods of a resource class or {@link javax.ws.rs.ext.MessageBodyWriter} can
+ * produce. If not specified then a container will assume that any type can be produced. Method level annotations
+ * override a class level annotation. A container is responsible for ensuring that the method invoked is capable of
+ * producing one of the media types requested in the HTTP request. If no such method is available the container must
+ * respond with a HTTP "406 Not Acceptable" as specified by RFC 2616.
  *
- * <p>A method for which there is a single-valued {@code @Produces}
- * is not required to set the media type of representations that it produces:
- * the container will use the value of the {@code @Produces} when
- * sending a response.</p>
+ * <p>
+ * A method for which there is a single-valued {@code @Produces} is not required to set the media type of
+ * representations that it produces: the container will use the value of the {@code @Produces} when sending a response.
+ * </p>
  *
  * @author Paul Sandoz
  * @author Marc Hadley
@@ -44,21 +41,21 @@ import java.lang.annotation.Target;
  * @since 1.0
  */
 @Inherited
-@Target({ElementType.TYPE, ElementType.METHOD})
+@Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface Produces {
 
     /**
-     * A list of media types. Each entry may specify a single type or consist
-     * of a comma separated list of types, with any leading or trailing white-spaces
-     * in a single type entry being ignored. For example:
+     * A list of media types. Each entry may specify a single type or consist of a comma separated list of types, with any
+     * leading or trailing white-spaces in a single type entry being ignored. For example:
+     *
      * <pre>
-     *  {"image/jpeg, image/gif ", " image/png"}
+     * { "image/jpeg, image/gif ", " image/png" }
      * </pre>
-     * Use of the comma-separated form allows definition of a common string constant
-     * for use on multiple targets.
-     * 
+     *
+     * Use of the comma-separated form allows definition of a common string constant for use on multiple targets.
+     *
      * @return media types to accept.
      */
     String[] value() default "*/*";

--- a/jaxrs-api/src/main/java/javax/ws/rs/QueryParam.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/QueryParam.java
@@ -23,37 +23,32 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Binds the value(s) of a HTTP query parameter to a resource method parameter,
- * resource class field, or resource class bean property.
- * Values are URL decoded unless this is disabled using the {@link Encoded}
- * annotation. A default value can be specified using the {@link DefaultValue}
- * annotation.
+ * Binds the value(s) of a HTTP query parameter to a resource method parameter, resource class field, or resource class
+ * bean property. Values are URL decoded unless this is disabled using the {@link Encoded} annotation. A default value
+ * can be specified using the {@link DefaultValue} annotation.
  *
- * The type {@code T} of the annotated parameter, field or property must
- * either:
+ * The type {@code T} of the annotated parameter, field or property must either:
  * <ol>
  * <li>Be a primitive type</li>
  * <li>Have a constructor that accepts a single {@code String} argument</li>
- * <li>Have a static method named {@code valueOf} or {@code fromString}
- * that accepts a single
- * {@code String} argument (see, for example, {@link Integer#valueOf(String)})</li>
- * <li>Have a registered implementation of {@link javax.ws.rs.ext.ParamConverterProvider}
- * JAX-RS extension SPI that returns a {@link javax.ws.rs.ext.ParamConverter}
- * instance capable of a "from string" conversion for the type.</li>
- * <li>Be {@code List<T>}, {@code Set<T>} or
- * {@code SortedSet<T>}, where {@code T} satisfies 2, 3 or 4 above.
- * The resulting collection is read-only.</li>
+ * <li>Have a static method named {@code valueOf} or {@code fromString} that accepts a single {@code String} argument
+ * (see, for example, {@link Integer#valueOf(String)})</li>
+ * <li>Have a registered implementation of {@link javax.ws.rs.ext.ParamConverterProvider} JAX-RS extension SPI that
+ * returns a {@link javax.ws.rs.ext.ParamConverter} instance capable of a "from string" conversion for the type.</li>
+ * <li>Be {@code List<T>}, {@code Set<T>} or {@code SortedSet<T>}, where {@code T} satisfies 2, 3 or 4 above. The
+ * resulting collection is read-only.</li>
  * </ol>
  *
- * <p>If the type is not one of the collection types listed in 5 above and the
- * query parameter is represented by multiple values then the first value (lexically)
- * of the parameter is used.</p>
+ * <p>
+ * If the type is not one of the collection types listed in 5 above and the query parameter is represented by multiple
+ * values then the first value (lexically) of the parameter is used.
+ * </p>
  *
- * <p>Because injection occurs at object creation time, use of this annotation
- * on resource class fields and bean properties is only supported for the
- * default per-request resource class lifecycle. Resource classes using
- * other lifecycles should only use this annotation on resource method
- * parameters.</p>
+ * <p>
+ * Because injection occurs at object creation time, use of this annotation on resource class fields and bean properties
+ * is only supported for the default per-request resource class lifecycle. Resource classes using other lifecycles
+ * should only use this annotation on resource method parameters.
+ * </p>
  *
  * @author Paul Sandoz
  * @author Marc Hadley
@@ -62,19 +57,17 @@ import java.lang.annotation.Target;
  * @see javax.ws.rs.core.UriInfo#getQueryParameters
  * @since 1.0
  */
-@Target({ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD})
+@Target({ ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface QueryParam {
 
     /**
-     * Defines the name of the HTTP query parameter whose value will be used
-     * to initialize the value of the annotated method argument, class field or
-     * bean property. The name is specified in decoded form, any percent encoded
-     * literals within the value will not be decoded and will instead be
-     * treated as literal text. E.g. if the parameter name is "a b" then the
-     * value of the annotation is "a b", <i>not</i> "a+b" or "a%20b".
-     * 
+     * Defines the name of the HTTP query parameter whose value will be used to initialize the value of the annotated method
+     * argument, class field or bean property. The name is specified in decoded form, any percent encoded literals within
+     * the value will not be decoded and will instead be treated as literal text. E.g. if the parameter name is "a b" then
+     * the value of the annotation is "a b", <i>not</i> "a+b" or "a%20b".
+     *
      * @return HTTP query parameter name.
      */
     String value();

--- a/jaxrs-api/src/main/java/javax/ws/rs/RedirectionException.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/RedirectionException.java
@@ -21,8 +21,7 @@ import java.net.URI;
 import javax.ws.rs.core.Response;
 
 /**
- * A runtime application exception indicating a request redirection
- * (HTTP {@code 3xx} status codes).
+ * A runtime application exception indicating a request redirection (HTTP {@code 3xx} status codes).
  *
  * @author Marek Potociar
  * @since 2.0
@@ -34,11 +33,10 @@ public class RedirectionException extends WebApplicationException {
     /**
      * Construct a new redirection exception.
      *
-     * @param status   redirection status. Must be a {@code 3xx} redirection code.
+     * @param status redirection status. Must be a {@code 3xx} redirection code.
      * @param location redirection URI placed into the response {@code Location} header.
      * @throws IllegalArgumentException in case the status code is {@code null} or is not from
-     *                                  {@link javax.ws.rs.core.Response.Status.Family#REDIRECTION} status code
-     *                                  family.
+     * {@link javax.ws.rs.core.Response.Status.Family#REDIRECTION} status code family.
      */
     public RedirectionException(final Response.Status status, final URI location) {
         super((Throwable) null, validate(Response.status(status).location(location).build(), Response.Status.Family.REDIRECTION));
@@ -47,13 +45,11 @@ public class RedirectionException extends WebApplicationException {
     /**
      * Construct a new redirection exception.
      *
-     * @param message  the detail message (which is saved for later retrieval
-     *                 by the {@link #getMessage()} method).
-     * @param status   redirection status. Must be a {@code 3xx} redirection code.
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param status redirection status. Must be a {@code 3xx} redirection code.
      * @param location redirection URI placed into the response {@code Location} header.
      * @throws IllegalArgumentException in case the status code is {@code null} or is not from
-     *                                  {@link javax.ws.rs.core.Response.Status.Family#REDIRECTION} status code
-     *                                  family.
+     * {@link javax.ws.rs.core.Response.Status.Family#REDIRECTION} status code family.
      */
     public RedirectionException(final String message, final Response.Status status, final URI location) {
         super(message, null, validate(Response.status(status).location(location).build(), Response.Status.Family.REDIRECTION));
@@ -62,11 +58,10 @@ public class RedirectionException extends WebApplicationException {
     /**
      * Construct a new redirection exception.
      *
-     * @param status   redirection status. Must be a {@code 3xx} redirection code.
+     * @param status redirection status. Must be a {@code 3xx} redirection code.
      * @param location redirection URI placed into the response {@code Location} header.
-     * @throws IllegalArgumentException in case the status code is not a valid HTTP status code or
-     *                                  if it is not from the {@link javax.ws.rs.core.Response.Status.Family#REDIRECTION}
-     *                                  status code family.
+     * @throws IllegalArgumentException in case the status code is not a valid HTTP status code or if it is not from the
+     * {@link javax.ws.rs.core.Response.Status.Family#REDIRECTION} status code family.
      */
     public RedirectionException(final int status, final URI location) {
         super((Throwable) null, validate(Response.status(status).location(location).build(), Response.Status.Family.REDIRECTION));
@@ -75,13 +70,11 @@ public class RedirectionException extends WebApplicationException {
     /**
      * Construct a new redirection exception.
      *
-     * @param message  the detail message (which is saved for later retrieval
-     *                 by the {@link #getMessage()} method).
-     * @param status   redirection status. Must be a {@code 3xx} redirection code.
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param status redirection status. Must be a {@code 3xx} redirection code.
      * @param location redirection URI placed into the response {@code Location} header.
-     * @throws IllegalArgumentException in case the status code is not a valid HTTP status code or
-     *                                  if it is not from the {@link javax.ws.rs.core.Response.Status.Family#REDIRECTION}
-     *                                  status code family.
+     * @throws IllegalArgumentException in case the status code is not a valid HTTP status code or if it is not from the
+     * {@link javax.ws.rs.core.Response.Status.Family#REDIRECTION} status code family.
      */
     public RedirectionException(final String message, final int status, final URI location) {
         super(message, null, validate(Response.status(status).location(location).build(), Response.Status.Family.REDIRECTION));
@@ -90,10 +83,9 @@ public class RedirectionException extends WebApplicationException {
     /**
      * Construct a new redirection exception.
      *
-     * @param response redirection response. Must have a status code set to a {@code 3xx}
-     *                 redirection code.
+     * @param response redirection response. Must have a status code set to a {@code 3xx} redirection code.
      * @throws IllegalArgumentException in case the response status code is not from the
-     *                                  {@link javax.ws.rs.core.Response.Status.Family#REDIRECTION} status code family.
+     * {@link javax.ws.rs.core.Response.Status.Family#REDIRECTION} status code family.
      */
     public RedirectionException(final Response response) {
         super((Throwable) null, validate(response, Response.Status.Family.REDIRECTION));
@@ -102,12 +94,10 @@ public class RedirectionException extends WebApplicationException {
     /**
      * Construct a new redirection exception.
      *
-     * @param message  the detail message (which is saved for later retrieval
-     *                 by the {@link #getMessage()} method).
-     * @param response redirection response. Must have a status code set to a {@code 3xx}
-     *                 redirection code.
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param response redirection response. Must have a status code set to a {@code 3xx} redirection code.
      * @throws IllegalArgumentException in case the response status code is not from the
-     *                                  {@link javax.ws.rs.core.Response.Status.Family#REDIRECTION} status code family.
+     * {@link javax.ws.rs.core.Response.Status.Family#REDIRECTION} status code family.
      */
     public RedirectionException(final String message, final Response response) {
         super(message, null, validate(response, Response.Status.Family.REDIRECTION));

--- a/jaxrs-api/src/main/java/javax/ws/rs/ServerErrorException.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ServerErrorException.java
@@ -19,8 +19,7 @@ package javax.ws.rs;
 import javax.ws.rs.core.Response;
 
 /**
- * A base runtime application exception indicating a server error
- * (HTTP {@code 5xx} status codes).
+ * A base runtime application exception indicating a server error (HTTP {@code 5xx} status codes).
  *
  * @author Marek Potociar
  * @since 2.0
@@ -34,8 +33,7 @@ public class ServerErrorException extends WebApplicationException {
      *
      * @param status server error status. Must be a {@code 5xx} status code.
      * @throws IllegalArgumentException in case the status code is {@code null} or is not from
-     *                                  {@link javax.ws.rs.core.Response.Status.Family#SERVER_ERROR} status code
-     *                                  family.
+     * {@link javax.ws.rs.core.Response.Status.Family#SERVER_ERROR} status code family.
      */
     public ServerErrorException(final Response.Status status) {
         super((Throwable) null, validate(Response.status(status).build(), Response.Status.Family.SERVER_ERROR));
@@ -44,12 +42,10 @@ public class ServerErrorException extends WebApplicationException {
     /**
      * Construct a new server error exception.
      *
-     * @param message the detail message (which is saved for later retrieval
-     *                by the {@link #getMessage()} method).
-     * @param status  server error status. Must be a {@code 5xx} status code.
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param status server error status. Must be a {@code 5xx} status code.
      * @throws IllegalArgumentException in case the status code is {@code null} or is not from
-     *                                  {@link javax.ws.rs.core.Response.Status.Family#SERVER_ERROR} status code
-     *                                  family.
+     * {@link javax.ws.rs.core.Response.Status.Family#SERVER_ERROR} status code family.
      */
     public ServerErrorException(final String message, final Response.Status status) {
         super(message, null, validate(Response.status(status).build(), Response.Status.Family.SERVER_ERROR));
@@ -59,9 +55,8 @@ public class ServerErrorException extends WebApplicationException {
      * Construct a new server error exception.
      *
      * @param status server error status. Must be a {@code 5xx} status code.
-     * @throws IllegalArgumentException in case the status code is not a valid HTTP status code or
-     *                                  if it is not from the {@link javax.ws.rs.core.Response.Status.Family#SERVER_ERROR}
-     *                                  status code family.
+     * @throws IllegalArgumentException in case the status code is not a valid HTTP status code or if it is not from the
+     * {@link javax.ws.rs.core.Response.Status.Family#SERVER_ERROR} status code family.
      */
     public ServerErrorException(final int status) {
         super((Throwable) null, validate(Response.status(status).build(), Response.Status.Family.SERVER_ERROR));
@@ -70,12 +65,10 @@ public class ServerErrorException extends WebApplicationException {
     /**
      * Construct a new server error exception.
      *
-     * @param message the detail message (which is saved for later retrieval
-     *                by the {@link #getMessage()} method).
-     * @param status  server error status. Must be a {@code 5xx} status code.
-     * @throws IllegalArgumentException in case the status code is not a valid HTTP status code or
-     *                                  if it is not from the {@link javax.ws.rs.core.Response.Status.Family#SERVER_ERROR}
-     *                                  status code family.
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param status server error status. Must be a {@code 5xx} status code.
+     * @throws IllegalArgumentException in case the status code is not a valid HTTP status code or if it is not from the
+     * {@link javax.ws.rs.core.Response.Status.Family#SERVER_ERROR} status code family.
      */
     public ServerErrorException(final String message, final int status) {
         super(message, null, validate(Response.status(status).build(), Response.Status.Family.SERVER_ERROR));
@@ -84,10 +77,9 @@ public class ServerErrorException extends WebApplicationException {
     /**
      * Construct a new server error exception.
      *
-     * @param response server error response. Must have a status code set to a {@code 5xx}
-     *                 status code.
+     * @param response server error response. Must have a status code set to a {@code 5xx} status code.
      * @throws IllegalArgumentException in case the response status code is not from the
-     *                                  {@link javax.ws.rs.core.Response.Status.Family#SERVER_ERROR} status code family.
+     * {@link javax.ws.rs.core.Response.Status.Family#SERVER_ERROR} status code family.
      */
     public ServerErrorException(final Response response) {
         super((Throwable) null, validate(response, Response.Status.Family.SERVER_ERROR));
@@ -96,12 +88,10 @@ public class ServerErrorException extends WebApplicationException {
     /**
      * Construct a new server error exception.
      *
-     * @param message  the detail message (which is saved for later retrieval
-     *                 by the {@link #getMessage()} method).
-     * @param response server error response. Must have a status code set to a {@code 5xx}
-     *                 status code.
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param response server error response. Must have a status code set to a {@code 5xx} status code.
      * @throws IllegalArgumentException in case the response status code is not from the
-     *                                  {@link javax.ws.rs.core.Response.Status.Family#SERVER_ERROR} status code family.
+     * {@link javax.ws.rs.core.Response.Status.Family#SERVER_ERROR} status code family.
      */
     public ServerErrorException(final String message, final Response response) {
         super(message, null, validate(response, Response.Status.Family.SERVER_ERROR));
@@ -111,10 +101,9 @@ public class ServerErrorException extends WebApplicationException {
      * Construct a new server error exception.
      *
      * @param status server error status. Must be a {@code 5xx} status code.
-     * @param cause  the underlying cause of the exception.
+     * @param cause the underlying cause of the exception.
      * @throws IllegalArgumentException in case the status code is {@code null} or is not from
-     *                                  {@link javax.ws.rs.core.Response.Status.Family#SERVER_ERROR} status code
-     *                                  family.
+     * {@link javax.ws.rs.core.Response.Status.Family#SERVER_ERROR} status code family.
      */
     public ServerErrorException(final Response.Status status, final Throwable cause) {
         super(cause, validate(Response.status(status).build(), Response.Status.Family.SERVER_ERROR));
@@ -123,13 +112,11 @@ public class ServerErrorException extends WebApplicationException {
     /**
      * Construct a new server error exception.
      *
-     * @param message the detail message (which is saved for later retrieval
-     *                by the {@link #getMessage()} method).
-     * @param status  server error status. Must be a {@code 5xx} status code.
-     * @param cause   the underlying cause of the exception.
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param status server error status. Must be a {@code 5xx} status code.
+     * @param cause the underlying cause of the exception.
      * @throws IllegalArgumentException in case the status code is {@code null} or is not from
-     *                                  {@link javax.ws.rs.core.Response.Status.Family#SERVER_ERROR} status code
-     *                                  family.
+     * {@link javax.ws.rs.core.Response.Status.Family#SERVER_ERROR} status code family.
      */
     public ServerErrorException(final String message, final Response.Status status, final Throwable cause) {
         super(message, cause, validate(Response.status(status).build(), Response.Status.Family.SERVER_ERROR));
@@ -139,10 +126,9 @@ public class ServerErrorException extends WebApplicationException {
      * Construct a new server error exception.
      *
      * @param status server error status. Must be a {@code 5xx} status code.
-     * @param cause  the underlying cause of the exception.
-     * @throws IllegalArgumentException in case the status code is not a valid HTTP status code or
-     *                                  if it is not from the {@link javax.ws.rs.core.Response.Status.Family#SERVER_ERROR}
-     *                                  status code family.
+     * @param cause the underlying cause of the exception.
+     * @throws IllegalArgumentException in case the status code is not a valid HTTP status code or if it is not from the
+     * {@link javax.ws.rs.core.Response.Status.Family#SERVER_ERROR} status code family.
      */
     public ServerErrorException(final int status, final Throwable cause) {
         super(cause, validate(Response.status(status).build(), Response.Status.Family.SERVER_ERROR));
@@ -151,13 +137,11 @@ public class ServerErrorException extends WebApplicationException {
     /**
      * Construct a new server error exception.
      *
-     * @param message the detail message (which is saved for later retrieval
-     *                by the {@link #getMessage()} method).
-     * @param status  server error status. Must be a {@code 5xx} status code.
-     * @param cause   the underlying cause of the exception.
-     * @throws IllegalArgumentException in case the status code is not a valid HTTP status code or
-     *                                  if it is not from the {@link javax.ws.rs.core.Response.Status.Family#SERVER_ERROR}
-     *                                  status code family.
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param status server error status. Must be a {@code 5xx} status code.
+     * @param cause the underlying cause of the exception.
+     * @throws IllegalArgumentException in case the status code is not a valid HTTP status code or if it is not from the
+     * {@link javax.ws.rs.core.Response.Status.Family#SERVER_ERROR} status code family.
      */
     public ServerErrorException(final String message, final int status, final Throwable cause) {
         super(message, cause, validate(Response.status(status).build(), Response.Status.Family.SERVER_ERROR));
@@ -166,11 +150,10 @@ public class ServerErrorException extends WebApplicationException {
     /**
      * Construct a new server error exception.
      *
-     * @param response server error response. Must have a status code set to a {@code 5xx}
-     *                 status code.
-     * @param cause    the underlying cause of the exception.
+     * @param response server error response. Must have a status code set to a {@code 5xx} status code.
+     * @param cause the underlying cause of the exception.
      * @throws IllegalArgumentException in case the response status code is not from the
-     *                                  {@link javax.ws.rs.core.Response.Status.Family#SERVER_ERROR} status code family.
+     * {@link javax.ws.rs.core.Response.Status.Family#SERVER_ERROR} status code family.
      */
     public ServerErrorException(final Response response, final Throwable cause) {
         super(cause, validate(response, Response.Status.Family.SERVER_ERROR));
@@ -179,13 +162,11 @@ public class ServerErrorException extends WebApplicationException {
     /**
      * Construct a new server error exception.
      *
-     * @param message  the detail message (which is saved for later retrieval
-     *                 by the {@link #getMessage()} method).
-     * @param response server error response. Must have a status code set to a {@code 5xx}
-     *                 status code.
-     * @param cause    the underlying cause of the exception.
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param response server error response. Must have a status code set to a {@code 5xx} status code.
+     * @param cause the underlying cause of the exception.
      * @throws IllegalArgumentException in case the response status code is not from the
-     *                                  {@link javax.ws.rs.core.Response.Status.Family#SERVER_ERROR} status code family.
+     * {@link javax.ws.rs.core.Response.Status.Family#SERVER_ERROR} status code family.
      */
     public ServerErrorException(final String message, final Response response, final Throwable cause) {
         super(message, cause, validate(response, Response.Status.Family.SERVER_ERROR));

--- a/jaxrs-api/src/main/java/javax/ws/rs/ServiceUnavailableException.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ServiceUnavailableException.java
@@ -37,27 +37,26 @@ public class ServiceUnavailableException extends ServerErrorException {
     private static final long serialVersionUID = 3821068205617492633L;
 
     /**
-     * Construct a new "service unavailable" exception without any "Retry-After" information
-     * specified for the failed request.
+     * Construct a new "service unavailable" exception without any "Retry-After" information specified for the failed
+     * request.
      */
     public ServiceUnavailableException() {
         super(Response.status(SERVICE_UNAVAILABLE).build());
     }
 
     /**
-     * Construct a new "service unavailable" exception without any "Retry-After" information
-     * specified for the failed request.
+     * Construct a new "service unavailable" exception without any "Retry-After" information specified for the failed
+     * request.
      *
-     * @param message the detail message (which is saved for later retrieval
-     *                by the {@link #getMessage()} method).
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
      */
     public ServiceUnavailableException(final String message) {
         super(message, Response.status(SERVICE_UNAVAILABLE).build());
     }
 
     /**
-     * Construct a new "service unavailable" exception with an interval specifying
-     * the "Retry-After" information for the failed request.
+     * Construct a new "service unavailable" exception with an interval specifying the "Retry-After" information for the
+     * failed request.
      *
      * @param retryAfter decimal interval in seconds after which the failed request may be retried.
      */
@@ -66,11 +65,10 @@ public class ServiceUnavailableException extends ServerErrorException {
     }
 
     /**
-     * Construct a new "service unavailable" exception with an interval specifying
-     * the "Retry-After" information for the failed request.
+     * Construct a new "service unavailable" exception with an interval specifying the "Retry-After" information for the
+     * failed request.
      *
-     * @param message    the detail message (which is saved for later retrieval
-     *                   by the {@link #getMessage()} method).
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
      * @param retryAfter decimal interval in seconds after which the failed request may be retried.
      */
     public ServiceUnavailableException(final String message, final Long retryAfter) {
@@ -78,8 +76,8 @@ public class ServiceUnavailableException extends ServerErrorException {
     }
 
     /**
-     * Construct a new "service unavailable" exception with an interval specifying
-     * the "Retry-After" information for the failed request.
+     * Construct a new "service unavailable" exception with an interval specifying the "Retry-After" information for the
+     * failed request.
      *
      * @param retryAfter a date/time after which the failed request may be retried.
      */
@@ -88,11 +86,10 @@ public class ServiceUnavailableException extends ServerErrorException {
     }
 
     /**
-     * Construct a new "service unavailable" exception with an interval specifying
-     * the "Retry-After" information for the failed request.
+     * Construct a new "service unavailable" exception with an interval specifying the "Retry-After" information for the
+     * failed request.
      *
-     * @param message    the detail message (which is saved for later retrieval
-     *                   by the {@link #getMessage()} method).
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
      * @param retryAfter a date/time after which the failed request may be retried.
      */
     public ServiceUnavailableException(final String message, final Date retryAfter) {
@@ -103,8 +100,7 @@ public class ServiceUnavailableException extends ServerErrorException {
      * Construct a new "service unavailable" exception.
      *
      * @param response error response.
-     * @throws IllegalArgumentException in case the status code set in the response
-     *                                  is not HTTP {@code 503}.
+     * @throws IllegalArgumentException in case the status code set in the response is not HTTP {@code 503}.
      */
     public ServiceUnavailableException(final Response response) {
         super(validate(response, SERVICE_UNAVAILABLE));
@@ -113,63 +109,55 @@ public class ServiceUnavailableException extends ServerErrorException {
     /**
      * Construct a new "service unavailable" exception.
      *
-     * @param message  the detail message (which is saved for later retrieval
-     *                 by the {@link #getMessage()} method).
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
      * @param response error response.
-     * @throws IllegalArgumentException in case the status code set in the response
-     *                                  is not HTTP {@code 503}.
+     * @throws IllegalArgumentException in case the status code set in the response is not HTTP {@code 503}.
      */
     public ServiceUnavailableException(final String message, final Response response) {
         super(message, validate(response, SERVICE_UNAVAILABLE));
     }
 
     /**
-     * Construct a new "service unavailable" exception with a date specifying
-     * the "Retry-After" information for the failed request and an underlying
-     * request failure cause.
+     * Construct a new "service unavailable" exception with a date specifying the "Retry-After" information for the failed
+     * request and an underlying request failure cause.
      *
      * @param retryAfter a date/time after which the failed request may be retried.
-     * @param cause      the underlying cause of the exception.
+     * @param cause the underlying cause of the exception.
      */
     public ServiceUnavailableException(final Date retryAfter, final Throwable cause) {
         super(Response.status(SERVICE_UNAVAILABLE).header(RETRY_AFTER, retryAfter).build(), cause);
     }
 
     /**
-     * Construct a new "service unavailable" exception with a date specifying
-     * the "Retry-After" information for the failed request and an underlying
-     * request failure cause.
+     * Construct a new "service unavailable" exception with a date specifying the "Retry-After" information for the failed
+     * request and an underlying request failure cause.
      *
-     * @param message    the detail message (which is saved for later retrieval
-     *                   by the {@link #getMessage()} method).
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
      * @param retryAfter a date/time after which the failed request may be retried.
-     * @param cause      the underlying cause of the exception.
+     * @param cause the underlying cause of the exception.
      */
     public ServiceUnavailableException(final String message, final Date retryAfter, final Throwable cause) {
         super(message, Response.status(SERVICE_UNAVAILABLE).header(RETRY_AFTER, retryAfter).build(), cause);
     }
 
     /**
-     * Construct a new "service unavailable" exception with an interval specifying
-     * the "Retry-After" information for the failed request and an underlying
-     * request failure cause.
+     * Construct a new "service unavailable" exception with an interval specifying the "Retry-After" information for the
+     * failed request and an underlying request failure cause.
      *
      * @param retryAfter decimal interval in seconds after which the failed request may be retried.
-     * @param cause      the underlying cause of the exception.
+     * @param cause the underlying cause of the exception.
      */
     public ServiceUnavailableException(final Long retryAfter, final Throwable cause) {
         super(Response.status(SERVICE_UNAVAILABLE).header(RETRY_AFTER, retryAfter).build(), cause);
     }
 
     /**
-     * Construct a new "service unavailable" exception with an interval specifying
-     * the "Retry-After" information for the failed request and an underlying
-     * request failure cause.
+     * Construct a new "service unavailable" exception with an interval specifying the "Retry-After" information for the
+     * failed request and an underlying request failure cause.
      *
-     * @param message    the detail message (which is saved for later retrieval
-     *                   by the {@link #getMessage()} method).
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
      * @param retryAfter decimal interval in seconds after which the failed request may be retried.
-     * @param cause      the underlying cause of the exception.
+     * @param cause the underlying cause of the exception.
      */
     public ServiceUnavailableException(final String message, final Long retryAfter, final Throwable cause) {
         super(message, Response.status(SERVICE_UNAVAILABLE).header(RETRY_AFTER, retryAfter).build(), cause);
@@ -179,9 +167,8 @@ public class ServiceUnavailableException extends ServerErrorException {
      * Construct a new "service unavailable" exception.
      *
      * @param response error response.
-     * @param cause    the underlying cause of the exception.
-     * @throws IllegalArgumentException in case the status code set in the response
-     *                                  is not HTTP {@code 503}.
+     * @param cause the underlying cause of the exception.
+     * @throws IllegalArgumentException in case the status code set in the response is not HTTP {@code 503}.
      */
     public ServiceUnavailableException(final Response response, final Throwable cause) {
         super(validate(response, SERVICE_UNAVAILABLE), cause);
@@ -190,23 +177,20 @@ public class ServiceUnavailableException extends ServerErrorException {
     /**
      * Construct a new "service unavailable" exception.
      *
-     * @param message  the detail message (which is saved for later retrieval
-     *                 by the {@link #getMessage()} method).
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
      * @param response error response.
-     * @param cause    the underlying cause of the exception.
-     * @throws IllegalArgumentException in case the status code set in the response
-     *                                  is not HTTP {@code 503}.
+     * @param cause the underlying cause of the exception.
+     * @throws IllegalArgumentException in case the status code set in the response is not HTTP {@code 503}.
      */
     public ServiceUnavailableException(final String message, final Response response, final Throwable cause) {
         super(message, validate(response, SERVICE_UNAVAILABLE), cause);
     }
 
     /**
-     * Check if the underlying response contains the information on when is it
-     * possible to {@link HttpHeaders#RETRY_AFTER retry the request}.
+     * Check if the underlying response contains the information on when is it possible to {@link HttpHeaders#RETRY_AFTER
+     * retry the request}.
      *
-     * @return {@code true} in case the retry time is specified in the underlying
-     *         response, {@code false} otherwise.
+     * @return {@code true} in case the retry time is specified in the underlying response, {@code false} otherwise.
      */
     public boolean hasRetryAfter() {
         return getResponse().getHeaders().containsKey(RETRY_AFTER);
@@ -215,11 +199,9 @@ public class ServiceUnavailableException extends ServerErrorException {
     /**
      * Get the retry time for the failed request.
      *
-     * @param requestTime time of sending the original request that may be used to compute
-     *                    the retry time (in case the retry time information specified as
-     *                    a decimal interval in seconds).
-     * @return time when the request may be retried or {@code null} if there is no retry
-     *         information available.
+     * @param requestTime time of sending the original request that may be used to compute the retry time (in case the retry
+     * time information specified as a decimal interval in seconds).
+     * @return time when the request may be retried or {@code null} if there is no retry information available.
      * @throws NullPointerException in case the {@code requestTime} parameter is {@code null}.
      */
     public Date getRetryTime(final Date requestTime) {
@@ -235,8 +217,7 @@ public class ServiceUnavailableException extends ServerErrorException {
             // not an decimal value; ignoring exception and parsing as date
         }
 
-        final RuntimeDelegate.HeaderDelegate<Date> dateDelegate =
-                RuntimeDelegate.getInstance().createHeaderDelegate(Date.class);
+        final RuntimeDelegate.HeaderDelegate<Date> dateDelegate = RuntimeDelegate.getInstance().createHeaderDelegate(Date.class);
         return dateDelegate.fromString(value);
     }
 }

--- a/jaxrs-api/src/main/java/javax/ws/rs/WebApplicationException.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/WebApplicationException.java
@@ -21,10 +21,9 @@ import javax.ws.rs.core.Response;
 /**
  * Runtime exception for applications.
  * <p>
- * This exception may be thrown by a resource method, provider or
- * {@link javax.ws.rs.core.StreamingOutput} implementation if a specific
- * HTTP error response needs to be produced. Only effective if thrown prior to
- * the response being committed.
+ * This exception may be thrown by a resource method, provider or {@link javax.ws.rs.core.StreamingOutput}
+ * implementation if a specific HTTP error response needs to be produced. Only effective if thrown prior to the response
+ * being committed.
  *
  * @author Paul Sandoz
  * @author Marek Potociar
@@ -36,8 +35,8 @@ public class WebApplicationException extends RuntimeException {
     private final Response response;
 
     /**
-     * Construct a new instance with a default HTTP status code of 500
-     * and a default message generated from the HTTP status code and the associated HTTP status reason phrase.
+     * Construct a new instance with a default HTTP status code of 500 and a default message generated from the HTTP status
+     * code and the associated HTTP status reason phrase.
      */
     public WebApplicationException() {
         this((Throwable) null, Response.Status.INTERNAL_SERVER_ERROR);
@@ -46,22 +45,19 @@ public class WebApplicationException extends RuntimeException {
     /**
      * Construct a new instance with the supplied message and a default HTTP status code of 500.
      *
-     * @param message the detail message (which is saved for later retrieval
-     *                by the {@link #getMessage()} method).
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
      * @since 2.0
      */
     public WebApplicationException(final String message) {
         this(message, null, Response.Status.INTERNAL_SERVER_ERROR);
     }
 
-
     /**
-     * Construct a new instance using the supplied response
-     * and a default message generated from the response's HTTP status code and the associated HTTP status reason phrase.
+     * Construct a new instance using the supplied response and a default message generated from the response's HTTP status
+     * code and the associated HTTP status reason phrase.
      *
-     * @param response the response that will be returned to the client, a value
-     *                 of null will be replaced with an internal server error response (status
-     *                 code 500).
+     * @param response the response that will be returned to the client, a value of null will be replaced with an internal
+     * server error response (status code 500).
      */
     public WebApplicationException(final Response response) {
         this((Throwable) null, response);
@@ -70,11 +66,9 @@ public class WebApplicationException extends RuntimeException {
     /**
      * Construct a new instance using the supplied message and response.
      *
-     * @param message  the detail message (which is saved for later retrieval
-     *                 by the {@link #getMessage()} method).
-     * @param response the response that will be returned to the client, a value
-     *                 of null will be replaced with an internal server error response (status
-     *                 code 500).
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param response the response that will be returned to the client, a value of null will be replaced with an internal
+     * server error response (status code 500).
      * @since 2.0
      */
     public WebApplicationException(final String message, final Response response) {
@@ -82,8 +76,8 @@ public class WebApplicationException extends RuntimeException {
     }
 
     /**
-     * Construct a new instance with the supplied HTTP status code
-     * and a default message generated from the HTTP status code and the associated HTTP status reason phrase.
+     * Construct a new instance with the supplied HTTP status code and a default message generated from the HTTP status code
+     * and the associated HTTP status reason phrase.
      *
      * @param status the HTTP status code that will be returned to the client.
      */
@@ -94,9 +88,8 @@ public class WebApplicationException extends RuntimeException {
     /**
      * Construct a new instance with a supplied message and HTTP status code.
      *
-     * @param message the detail message (which is saved for later retrieval
-     *                by the {@link #getMessage()} method).
-     * @param status  the HTTP status code that will be returned to the client.
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param status the HTTP status code that will be returned to the client.
      * @since 2.0
      */
     public WebApplicationException(final String message, final int status) {
@@ -104,8 +97,8 @@ public class WebApplicationException extends RuntimeException {
     }
 
     /**
-     * Construct a new instance with the supplied HTTP status
-     * and a default message generated from the HTTP status code and the associated HTTP status reason phrase.
+     * Construct a new instance with the supplied HTTP status and a default message generated from the HTTP status code and
+     * the associated HTTP status reason phrase.
      *
      * @param status the HTTP status code that will be returned to the client.
      * @throws IllegalArgumentException if status is {@code null}.
@@ -117,9 +110,8 @@ public class WebApplicationException extends RuntimeException {
     /**
      * Construct a new instance with the supplied message and HTTP status.
      *
-     * @param message the detail message (which is saved for later retrieval
-     *                by the {@link #getMessage()} method).
-     * @param status  the HTTP status code that will be returned to the client.
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param status the HTTP status code that will be returned to the client.
      * @throws IllegalArgumentException if status is {@code null}.
      * @since 2.0
      */
@@ -128,8 +120,8 @@ public class WebApplicationException extends RuntimeException {
     }
 
     /**
-     * Construct a new instance with the supplied root cause, default HTTP status code of 500
-     * and a default message generated from the HTTP status code and the associated HTTP status reason phrase.
+     * Construct a new instance with the supplied root cause, default HTTP status code of 500 and a default message
+     * generated from the HTTP status code and the associated HTTP status reason phrase.
      *
      * @param cause the underlying cause of the exception.
      */
@@ -140,9 +132,8 @@ public class WebApplicationException extends RuntimeException {
     /**
      * Construct a new instance with the supplied message, root cause and default HTTP status code of 500.
      *
-     * @param message the detail message (which is saved for later retrieval
-     *                by the {@link #getMessage()} method).
-     * @param cause   the underlying cause of the exception.
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param cause the underlying cause of the exception.
      * @since 2.0
      */
     public WebApplicationException(final String message, final Throwable cause) {
@@ -150,13 +141,12 @@ public class WebApplicationException extends RuntimeException {
     }
 
     /**
-     * Construct a new instance with the supplied root cause, response
-     * and a default message generated from the response's HTTP status code and the associated HTTP status reason phrase.
+     * Construct a new instance with the supplied root cause, response and a default message generated from the response's
+     * HTTP status code and the associated HTTP status reason phrase.
      *
-     * @param response the response that will be returned to the client,
-     *                 a value of null will be replaced with an internal server error
-     *                 response (status code 500).
-     * @param cause    the underlying cause of the exception.
+     * @param response the response that will be returned to the client, a value of null will be replaced with an internal
+     * server error response (status code 500).
+     * @param cause the underlying cause of the exception.
      */
     public WebApplicationException(final Throwable cause, final Response response) {
         this(computeExceptionMessage(response), cause, response);
@@ -165,12 +155,10 @@ public class WebApplicationException extends RuntimeException {
     /**
      * Construct a new instance with the supplied message, root cause and response.
      *
-     * @param message  the detail message (which is saved for later retrieval
-     *                 by the {@link #getMessage()} method).
-     * @param response the response that will be returned to the client,
-     *                 a value of null will be replaced with an internal server error
-     *                 response (status code 500).
-     * @param cause    the underlying cause of the exception.
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param response the response that will be returned to the client, a value of null will be replaced with an internal
+     * server error response (status code 500).
+     * @param cause the underlying cause of the exception.
      * @since 2.0
      */
     public WebApplicationException(final String message, final Throwable cause, final Response response) {
@@ -193,11 +181,11 @@ public class WebApplicationException extends RuntimeException {
     }
 
     /**
-     * Construct a new instance with the supplied root cause, HTTP status code
-     * and a default message generated from the HTTP status code and the associated HTTP status reason phrase.
+     * Construct a new instance with the supplied root cause, HTTP status code and a default message generated from the HTTP
+     * status code and the associated HTTP status reason phrase.
      *
      * @param status the HTTP status code that will be returned to the client.
-     * @param cause  the underlying cause of the exception.
+     * @param cause the underlying cause of the exception.
      */
     public WebApplicationException(final Throwable cause, final int status) {
         this(cause, Response.status(status).build());
@@ -206,10 +194,9 @@ public class WebApplicationException extends RuntimeException {
     /**
      * Construct a new instance with the supplied message, root cause and HTTP status code.
      *
-     * @param message the detail message (which is saved for later retrieval
-     *                by the {@link #getMessage()} method).
-     * @param status  the HTTP status code that will be returned to the client.
-     * @param cause   the underlying cause of the exception.
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param status the HTTP status code that will be returned to the client.
+     * @param cause the underlying cause of the exception.
      * @since 2.0
      */
     public WebApplicationException(final String message, final Throwable cause, final int status) {
@@ -217,11 +204,11 @@ public class WebApplicationException extends RuntimeException {
     }
 
     /**
-     * Construct a new instance with the supplied root cause, HTTP status code
-     * and a default message generated from the HTTP status code and the associated HTTP status reason phrase.
+     * Construct a new instance with the supplied root cause, HTTP status code and a default message generated from the HTTP
+     * status code and the associated HTTP status reason phrase.
      *
      * @param status the HTTP status code that will be returned to the client.
-     * @param cause  the underlying cause of the exception.
+     * @param cause the underlying cause of the exception.
      * @throws IllegalArgumentException if status is {@code null}.
      */
     public WebApplicationException(final Throwable cause, final Response.Status status)
@@ -232,10 +219,9 @@ public class WebApplicationException extends RuntimeException {
     /**
      * Construct a new instance with a the supplied message, root cause and HTTP status code.
      *
-     * @param message the detail message (which is saved for later retrieval
-     *                by the {@link #getMessage()} method).
-     * @param status  the HTTP status code that will be returned to the client.
-     * @param cause   the underlying cause of the exception.
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param status the HTTP status code that will be returned to the client.
+     * @param cause the underlying cause of the exception.
      * @since 2.0
      */
     public WebApplicationException(final String message, final Throwable cause, final Response.Status status)
@@ -253,10 +239,9 @@ public class WebApplicationException extends RuntimeException {
     }
 
     /**
-     * Validate that a {@link javax.ws.rs.core.Response} object has an expected HTTP response
-     * status code set.
+     * Validate that a {@link javax.ws.rs.core.Response} object has an expected HTTP response status code set.
      *
-     * @param response       response object.
+     * @param response response object.
      * @param expectedStatus expected response status code.
      * @return validated response object.
      * @throws IllegalArgumentException if the response validation failed.
@@ -271,10 +256,9 @@ public class WebApplicationException extends RuntimeException {
     }
 
     /**
-     * Validate that a {@link javax.ws.rs.core.Response} object has an expected HTTP response
-     * status code set.
+     * Validate that a {@link javax.ws.rs.core.Response} object has an expected HTTP response status code set.
      *
-     * @param response             response object.
+     * @param response response object.
      * @param expectedStatusFamily expected response status code family.
      * @return validated response object.
      * @throws IllegalArgumentException if the response validation failed.

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/AsyncInvoker.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/AsyncInvoker.java
@@ -35,13 +35,11 @@ public interface AsyncInvoker {
     /**
      * Invoke HTTP GET method for the current request asynchronously.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps a {@link javax.ws.rs.ProcessingException} thrown in case of an invocation processing
-     * failure.
-     * Note that in case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
-     * instance whose processing has failed.
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps a {@link javax.ws.rs.ProcessingException} thrown
+     * in case of an invocation processing failure. Note that in case a processing of a properly received response fails,
+     * the wrapped processing exception will be of {@link ResponseProcessingException} type and will contain the
+     * {@link Response} instance whose processing has failed.
      *
      * @return invocation response {@link Future future}.
      */
@@ -50,17 +48,15 @@ public interface AsyncInvoker {
     /**
      * Invoke HTTP GET method for the current request asynchronously.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps either a {@link javax.ws.rs.ProcessingException} thrown in case of an invocation processing
-     * failure or a {@link WebApplicationException} or one of its subclasses thrown in case the
-     * received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     * successful} and the specified response type is not {@link javax.ws.rs.core.Response}.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
-     * instance whose processing has failed.
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps either a {@link javax.ws.rs.ProcessingException}
+     * thrown in case of an invocation processing failure or a {@link WebApplicationException} or one of its subclasses
+     * thrown in case the received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
+     * successful} and the specified response type is not {@link javax.ws.rs.core.Response}. In case a processing of a
+     * properly received response fails, the wrapped processing exception will be of {@link ResponseProcessingException}
+     * type and will contain the {@link Response} instance whose processing has failed.
      *
-     * @param <T>          response entity type.
+     * @param <T> response entity type.
      * @param responseType Java type the response entity will be converted to.
      * @return invocation response {@link Future future}.
      */
@@ -69,19 +65,16 @@ public interface AsyncInvoker {
     /**
      * Invoke HTTP GET method for the current request asynchronously.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps either a {@link javax.ws.rs.ProcessingException} thrown in case of an invocation processing
-     * failure or a {@link WebApplicationException} or one of its subclasses thrown in case the
-     * received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     * successful} and the specified response type is not {@link javax.ws.rs.core.Response}.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
-     * instance whose processing has failed.
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps either a {@link javax.ws.rs.ProcessingException}
+     * thrown in case of an invocation processing failure or a {@link WebApplicationException} or one of its subclasses
+     * thrown in case the received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
+     * successful} and the specified response type is not {@link javax.ws.rs.core.Response}. In case a processing of a
+     * properly received response fails, the wrapped processing exception will be of {@link ResponseProcessingException}
+     * type and will contain the {@link Response} instance whose processing has failed.
      *
-     * @param <T>          generic response entity type.
-     * @param responseType representation of a generic Java type the response
-     *                     entity will be converted to.
+     * @param <T> generic response entity type.
+     * @param responseType representation of a generic Java type the response entity will be converted to.
      * @return invocation response {@link Future future}.
      */
     <T> Future<T> get(GenericType<T> responseType);
@@ -89,18 +82,15 @@ public interface AsyncInvoker {
     /**
      * Invoke HTTP GET method for the current request asynchronously.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps either a {@link javax.ws.rs.ProcessingException} thrown in case of an invocation processing
-     * failure or a {@link WebApplicationException} or one of its subclasses thrown in case the
-     * received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     * successful} and the generic type of the supplied response callback is not
-     * {@link javax.ws.rs.core.Response}.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
-     * instance whose processing has failed.
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps either a {@link javax.ws.rs.ProcessingException}
+     * thrown in case of an invocation processing failure or a {@link WebApplicationException} or one of its subclasses
+     * thrown in case the received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
+     * successful} and the generic type of the supplied response callback is not {@link javax.ws.rs.core.Response}. In case
+     * a processing of a properly received response fails, the wrapped processing exception will be of
+     * {@link ResponseProcessingException} type and will contain the {@link Response} instance whose processing has failed.
      *
-     * @param <T>      generic response entity type.
+     * @param <T> generic response entity type.
      * @param callback asynchronous invocation callback.
      * @return invocation response {@link Future future}.
      */
@@ -111,18 +101,15 @@ public interface AsyncInvoker {
     /**
      * Invoke HTTP PUT method for the current request asynchronously.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps a {@link javax.ws.rs.ProcessingException} thrown in case of an invocation processing
-     * failure.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps a {@link javax.ws.rs.ProcessingException} thrown
+     * in case of an invocation processing failure. In case a processing of a properly received response fails, the wrapped
+     * processing exception will be of {@link ResponseProcessingException} type and will contain the {@link Response}
      * instance whose processing has failed.
      *
-     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information.
-     *               Any variant-related HTTP headers previously set (namely {@code Content-Type},
-     *               {@code Content-Language} and {@code Content-Encoding}) will be overwritten using
-     *               the entity variant information.
+     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information. Any variant-related
+     * HTTP headers previously set (namely {@code Content-Type}, {@code Content-Language} and {@code Content-Encoding}) will
+     * be overwritten using the entity variant information.
      * @return invocation response {@link Future future}.
      */
     Future<Response> put(Entity<?> entity);
@@ -130,21 +117,18 @@ public interface AsyncInvoker {
     /**
      * Invoke HTTP PUT method for the current request asynchronously.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps either a {@link javax.ws.rs.ProcessingException} thrown in case of an invocation processing
-     * failure or a {@link WebApplicationException} or one of its subclasses thrown in case the
-     * received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     * successful} and the specified response type is not {@link javax.ws.rs.core.Response}.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
-     * instance whose processing has failed.
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps either a {@link javax.ws.rs.ProcessingException}
+     * thrown in case of an invocation processing failure or a {@link WebApplicationException} or one of its subclasses
+     * thrown in case the received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
+     * successful} and the specified response type is not {@link javax.ws.rs.core.Response}. In case a processing of a
+     * properly received response fails, the wrapped processing exception will be of {@link ResponseProcessingException}
+     * type and will contain the {@link Response} instance whose processing has failed.
      *
-     * @param <T>          response entity type.
-     * @param entity       request entity, including it's full {@link javax.ws.rs.core.Variant} information.
-     *                     Any variant-related HTTP headers previously set (namely {@code Content-Type},
-     *                     {@code Content-Language} and {@code Content-Encoding}) will be overwritten using
-     *                     the entity variant information.
+     * @param <T> response entity type.
+     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information. Any variant-related
+     * HTTP headers previously set (namely {@code Content-Type}, {@code Content-Language} and {@code Content-Encoding}) will
+     * be overwritten using the entity variant information.
      * @param responseType Java type the response entity will be converted to.
      * @return invocation response {@link Future future}.
      */
@@ -153,23 +137,19 @@ public interface AsyncInvoker {
     /**
      * Invoke HTTP PUT method for the current request asynchronously.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps either a {@link javax.ws.rs.ProcessingException} thrown in case of an invocation processing
-     * failure or a {@link WebApplicationException} or one of its subclasses thrown in case the
-     * received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     * successful} and the specified response type is not {@link javax.ws.rs.core.Response}.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
-     * instance whose processing has failed.
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps either a {@link javax.ws.rs.ProcessingException}
+     * thrown in case of an invocation processing failure or a {@link WebApplicationException} or one of its subclasses
+     * thrown in case the received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
+     * successful} and the specified response type is not {@link javax.ws.rs.core.Response}. In case a processing of a
+     * properly received response fails, the wrapped processing exception will be of {@link ResponseProcessingException}
+     * type and will contain the {@link Response} instance whose processing has failed.
      *
-     * @param <T>          generic response entity type.
-     * @param entity       request entity, including it's full {@link javax.ws.rs.core.Variant} information.
-     *                     Any variant-related HTTP headers previously set (namely {@code Content-Type},
-     *                     {@code Content-Language} and {@code Content-Encoding}) will be overwritten using
-     *                     the entity variant information.
-     * @param responseType representation of a generic Java type the response
-     *                     entity will be converted to.
+     * @param <T> generic response entity type.
+     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information. Any variant-related
+     * HTTP headers previously set (namely {@code Content-Type}, {@code Content-Language} and {@code Content-Encoding}) will
+     * be overwritten using the entity variant information.
+     * @param responseType representation of a generic Java type the response entity will be converted to.
      * @return invocation response {@link Future future}.
      */
     <T> Future<T> put(Entity<?> entity, GenericType<T> responseType);
@@ -177,22 +157,18 @@ public interface AsyncInvoker {
     /**
      * Invoke HTTP PUT method for the current request asynchronously.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps either a {@link javax.ws.rs.ProcessingException} thrown in case of an invocation processing
-     * failure or a {@link WebApplicationException} or one of its subclasses thrown in case the
-     * received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     * successful} and the generic type of the supplied response callback is not
-     * {@link javax.ws.rs.core.Response}.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
-     * instance whose processing has failed.
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps either a {@link javax.ws.rs.ProcessingException}
+     * thrown in case of an invocation processing failure or a {@link WebApplicationException} or one of its subclasses
+     * thrown in case the received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
+     * successful} and the generic type of the supplied response callback is not {@link javax.ws.rs.core.Response}. In case
+     * a processing of a properly received response fails, the wrapped processing exception will be of
+     * {@link ResponseProcessingException} type and will contain the {@link Response} instance whose processing has failed.
      *
-     * @param <T>      generic response entity type.
-     * @param entity   request entity, including it's full {@link javax.ws.rs.core.Variant} information.
-     *                 Any variant-related HTTP headers previously set (namely {@code Content-Type},
-     *                 {@code Content-Language} and {@code Content-Encoding}) will be overwritten using
-     *                 the entity variant information.
+     * @param <T> generic response entity type.
+     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information. Any variant-related
+     * HTTP headers previously set (namely {@code Content-Type}, {@code Content-Language} and {@code Content-Encoding}) will
+     * be overwritten using the entity variant information.
      * @param callback asynchronous invocation callback.
      * @return invocation response {@link Future future}.
      */
@@ -203,42 +179,35 @@ public interface AsyncInvoker {
     /**
      * Invoke HTTP POST method for the current request asynchronously.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps a {@link javax.ws.rs.ProcessingException} thrown in case of an invocation processing
-     * failure.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps a {@link javax.ws.rs.ProcessingException} thrown
+     * in case of an invocation processing failure. In case a processing of a properly received response fails, the wrapped
+     * processing exception will be of {@link ResponseProcessingException} type and will contain the {@link Response}
      * instance whose processing has failed.
      *
-     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information.
-     *               Any variant-related HTTP headers previously set (namely {@code Content-Type},
-     *               {@code Content-Language} and {@code Content-Encoding}) will be overwritten using
-     *               the entity variant information.
+     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information. Any variant-related
+     * HTTP headers previously set (namely {@code Content-Type}, {@code Content-Language} and {@code Content-Encoding}) will
+     * be overwritten using the entity variant information.
      * @return invocation response {@link Future future}.
-     * @throws javax.ws.rs.ProcessingException
-     *          in case the invocation processing has failed.
+     * @throws javax.ws.rs.ProcessingException in case the invocation processing has failed.
      */
     Future<Response> post(Entity<?> entity);
 
     /**
      * Invoke HTTP POST method for the current request asynchronously.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps either a {@link javax.ws.rs.ProcessingException} thrown in case of an invocation processing
-     * failure or a {@link WebApplicationException} or one of its subclasses thrown in case the
-     * received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     * successful} and the specified response type is not {@link javax.ws.rs.core.Response}.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
-     * instance whose processing has failed.
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps either a {@link javax.ws.rs.ProcessingException}
+     * thrown in case of an invocation processing failure or a {@link WebApplicationException} or one of its subclasses
+     * thrown in case the received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
+     * successful} and the specified response type is not {@link javax.ws.rs.core.Response}. In case a processing of a
+     * properly received response fails, the wrapped processing exception will be of {@link ResponseProcessingException}
+     * type and will contain the {@link Response} instance whose processing has failed.
      *
-     * @param <T>          response entity type.
-     * @param entity       request entity, including it's full {@link javax.ws.rs.core.Variant} information.
-     *                     Any variant-related HTTP headers previously set (namely {@code Content-Type},
-     *                     {@code Content-Language} and {@code Content-Encoding}) will be overwritten using
-     *                     the entity variant information.
+     * @param <T> response entity type.
+     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information. Any variant-related
+     * HTTP headers previously set (namely {@code Content-Type}, {@code Content-Language} and {@code Content-Encoding}) will
+     * be overwritten using the entity variant information.
      * @param responseType Java type the response entity will be converted to.
      * @return invocation response {@link Future future}.
      */
@@ -247,23 +216,19 @@ public interface AsyncInvoker {
     /**
      * Invoke HTTP POST method for the current request asynchronously.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps either a {@link javax.ws.rs.ProcessingException} thrown in case of an invocation processing
-     * failure or a {@link WebApplicationException} or one of its subclasses thrown in case the
-     * received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     * successful} and the specified response type is not {@link javax.ws.rs.core.Response}.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
-     * instance whose processing has failed.
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps either a {@link javax.ws.rs.ProcessingException}
+     * thrown in case of an invocation processing failure or a {@link WebApplicationException} or one of its subclasses
+     * thrown in case the received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
+     * successful} and the specified response type is not {@link javax.ws.rs.core.Response}. In case a processing of a
+     * properly received response fails, the wrapped processing exception will be of {@link ResponseProcessingException}
+     * type and will contain the {@link Response} instance whose processing has failed.
      *
-     * @param <T>          generic response entity type.
-     * @param entity       request entity, including it's full {@link javax.ws.rs.core.Variant} information.
-     *                     Any variant-related HTTP headers previously set (namely {@code Content-Type},
-     *                     {@code Content-Language} and {@code Content-Encoding}) will be overwritten using
-     *                     the entity variant information.
-     * @param responseType representation of a generic Java type the response
-     *                     entity will be converted to.
+     * @param <T> generic response entity type.
+     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information. Any variant-related
+     * HTTP headers previously set (namely {@code Content-Type}, {@code Content-Language} and {@code Content-Encoding}) will
+     * be overwritten using the entity variant information.
+     * @param responseType representation of a generic Java type the response entity will be converted to.
      * @return invocation response {@link Future future}.
      */
     <T> Future<T> post(Entity<?> entity, GenericType<T> responseType);
@@ -271,22 +236,18 @@ public interface AsyncInvoker {
     /**
      * Invoke HTTP POST method for the current request asynchronously.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps either a {@link javax.ws.rs.ProcessingException} thrown in case of an invocation processing
-     * failure or a {@link WebApplicationException} or one of its subclasses thrown in case the
-     * received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     * successful} and the generic type of the supplied response callback is not
-     * {@link javax.ws.rs.core.Response}.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
-     * instance whose processing has failed.
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps either a {@link javax.ws.rs.ProcessingException}
+     * thrown in case of an invocation processing failure or a {@link WebApplicationException} or one of its subclasses
+     * thrown in case the received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
+     * successful} and the generic type of the supplied response callback is not {@link javax.ws.rs.core.Response}. In case
+     * a processing of a properly received response fails, the wrapped processing exception will be of
+     * {@link ResponseProcessingException} type and will contain the {@link Response} instance whose processing has failed.
      *
-     * @param <T>      generic response entity type.
-     * @param entity   request entity, including it's full {@link javax.ws.rs.core.Variant} information.
-     *                 Any variant-related HTTP headers previously set (namely {@code Content-Type},
-     *                 {@code Content-Language} and {@code Content-Encoding}) will be overwritten using
-     *                 the entity variant information.
+     * @param <T> generic response entity type.
+     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information. Any variant-related
+     * HTTP headers previously set (namely {@code Content-Type}, {@code Content-Language} and {@code Content-Encoding}) will
+     * be overwritten using the entity variant information.
      * @param callback asynchronous invocation callback.
      * @return invocation response {@link Future future}.
      */
@@ -297,12 +258,10 @@ public interface AsyncInvoker {
     /**
      * Invoke HTTP DELETE method for the current request asynchronously.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps a {@link javax.ws.rs.ProcessingException} thrown in case of an invocation processing
-     * failure.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps a {@link javax.ws.rs.ProcessingException} thrown
+     * in case of an invocation processing failure. In case a processing of a properly received response fails, the wrapped
+     * processing exception will be of {@link ResponseProcessingException} type and will contain the {@link Response}
      * instance whose processing has failed.
      *
      * @return invocation response {@link Future future}.
@@ -312,17 +271,15 @@ public interface AsyncInvoker {
     /**
      * Invoke HTTP DELETE method for the current request asynchronously.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps either a {@link javax.ws.rs.ProcessingException} thrown in case of an invocation processing
-     * failure or a {@link WebApplicationException} or one of its subclasses thrown in case the
-     * received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     * successful} and the specified response type is not {@link javax.ws.rs.core.Response}.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
-     * instance whose processing has failed.
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps either a {@link javax.ws.rs.ProcessingException}
+     * thrown in case of an invocation processing failure or a {@link WebApplicationException} or one of its subclasses
+     * thrown in case the received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
+     * successful} and the specified response type is not {@link javax.ws.rs.core.Response}. In case a processing of a
+     * properly received response fails, the wrapped processing exception will be of {@link ResponseProcessingException}
+     * type and will contain the {@link Response} instance whose processing has failed.
      *
-     * @param <T>          response entity type.
+     * @param <T> response entity type.
      * @param responseType Java type the response entity will be converted to.
      * @return invocation response {@link Future future}.
      */
@@ -331,19 +288,16 @@ public interface AsyncInvoker {
     /**
      * Invoke HTTP DELETE method for the current request asynchronously.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps either a {@link javax.ws.rs.ProcessingException} thrown in case of an invocation processing
-     * failure or a {@link WebApplicationException} or one of its subclasses thrown in case the
-     * received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     * successful} and the specified response type is not {@link javax.ws.rs.core.Response}.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
-     * instance whose processing has failed.
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps either a {@link javax.ws.rs.ProcessingException}
+     * thrown in case of an invocation processing failure or a {@link WebApplicationException} or one of its subclasses
+     * thrown in case the received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
+     * successful} and the specified response type is not {@link javax.ws.rs.core.Response}. In case a processing of a
+     * properly received response fails, the wrapped processing exception will be of {@link ResponseProcessingException}
+     * type and will contain the {@link Response} instance whose processing has failed.
      *
-     * @param <T>          generic response entity type.
-     * @param responseType representation of a generic Java type the response
-     *                     entity will be converted to.
+     * @param <T> generic response entity type.
+     * @param responseType representation of a generic Java type the response entity will be converted to.
      * @return invocation response {@link Future future}.
      */
     <T> Future<T> delete(GenericType<T> responseType);
@@ -351,18 +305,15 @@ public interface AsyncInvoker {
     /**
      * Invoke HTTP DELETE method for the current request asynchronously.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps either a {@link javax.ws.rs.ProcessingException} thrown in case of an invocation processing
-     * failure or a {@link WebApplicationException} or one of its subclasses thrown in case the
-     * received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     * successful} and the generic type of the supplied response callback is not
-     * {@link javax.ws.rs.core.Response}.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
-     * instance whose processing has failed.
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps either a {@link javax.ws.rs.ProcessingException}
+     * thrown in case of an invocation processing failure or a {@link WebApplicationException} or one of its subclasses
+     * thrown in case the received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
+     * successful} and the generic type of the supplied response callback is not {@link javax.ws.rs.core.Response}. In case
+     * a processing of a properly received response fails, the wrapped processing exception will be of
+     * {@link ResponseProcessingException} type and will contain the {@link Response} instance whose processing has failed.
      *
-     * @param <T>      generic response entity type.
+     * @param <T> generic response entity type.
      * @param callback asynchronous invocation callback.
      * @return invocation response {@link Future future}.
      */
@@ -373,12 +324,10 @@ public interface AsyncInvoker {
     /**
      * Invoke HTTP HEAD method for the current request asynchronously.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps a {@link javax.ws.rs.ProcessingException} thrown in case of an invocation processing
-     * failure.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps a {@link javax.ws.rs.ProcessingException} thrown
+     * in case of an invocation processing failure. In case a processing of a properly received response fails, the wrapped
+     * processing exception will be of {@link ResponseProcessingException} type and will contain the {@link Response}
      * instance whose processing has failed.
      *
      * @return invocation response {@link Future future}.
@@ -388,12 +337,10 @@ public interface AsyncInvoker {
     /**
      * Invoke HTTP HEAD method for the current request asynchronously.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps a {@link javax.ws.rs.ProcessingException} thrown in case of an invocation processing
-     * failure.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps a {@link javax.ws.rs.ProcessingException} thrown
+     * in case of an invocation processing failure. In case a processing of a properly received response fails, the wrapped
+     * processing exception will be of {@link ResponseProcessingException} type and will contain the {@link Response}
      * instance whose processing has failed.
      *
      * @param callback asynchronous invocation callback.
@@ -406,12 +353,10 @@ public interface AsyncInvoker {
     /**
      * Invoke HTTP OPTIONS method for the current request asynchronously.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps a {@link javax.ws.rs.ProcessingException} thrown in case of an invocation processing
-     * failure.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps a {@link javax.ws.rs.ProcessingException} thrown
+     * in case of an invocation processing failure. In case a processing of a properly received response fails, the wrapped
+     * processing exception will be of {@link ResponseProcessingException} type and will contain the {@link Response}
      * instance whose processing has failed.
      *
      * @return invocation response {@link Future future}.
@@ -421,17 +366,15 @@ public interface AsyncInvoker {
     /**
      * Invoke HTTP OPTIONS method for the current request asynchronously.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps either a {@link javax.ws.rs.ProcessingException} thrown in case of an invocation processing
-     * failure or a {@link WebApplicationException} or one of its subclasses thrown in case the
-     * received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     * successful} and the specified response type is not {@link javax.ws.rs.core.Response}.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
-     * instance whose processing has failed.
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps either a {@link javax.ws.rs.ProcessingException}
+     * thrown in case of an invocation processing failure or a {@link WebApplicationException} or one of its subclasses
+     * thrown in case the received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
+     * successful} and the specified response type is not {@link javax.ws.rs.core.Response}. In case a processing of a
+     * properly received response fails, the wrapped processing exception will be of {@link ResponseProcessingException}
+     * type and will contain the {@link Response} instance whose processing has failed.
      *
-     * @param <T>          response entity type.
+     * @param <T> response entity type.
      * @param responseType Java type the response entity will be converted to.
      * @return invocation response {@link Future future}.
      */
@@ -440,19 +383,16 @@ public interface AsyncInvoker {
     /**
      * Invoke HTTP OPTIONS method for the current request asynchronously.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps either a {@link javax.ws.rs.ProcessingException} thrown in case of an invocation processing
-     * failure or a {@link WebApplicationException} or one of its subclasses thrown in case the
-     * received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     * successful} and the specified response type is not {@link javax.ws.rs.core.Response}.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
-     * instance whose processing has failed.
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps either a {@link javax.ws.rs.ProcessingException}
+     * thrown in case of an invocation processing failure or a {@link WebApplicationException} or one of its subclasses
+     * thrown in case the received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
+     * successful} and the specified response type is not {@link javax.ws.rs.core.Response}. In case a processing of a
+     * properly received response fails, the wrapped processing exception will be of {@link ResponseProcessingException}
+     * type and will contain the {@link Response} instance whose processing has failed.
      *
-     * @param <T>          generic response entity type.
-     * @param responseType representation of a generic Java type the response
-     *                     entity will be converted to.
+     * @param <T> generic response entity type.
+     * @param responseType representation of a generic Java type the response entity will be converted to.
      * @return invocation response {@link Future future}.
      */
     <T> Future<T> options(GenericType<T> responseType);
@@ -460,18 +400,15 @@ public interface AsyncInvoker {
     /**
      * Invoke HTTP OPTIONS method for the current request asynchronously.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps either a {@link javax.ws.rs.ProcessingException} thrown in case of an invocation processing
-     * failure or a {@link WebApplicationException} or one of its subclasses thrown in case the
-     * received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     * successful} and the generic type of the supplied response callback is not
-     * {@link javax.ws.rs.core.Response}.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
-     * instance whose processing has failed.
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps either a {@link javax.ws.rs.ProcessingException}
+     * thrown in case of an invocation processing failure or a {@link WebApplicationException} or one of its subclasses
+     * thrown in case the received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
+     * successful} and the generic type of the supplied response callback is not {@link javax.ws.rs.core.Response}. In case
+     * a processing of a properly received response fails, the wrapped processing exception will be of
+     * {@link ResponseProcessingException} type and will contain the {@link Response} instance whose processing has failed.
      *
-     * @param <T>      generic response entity type.
+     * @param <T> generic response entity type.
      * @param callback asynchronous invocation callback.
      * @return invocation response {@link Future future}.
      */
@@ -482,12 +419,10 @@ public interface AsyncInvoker {
     /**
      * Invoke HTTP TRACE method for the current request asynchronously.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps a {@link javax.ws.rs.ProcessingException} thrown in case of an invocation processing
-     * failure.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps a {@link javax.ws.rs.ProcessingException} thrown
+     * in case of an invocation processing failure. In case a processing of a properly received response fails, the wrapped
+     * processing exception will be of {@link ResponseProcessingException} type and will contain the {@link Response}
      * instance whose processing has failed.
      *
      * @return invocation response {@link Future future}.
@@ -497,17 +432,15 @@ public interface AsyncInvoker {
     /**
      * Invoke HTTP TRACE method for the current request asynchronously.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps either a {@link javax.ws.rs.ProcessingException} thrown in case of an invocation processing
-     * failure or a {@link WebApplicationException} or one of its subclasses thrown in case the
-     * received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     * successful} and the specified response type is not {@link javax.ws.rs.core.Response}.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
-     * instance whose processing has failed.
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps either a {@link javax.ws.rs.ProcessingException}
+     * thrown in case of an invocation processing failure or a {@link WebApplicationException} or one of its subclasses
+     * thrown in case the received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
+     * successful} and the specified response type is not {@link javax.ws.rs.core.Response}. In case a processing of a
+     * properly received response fails, the wrapped processing exception will be of {@link ResponseProcessingException}
+     * type and will contain the {@link Response} instance whose processing has failed.
      *
-     * @param <T>          response entity type.
+     * @param <T> response entity type.
      * @param responseType Java type the response entity will be converted to.
      * @return invocation response {@link Future future}.
      */
@@ -516,19 +449,16 @@ public interface AsyncInvoker {
     /**
      * Invoke HTTP TRACE method for the current request asynchronously.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps either a {@link javax.ws.rs.ProcessingException} thrown in case of an invocation processing
-     * failure or a {@link WebApplicationException} or one of its subclasses thrown in case the
-     * received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     * successful} and the specified response type is not {@link javax.ws.rs.core.Response}.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
-     * instance whose processing has failed.
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps either a {@link javax.ws.rs.ProcessingException}
+     * thrown in case of an invocation processing failure or a {@link WebApplicationException} or one of its subclasses
+     * thrown in case the received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
+     * successful} and the specified response type is not {@link javax.ws.rs.core.Response}. In case a processing of a
+     * properly received response fails, the wrapped processing exception will be of {@link ResponseProcessingException}
+     * type and will contain the {@link Response} instance whose processing has failed.
      *
-     * @param <T>          generic response entity type.
-     * @param responseType representation of a generic Java type the response
-     *                     entity will be converted to.
+     * @param <T> generic response entity type.
+     * @param responseType representation of a generic Java type the response entity will be converted to.
      * @return invocation response {@link Future future}.
      */
     <T> Future<T> trace(GenericType<T> responseType);
@@ -536,18 +466,15 @@ public interface AsyncInvoker {
     /**
      * Invoke HTTP TRACE method for the current request asynchronously.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps either a {@link javax.ws.rs.ProcessingException} thrown in case of an invocation processing
-     * failure or a {@link WebApplicationException} or one of its subclasses thrown in case the
-     * received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     * successful} and the generic type of the supplied response callback is not
-     * {@link javax.ws.rs.core.Response}.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
-     * instance whose processing has failed.
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps either a {@link javax.ws.rs.ProcessingException}
+     * thrown in case of an invocation processing failure or a {@link WebApplicationException} or one of its subclasses
+     * thrown in case the received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
+     * successful} and the generic type of the supplied response callback is not {@link javax.ws.rs.core.Response}. In case
+     * a processing of a properly received response fails, the wrapped processing exception will be of
+     * {@link ResponseProcessingException} type and will contain the {@link Response} instance whose processing has failed.
      *
-     * @param <T>      generic response entity type.
+     * @param <T> generic response entity type.
      * @param callback asynchronous invocation callback.
      * @return invocation response {@link Future future}.
      */
@@ -558,12 +485,10 @@ public interface AsyncInvoker {
     /**
      * Invoke an arbitrary method for the current request asynchronously.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps a {@link javax.ws.rs.ProcessingException} thrown in case of an invocation processing
-     * failure.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps a {@link javax.ws.rs.ProcessingException} thrown
+     * in case of an invocation processing failure. In case a processing of a properly received response fails, the wrapped
+     * processing exception will be of {@link ResponseProcessingException} type and will contain the {@link Response}
      * instance whose processing has failed.
      *
      * @param name method name.
@@ -574,18 +499,16 @@ public interface AsyncInvoker {
     /**
      * Invoke an arbitrary method for the current request asynchronously.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps either a {@link javax.ws.rs.ProcessingException} thrown in case of an invocation processing
-     * failure or a {@link WebApplicationException} or one of its subclasses thrown in case the
-     * received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     * successful} and the specified response type is not {@link javax.ws.rs.core.Response}.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
-     * instance whose processing has failed.
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps either a {@link javax.ws.rs.ProcessingException}
+     * thrown in case of an invocation processing failure or a {@link WebApplicationException} or one of its subclasses
+     * thrown in case the received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
+     * successful} and the specified response type is not {@link javax.ws.rs.core.Response}. In case a processing of a
+     * properly received response fails, the wrapped processing exception will be of {@link ResponseProcessingException}
+     * type and will contain the {@link Response} instance whose processing has failed.
      *
-     * @param <T>          response entity type.
-     * @param name         method name.
+     * @param <T> response entity type.
+     * @param name method name.
      * @param responseType Java type the response entity will be converted to.
      * @return invocation response {@link Future future}.
      */
@@ -594,20 +517,17 @@ public interface AsyncInvoker {
     /**
      * Invoke an arbitrary method for the current request asynchronously.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps either a {@link javax.ws.rs.ProcessingException} thrown in case of an invocation processing
-     * failure or a {@link WebApplicationException} or one of its subclasses thrown in case the
-     * received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     * successful} and the specified response type is not {@link javax.ws.rs.core.Response}.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
-     * instance whose processing has failed.
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps either a {@link javax.ws.rs.ProcessingException}
+     * thrown in case of an invocation processing failure or a {@link WebApplicationException} or one of its subclasses
+     * thrown in case the received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
+     * successful} and the specified response type is not {@link javax.ws.rs.core.Response}. In case a processing of a
+     * properly received response fails, the wrapped processing exception will be of {@link ResponseProcessingException}
+     * type and will contain the {@link Response} instance whose processing has failed.
      *
-     * @param <T>          generic response entity type.
-     * @param name         method name.
-     * @param responseType representation of a generic Java type the response
-     *                     entity will be converted to.
+     * @param <T> generic response entity type.
+     * @param name method name.
+     * @param responseType representation of a generic Java type the response entity will be converted to.
      * @return invocation response {@link Future future}.
      */
     <T> Future<T> method(String name, GenericType<T> responseType);
@@ -615,19 +535,16 @@ public interface AsyncInvoker {
     /**
      * Invoke an arbitrary method for the current request asynchronously.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps either a {@link javax.ws.rs.ProcessingException} thrown in case of an invocation processing
-     * failure or a {@link WebApplicationException} or one of its subclasses thrown in case the
-     * received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     * successful} and the generic type of the supplied response callback is not
-     * {@link javax.ws.rs.core.Response}.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
-     * instance whose processing has failed.
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps either a {@link javax.ws.rs.ProcessingException}
+     * thrown in case of an invocation processing failure or a {@link WebApplicationException} or one of its subclasses
+     * thrown in case the received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
+     * successful} and the generic type of the supplied response callback is not {@link javax.ws.rs.core.Response}. In case
+     * a processing of a properly received response fails, the wrapped processing exception will be of
+     * {@link ResponseProcessingException} type and will contain the {@link Response} instance whose processing has failed.
      *
-     * @param <T>      generic response entity type.
-     * @param name     method name.
+     * @param <T> generic response entity type.
+     * @param name method name.
      * @param callback asynchronous invocation callback.
      * @return invocation response {@link Future future}.
      */
@@ -636,19 +553,16 @@ public interface AsyncInvoker {
     /**
      * Invoke an arbitrary method for the current request asynchronously.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps a {@link javax.ws.rs.ProcessingException} thrown in case of an invocation processing
-     * failure.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps a {@link javax.ws.rs.ProcessingException} thrown
+     * in case of an invocation processing failure. In case a processing of a properly received response fails, the wrapped
+     * processing exception will be of {@link ResponseProcessingException} type and will contain the {@link Response}
      * instance whose processing has failed.
      *
-     * @param name   method name.
-     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information.
-     *               Any variant-related HTTP headers previously set (namely {@code Content-Type},
-     *               {@code Content-Language} and {@code Content-Encoding}) will be overwritten using
-     *               the entity variant information.
+     * @param name method name.
+     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information. Any variant-related
+     * HTTP headers previously set (namely {@code Content-Type}, {@code Content-Language} and {@code Content-Encoding}) will
+     * be overwritten using the entity variant information.
      * @return invocation response {@link Future future}.
      */
     Future<Response> method(String name, Entity<?> entity);
@@ -656,22 +570,19 @@ public interface AsyncInvoker {
     /**
      * Invoke an arbitrary method for the current request asynchronously.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps either a {@link javax.ws.rs.ProcessingException} thrown in case of an invocation processing
-     * failure or a {@link WebApplicationException} or one of its subclasses thrown in case the
-     * received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     * successful} and the specified response type is not {@link javax.ws.rs.core.Response}.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
-     * instance whose processing has failed.
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps either a {@link javax.ws.rs.ProcessingException}
+     * thrown in case of an invocation processing failure or a {@link WebApplicationException} or one of its subclasses
+     * thrown in case the received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
+     * successful} and the specified response type is not {@link javax.ws.rs.core.Response}. In case a processing of a
+     * properly received response fails, the wrapped processing exception will be of {@link ResponseProcessingException}
+     * type and will contain the {@link Response} instance whose processing has failed.
      *
-     * @param <T>          response entity type.
-     * @param name         method name.
-     * @param entity       request entity, including it's full {@link javax.ws.rs.core.Variant} information.
-     *                     Any variant-related HTTP headers previously set (namely {@code Content-Type},
-     *                     {@code Content-Language} and {@code Content-Encoding}) will be overwritten using
-     *                     the entity variant information.
+     * @param <T> response entity type.
+     * @param name method name.
+     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information. Any variant-related
+     * HTTP headers previously set (namely {@code Content-Type}, {@code Content-Language} and {@code Content-Encoding}) will
+     * be overwritten using the entity variant information.
      * @param responseType Java type the response entity will be converted to.
      * @return invocation response {@link Future future}.
      */
@@ -680,24 +591,20 @@ public interface AsyncInvoker {
     /**
      * Invoke an arbitrary method for the current request asynchronously.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps either a {@link javax.ws.rs.ProcessingException} thrown in case of an invocation processing
-     * failure or a {@link WebApplicationException} or one of its subclasses thrown in case the
-     * received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     * successful} and the specified response type is not {@link javax.ws.rs.core.Response}.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
-     * instance whose processing has failed.
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps either a {@link javax.ws.rs.ProcessingException}
+     * thrown in case of an invocation processing failure or a {@link WebApplicationException} or one of its subclasses
+     * thrown in case the received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
+     * successful} and the specified response type is not {@link javax.ws.rs.core.Response}. In case a processing of a
+     * properly received response fails, the wrapped processing exception will be of {@link ResponseProcessingException}
+     * type and will contain the {@link Response} instance whose processing has failed.
      *
-     * @param <T>          generic response entity type.
-     * @param name         method name.
-     * @param entity       request entity, including it's full {@link javax.ws.rs.core.Variant} information.
-     *                     Any variant-related HTTP headers previously set (namely {@code Content-Type},
-     *                     {@code Content-Language} and {@code Content-Encoding}) will be overwritten using
-     *                     the entity variant information.
-     * @param responseType representation of a generic Java type the response
-     *                     entity will be converted to.
+     * @param <T> generic response entity type.
+     * @param name method name.
+     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information. Any variant-related
+     * HTTP headers previously set (namely {@code Content-Type}, {@code Content-Language} and {@code Content-Encoding}) will
+     * be overwritten using the entity variant information.
+     * @param responseType representation of a generic Java type the response entity will be converted to.
      * @return invocation response {@link Future future}.
      */
     <T> Future<T> method(String name, Entity<?> entity, GenericType<T> responseType);
@@ -705,23 +612,19 @@ public interface AsyncInvoker {
     /**
      * Invoke an arbitrary method for the current request asynchronously.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps either a {@link javax.ws.rs.ProcessingException} thrown in case of an invocation processing
-     * failure or a {@link WebApplicationException} or one of its subclasses thrown in case the
-     * received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     * successful} and the generic type of the supplied response callback is not
-     * {@link javax.ws.rs.core.Response}.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
-     * instance whose processing has failed.
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps either a {@link javax.ws.rs.ProcessingException}
+     * thrown in case of an invocation processing failure or a {@link WebApplicationException} or one of its subclasses
+     * thrown in case the received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
+     * successful} and the generic type of the supplied response callback is not {@link javax.ws.rs.core.Response}. In case
+     * a processing of a properly received response fails, the wrapped processing exception will be of
+     * {@link ResponseProcessingException} type and will contain the {@link Response} instance whose processing has failed.
      *
-     * @param <T>      generic response entity type.
-     * @param name     method name.
-     * @param entity   request entity, including it's full {@link javax.ws.rs.core.Variant} information.
-     *                 Any variant-related HTTP headers previously set (namely {@code Content-Type},
-     *                 {@code Content-Language} and {@code Content-Encoding}) will be overwritten using
-     *                 the entity variant information.
+     * @param <T> generic response entity type.
+     * @param name method name.
+     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information. Any variant-related
+     * HTTP headers previously set (namely {@code Content-Type}, {@code Content-Language} and {@code Content-Encoding}) will
+     * be overwritten using the entity variant information.
      * @param callback asynchronous invocation callback.
      * @return invocation response {@link Future future}.
      */

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/Client.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/Client.java
@@ -26,15 +26,13 @@ import javax.ws.rs.core.UriBuilder;
 
 /**
  * <p>
- * Client is the main entry point to the fluent API used to build and execute client
- * requests in order to consume responses returned.
+ * Client is the main entry point to the fluent API used to build and execute client requests in order to consume
+ * responses returned.
  * </p>
- * Clients are heavy-weight objects that manage the client-side communication
- * infrastructure. Initialization as well as disposal of a {@code Client} instance
- * may be a rather expensive operation. It is therefore advised to construct only
- * a small number of {@code Client} instances in the application. Client instances
- * must be {@link #close() properly closed} before being disposed to avoid leaking
- * resources.
+ * Clients are heavy-weight objects that manage the client-side communication infrastructure. Initialization as well as
+ * disposal of a {@code Client} instance may be a rather expensive operation. It is therefore advised to construct only
+ * a small number of {@code Client} instances in the application. Client instances must be {@link #close() properly
+ * closed} before being disposed to avoid leaking resources.
  *
  * @author Marek Potociar
  * @see javax.ws.rs.core.Configurable
@@ -44,14 +42,13 @@ public interface Client extends Configurable<Client>, AutoCloseable {
 
     /**
      * <p>
-     * Close client instance and all it's associated resources. Subsequent calls
-     * have no effect and are ignored. Once the client is closed, invoking any
-     * other method on the client instance would result in an {@link IllegalStateException}
+     * Close client instance and all it's associated resources. Subsequent calls have no effect and are ignored. Once the
+     * client is closed, invoking any other method on the client instance would result in an {@link IllegalStateException}
      * being thrown.
      * </p>
-     * Calling this method effectively invalidates all {@link WebTarget resource targets}
-     * produced by the client instance. Invoking any method on such targets once the client
-     * is closed would result in an {@link IllegalStateException} being thrown.
+     * Calling this method effectively invalidates all {@link WebTarget resource targets} produced by the client instance.
+     * Invoking any method on such targets once the client is closed would result in an {@link IllegalStateException} being
+     * thrown.
      */
     @Override
     public void close();
@@ -62,7 +59,7 @@ public interface Client extends Configurable<Client>, AutoCloseable {
      * @param uri web resource URI. May contain template parameters. Must not be {@code null}.
      * @return web resource target bound to the provided URI.
      * @throws IllegalArgumentException in case the supplied string is not a valid URI template.
-     * @throws NullPointerException     in case the supplied argument is {@code null}.
+     * @throws NullPointerException in case the supplied argument is {@code null}.
      */
     public WebTarget target(String uri);
 
@@ -94,13 +91,14 @@ public interface Client extends Configurable<Client>, AutoCloseable {
     public WebTarget target(Link link);
 
     /**
-     * <p>Build an invocation builder from a link. It uses the URI and the type
-     * of the link to initialize the invocation builder. The type is used as the
-     * initial value for the HTTP Accept header, if present.</p>
+     * <p>
+     * Build an invocation builder from a link. It uses the URI and the type of the link to initialize the invocation
+     * builder. The type is used as the initial value for the HTTP Accept header, if present.
+     * </p>
      *
      * @param link link to build invocation from. Must not be {@code null}.
      * @return newly created invocation builder.
-     * @throws NullPointerException     in case link is {@code null}.
+     * @throws NullPointerException in case link is {@code null}.
      */
     public Invocation.Builder invocation(Link link);
 
@@ -112,8 +110,7 @@ public interface Client extends Configurable<Client>, AutoCloseable {
     public SSLContext getSslContext();
 
     /**
-     * Get the hostname verifier configured in the client or {@code null} in case
-     * no hostname verifier has been configured.
+     * Get the hostname verifier configured in the client or {@code null} in case no hostname verifier has been configured.
      *
      * @return client hostname verifier or {@code null} if not set.
      */

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/ClientBuilder.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/ClientBuilder.java
@@ -31,8 +31,7 @@ import javax.ws.rs.core.Configuration;
 import javax.ws.rs.sse.SseEventSource;
 
 /**
- * Main entry point to the client API used to bootstrap {@link javax.ws.rs.client.Client}
- * instances.
+ * Main entry point to the client API used to bootstrap {@link javax.ws.rs.client.Client} instances.
  *
  * @author Marek Potociar
  * @since 2.0
@@ -40,16 +39,14 @@ import javax.ws.rs.sse.SseEventSource;
 public abstract class ClientBuilder implements Configurable<ClientBuilder> {
 
     /**
-     * Name of the property identifying the {@link ClientBuilder} implementation
-     * to be returned from {@link ClientBuilder#newBuilder()}.
+     * Name of the property identifying the {@link ClientBuilder} implementation to be returned from
+     * {@link ClientBuilder#newBuilder()}.
      */
-    public static final String JAXRS_DEFAULT_CLIENT_BUILDER_PROPERTY =
-            "javax.ws.rs.client.ClientBuilder";
+    public static final String JAXRS_DEFAULT_CLIENT_BUILDER_PROPERTY = "javax.ws.rs.client.ClientBuilder";
     /**
      * Default client builder implementation class name.
      */
-    private static final String JAXRS_DEFAULT_CLIENT_BUILDER =
-            "org.glassfish.jersey.client.JerseyClientBuilder";
+    private static final String JAXRS_DEFAULT_CLIENT_BUILDER = "org.glassfish.jersey.client.JerseyClientBuilder";
 
     /**
      * Allows custom implementations to extend the {@code ClientBuilder} class.
@@ -58,16 +55,15 @@ public abstract class ClientBuilder implements Configurable<ClientBuilder> {
     }
 
     /**
-     * Create a new {@code ClientBuilder} instance using the default client builder
-     * implementation class provided by the JAX-RS implementation provider.
+     * Create a new {@code ClientBuilder} instance using the default client builder implementation class provided by the
+     * JAX-RS implementation provider.
      *
      * @return new client builder instance.
      */
     public static ClientBuilder newBuilder() {
         try {
-            Object delegate =
-                    FactoryFinder.find(JAXRS_DEFAULT_CLIENT_BUILDER_PROPERTY,
-                            JAXRS_DEFAULT_CLIENT_BUILDER, ClientBuilder.class);
+            Object delegate = FactoryFinder.find(JAXRS_DEFAULT_CLIENT_BUILDER_PROPERTY,
+                    JAXRS_DEFAULT_CLIENT_BUILDER, ClientBuilder.class);
             if (!(delegate instanceof ClientBuilder)) {
                 Class pClass = ClientBuilder.class;
                 String classnameAsResource = pClass.getName().replace('.', '/') + ".class";
@@ -87,8 +83,8 @@ public abstract class ClientBuilder implements Configurable<ClientBuilder> {
     }
 
     /**
-     * Create a new {@link Client} instance using the default client builder implementation
-     * class provided by the JAX-RS implementation provider.
+     * Create a new {@link Client} instance using the default client builder implementation class provided by the JAX-RS
+     * implementation provider.
      *
      * @return new client instance.
      */
@@ -97,11 +93,10 @@ public abstract class ClientBuilder implements Configurable<ClientBuilder> {
     }
 
     /**
-     * Create a new custom-configured {@link Client} instance using the default client builder
-     * implementation class provided by the JAX-RS implementation provider.
+     * Create a new custom-configured {@link Client} instance using the default client builder implementation class provided
+     * by the JAX-RS implementation provider.
      *
-     * @param configuration data used to provide initial configuration for the new
-     *                      client instance.
+     * @param configuration data used to provide initial configuration for the new client instance.
      * @return new configured client instance.
      */
     public static Client newClient(final Configuration configuration) {
@@ -111,26 +106,22 @@ public abstract class ClientBuilder implements Configurable<ClientBuilder> {
     /**
      * Set the internal configuration state to an externally provided configuration state.
      *
-     * @param config external configuration state to replace the configuration of this configurable
-     *               instance.
+     * @param config external configuration state to replace the configuration of this configurable instance.
      * @return the updated client builder instance.
      */
     public abstract ClientBuilder withConfig(Configuration config);
 
     /**
-     * Set the SSL context that will be used when creating secured transport connections
-     * to server endpoints from {@link WebTarget web targets} created by the client
-     * instance that is using this SSL context. The SSL context is expected to have all the
-     * security infrastructure initialized, including the key and trust managers.
+     * Set the SSL context that will be used when creating secured transport connections to server endpoints from
+     * {@link WebTarget web targets} created by the client instance that is using this SSL context. The SSL context is
+     * expected to have all the security infrastructure initialized, including the key and trust managers.
      * <p>
-     * Setting a SSL context instance resets any {@link #keyStore(java.security.KeyStore, char[])
-     * key store} or {@link #trustStore(java.security.KeyStore) trust store} values previously
-     * specified.
+     * Setting a SSL context instance resets any {@link #keyStore(java.security.KeyStore, char[]) key store} or
+     * {@link #trustStore(java.security.KeyStore) trust store} values previously specified.
      * </p>
      *
-     * @param sslContext secure socket protocol implementation which acts as a factory
-     *                   for secure socket factories or {@link javax.net.ssl.SSLEngine
-     *                   SSL engines}. Must not be {@code null}.
+     * @param sslContext secure socket protocol implementation which acts as a factory for secure socket factories or
+     * {@link javax.net.ssl.SSLEngine SSL engines}. Must not be {@code null}.
      * @return an updated client builder instance.
      * @throws NullPointerException in case the {@code sslContext} parameter is {@code null}.
      * @see #keyStore(java.security.KeyStore, char[])
@@ -143,12 +134,12 @@ public abstract class ClientBuilder implements Configurable<ClientBuilder> {
      * Set the client-side key store. Key store contains client's private keys, and the certificates with their
      * corresponding public keys.
      * <p>
-     * Setting a key store instance resets any {@link #sslContext(javax.net.ssl.SSLContext) SSL context instance}
-     * value previously specified.
+     * Setting a key store instance resets any {@link #sslContext(javax.net.ssl.SSLContext) SSL context instance} value
+     * previously specified.
      * </p>
      * <p>
-     * Note that a custom key store is only required if you want to enable a custom setup of a 2-way SSL connections
-     * (client certificate authentication).
+     * Note that a custom key store is only required if you want to enable a custom setup of a 2-way SSL connections (client
+     * certificate authentication).
      * </p>
      *
      * @param keyStore client-side key store. Must not be {@code null}.
@@ -165,14 +156,14 @@ public abstract class ClientBuilder implements Configurable<ClientBuilder> {
      * Set the client-side key store. Key store contains client's private keys, and the certificates with their
      * corresponding public keys.
      * <p>
-     * Setting a key store instance resets any {@link #sslContext(javax.net.ssl.SSLContext) SSL context instance}
-     * value previously specified.
+     * Setting a key store instance resets any {@link #sslContext(javax.net.ssl.SSLContext) SSL context instance} value
+     * previously specified.
      * </p>
      * <p>
-     * Note that for improved security of working with password data and avoid storing passwords in Java string
-     * objects, the {@link #keyStore(java.security.KeyStore, char[])} version of the method can be utilized.
-     * Also note that a custom key store is only required if you want to enable a custom setup of a 2-way SSL
-     * connections (client certificate authentication).
+     * Note that for improved security of working with password data and avoid storing passwords in Java string objects, the
+     * {@link #keyStore(java.security.KeyStore, char[])} version of the method can be utilized. Also note that a custom key
+     * store is only required if you want to enable a custom setup of a 2-way SSL connections (client certificate
+     * authentication).
      * </p>
      *
      * @param keyStore client-side key store. Must not be {@code null}.
@@ -188,16 +179,15 @@ public abstract class ClientBuilder implements Configurable<ClientBuilder> {
     }
 
     /**
-     * Set the client-side trust store. Trust store is expected to contain certificates from other parties
-     * the client is you expect to communicate with, or from Certificate Authorities that are trusted to
-     * identify other parties.
+     * Set the client-side trust store. Trust store is expected to contain certificates from other parties the client is you
+     * expect to communicate with, or from Certificate Authorities that are trusted to identify other parties.
      * <p>
-     * Setting a trust store instance resets any {@link #sslContext(javax.net.ssl.SSLContext) SSL context instance}
-     * value previously specified.
+     * Setting a trust store instance resets any {@link #sslContext(javax.net.ssl.SSLContext) SSL context instance} value
+     * previously specified.
      * </p>
      * <p>
-     * In case a custom trust store or custom SSL context is not specified, the trust management will be
-     * configured to use the default Java runtime settings.
+     * In case a custom trust store or custom SSL context is not specified, the trust management will be configured to use
+     * the default Java runtime settings.
      * </p>
      *
      * @param trustStore client-side trust store. Must not be {@code null}.
@@ -210,8 +200,8 @@ public abstract class ClientBuilder implements Configurable<ClientBuilder> {
     public abstract ClientBuilder trustStore(final KeyStore trustStore);
 
     /**
-     * Set the hostname verifier to be used by the client to verify the endpoint's hostname against it's
-     * identification information.
+     * Set the hostname verifier to be used by the client to verify the endpoint's hostname against it's identification
+     * information.
      *
      * @param verifier hostname verifier.
      * @return an updated client builder instance.
@@ -223,9 +213,9 @@ public abstract class ClientBuilder implements Configurable<ClientBuilder> {
      * <p>
      * Provided executor service will be used for executing asynchronous tasks.
      * <p>
-     * When running in a Java EE container, implementations are required to use the container-managed
-     * executor service by default.  In Java SE, the default is implementation-specific.  In either
-     * case, calling this method will override the default.
+     * When running in a Java EE container, implementations are required to use the container-managed executor service by
+     * default. In Java SE, the default is implementation-specific. In either case, calling this method will override the
+     * default.
      *
      * @param executorService executor service to be used for async invocations.
      * @return an updated client builder instance.
@@ -241,9 +231,9 @@ public abstract class ClientBuilder implements Configurable<ClientBuilder> {
      * <p>
      * Provided executor service will be used for executing scheduled asynchronous tasks.
      * <p>
-     * When running in a Java EE container, implementations are required to use the container-managed
-     * scheduled executor service by default.  In Java SE the default is implementation-specific.  In
-     * either case, calling this method will override the default.
+     * When running in a Java EE container, implementations are required to use the container-managed scheduled executor
+     * service by default. In Java SE the default is implementation-specific. In either case, calling this method will
+     * override the default.
      *
      * @param scheduledExecutorService executor service to be used for scheduled async invocations.
      * @return an updated client builder instance.
@@ -258,7 +248,7 @@ public abstract class ClientBuilder implements Configurable<ClientBuilder> {
      * Value {@code 0} represents infinity. Negative values are not allowed.
      *
      * @param timeout the maximum time to wait.
-     * @param unit    the time unit of the timeout argument.
+     * @param unit the time unit of the timeout argument.
      * @return an updated client builder instance.
      * @throws IllegalArgumentException when the value is negative.
      * @since 2.1
@@ -274,7 +264,7 @@ public abstract class ClientBuilder implements Configurable<ClientBuilder> {
      * Value {@code 0} represents infinity. Negative values are not allowed.
      *
      * @param timeout the maximum time to wait.
-     * @param unit    the time unit of the timeout argument.
+     * @param unit the time unit of the timeout argument.
      * @return an updated client builder instance.
      * @throws IllegalArgumentException when the value is negative.
      * @since 2.1
@@ -282,8 +272,7 @@ public abstract class ClientBuilder implements Configurable<ClientBuilder> {
     public abstract ClientBuilder readTimeout(long timeout, TimeUnit unit);
 
     /**
-     * Build a new client instance using all the configuration previously specified
-     * in this client builder.
+     * Build a new client instance using all the configuration previously specified in this client builder.
      *
      * @return a new client instance.
      */

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/ClientRequestContext.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/ClientRequestContext.java
@@ -36,9 +36,8 @@ import javax.ws.rs.ext.MessageBodyWriter;
 /**
  * Client request filter context.
  *
- * A mutable class that provides request-specific information for the filter,
- * such as request URI, message headers, message entity or request-scoped
- * properties. The exposed setters allow modification of the exposed request-specific
+ * A mutable class that provides request-specific information for the filter, such as request URI, message headers,
+ * message entity or request-scoped properties. The exposed setters allow modification of the exposed request-specific
  * information.
  *
  * @author Marek Potociar
@@ -47,31 +46,29 @@ import javax.ws.rs.ext.MessageBodyWriter;
 public interface ClientRequestContext {
 
     /**
-     * Returns the property with the given name registered in the current request/response
-     * exchange context, or {@code null} if there is no property by that name.
+     * Returns the property with the given name registered in the current request/response exchange context, or {@code null}
+     * if there is no property by that name.
      * <p>
-     * A property allows a JAX-RS filters and interceptors to exchange
-     * additional custom information not already provided by this interface.
+     * A property allows a JAX-RS filters and interceptors to exchange additional custom information not already provided by
+     * this interface.
      * </p>
      * <p>
-     * A list of supported properties can be retrieved using {@link #getPropertyNames()}.
-     * Custom property names should follow the same convention as package names.
+     * A list of supported properties can be retrieved using {@link #getPropertyNames()}. Custom property names should
+     * follow the same convention as package names.
      * </p>
      *
      * @param name a {@code String} specifying the name of the property.
-     * @return an {@code Object} containing the value of the property, or
-     *         {@code null} if no property exists matching the given name.
+     * @return an {@code Object} containing the value of the property, or {@code null} if no property exists matching the
+     * given name.
      * @see #getPropertyNames()
      */
     public Object getProperty(String name);
 
-
     /**
-     * Returns an immutable {@link Collection collection} containing the property names
-     * available within the context of the current request/response exchange context.
+     * Returns an immutable {@link Collection collection} containing the property names available within the context of the
+     * current request/response exchange context.
      * <p>
-     * Use the {@link #getProperty} method with a property name to get the value of
-     * a property.
+     * Use the {@link #getProperty} method with a property name to get the value of a property.
      * </p>
      *
      * @return an immutable {@link Collection collection} of property names.
@@ -79,33 +76,29 @@ public interface ClientRequestContext {
      */
     public Collection<String> getPropertyNames();
 
-
     /**
-     * Binds an object to a given property name in the current request/response
-     * exchange context. If the name specified is already used for a property,
-     * this method will replace the value of the property with the new value.
+     * Binds an object to a given property name in the current request/response exchange context. If the name specified is
+     * already used for a property, this method will replace the value of the property with the new value.
      * <p>
-     * A property allows a JAX-RS filters and interceptors to exchange
-     * additional custom information not already provided by this interface.
+     * A property allows a JAX-RS filters and interceptors to exchange additional custom information not already provided by
+     * this interface.
      * </p>
      * <p>
-     * A list of supported properties can be retrieved using {@link #getPropertyNames()}.
-     * Custom property names should follow the same convention as package names.
+     * A list of supported properties can be retrieved using {@link #getPropertyNames()}. Custom property names should
+     * follow the same convention as package names.
      * </p>
      * <p>
-     * If a {@code null} value is passed, the effect is the same as calling the
-     * {@link #removeProperty(String)} method.
+     * If a {@code null} value is passed, the effect is the same as calling the {@link #removeProperty(String)} method.
      * </p>
      *
-     * @param name   a {@code String} specifying the name of the property.
+     * @param name a {@code String} specifying the name of the property.
      * @param object an {@code Object} representing the property to be bound.
      */
     public void setProperty(String name, Object object);
 
     /**
-     * Removes a property with the given name from the current request/response
-     * exchange context. After removal, subsequent calls to {@link #getProperty}
-     * to retrieve the property value will return {@code null}.
+     * Removes a property with the given name from the current request/response exchange context. After removal, subsequent
+     * calls to {@link #getProperty} to retrieve the property value will return {@code null}.
      *
      * @param name a {@code String} specifying the name of the property to be removed.
      */
@@ -153,14 +146,12 @@ public interface ClientRequestContext {
     /**
      * Get a string view of header values associated with the message.
      *
-     * Changes in the underlying {@link #getHeaders() headers map} are reflected
-     * in this view.
+     * Changes in the underlying {@link #getHeaders() headers map} are reflected in this view.
      * <p>
      * The method converts the non-string header values to strings using a
      * {@link javax.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one is available via
-     * {@link javax.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the
-     * class of the value or using the values {@code toString} method if a header delegate is
-     * not available.
+     * {@link javax.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the class of the value or using the
+     * values {@code toString} method if a header delegate is not available.
      * </p>
      *
      * @return response headers as a string view of header values.
@@ -172,18 +163,14 @@ public interface ClientRequestContext {
     /**
      * Get a message header as a single string value.
      *
-     * Each single header value is converted to String using a
-     * {@link javax.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one is available
-     * via {@link javax.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)}
-     * for the header value class or using its {@code toString} method  if a header
-     * delegate is not available.
+     * Each single header value is converted to String using a {@link javax.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one
+     * is available via {@link javax.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the header value
+     * class or using its {@code toString} method if a header delegate is not available.
      *
      * @param name the message header.
-     * @return the message header value. If the message header is not present then
-     *         {@code null} is returned. If the message header is present but has no
-     *         value then the empty string is returned. If the message header is present
-     *         more than once then the values of joined together and separated by a ','
-     *         character.
+     * @return the message header value. If the message header is not present then {@code null} is returned. If the message
+     * header is present but has no value then the empty string is returned. If the message header is present more than once
+     * then the values of joined together and separated by a ',' character.
      * @see #getHeaders()
      * @see #getStringHeaders()
      */
@@ -206,24 +193,22 @@ public interface ClientRequestContext {
     /**
      * Get the media type of the entity.
      *
-     * @return the media type or {@code null} if not specified (e.g. there's no
-     *         request entity).
+     * @return the media type or {@code null} if not specified (e.g. there's no request entity).
      */
     public MediaType getMediaType();
 
     /**
      * Get a list of media types that are acceptable for the response.
      *
-     * @return a read-only list of requested response media types sorted according
-     *         to their q-value, with highest preference first.
+     * @return a read-only list of requested response media types sorted according to their q-value, with highest preference
+     * first.
      */
     public List<MediaType> getAcceptableMediaTypes();
 
     /**
      * Get a list of languages that are acceptable for the response.
      *
-     * @return a read-only list of acceptable languages sorted according
-     *         to their q-value, with highest preference first.
+     * @return a read-only list of acceptable languages sorted according to their q-value, with highest preference first.
      */
     public List<Locale> getAcceptableLanguages();
 
@@ -237,11 +222,9 @@ public interface ClientRequestContext {
     /**
      * Check if there is an entity available in the request.
      *
-     * The method returns {@code true} if the entity is present, returns
-     * {@code false} otherwise.
+     * The method returns {@code true} if the entity is present, returns {@code false} otherwise.
      *
-     * @return {@code true} if there is an entity present in the message,
-     *         {@code false} otherwise.
+     * @return {@code true} if there is an entity present in the message, {@code false} otherwise.
      */
     public boolean hasEntity();
 
@@ -250,8 +233,7 @@ public interface ClientRequestContext {
      *
      * Returns {@code null} if the message does not contain an entity.
      *
-     * @return the message entity or {@code null} if message does not contain an
-     *         entity body.
+     * @return the message entity or {@code null} if message does not contain an entity body.
      */
     public Object getEntity();
 
@@ -270,12 +252,11 @@ public interface ClientRequestContext {
     public Type getEntityType();
 
     /**
-     * Set a new message entity. The existing entity {@link #getEntityAnnotations() annotations}
-     * and {@link #getMediaType() media type} are preserved.
+     * Set a new message entity. The existing entity {@link #getEntityAnnotations() annotations} and {@link #getMediaType()
+     * media type} are preserved.
      * <p>
-     * It is the callers responsibility to wrap the actual entity with
-     * {@link javax.ws.rs.core.GenericEntity} if preservation of its generic
-     * type is required.
+     * It is the callers responsibility to wrap the actual entity with {@link javax.ws.rs.core.GenericEntity} if
+     * preservation of its generic type is required.
      * </p>
      *
      * @param entity entity object.
@@ -287,14 +268,13 @@ public interface ClientRequestContext {
     /**
      * Set a new message entity, including the attached annotations and the media type.
      * <p>
-     * It is the callers responsibility to wrap the actual entity with
-     * {@link javax.ws.rs.core.GenericEntity} if preservation of its generic
-     * type is required.
+     * It is the callers responsibility to wrap the actual entity with {@link javax.ws.rs.core.GenericEntity} if
+     * preservation of its generic type is required.
      * </p>
      *
-     * @param entity      entity object.
+     * @param entity entity object.
      * @param annotations annotations attached to the entity instance.
-     * @param mediaType   entity media type.
+     * @param mediaType entity media type.
      * @see #setEntity(Object)
      * @see MessageBodyWriter
      */
@@ -306,29 +286,25 @@ public interface ClientRequestContext {
     /**
      * Get the annotations attached to the entity instance.
      * <p>
-     * Note that the returned annotations array contains only those annotations
-     * explicitly attached to entity instance (such as the ones attached using
-     * {@link Entity#Entity(Object, javax.ws.rs.core.MediaType, java.lang.annotation.Annotation[])} method).
-     * The entity instance annotations array does not include annotations declared on the entity
-     * implementation class or its ancestors.
+     * Note that the returned annotations array contains only those annotations explicitly attached to entity instance (such
+     * as the ones attached using
+     * {@link Entity#Entity(Object, javax.ws.rs.core.MediaType, java.lang.annotation.Annotation[])} method). The entity
+     * instance annotations array does not include annotations declared on the entity implementation class or its ancestors.
      * </p>
      *
      * @return annotations attached to the entity instance.
      */
     public Annotation[] getEntityAnnotations();
 
-
     /**
-     * Get the entity output stream. The JAX-RS runtime is responsible for
-     * closing the output stream.
+     * Get the entity output stream. The JAX-RS runtime is responsible for closing the output stream.
      *
      * @return entity output stream.
      */
     public OutputStream getEntityStream();
 
     /**
-     * Set a new entity output stream. The JAX-RS runtime is responsible for
-     * closing the output stream.
+     * Set a new entity output stream. The JAX-RS runtime is responsible for closing the output stream.
      *
      * @param outputStream new entity output stream.
      */
@@ -351,9 +327,8 @@ public interface ClientRequestContext {
     /**
      * Abort the filter chain with a response.
      *
-     * This method breaks the filter chain processing and returns the provided
-     * response back to the client. The provided response goes through the
-     * chain of applicable response filters.
+     * This method breaks the filter chain processing and returns the provided response back to the client. The provided
+     * response goes through the chain of applicable response filters.
      *
      * @param response response to be sent back to the client.
      */

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/ClientRequestFilter.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/ClientRequestFilter.java
@@ -21,9 +21,8 @@ import java.io.IOException;
 /**
  * An extension interface implemented by client request filters.
  *
- * Filters implementing this interface MUST be annotated with
- * {@link javax.ws.rs.ext.Provider &#64;Provider} to be discovered by the JAX-RS
- * runtime. This type of filters is supported only as part of the Client API.
+ * Filters implementing this interface MUST be annotated with {@link javax.ws.rs.ext.Provider &#64;Provider} to be
+ * discovered by the JAX-RS runtime. This type of filters is supported only as part of the Client API.
  *
  * @author Marek Potociar
  * @author Santiago Pericas-Geertsen
@@ -33,11 +32,10 @@ import java.io.IOException;
 public interface ClientRequestFilter {
 
     /**
-     * Filter method called before a request has been dispatched to a client
-     * transport layer.
+     * Filter method called before a request has been dispatched to a client transport layer.
      *
-     * Filters in the filter chain are ordered according to their {@code javax.annotation.Priority}
-     * class-level annotation value.
+     * Filters in the filter chain are ordered according to their {@code javax.annotation.Priority} class-level annotation
+     * value.
      *
      * @param requestContext request context.
      * @throws IOException if an I/O exception occurs.

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/ClientResponseContext.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/ClientResponseContext.java
@@ -33,10 +33,8 @@ import javax.ws.rs.core.Response;
 /**
  * Client response filter context.
  *
- * A mutable class that provides response-specific information for the filter,
- * such as message headers, message entity or request-scoped properties.
- * The exposed setters allow modification of the exposed response-specific
- * information.
+ * A mutable class that provides response-specific information for the filter, such as message headers, message entity
+ * or request-scoped properties. The exposed setters allow modification of the exposed response-specific information.
  *
  * @author Marek Potociar
  * @since 2.0
@@ -60,14 +58,12 @@ public interface ClientResponseContext {
     /**
      * Get the complete status information associated with the response.
      *
-     * @return the response status information or {@code null} if the status was
-     *         not set.
+     * @return the response status information or {@code null} if the status was not set.
      */
     public Response.StatusType getStatusInfo();
 
     /**
-     * Set the complete status information (status code and reason phrase) associated
-     * with the response.
+     * Set the complete status information (status code and reason phrase) associated with the response.
      *
      * @param statusInfo the response status information.
      */
@@ -85,11 +81,9 @@ public interface ClientResponseContext {
      * Get a message header as a single string value.
      *
      * @param name the message header.
-     * @return the message header value. If the message header is not present then
-     *         {@code null} is returned. If the message header is present but has no
-     *         value then the empty string is returned. If the message header is present
-     *         more than once then the values of joined together and separated by a ','
-     *         character.
+     * @return the message header value. If the message header is not present then {@code null} is returned. If the message
+     * header is present but has no value then the empty string is returned. If the message header is present more than once
+     * then the values of joined together and separated by a ',' character.
      * @see #getHeaders()
      */
     public String getHeaderString(String name);
@@ -97,8 +91,7 @@ public interface ClientResponseContext {
     /**
      * Get the allowed HTTP methods from the Allow HTTP header.
      *
-     * @return the allowed HTTP methods, all methods will returned as upper case
-     *         strings.
+     * @return the allowed HTTP methods, all methods will returned as upper case strings.
      */
     public Set<String> getAllowedMethods();
 
@@ -119,16 +112,14 @@ public interface ClientResponseContext {
     /**
      * Get Content-Length value.
      *
-     * @return Content-Length as integer if present and valid number. In other
-     *         cases returns -1.
+     * @return Content-Length as integer if present and valid number. In other cases returns -1.
      */
     public int getLength();
 
     /**
      * Get the media type of the entity.
      *
-     * @return the media type or {@code null} if not specified (e.g. there's no
-     *         response entity).
+     * @return the media type or {@code null} if not specified (e.g. there's no response entity).
      */
     public MediaType getMediaType();
 
@@ -163,8 +154,7 @@ public interface ClientResponseContext {
     /**
      * Get the links attached to the message as header.
      *
-     * @return links, may return empty {@link Set} if no links are present. Never
-     *         returns {@code null}.
+     * @return links, may return empty {@link Set} if no links are present. Never returns {@code null}.
      */
     public Set<Link> getLinks();
 
@@ -172,8 +162,7 @@ public interface ClientResponseContext {
      * Check if link for relation exists.
      *
      * @param relation link relation.
-     * @return {@code true} if the for the relation link exists, {@code false}
-     *         otherwise.
+     * @return {@code true} if the for the relation link exists, {@code false} otherwise.
      */
     boolean hasLink(String relation);
 
@@ -186,38 +175,31 @@ public interface ClientResponseContext {
     public Link getLink(String relation);
 
     /**
-     * Convenience method that returns a {@link javax.ws.rs.core.Link.Builder Link.Builder}
-     * for the relation.
+     * Convenience method that returns a {@link javax.ws.rs.core.Link.Builder Link.Builder} for the relation.
      *
      * @param relation link relation.
-     * @return the link builder for the relation, otherwise {@code null} if not
-     *         present.
+     * @return the link builder for the relation, otherwise {@code null} if not present.
      */
     public Link.Builder getLinkBuilder(String relation);
 
     /**
-     * Check if there is a non-empty entity input stream is available in the response
-     * message.
+     * Check if there is a non-empty entity input stream is available in the response message.
      *
-     * The method returns {@code true} if the entity is present, returns
-     * {@code false} otherwise.
+     * The method returns {@code true} if the entity is present, returns {@code false} otherwise.
      *
-     * @return {@code true} if there is an entity present in the message,
-     *         {@code false} otherwise.
+     * @return {@code true} if there is an entity present in the message, {@code false} otherwise.
      */
     public boolean hasEntity();
 
     /**
-     * Get the entity input stream. The JAX-RS runtime is responsible for
-     * closing the input stream.
+     * Get the entity input stream. The JAX-RS runtime is responsible for closing the input stream.
      *
      * @return entity input stream.
      */
     public InputStream getEntityStream();
 
     /**
-     * Set a new entity input stream. The JAX-RS runtime is responsible for
-     * closing the input stream.
+     * Set a new entity input stream. The JAX-RS runtime is responsible for closing the input stream.
      *
      * @param input new entity input stream.
      */

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/ClientResponseFilter.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/ClientResponseFilter.java
@@ -21,9 +21,8 @@ import java.io.IOException;
 /**
  * An extension interface implemented by client response filters.
  *
- * Filters implementing this interface MUST be annotated with
- * {@link javax.ws.rs.ext.Provider &#64;Provider} to be discovered by the JAX-RS
- * runtime. This type of filters is supported only as part of the Client API.
+ * Filters implementing this interface MUST be annotated with {@link javax.ws.rs.ext.Provider &#64;Provider} to be
+ * discovered by the JAX-RS runtime. This type of filters is supported only as part of the Client API.
  *
  * @author Marek Potociar
  * @author Santiago Pericas-Geertsen
@@ -33,14 +32,13 @@ import java.io.IOException;
 public interface ClientResponseFilter {
 
     /**
-     * Filter method called after a response has been provided for a request
-     * (either by a {@link ClientRequestFilter request filter} or when the
-     * HTTP invocation returns).
+     * Filter method called after a response has been provided for a request (either by a {@link ClientRequestFilter request
+     * filter} or when the HTTP invocation returns).
      *
-     * Filters in the filter chain are ordered according to their {@code javax.annotation.Priority}
-     * class-level annotation value.
+     * Filters in the filter chain are ordered according to their {@code javax.annotation.Priority} class-level annotation
+     * value.
      *
-     * @param requestContext  request context.
+     * @param requestContext request context.
      * @param responseContext response context.
      * @throws IOException if an I/O exception occurs.
      */

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/CompletionStageRxInvoker.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/CompletionStageRxInvoker.java
@@ -105,4 +105,3 @@ public interface CompletionStageRxInvoker extends RxInvoker<CompletionStage> {
     @Override
     public <T> CompletionStage<T> method(String name, Entity<?> entity, GenericType<T> responseType);
 }
-

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/Entity.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/Entity.java
@@ -41,8 +41,8 @@ public final class Entity<T> {
     /**
      * Create an entity using a supplied content media type.
      *
-     * @param <T>       entity Java type.
-     * @param entity    entity data.
+     * @param <T> entity Java type.
+     * @param entity entity data.
      * @param mediaType entity content type.
      * @return entity instance.
      */
@@ -53,9 +53,9 @@ public final class Entity<T> {
     /**
      * Create an entity using a supplied content media type.
      *
-     * @param <T>         entity Java type.
-     * @param entity      entity data.
-     * @param mediaType   entity content type.
+     * @param <T> entity Java type.
+     * @param entity entity data.
+     * @param mediaType entity content type.
      * @param annotations entity annotations.
      * @return entity instance.
      */
@@ -66,12 +66,11 @@ public final class Entity<T> {
     /**
      * Create an entity using a supplied content media type.
      *
-     * @param <T>       entity Java type.
-     * @param entity    entity data.
+     * @param <T> entity Java type.
+     * @param entity entity data.
      * @param mediaType entity content type.
      * @return entity instance.
-     * @throws IllegalArgumentException if the supplied string cannot be parsed
-     *                                  or is {@code null}.
+     * @throws IllegalArgumentException if the supplied string cannot be parsed or is {@code null}.
      */
     public static <T> Entity<T> entity(final T entity, final String mediaType) {
         return new Entity<T>(entity, MediaType.valueOf(mediaType));
@@ -80,8 +79,8 @@ public final class Entity<T> {
     /**
      * Create an entity using a supplied content media type.
      *
-     * @param <T>     entity Java type.
-     * @param entity  entity data.
+     * @param <T> entity Java type.
+     * @param entity entity data.
      * @param variant entity {@link Variant variant} information.
      * @return entity instance.
      */
@@ -92,9 +91,9 @@ public final class Entity<T> {
     /**
      * Create an entity using a supplied content media type.
      *
-     * @param <T>         entity Java type.
-     * @param entity      entity data.
-     * @param variant     entity {@link Variant variant} information.
+     * @param <T> entity Java type.
+     * @param entity entity data.
+     * @param variant entity {@link Variant variant} information.
      * @param annotations entity annotations.
      * @return entity instance.
      */
@@ -105,7 +104,7 @@ public final class Entity<T> {
     /**
      * Create a {@value javax.ws.rs.core.MediaType#TEXT_PLAIN} entity.
      *
-     * @param <T>    entity Java type.
+     * @param <T> entity Java type.
      * @param entity entity data.
      * @return {@value javax.ws.rs.core.MediaType#TEXT_PLAIN} entity instance.
      */
@@ -116,7 +115,7 @@ public final class Entity<T> {
     /**
      * Create an {@value javax.ws.rs.core.MediaType#APPLICATION_XML} entity.
      *
-     * @param <T>    entity Java type.
+     * @param <T> entity Java type.
      * @param entity entity data.
      * @return {@value javax.ws.rs.core.MediaType#APPLICATION_XML} entity instance.
      */
@@ -127,7 +126,7 @@ public final class Entity<T> {
     /**
      * Create an {@value javax.ws.rs.core.MediaType#APPLICATION_JSON} entity.
      *
-     * @param <T>    entity Java type.
+     * @param <T> entity Java type.
      * @param entity entity data.
      * @return {@value javax.ws.rs.core.MediaType#APPLICATION_JSON} entity instance.
      */
@@ -138,7 +137,7 @@ public final class Entity<T> {
     /**
      * Create a {@value javax.ws.rs.core.MediaType#TEXT_HTML} entity.
      *
-     * @param <T>    entity Java type.
+     * @param <T> entity Java type.
      * @param entity entity data.
      * @return {@value javax.ws.rs.core.MediaType#TEXT_HTML} entity instance.
      */
@@ -149,34 +148,29 @@ public final class Entity<T> {
     /**
      * Create an {@value javax.ws.rs.core.MediaType#APPLICATION_XHTML_XML} entity.
      *
-     * @param <T>    entity Java type.
+     * @param <T> entity Java type.
      * @param entity entity data.
-     * @return {@value javax.ws.rs.core.MediaType#APPLICATION_XHTML_XML} entity
-     *         instance.
+     * @return {@value javax.ws.rs.core.MediaType#APPLICATION_XHTML_XML} entity instance.
      */
     public static <T> Entity<T> xhtml(final T entity) {
         return new Entity<T>(entity, MediaType.APPLICATION_XHTML_XML_TYPE);
     }
 
     /**
-     * Create an {@value javax.ws.rs.core.MediaType#APPLICATION_FORM_URLENCODED}
-     * form entity.
+     * Create an {@value javax.ws.rs.core.MediaType#APPLICATION_FORM_URLENCODED} form entity.
      *
      * @param form form data.
-     * @return {@value javax.ws.rs.core.MediaType#APPLICATION_FORM_URLENCODED}
-     *         form entity instance.
+     * @return {@value javax.ws.rs.core.MediaType#APPLICATION_FORM_URLENCODED} form entity instance.
      */
     public static Entity<Form> form(final Form form) {
         return new Entity<Form>(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE);
     }
 
     /**
-     * Create an {@value javax.ws.rs.core.MediaType#APPLICATION_FORM_URLENCODED}
-     * form entity.
+     * Create an {@value javax.ws.rs.core.MediaType#APPLICATION_FORM_URLENCODED} form entity.
      *
      * @param formData multivalued map representing the form data.
-     * @return {@value javax.ws.rs.core.MediaType#APPLICATION_FORM_URLENCODED}
-     *         form entity instance.
+     * @return {@value javax.ws.rs.core.MediaType#APPLICATION_FORM_URLENCODED} form entity instance.
      */
     public static Entity<Form> form(final MultivaluedMap<String, String> formData) {
         return new Entity<Form>(new Form(formData), MediaType.APPLICATION_FORM_URLENCODED_TYPE);
@@ -249,8 +243,7 @@ public final class Entity<T> {
     /**
      * Get the entity annotations.
      *
-     * @return entity annotations if set, an empty annotation array if no
-     *         entity annotations have been specified.
+     * @return entity annotations if set, an empty annotation array if no entity annotations have been specified.
      */
     public Annotation[] getAnnotations() {
         return annotations;
@@ -258,14 +251,19 @@ public final class Entity<T> {
 
     @Override
     public boolean equals(final Object o) {
-        if (this == o) return true;
-        if (!(o instanceof Entity)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof Entity))
+            return false;
 
         Entity entity1 = (Entity) o;
 
-        if (!Arrays.equals(annotations, entity1.annotations)) return false;
-        if (entity != null ? !entity.equals(entity1.entity) : entity1.entity != null) return false;
-        if (variant != null ? !variant.equals(entity1.variant) : entity1.variant != null) return false;
+        if (!Arrays.equals(annotations, entity1.annotations))
+            return false;
+        if (entity != null ? !entity.equals(entity1.entity) : entity1.entity != null)
+            return false;
+        if (variant != null ? !variant.equals(entity1.variant) : entity1.variant != null)
+            return false;
 
         return true;
     }

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/FactoryFinder.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/FactoryFinder.java
@@ -60,14 +60,12 @@ final class FactoryFinder {
     }
 
     /**
-     * Creates an instance of the specified class using the specified
-     * {@code ClassLoader} object.
+     * Creates an instance of the specified class using the specified {@code ClassLoader} object.
      *
-     * @param className   name of the class to be instantiated.
+     * @param className name of the class to be instantiated.
      * @param classLoader class loader to be used.
      * @return instance of the specified class.
-     * @throws ClassNotFoundException if the given class could not be found
-     *                                or could not be instantiated.
+     * @throws ClassNotFoundException if the given class could not be found or could not be instantiated.
      */
     private static Object newInstance(final String className, final ClassLoader classLoader) throws ClassNotFoundException {
         try {
@@ -81,8 +79,8 @@ final class FactoryFinder {
                     LOGGER.log(
                             Level.FINE,
                             "Unable to load provider class " + className
-                            + " using custom classloader " + classLoader.getClass().getName()
-                            + " trying again with current classloader.",
+                                    + " using custom classloader " + classLoader.getClass().getName()
+                                    + " trying again with current classloader.",
                             ex);
                     spiClass = Class.forName(className);
                 }
@@ -96,25 +94,19 @@ final class FactoryFinder {
     }
 
     /**
-     * Finds the implementation {@code Class} for the given factory name,
-     * or if that fails, finds the {@code Class} for the given fallback
-     * class name and create its instance. The arguments supplied MUST be
-     * used in order. If using the first argument is successful, the second
-     * one will not be used.
+     * Finds the implementation {@code Class} for the given factory name, or if that fails, finds the {@code Class} for the
+     * given fallback class name and create its instance. The arguments supplied MUST be used in order. If using the first
+     * argument is successful, the second one will not be used.
      * <p>
      * This method is package private so that this code can be shared.
      *
-     * @param factoryId         the name of the factory to find, which is
-     *                          a system property.
-     * @param fallbackClassName the implementation class name, which is
-     *                          to be used only if nothing else.
-     *                          is found; {@code null} to indicate that
-     *                          there is no fallback class name.
-     * @param service           service to be found.
-     * @param <T>               type of the service to be found.
+     * @param factoryId the name of the factory to find, which is a system property.
+     * @param fallbackClassName the implementation class name, which is to be used only if nothing else. is found;
+     * {@code null} to indicate that there is no fallback class name.
+     * @param service service to be found.
+     * @param <T> type of the service to be found.
      * @return the instance of the specified service; may not be {@code null}.
-     * @throws ClassNotFoundException if the given class could not be found
-     *                                or could not be instantiated.
+     * @throws ClassNotFoundException if the given class could not be found or could not be instantiated.
      */
     static <T> Object find(final String factoryId, final String fallbackClassName, final Class<T> service) throws ClassNotFoundException {
         ClassLoader classLoader = getContextClassLoader();
@@ -122,7 +114,7 @@ final class FactoryFinder {
         try {
             Iterator<T> iterator = ServiceLoader.load(service, FactoryFinder.getContextClassLoader()).iterator();
 
-            if(iterator.hasNext()) {
+            if (iterator.hasNext()) {
                 return iterator.next();
             }
         } catch (Exception | ServiceConfigurationError ex) {
@@ -132,7 +124,7 @@ final class FactoryFinder {
         try {
             Iterator<T> iterator = ServiceLoader.load(service, FactoryFinder.class.getClassLoader()).iterator();
 
-            if(iterator.hasNext()) {
+            if (iterator.hasNext()) {
                 return iterator.next();
             }
         } catch (Exception | ServiceConfigurationError ex) {

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/Invocation.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/Invocation.java
@@ -31,11 +31,10 @@ import javax.ws.rs.core.Response;
 /**
  * A client request invocation.
  *
- * An invocation is a request that has been prepared and is ready for execution.
- * Invocations provide a generic (command) interface that enables a separation of
- * concerns between the creator and the submitter. In particular, the submitter
- * does not need to know how the invocation was prepared, but only how it should
- * be executed (synchronously or asynchronously) and when.
+ * An invocation is a request that has been prepared and is ready for execution. Invocations provide a generic (command)
+ * interface that enables a separation of concerns between the creator and the submitter. In particular, the submitter
+ * does not need to know how the invocation was prepared, but only how it should be executed (synchronously or
+ * asynchronously) and when.
  *
  * @author Marek Potociar
  * @author Santiago Pericas-Geertsen
@@ -46,44 +45,45 @@ public interface Invocation {
     /**
      * A client request invocation builder.
      *
-     * The builder, obtained via a call to one of the {@code request(...)}
-     * methods on a {@link WebTarget resource target}, provides methods for
-     * preparing a client request invocation. Once the request is prepared
-     * the invocation builder can be either used to build an {@link Invocation}
-     * with a generic execution interface:
+     * The builder, obtained via a call to one of the {@code request(...)} methods on a {@link WebTarget resource target},
+     * provides methods for preparing a client request invocation. Once the request is prepared the invocation builder can
+     * be either used to build an {@link Invocation} with a generic execution interface:
+     *
      * <pre>
-     *   Client client = ClientBuilder.newClient();
-     *   WebTarget resourceTarget = client.target("http://examples.jaxrs.com/");
+     * Client client = ClientBuilder.newClient();
+     * WebTarget resourceTarget = client.target("http://examples.jaxrs.com/");
      *
-     *   // Build a HTTP GET request that accepts "text/plain" response type
-     *   // and contains a custom HTTP header entry "Foo: bar".
-     *   Invocation invocation = resourceTarget.request("text/plain")
-     *           .header("Foo", "bar").buildGet();
+     * // Build a HTTP GET request that accepts "text/plain" response type
+     * // and contains a custom HTTP header entry "Foo: bar".
+     * Invocation invocation = resourceTarget.request("text/plain")
+     *         .header("Foo", "bar").buildGet();
      *
-     *   // Invoke the request using generic interface
-     *   String response = invocation.invoke(String.class);
+     * // Invoke the request using generic interface
+     * String response = invocation.invoke(String.class);
      * </pre>
-     * Alternatively, one of the inherited {@link SyncInvoker synchronous invocation
-     * methods} can be used to invoke the prepared request and return the server
-     * response in a single step, e.g.:
-     * <pre>
-     *   Client client = ClientBuilder.newClient();
-     *   WebTarget resourceTarget = client.target("http://examples.jaxrs.com/");
      *
-     *   // Build and invoke the get request in a single step
-     *   String response = resourceTarget.request("text/plain")
-     *           .header("Foo", "bar").get(String.class);
+     * Alternatively, one of the inherited {@link SyncInvoker synchronous invocation methods} can be used to invoke the
+     * prepared request and return the server response in a single step, e.g.:
+     *
+     * <pre>
+     * Client client = ClientBuilder.newClient();
+     * WebTarget resourceTarget = client.target("http://examples.jaxrs.com/");
+     *
+     * // Build and invoke the get request in a single step
+     * String response = resourceTarget.request("text/plain")
+     *         .header("Foo", "bar").get(String.class);
      * </pre>
-     * Once the request is fully prepared for invoking, switching to an
-     * {@link AsyncInvoker asynchronous invocation} mode is possible by
-     * calling the {@link #async() } method on the builder, e.g.:
-     * <pre>
-     *   Client client = ClientBuilder.newClient();
-     *   WebTarget resourceTarget = client.target("http://examples.jaxrs.com/");
      *
-     *   // Build and invoke the get request asynchronously in a single step
-     *   Future&lt;String&gt; response = resourceTarget.request("text/plain")
-     *           .header("Foo", "bar").async().get(String.class);
+     * Once the request is fully prepared for invoking, switching to an {@link AsyncInvoker asynchronous invocation} mode is
+     * possible by calling the {@link #async() } method on the builder, e.g.:
+     *
+     * <pre>
+     * Client client = ClientBuilder.newClient();
+     * WebTarget resourceTarget = client.target("http://examples.jaxrs.com/");
+     *
+     * // Build and invoke the get request asynchronously in a single step
+     * Future&lt;String&gt; response = resourceTarget.request("text/plain")
+     *         .header("Foo", "bar").async().get(String.class);
      * </pre>
      */
     public static interface Builder extends SyncInvoker {
@@ -99,14 +99,12 @@ public interface Invocation {
         public Invocation build(String method);
 
         /**
-         * Build a request invocation using an arbitrary request method name and
-         * request entity.
+         * Build a request invocation using an arbitrary request method name and request entity.
          *
          * @param method request method name.
-         * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information.
-         *               Any variant-related HTTP headers previously set (namely {@code Content-Type},
-         *               {@code Content-Language} and {@code Content-Encoding}) will be overwritten using
-         *               the entity variant information.
+         * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information. Any variant-related
+         * HTTP headers previously set (namely {@code Content-Type}, {@code Content-Language} and {@code Content-Encoding}) will
+         * be overwritten using the entity variant information.
          * @return invocation encapsulating the built request.
          */
         public Invocation build(String method, Entity<?> entity);
@@ -128,10 +126,9 @@ public interface Invocation {
         /**
          * Build a POST request invocation.
          *
-         * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information.
-         *               Any variant-related HTTP headers previously set (namely {@code Content-Type},
-         *               {@code Content-Language} and {@code Content-Encoding}) will be overwritten using
-         *               the entity variant information.
+         * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information. Any variant-related
+         * HTTP headers previously set (namely {@code Content-Type}, {@code Content-Language} and {@code Content-Encoding}) will
+         * be overwritten using the entity variant information.
          * @return invocation encapsulating the built POST request.
          */
         public Invocation buildPost(Entity<?> entity);
@@ -139,17 +136,15 @@ public interface Invocation {
         /**
          * Build a PUT request invocation.
          *
-         * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information.
-         *               Any variant-related HTTP headers previously set (namely {@code Content-Type},
-         *               {@code Content-Language} and {@code Content-Encoding}) will be overwritten using
-         *               the entity variant information.
+         * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information. Any variant-related
+         * HTTP headers previously set (namely {@code Content-Type}, {@code Content-Language} and {@code Content-Encoding}) will
+         * be overwritten using the entity variant information.
          * @return invocation encapsulating the built PUT request.
          */
         public Invocation buildPut(Entity<?> entity);
 
         /**
-         * Access the asynchronous uniform request invocation interface to
-         * asynchronously invoke the built request.
+         * Access the asynchronous uniform request invocation interface to asynchronously invoke the built request.
          *
          * @return asynchronous uniform request invocation interface.
          */
@@ -206,7 +201,7 @@ public interface Invocation {
         /**
          * Add a cookie to be set.
          *
-         * @param name  the name of the cookie.
+         * @param name the name of the cookie.
          * @param value the value of the cookie.
          * @return the updated builder.
          */
@@ -215,8 +210,8 @@ public interface Invocation {
         /**
          * Set the cache control data of the message.
          *
-         * @param cacheControl the cache control directives, if {@code null}
-         *                     any existing cache control directives will be removed.
+         * @param cacheControl the cache control directives, if {@code null} any existing cache control directives will be
+         * removed.
          * @return the updated builder.
          */
         public Builder cacheControl(CacheControl cacheControl);
@@ -224,13 +219,12 @@ public interface Invocation {
         /**
          * Add an arbitrary header.
          *
-         * @param name  the name of the header
-         * @param value the value of the header, the header will be serialized
-         *              using a {@link javax.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if
-         *              one is available via {@link javax.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)}
-         *              for the class of {@code value} or using its {@code toString} method
-         *              if a header delegate is not available. If {@code value} is {@code null}
-         *              then all current headers of the same name will be removed.
+         * @param name the name of the header
+         * @param value the value of the header, the header will be serialized using a
+         * {@link javax.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one is available via
+         * {@link javax.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the class of {@code value} or using
+         * its {@code toString} method if a header delegate is not available. If {@code value} is {@code null} then all current
+         * headers of the same name will be removed.
          * @return the updated builder.
          */
         public Builder header(String name, Object value);
@@ -238,8 +232,7 @@ public interface Invocation {
         /**
          * Replaces all existing headers with the newly supplied headers.
          *
-         * @param headers new headers to be set, if {@code null} all existing
-         *                headers will be removed.
+         * @param headers new headers to be set, if {@code null} all existing headers will be removed.
          * @return the updated builder.
          */
         public Builder headers(MultivaluedMap<String, Object> headers);
@@ -247,17 +240,14 @@ public interface Invocation {
         /**
          * Set a new property in the context of a request represented by this invocation builder.
          * <p>
-         * The property is available for a later retrieval via {@link ClientRequestContext#getProperty(String)}
-         * or {@link javax.ws.rs.ext.InterceptorContext#getProperty(String)}.
-         * If a property with a given name is already set in the request context,
-         * the existing value of the property will be updated.
-         * Setting a {@code null} value into a property effectively removes the property
-         * from the request property bag.
+         * The property is available for a later retrieval via {@link ClientRequestContext#getProperty(String)} or
+         * {@link javax.ws.rs.ext.InterceptorContext#getProperty(String)}. If a property with a given name is already set in the
+         * request context, the existing value of the property will be updated. Setting a {@code null} value into a property
+         * effectively removes the property from the request property bag.
          * </p>
          *
-         * @param name  property name.
-         * @param value (new) property value. {@code null} value removes the property
-         *              with the given name.
+         * @param name property name.
+         * @param value (new) property value. {@code null} value removes the property with the given name.
          * @return the updated builder.
          * @see Invocation#property(String, Object)
          */
@@ -273,11 +263,11 @@ public interface Invocation {
         public CompletionStageRxInvoker rx();
 
         /**
-         * Access a reactive invoker based on a {@link RxInvoker} subclass provider. Note
-         * that corresponding {@link RxInvokerProvider} must be registered in the client runtime.
+         * Access a reactive invoker based on a {@link RxInvoker} subclass provider. Note that corresponding
+         * {@link RxInvokerProvider} must be registered in the client runtime.
          * <p>
-         * This method is an extension point for JAX-RS implementations to support other types
-         * representing asynchronous computations.
+         * This method is an extension point for JAX-RS implementations to support other types representing asynchronous
+         * computations.
          *
          * @param <T> generic invoker type.
          * @param clazz {@link RxInvoker} subclass.
@@ -293,17 +283,14 @@ public interface Invocation {
     /**
      * Set a new property in the context of a request represented by this invocation.
      * <p>
-     * The property is available for a later retrieval via {@link ClientRequestContext#getProperty(String)}
-     * or {@link javax.ws.rs.ext.InterceptorContext#getProperty(String)}.
-     * If a property with a given name is already set in the request context,
-     * the existing value of the property will be updated.
-     * Setting a {@code null} value into a property effectively removes the property
-     * from the request property bag.
+     * The property is available for a later retrieval via {@link ClientRequestContext#getProperty(String)} or
+     * {@link javax.ws.rs.ext.InterceptorContext#getProperty(String)}. If a property with a given name is already set in the
+     * request context, the existing value of the property will be updated. Setting a {@code null} value into a property
+     * effectively removes the property from the request property bag.
      * </p>
      *
-     * @param name  property name.
-     * @param value (new) property value. {@code null} value removes the property
-     *              with the given name.
+     * @param name property name.
+     * @param value (new) property value. {@code null} value removes the property with the given name.
      * @return the updated invocation.
      * @see Invocation.Builder#property(String, Object)
      */
@@ -312,139 +299,108 @@ public interface Invocation {
     /**
      * Synchronously invoke the request and receive a response back.
      *
-     * @return {@link Response response} object as a result of the request
-     *         invocation.
-     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter
-     *                                     or during conversion of the response entity data to an instance
-     *                                     of a particular Java type).
-     * @throws ProcessingException         in case the request processing or subsequent I/O operation fails.
+     * @return {@link Response response} object as a result of the request invocation.
+     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter or during
+     * conversion of the response entity data to an instance of a particular Java type).
+     * @throws ProcessingException in case the request processing or subsequent I/O operation fails.
      */
     public Response invoke();
 
     /**
-     * Synchronously invoke the request and receive a response of the specified
-     * type back.
+     * Synchronously invoke the request and receive a response of the specified type back.
      *
-     * @param <T>          response type
+     * @param <T> response type
      * @param responseType Java type the response should be converted into.
-     * @return response object of the specified type as a result of the request
-     *         invocation.
-     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter
-     *                                     or during conversion of the response entity data to an instance
-     *                                     of a particular Java type).
-     * @throws ProcessingException         in case the request processing or subsequent I/O operation fails.
-     * @throws WebApplicationException     in case the response status code of the response
-     *                                     returned by the server is not
-     *                                     {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     *                                     successful} and the specified response type is not
-     *                                     {@link javax.ws.rs.core.Response}.
+     * @return response object of the specified type as a result of the request invocation.
+     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter or during
+     * conversion of the response entity data to an instance of a particular Java type).
+     * @throws ProcessingException in case the request processing or subsequent I/O operation fails.
+     * @throws WebApplicationException in case the response status code of the response returned by the server is not
+     * {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and the specified response type is not
+     * {@link javax.ws.rs.core.Response}.
      */
     public <T> T invoke(Class<T> responseType);
 
     /**
-     * Synchronously invoke the request and receive a response of the specified
-     * generic type back.
+     * Synchronously invoke the request and receive a response of the specified generic type back.
      *
-     * @param <T>          generic response type
-     * @param responseType type literal representing a generic Java type the
-     *                     response should be converted into.
-     * @return response object of the specified generic type as a result of the
-     *         request invocation.
-     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter
-     *                                     or during conversion of the response entity data to an instance
-     *                                     of a particular Java type).
-     * @throws ProcessingException         in case the request processing or subsequent I/O operation fails.
-     * @throws WebApplicationException     in case the response status code of the response
-     *                                     returned by the server is not
-     *                                     {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     *                                     successful}.
+     * @param <T> generic response type
+     * @param responseType type literal representing a generic Java type the response should be converted into.
+     * @return response object of the specified generic type as a result of the request invocation.
+     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter or during
+     * conversion of the response entity data to an instance of a particular Java type).
+     * @throws ProcessingException in case the request processing or subsequent I/O operation fails.
+     * @throws WebApplicationException in case the response status code of the response returned by the server is not
+     * {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful}.
      */
     public <T> T invoke(GenericType<T> responseType);
 
     /**
-     * Submit the request for an asynchronous invocation and receive a future
-     * response back.
+     * Submit the request for an asynchronous invocation and receive a future response back.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps a {@link ProcessingException} thrown in case of an invocation processing
-     * failure.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
-     * instance whose processing has failed.
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps a {@link ProcessingException} thrown in case of
+     * an invocation processing failure. In case a processing of a properly received response fails, the wrapped processing
+     * exception will be of {@link ResponseProcessingException} type and will contain the {@link Response} instance whose
+     * processing has failed.
      * </p>
      *
-     * @return future {@link Response response} object as a result of the request
-     *         invocation.
+     * @return future {@link Response response} object as a result of the request invocation.
      */
     public Future<Response> submit();
 
     /**
-     * Submit the request for an asynchronous invocation and receive a future
-     * response of the specified type back.
+     * Submit the request for an asynchronous invocation and receive a future response of the specified type back.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps either a {@link ProcessingException} thrown in case of an invocation processing
-     * failure or a {@link WebApplicationException} or one of its subclasses thrown in case the
-     * received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     * successful} and the specified response type is not {@link javax.ws.rs.core.Response}.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
-     * instance whose processing has failed.
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps either a {@link ProcessingException} thrown in
+     * case of an invocation processing failure or a {@link WebApplicationException} or one of its subclasses thrown in case
+     * the received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and
+     * the specified response type is not {@link javax.ws.rs.core.Response}. In case a processing of a properly received
+     * response fails, the wrapped processing exception will be of {@link ResponseProcessingException} type and will contain
+     * the {@link Response} instance whose processing has failed.
      * </p>
      *
-     * @param <T>          response type
+     * @param <T> response type
      * @param responseType Java type the response should be converted into.
-     * @return future response object of the specified type as a result of the
-     *         request invocation.
+     * @return future response object of the specified type as a result of the request invocation.
      */
     public <T> Future<T> submit(Class<T> responseType);
 
     /**
-     * Submit the request for an asynchronous invocation and receive a future
-     * response of the specified generic type back.
+     * Submit the request for an asynchronous invocation and receive a future response of the specified generic type back.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps either a {@link ProcessingException} thrown in case of an invocation processing
-     * failure or a {@link WebApplicationException} or one of its subclasses thrown in case the
-     * received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     * successful} and the specified response type is not {@link javax.ws.rs.core.Response}.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
-     * instance whose processing has failed.
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps either a {@link ProcessingException} thrown in
+     * case of an invocation processing failure or a {@link WebApplicationException} or one of its subclasses thrown in case
+     * the received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and
+     * the specified response type is not {@link javax.ws.rs.core.Response}. In case a processing of a properly received
+     * response fails, the wrapped processing exception will be of {@link ResponseProcessingException} type and will contain
+     * the {@link Response} instance whose processing has failed.
      * </p>
      *
-     * @param <T>          generic response type
-     * @param responseType type literal representing a generic Java type the
-     *                     response should be converted into.
-     * @return future response object of the specified generic type as a result
-     *         of the request invocation.
+     * @param <T> generic response type
+     * @param responseType type literal representing a generic Java type the response should be converted into.
+     * @return future response object of the specified generic type as a result of the request invocation.
      */
     public <T> Future<T> submit(GenericType<T> responseType);
 
     /**
-     * Submit the request for an asynchronous invocation and register an
-     * {@link InvocationCallback} to process the future result of the invocation.
+     * Submit the request for an asynchronous invocation and register an {@link InvocationCallback} to process the future
+     * result of the invocation.
      * <p>
-     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned
-     * {@code Future} instance may throw an {@link java.util.concurrent.ExecutionException}
-     * that wraps either a {@link ProcessingException} thrown in case of an invocation processing
-     * failure or a {@link WebApplicationException} or one of its subclasses thrown in case the
-     * received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     * successful} and the generic type of the supplied response callback is not
-     * {@link javax.ws.rs.core.Response}.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link Response}
-     * instance whose processing has failed.
+     * Note that calling the {@link java.util.concurrent.Future#get()} method on the returned {@code Future} instance may
+     * throw an {@link java.util.concurrent.ExecutionException} that wraps either a {@link ProcessingException} thrown in
+     * case of an invocation processing failure or a {@link WebApplicationException} or one of its subclasses thrown in case
+     * the received response status code is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and
+     * the generic type of the supplied response callback is not {@link javax.ws.rs.core.Response}. In case a processing of
+     * a properly received response fails, the wrapped processing exception will be of {@link ResponseProcessingException}
+     * type and will contain the {@link Response} instance whose processing has failed.
      * </p>
      *
-     * @param <T>      response type
-     * @param callback invocation callback for asynchronous processing of the
-     *                 request invocation result.
-     * @return future response object of the specified type as a result of the
-     *         request invocation.
+     * @param <T> response type
+     * @param callback invocation callback for asynchronous processing of the request invocation result.
+     * @return future response object of the specified type as a result of the request invocation.
      */
     public <T> Future<T> submit(InvocationCallback<T> callback);
 }

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/InvocationCallback.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/InvocationCallback.java
@@ -17,24 +17,21 @@
 package javax.ws.rs.client;
 
 /**
- * Callback that can be implemented to receive the asynchronous processing
- * events from the invocation processing.
+ * Callback that can be implemented to receive the asynchronous processing events from the invocation processing.
  *
- * @param <RESPONSE> response type. It can be either a general-purpose
- *                   {@link javax.ws.rs.core.Response} or the anticipated response entity
- *                   type.
+ * @param <RESPONSE> response type. It can be either a general-purpose {@link javax.ws.rs.core.Response} or the
+ * anticipated response entity type.
  * @author Marek Potociar
  * @since 2.0
  */
 public interface InvocationCallback<RESPONSE> {
 
     /**
-     * Called when the invocation was successfully completed. Note that this does
-     * not necessarily mean the response has bean fully read, which depends on the
-     * parameterized invocation callback response type.
+     * Called when the invocation was successfully completed. Note that this does not necessarily mean the response has bean
+     * fully read, which depends on the parameterized invocation callback response type.
      * <p>
-     * Once this invocation callback method returns, the underlying {@link javax.ws.rs.core.Response}
-     * instance will be automatically closed by the runtime.
+     * Once this invocation callback method returns, the underlying {@link javax.ws.rs.core.Response} instance will be
+     * automatically closed by the runtime.
      * </p>
      *
      * @param response response data.
@@ -44,23 +41,19 @@ public interface InvocationCallback<RESPONSE> {
     /**
      * Called when the invocation has failed for any reason.
      * <p>
-     * Note that the provided {@link Throwable} may be a {@link javax.ws.rs.ProcessingException} in case the
-     * invocation processing failure has been caused by a client-side runtime component error.
-     * The {@code Throwable} may also be a {@link javax.ws.rs.WebApplicationException} or one
-     * of its subclasses in case the response status code is not
-     * {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and the generic
-     * callback type is not {@link javax.ws.rs.core.Response}.
-     * In case a processing of a properly received response fails, the wrapped processing exception
-     * will be of {@link ResponseProcessingException} type and will contain the {@link javax.ws.rs.core.Response}
-     * instance whose processing has failed.
-     * A {@link java.util.concurrent.CancellationException} would be indicate that the invocation
-     * has been cancelled.
-     * An {@link InterruptedException} would indicate that the thread executing the invocation has
-     * been interrupted.
+     * Note that the provided {@link Throwable} may be a {@link javax.ws.rs.ProcessingException} in case the invocation
+     * processing failure has been caused by a client-side runtime component error. The {@code Throwable} may also be a
+     * {@link javax.ws.rs.WebApplicationException} or one of its subclasses in case the response status code is not
+     * {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and the generic callback type is not
+     * {@link javax.ws.rs.core.Response}. In case a processing of a properly received response fails, the wrapped processing
+     * exception will be of {@link ResponseProcessingException} type and will contain the {@link javax.ws.rs.core.Response}
+     * instance whose processing has failed. A {@link java.util.concurrent.CancellationException} would be indicate that the
+     * invocation has been cancelled. An {@link InterruptedException} would indicate that the thread executing the
+     * invocation has been interrupted.
      * </p>
      * <p>
-     * Once this invocation callback method returns, the underlying {@link javax.ws.rs.core.Response}
-     * instance will be automatically closed by the runtime.
+     * Once this invocation callback method returns, the underlying {@link javax.ws.rs.core.Response} instance will be
+     * automatically closed by the runtime.
      * </p>
      *
      * @param throwable contains failure details.

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/ResponseProcessingException.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/ResponseProcessingException.java
@@ -20,10 +20,9 @@ import javax.ws.rs.ProcessingException;
 import javax.ws.rs.core.Response;
 
 /**
- * JAX-RS client-side runtime processing exception thrown to indicate that
- * response processing has failed (e.g. in a filter chain or during message
- * entity de-serialization). The exception contains the nested {@link Response}
- * instance for which the runtime response processing failed.
+ * JAX-RS client-side runtime processing exception thrown to indicate that response processing has failed (e.g. in a
+ * filter chain or during message entity de-serialization). The exception contains the nested {@link Response} instance
+ * for which the runtime response processing failed.
  *
  * @author Marek Potociar (marek.potociar at oracle.com)
  * @since 2.0
@@ -35,17 +34,14 @@ public class ResponseProcessingException extends ProcessingException {
     private final Response response;
 
     /**
-     * Constructs a new JAX-RS runtime response processing exception
-     * for a specific {@link Response response} with the specified cause
-     * and a detail message of {@code (cause==null ? null : cause.toString())}
-     * (which typically contains the class and detail message of {@code cause}).
-     * This constructor is useful for runtime exceptions that are little more
+     * Constructs a new JAX-RS runtime response processing exception for a specific {@link Response response} with the
+     * specified cause and a detail message of {@code (cause==null ? null : cause.toString())} (which typically contains the
+     * class and detail message of {@code cause}). This constructor is useful for runtime exceptions that are little more
      * than wrappers for other throwables.
      *
      * @param response the response instance for which the processing failed.
-     * @param cause the cause (which is saved for later retrieval by the
-     *              {@link #getCause()} method). (A {@code null} value is permitted,
-     *              and indicates that the cause is nonexistent or unknown.)
+     * @param cause the cause (which is saved for later retrieval by the {@link #getCause()} method). (A {@code null} value
+     * is permitted, and indicates that the cause is nonexistent or unknown.)
      */
     public ResponseProcessingException(final Response response, final Throwable cause) {
         super(cause);
@@ -53,18 +49,16 @@ public class ResponseProcessingException extends ProcessingException {
     }
 
     /**
-     * <p>Constructs a new JAX-RS runtime response processing exception with the specified detail
-     * message and cause.
+     * <p>
+     * Constructs a new JAX-RS runtime response processing exception with the specified detail message and cause.
      * </p>
-     * Note that the detail message associated with {@code cause} is <i>not</i>
-     * automatically incorporated in this runtime exception's detail message.
+     * Note that the detail message associated with {@code cause} is <i>not</i> automatically incorporated in this runtime
+     * exception's detail message.
      *
      * @param response the response instance for which the processing failed.
-     * @param message the detail message (which is saved for later retrieval
-     *                by the {@link #getMessage()} method).
-     * @param cause   the cause (which is saved for later retrieval by the
-     *                {@link #getCause()} method). (A {@code null} value is permitted,
-     *                and indicates that the cause is nonexistent or unknown.)
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param cause the cause (which is saved for later retrieval by the {@link #getCause()} method). (A {@code null} value
+     * is permitted, and indicates that the cause is nonexistent or unknown.)
      */
     public ResponseProcessingException(final Response response, final String message, final Throwable cause) {
         super(message, cause);
@@ -72,13 +66,11 @@ public class ResponseProcessingException extends ProcessingException {
     }
 
     /**
-     * Constructs a new JAX-RS runtime processing exception with the specified detail
-     * message. The cause is not initialized, and may subsequently be initialized
-     * by a call to {@link #initCause}.
+     * Constructs a new JAX-RS runtime processing exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to {@link #initCause}.
      *
      * @param response the response instance for which the processing failed.
-     * @param message the detail message (which is saved for later retrieval
-     *                by the {@link #getMessage()} method).
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
      */
     public ResponseProcessingException(final Response response, final String message) {
         super(message);

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/RxInvoker.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/RxInvoker.java
@@ -19,10 +19,9 @@ package javax.ws.rs.client;
 import javax.ws.rs.core.GenericType;
 
 /**
- * Uniform interface for reactive invocation of HTTP methods. All reactive invokers in JAX-RS must
- * implement this interface. The type parameter {@code T} represents the Java type of an asynchronous
- * computation. All JAX-RS implementations MUST support the default reactive invoker based on
- * {@link java.util.concurrent.CompletionStage}.
+ * Uniform interface for reactive invocation of HTTP methods. All reactive invokers in JAX-RS must implement this
+ * interface. The type parameter {@code T} represents the Java type of an asynchronous computation. All JAX-RS
+ * implementations MUST support the default reactive invoker based on {@link java.util.concurrent.CompletionStage}.
  *
  * @param <T> a type representing the asynchronous computation.
  * @author Marek Potociar
@@ -36,10 +35,9 @@ public interface RxInvoker<T> {
      * Invoke HTTP GET method for the current request.
      *
      * @return invocation response wrapped in the completion aware type.
-     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a
-     *                                                        filter or during conversion of the response entity data to an
-     *                                                        instance of a particular Java type).
-     * @throws javax.ws.rs.ProcessingException                in case the request processing or subsequent I/O operation fails.
+     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in
+     * a filter or during conversion of the response entity data to an instance of a particular Java type).
+     * @throws javax.ws.rs.ProcessingException in case the request processing or subsequent I/O operation fails.
      */
     public T get();
 
@@ -47,17 +45,14 @@ public interface RxInvoker<T> {
      * Invoke HTTP GET method for the current request.
      *
      * @param responseType Java type the response entity will be converted to.
-     * @param <R>          response entity type.
+     * @param <R> response entity type.
      * @return invocation response wrapped in the completion aware type.
-     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a
-     *                                                        filter or during conversion of the response entity data to an
-     *                                                        instance of a particular Java type).
-     * @throws javax.ws.rs.ProcessingException                in case the request processing or subsequent I/O operation fails.
-     * @throws javax.ws.rs.WebApplicationException            in case the response status code of the response returned by the
-     *                                                        server is not
-     *                                                        {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     *                                                        successful} and the specified response type is not
-     *                                                        {@link javax.ws.rs.core.Response}.
+     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in
+     * a filter or during conversion of the response entity data to an instance of a particular Java type).
+     * @throws javax.ws.rs.ProcessingException in case the request processing or subsequent I/O operation fails.
+     * @throws javax.ws.rs.WebApplicationException in case the response status code of the response returned by the server
+     * is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and the specified response type is not
+     * {@link javax.ws.rs.core.Response}.
      */
     public <R> T get(Class<R> responseType);
 
@@ -65,135 +60,112 @@ public interface RxInvoker<T> {
      * Invoke HTTP GET method for the current request.
      *
      * @param responseType representation of a generic Java type the response entity will be converted to.
-     * @param <R>          generic response entity type.
+     * @param <R> generic response entity type.
      * @return invocation response wrapped in the completion aware type.
-     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a
-     *                                                        filter or during conversion of the response entity data to an
-     *                                                        instance of a particular Java type).
-     * @throws javax.ws.rs.ProcessingException                in case the request processing or subsequent I/O operation fails.
-     * @throws javax.ws.rs.WebApplicationException            in case the response status code of the response returned by the
-     *                                                        server is not
-     *                                                        {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     *                                                        successful} and the specified response type is not
-     *                                                        {@link javax.ws.rs.core.Response}.
+     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in
+     * a filter or during conversion of the response entity data to an instance of a particular Java type).
+     * @throws javax.ws.rs.ProcessingException in case the request processing or subsequent I/O operation fails.
+     * @throws javax.ws.rs.WebApplicationException in case the response status code of the response returned by the server
+     * is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and the specified response type is not
+     * {@link javax.ws.rs.core.Response}.
      */
     public <R> T get(GenericType<R> responseType);
 
     /**
      * Invoke HTTP PUT method for the current request.
      *
-     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information.
-     *               Any variant-related HTTP headers previously set (namely {@code Content-Type},
-     *               {@code Content-Language} and {@code Content-Encoding}) will be overwritten using
-     *               the entity variant information.
+     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information. Any variant-related
+     * HTTP headers previously set (namely {@code Content-Type}, {@code Content-Language} and {@code Content-Encoding}) will
+     * be overwritten using the entity variant information.
      * @return invocation response wrapped in the completion aware type.
-     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a
-     *                                                        filter or during conversion of the response entity data to an
-     *                                                        instance of a particular Java type).
-     * @throws javax.ws.rs.ProcessingException                in case the request processing or subsequent I/O operation fails.
+     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in
+     * a filter or during conversion of the response entity data to an instance of a particular Java type).
+     * @throws javax.ws.rs.ProcessingException in case the request processing or subsequent I/O operation fails.
      */
     public T put(Entity<?> entity);
 
     /**
      * Invoke HTTP PUT method for the current request.
      *
-     * @param entity       request entity, including it's full {@link javax.ws.rs.core.Variant} information.
-     *                     Any variant-related HTTP headers previously set (namely {@code Content-Type},
-     *                     {@code Content-Language} and {@code Content-Encoding}) will be overwritten using
-     *                     the entity variant information.
+     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information. Any variant-related
+     * HTTP headers previously set (namely {@code Content-Type}, {@code Content-Language} and {@code Content-Encoding}) will
+     * be overwritten using the entity variant information.
      * @param responseType Java type the response entity will be converted to.
-     * @param <R>          response entity type.
+     * @param <R> response entity type.
      * @return invocation response wrapped in the completion aware type.
-     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a
-     *                                                        filter or during conversion of the response entity data to an
-     *                                                        instance of a particular Java type).
-     * @throws javax.ws.rs.ProcessingException                in case the request processing or subsequent I/O operation fails.
-     * @throws javax.ws.rs.WebApplicationException            in case the response status code of the response returned by the
-     *                                                        server is not
-     *                                                        {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     *                                                        successful} and the specified response type is not
-     *                                                        {@link javax.ws.rs.core.Response}.
+     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in
+     * a filter or during conversion of the response entity data to an instance of a particular Java type).
+     * @throws javax.ws.rs.ProcessingException in case the request processing or subsequent I/O operation fails.
+     * @throws javax.ws.rs.WebApplicationException in case the response status code of the response returned by the server
+     * is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and the specified response type is not
+     * {@link javax.ws.rs.core.Response}.
      */
     public <R> T put(Entity<?> entity, Class<R> responseType);
 
     /**
      * Invoke HTTP PUT method for the current request.
      *
-     * @param entity       request entity, including it's full {@link javax.ws.rs.core.Variant} information.
-     *                     Any variant-related HTTP headers previously set (namely {@code Content-Type},
-     *                     {@code Content-Language} and {@code Content-Encoding}) will be overwritten using
-     *                     the entity variant information.
+     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information. Any variant-related
+     * HTTP headers previously set (namely {@code Content-Type}, {@code Content-Language} and {@code Content-Encoding}) will
+     * be overwritten using the entity variant information.
      * @param responseType representation of a generic Java type the response entity will be converted to.
-     * @param <R>          generic response entity type.
+     * @param <R> generic response entity type.
      * @return invocation response wrapped in the completion aware type.
-     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a
-     *                                                        filter or during conversion of the response entity data to an
-     *                                                        instance of a particular Java type).
-     * @throws javax.ws.rs.ProcessingException                in case the request processing or subsequent I/O operation fails.
-     * @throws javax.ws.rs.WebApplicationException            in case the response status code of the response returned by the
-     *                                                        server is not
-     *                                                        {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     *                                                        successful} and the specified response type is not
-     *                                                        {@link javax.ws.rs.core.Response}.
+     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in
+     * a filter or during conversion of the response entity data to an instance of a particular Java type).
+     * @throws javax.ws.rs.ProcessingException in case the request processing or subsequent I/O operation fails.
+     * @throws javax.ws.rs.WebApplicationException in case the response status code of the response returned by the server
+     * is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and the specified response type is not
+     * {@link javax.ws.rs.core.Response}.
      */
     public <R> T put(Entity<?> entity, GenericType<R> responseType);
 
     /**
      * Invoke HTTP POST method for the current request.
      *
-     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information.
-     *               Any variant-related HTTP headers previously set (namely {@code Content-Type},
-     *               {@code Content-Language} and {@code Content-Encoding}) will be overwritten using
-     *               the entity variant information.
+     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information. Any variant-related
+     * HTTP headers previously set (namely {@code Content-Type}, {@code Content-Language} and {@code Content-Encoding}) will
+     * be overwritten using the entity variant information.
      * @return invocation response wrapped in the completion aware type.
-     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a
-     *                                                        filter or during conversion of the response entity data to an
-     *                                                        instance of a particular Java type).
-     * @throws javax.ws.rs.ProcessingException                in case the request processing or subsequent I/O operation fails.
+     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in
+     * a filter or during conversion of the response entity data to an instance of a particular Java type).
+     * @throws javax.ws.rs.ProcessingException in case the request processing or subsequent I/O operation fails.
      */
     public T post(Entity<?> entity);
 
     /**
      * Invoke HTTP POST method for the current request.
      *
-     * @param entity       request entity, including it's full {@link javax.ws.rs.core.Variant} information.
-     *                     Any variant-related HTTP headers previously set (namely {@code Content-Type},
-     *                     {@code Content-Language} and {@code Content-Encoding}) will be overwritten using
-     *                     the entity variant information.
+     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information. Any variant-related
+     * HTTP headers previously set (namely {@code Content-Type}, {@code Content-Language} and {@code Content-Encoding}) will
+     * be overwritten using the entity variant information.
      * @param responseType Java type the response entity will be converted to.
-     * @param <R>          response entity type.
+     * @param <R> response entity type.
      * @return invocation response wrapped in the completion aware type.
-     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a
-     *                                                        filter or during conversion of the response entity data to an
-     *                                                        instance of a particular Java type).
-     * @throws javax.ws.rs.ProcessingException                in case the request processing or subsequent I/O operation fails.
-     * @throws javax.ws.rs.WebApplicationException            in case the response status code of the response returned by the
-     *                                                        server is not
-     *                                                        {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     *                                                        successful} and the specified response type is not
-     *                                                        {@link javax.ws.rs.core.Response}.
+     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in
+     * a filter or during conversion of the response entity data to an instance of a particular Java type).
+     * @throws javax.ws.rs.ProcessingException in case the request processing or subsequent I/O operation fails.
+     * @throws javax.ws.rs.WebApplicationException in case the response status code of the response returned by the server
+     * is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and the specified response type is not
+     * {@link javax.ws.rs.core.Response}.
      */
     public <R> T post(Entity<?> entity, Class<R> responseType);
 
     /**
      * Invoke HTTP POST method for the current request.
      *
-     * @param entity       request entity, including it's full {@link javax.ws.rs.core.Variant} information.
-     *                     Any variant-related HTTP headers previously set (namely {@code Content-Type},
-     *                     {@code Content-Language} and {@code Content-Encoding}) will be overwritten using
-     *                     the entity variant information.
+     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information. Any variant-related
+     * HTTP headers previously set (namely {@code Content-Type}, {@code Content-Language} and {@code Content-Encoding}) will
+     * be overwritten using the entity variant information.
      * @param responseType representation of a generic Java type the response entity will be converted to.
-     * @param <R>          generic response entity type.
+     * @param <R> generic response entity type.
      * @return invocation response wrapped in the completion aware type.
-     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a
-     *                                                        filter or during conversion of the response entity data to an
-     *                                                        instance of a particular Java type).
-     * @throws javax.ws.rs.ProcessingException                in case the request processing or subsequent I/O operation fails.
-     * @throws javax.ws.rs.WebApplicationException            in case the response status code of the response returned by the
-     *                                                        server is not
-     *                                                        {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     *                                                        successful} and the specified response type is not
-     *                                                        {@link javax.ws.rs.core.Response}.
+     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in
+     * a filter or during conversion of the response entity data to an instance of a particular Java type).
+     * @throws javax.ws.rs.ProcessingException in case the request processing or subsequent I/O operation fails.
+     * @throws javax.ws.rs.WebApplicationException in case the response status code of the response returned by the server
+     * is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and the specified response type is not
+     * {@link javax.ws.rs.core.Response}.
      */
     public <R> T post(Entity<?> entity, GenericType<R> responseType);
 
@@ -201,10 +173,9 @@ public interface RxInvoker<T> {
      * Invoke HTTP DELETE method for the current request.
      *
      * @return invocation response wrapped in the completion aware type.
-     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a
-     *                                                        filter or during conversion of the response entity data to an
-     *                                                        instance of a particular Java type).
-     * @throws javax.ws.rs.ProcessingException                in case the request processing or subsequent I/O operation fails.
+     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in
+     * a filter or during conversion of the response entity data to an instance of a particular Java type).
+     * @throws javax.ws.rs.ProcessingException in case the request processing or subsequent I/O operation fails.
      */
     public T delete();
 
@@ -212,17 +183,14 @@ public interface RxInvoker<T> {
      * Invoke HTTP DELETE method for the current request.
      *
      * @param responseType Java type the response entity will be converted to.
-     * @param <R>          response entity type.
+     * @param <R> response entity type.
      * @return invocation response wrapped in the completion aware type.
-     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a
-     *                                                        filter or during conversion of the response entity data to an
-     *                                                        instance of a particular Java type).
-     * @throws javax.ws.rs.ProcessingException                in case the request processing or subsequent I/O operation fails.
-     * @throws javax.ws.rs.WebApplicationException            in case the response status code of the response returned by the
-     *                                                        server is not
-     *                                                        {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     *                                                        successful} and the specified response type is not
-     *                                                        {@link javax.ws.rs.core.Response}.
+     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in
+     * a filter or during conversion of the response entity data to an instance of a particular Java type).
+     * @throws javax.ws.rs.ProcessingException in case the request processing or subsequent I/O operation fails.
+     * @throws javax.ws.rs.WebApplicationException in case the response status code of the response returned by the server
+     * is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and the specified response type is not
+     * {@link javax.ws.rs.core.Response}.
      */
     public <R> T delete(Class<R> responseType);
 
@@ -230,17 +198,14 @@ public interface RxInvoker<T> {
      * Invoke HTTP DELETE method for the current request.
      *
      * @param responseType representation of a generic Java type the response entity will be converted to.
-     * @param <R>          generic response entity type.
+     * @param <R> generic response entity type.
      * @return invocation response wrapped in the completion aware type.
-     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a
-     *                                                        filter or during conversion of the response entity data to an
-     *                                                        instance of a particular Java type).
-     * @throws javax.ws.rs.ProcessingException                in case the request processing or subsequent I/O operation fails.
-     * @throws javax.ws.rs.WebApplicationException            in case the response status code of the response returned by the
-     *                                                        server is not
-     *                                                        {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     *                                                        successful} and the specified response type is not
-     *                                                        {@link javax.ws.rs.core.Response}.
+     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in
+     * a filter or during conversion of the response entity data to an instance of a particular Java type).
+     * @throws javax.ws.rs.ProcessingException in case the request processing or subsequent I/O operation fails.
+     * @throws javax.ws.rs.WebApplicationException in case the response status code of the response returned by the server
+     * is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and the specified response type is not
+     * {@link javax.ws.rs.core.Response}.
      */
     public <R> T delete(GenericType<R> responseType);
 
@@ -248,10 +213,9 @@ public interface RxInvoker<T> {
      * Invoke HTTP HEAD method for the current request.
      *
      * @return invocation response wrapped in the completion aware type.
-     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a
-     *                                                        filter or during conversion of the response entity data to an
-     *                                                        instance of a particular Java type).
-     * @throws javax.ws.rs.ProcessingException                in case the request processing or subsequent I/O operation fails.
+     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in
+     * a filter or during conversion of the response entity data to an instance of a particular Java type).
+     * @throws javax.ws.rs.ProcessingException in case the request processing or subsequent I/O operation fails.
      */
     public T head();
 
@@ -259,10 +223,9 @@ public interface RxInvoker<T> {
      * Invoke HTTP OPTIONS method for the current request.
      *
      * @return invocation response wrapped in the completion aware type.
-     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a
-     *                                                        filter or during conversion of the response entity data to an
-     *                                                        instance of a particular Java type).
-     * @throws javax.ws.rs.ProcessingException                in case the request processing or subsequent I/O operation fails.
+     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in
+     * a filter or during conversion of the response entity data to an instance of a particular Java type).
+     * @throws javax.ws.rs.ProcessingException in case the request processing or subsequent I/O operation fails.
      */
     public T options();
 
@@ -270,17 +233,14 @@ public interface RxInvoker<T> {
      * Invoke HTTP OPTIONS method for the current request.
      *
      * @param responseType Java type the response entity will be converted to.
-     * @param <R>          response entity type.
+     * @param <R> response entity type.
      * @return invocation response wrapped in the completion aware type.
-     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a
-     *                                                        filter or during conversion of the response entity data to an
-     *                                                        instance of a particular Java type).
-     * @throws javax.ws.rs.ProcessingException                in case the request processing or subsequent I/O operation fails.
-     * @throws javax.ws.rs.WebApplicationException            in case the response status code of the response returned by the
-     *                                                        server is not
-     *                                                        {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     *                                                        successful} and the specified response type is not
-     *                                                        {@link javax.ws.rs.core.Response}.
+     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in
+     * a filter or during conversion of the response entity data to an instance of a particular Java type).
+     * @throws javax.ws.rs.ProcessingException in case the request processing or subsequent I/O operation fails.
+     * @throws javax.ws.rs.WebApplicationException in case the response status code of the response returned by the server
+     * is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and the specified response type is not
+     * {@link javax.ws.rs.core.Response}.
      */
     public <R> T options(Class<R> responseType);
 
@@ -288,17 +248,14 @@ public interface RxInvoker<T> {
      * Invoke HTTP OPTIONS method for the current request.
      *
      * @param responseType representation of a generic Java type the response entity will be converted to.
-     * @param <R>          generic response entity type.
+     * @param <R> generic response entity type.
      * @return invocation response wrapped in the completion aware type.
-     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a
-     *                                                        filter or during conversion of the response entity data to an
-     *                                                        instance of a particular Java type).
-     * @throws javax.ws.rs.ProcessingException                in case the request processing or subsequent I/O operation fails.
-     * @throws javax.ws.rs.WebApplicationException            in case the response status code of the response returned by the
-     *                                                        server is not
-     *                                                        {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     *                                                        successful} and the specified response type is not
-     *                                                        {@link javax.ws.rs.core.Response}.
+     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in
+     * a filter or during conversion of the response entity data to an instance of a particular Java type).
+     * @throws javax.ws.rs.ProcessingException in case the request processing or subsequent I/O operation fails.
+     * @throws javax.ws.rs.WebApplicationException in case the response status code of the response returned by the server
+     * is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and the specified response type is not
+     * {@link javax.ws.rs.core.Response}.
      */
     public <R> T options(GenericType<R> responseType);
 
@@ -306,10 +263,9 @@ public interface RxInvoker<T> {
      * Invoke HTTP TRACE method for the current request.
      *
      * @return invocation response wrapped in the completion aware type.
-     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a
-     *                                                        filter or during conversion of the response entity data to an
-     *                                                        instance of a particular Java type).
-     * @throws javax.ws.rs.ProcessingException                in case the request processing or subsequent I/O operation fails.
+     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in
+     * a filter or during conversion of the response entity data to an instance of a particular Java type).
+     * @throws javax.ws.rs.ProcessingException in case the request processing or subsequent I/O operation fails.
      */
     public T trace();
 
@@ -317,17 +273,14 @@ public interface RxInvoker<T> {
      * Invoke HTTP TRACE method for the current request.
      *
      * @param responseType Java type the response entity will be converted to.
-     * @param <R>          response entity type.
+     * @param <R> response entity type.
      * @return invocation response wrapped in the completion aware type.
-     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a
-     *                                                        filter or during conversion of the response entity data to an
-     *                                                        instance of a particular Java type).
-     * @throws javax.ws.rs.ProcessingException                in case the request processing or subsequent I/O operation fails.
-     * @throws javax.ws.rs.WebApplicationException            in case the response status code of the response returned by the
-     *                                                        server is not
-     *                                                        {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     *                                                        successful} and the specified response type is not
-     *                                                        {@link javax.ws.rs.core.Response}.
+     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in
+     * a filter or during conversion of the response entity data to an instance of a particular Java type).
+     * @throws javax.ws.rs.ProcessingException in case the request processing or subsequent I/O operation fails.
+     * @throws javax.ws.rs.WebApplicationException in case the response status code of the response returned by the server
+     * is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and the specified response type is not
+     * {@link javax.ws.rs.core.Response}.
      */
     public <R> T trace(Class<R> responseType);
 
@@ -335,17 +288,14 @@ public interface RxInvoker<T> {
      * Invoke HTTP TRACE method for the current request.
      *
      * @param responseType representation of a generic Java type the response entity will be converted to.
-     * @param <R>          generic response entity type.
+     * @param <R> generic response entity type.
      * @return invocation response wrapped in the completion aware type.
-     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a
-     *                                                        filter or during conversion of the response entity data to an
-     *                                                        instance of a particular Java type).
-     * @throws javax.ws.rs.ProcessingException                in case the request processing or subsequent I/O operation fails.
-     * @throws javax.ws.rs.WebApplicationException            in case the response status code of the response returned by the
-     *                                                        server is not
-     *                                                        {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     *                                                        successful} and the specified response type is not
-     *                                                        {@link javax.ws.rs.core.Response}.
+     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in
+     * a filter or during conversion of the response entity data to an instance of a particular Java type).
+     * @throws javax.ws.rs.ProcessingException in case the request processing or subsequent I/O operation fails.
+     * @throws javax.ws.rs.WebApplicationException in case the response status code of the response returned by the server
+     * is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and the specified response type is not
+     * {@link javax.ws.rs.core.Response}.
      */
     public <R> T trace(GenericType<R> responseType);
 
@@ -354,111 +304,93 @@ public interface RxInvoker<T> {
      *
      * @param name method name.
      * @return invocation response wrapped in the completion aware type..
-     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a
-     *                                                        filter or during conversion of the response entity data to an
-     *                                                        instance of a particular Java type).
-     * @throws javax.ws.rs.ProcessingException                in case the request processing or subsequent I/O operation fails.
+     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in
+     * a filter or during conversion of the response entity data to an instance of a particular Java type).
+     * @throws javax.ws.rs.ProcessingException in case the request processing or subsequent I/O operation fails.
      */
     public T method(String name);
 
     /**
      * Invoke an arbitrary method for the current request.
      *
-     * @param name         method name.
+     * @param name method name.
      * @param responseType Java type the response entity will be converted to.
-     * @param <R>          response entity type.
+     * @param <R> response entity type.
      * @return invocation response wrapped in the completion aware type..
-     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a
-     *                                                        filter or during conversion of the response entity data to an
-     *                                                        instance of a particular Java type).
-     * @throws javax.ws.rs.ProcessingException                in case the request processing or subsequent I/O operation fails.
-     * @throws javax.ws.rs.WebApplicationException            in case the response status code of the response returned by the
-     *                                                        server is not
-     *                                                        {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     *                                                        successful} and the specified response type is not
-     *                                                        {@link javax.ws.rs.core.Response}.
+     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in
+     * a filter or during conversion of the response entity data to an instance of a particular Java type).
+     * @throws javax.ws.rs.ProcessingException in case the request processing or subsequent I/O operation fails.
+     * @throws javax.ws.rs.WebApplicationException in case the response status code of the response returned by the server
+     * is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and the specified response type is not
+     * {@link javax.ws.rs.core.Response}.
      */
     public <R> T method(String name, Class<R> responseType);
 
     /**
      * Invoke an arbitrary method for the current request.
      *
-     * @param name         method name.
+     * @param name method name.
      * @param responseType representation of a generic Java type the response entity will be converted to.
-     * @param <R>          generic response entity type.
+     * @param <R> generic response entity type.
      * @return invocation response wrapped in the completion aware type..
-     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a
-     *                                                        filter or during conversion of the response entity data to an
-     *                                                        instance of a particular Java type).
-     * @throws javax.ws.rs.ProcessingException                in case the request processing or subsequent I/O operation fails.
-     * @throws javax.ws.rs.WebApplicationException            in case the response status code of the response returned by the
-     *                                                        server is not
-     *                                                        {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     *                                                        successful} and the specified response type is not
-     *                                                        {@link javax.ws.rs.core.Response}.
+     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in
+     * a filter or during conversion of the response entity data to an instance of a particular Java type).
+     * @throws javax.ws.rs.ProcessingException in case the request processing or subsequent I/O operation fails.
+     * @throws javax.ws.rs.WebApplicationException in case the response status code of the response returned by the server
+     * is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and the specified response type is not
+     * {@link javax.ws.rs.core.Response}.
      */
     public <R> T method(String name, GenericType<R> responseType);
 
     /**
      * Invoke an arbitrary method for the current request.
      *
-     * @param name   method name.
-     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information.
-     *               Any variant-related HTTP headers previously set (namely {@code Content-Type},
-     *               {@code Content-Language} and {@code Content-Encoding}) will be overwritten using
-     *               the entity variant information.
+     * @param name method name.
+     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information. Any variant-related
+     * HTTP headers previously set (namely {@code Content-Type}, {@code Content-Language} and {@code Content-Encoding}) will
+     * be overwritten using the entity variant information.
      * @return invocation response wrapped in the completion aware type..
-     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a
-     *                                                        filter or during conversion of the response entity data to an
-     *                                                        instance of a particular Java type).
-     * @throws javax.ws.rs.ProcessingException                in case the request processing or subsequent I/O operation fails.
+     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in
+     * a filter or during conversion of the response entity data to an instance of a particular Java type).
+     * @throws javax.ws.rs.ProcessingException in case the request processing or subsequent I/O operation fails.
      */
     public T method(String name, Entity<?> entity);
 
     /**
      * Invoke an arbitrary method for the current request.
      *
-     * @param name         method name.
-     * @param entity       request entity, including it's full {@link javax.ws.rs.core.Variant} information.
-     *                     Any variant-related HTTP headers previously set (namely {@code Content-Type},
-     *                     {@code Content-Language} and {@code Content-Encoding}) will be overwritten using
-     *                     the entity variant information.
+     * @param name method name.
+     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information. Any variant-related
+     * HTTP headers previously set (namely {@code Content-Type}, {@code Content-Language} and {@code Content-Encoding}) will
+     * be overwritten using the entity variant information.
      * @param responseType Java type the response entity will be converted to.
-     * @param <R>          response entity type.
+     * @param <R> response entity type.
      * @return invocation response wrapped in the completion aware type..
-     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a
-     *                                                        filter or during conversion of the response entity data to an
-     *                                                        instance of a particular Java type).
-     * @throws javax.ws.rs.ProcessingException                in case the request processing or subsequent I/O operation fails.
-     * @throws javax.ws.rs.WebApplicationException            in case the response status code of the response returned by the
-     *                                                        server is not
-     *                                                        {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     *                                                        successful} and the specified response type is not
-     *                                                        {@link javax.ws.rs.core.Response}.
+     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in
+     * a filter or during conversion of the response entity data to an instance of a particular Java type).
+     * @throws javax.ws.rs.ProcessingException in case the request processing or subsequent I/O operation fails.
+     * @throws javax.ws.rs.WebApplicationException in case the response status code of the response returned by the server
+     * is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and the specified response type is not
+     * {@link javax.ws.rs.core.Response}.
      */
     public <R> T method(String name, Entity<?> entity, Class<R> responseType);
 
     /**
      * Invoke an arbitrary method for the current request.
      *
-     * @param name         method name.
-     * @param entity       request entity, including it's full {@link javax.ws.rs.core.Variant} information.
-     *                     Any variant-related HTTP headers previously set (namely {@code Content-Type},
-     *                     {@code Content-Language} and {@code Content-Encoding}) will be overwritten using
-     *                     the entity variant information.
+     * @param name method name.
+     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information. Any variant-related
+     * HTTP headers previously set (namely {@code Content-Type}, {@code Content-Language} and {@code Content-Encoding}) will
+     * be overwritten using the entity variant information.
      * @param responseType representation of a generic Java type the response entity will be converted to.
-     * @param <R>          generic response entity type.
+     * @param <R> generic response entity type.
      * @return invocation response wrapped in the completion aware type..
-     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a
-     *                                                        filter or during conversion of the response entity data to an
-     *                                                        instance of a particular Java type).
-     * @throws javax.ws.rs.ProcessingException                in case the request processing or subsequent I/O operation fails.
-     * @throws javax.ws.rs.WebApplicationException            in case the response status code of the response returned by the
-     *                                                        server is not
-     *                                                        {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     *                                                        successful} and the specified response type is not
-     *                                                        {@link javax.ws.rs.core.Response}.
+     * @throws javax.ws.rs.client.ResponseProcessingException in case processing of a received HTTP response fails (e.g. in
+     * a filter or during conversion of the response entity data to an instance of a particular Java type).
+     * @throws javax.ws.rs.ProcessingException in case the request processing or subsequent I/O operation fails.
+     * @throws javax.ws.rs.WebApplicationException in case the response status code of the response returned by the server
+     * is not {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and the specified response type is not
+     * {@link javax.ws.rs.core.Response}.
      */
     public <R> T method(String name, Entity<?> entity, GenericType<R> responseType);
 }
-

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/RxInvokerProvider.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/RxInvokerProvider.java
@@ -21,9 +21,8 @@ import java.util.concurrent.ExecutorService;
 /**
  * {@link RxInvoker} provider.
  * <p>
- * {@code RxInvokerProvider} must be registered in the client runtime using {@link Client#register(Class)}.
- * It provides a way to plug-in support for other reactive implementations,
- * see {@link Invocation.Builder#rx(Class)}.
+ * {@code RxInvokerProvider} must be registered in the client runtime using {@link Client#register(Class)}. It provides
+ * a way to plug-in support for other reactive implementations, see {@link Invocation.Builder#rx(Class)}.
  *
  * @param <T> {@code RxInvoker} subclass type.
  * @author Pavel Bucek
@@ -45,10 +44,10 @@ public interface RxInvokerProvider<T extends RxInvoker> {
      * <p>
      * The returned instance has to be thread safe.
      *
-     * @param syncInvoker     {@code SyncInvoker} used to execute current request.
-     * @param executorService executor service, which should be used for executing reactive callbacks invocations.
-     *                        It can be {@code null}; in that case it's up to the implementation to choose the best
-     *                        {@code ExecutorService} in given environment.
+     * @param syncInvoker {@code SyncInvoker} used to execute current request.
+     * @param executorService executor service, which should be used for executing reactive callbacks invocations. It can be
+     * {@code null}; in that case it's up to the implementation to choose the best {@code ExecutorService} in given
+     * environment.
      * @return instance of the {@code RxInvoker} subclass.
      * @see ClientBuilder#executorService(ExecutorService)
      */

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/SyncInvoker.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/SyncInvoker.java
@@ -35,45 +35,37 @@ public interface SyncInvoker {
      * Invoke HTTP GET method for the current request synchronously.
      *
      * @return invocation response.
-     * @throws javax.ws.rs.ProcessingException
-     *          in case the invocation processing has failed.
+     * @throws javax.ws.rs.ProcessingException in case the invocation processing has failed.
      */
     Response get();
 
     /**
      * Invoke HTTP GET method for the current request synchronously.
      *
-     * @param <T>          response entity type.
+     * @param <T> response entity type.
      * @param responseType Java type the response entity will be converted to.
      * @return invocation response.
-     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter
-     *                                     or during conversion of the response entity data to an instance
-     *                                     of a particular Java type).
-     * @throws ProcessingException         in case the request processing or subsequent I/O operation fails.
-     * @throws WebApplicationException     in case the response status code of the response
-     *                                     returned by the server is not
-     *                                     {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     *                                     successful} and the specified response type is not
-     *                                     {@link javax.ws.rs.core.Response}.
+     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter or during
+     * conversion of the response entity data to an instance of a particular Java type).
+     * @throws ProcessingException in case the request processing or subsequent I/O operation fails.
+     * @throws WebApplicationException in case the response status code of the response returned by the server is not
+     * {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and the specified response type is not
+     * {@link javax.ws.rs.core.Response}.
      */
     <T> T get(Class<T> responseType);
 
     /**
      * Invoke HTTP GET method for the current request synchronously.
      *
-     * @param <T>          generic response entity type.
-     * @param responseType representation of a generic Java type the response
-     *                     entity will be converted to.
+     * @param <T> generic response entity type.
+     * @param responseType representation of a generic Java type the response entity will be converted to.
      * @return invocation response.
-     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter
-     *                                     or during conversion of the response entity data to an instance
-     *                                     of a particular Java type).
-     * @throws ProcessingException         in case the request processing or subsequent I/O operation fails.
-     * @throws WebApplicationException     in case the response status code of the response
-     *                                     returned by the server is not
-     *                                     {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     *                                     successful} and the specified generic response type does not represent
-     *                                     {@link javax.ws.rs.core.Response}
+     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter or during
+     * conversion of the response entity data to an instance of a particular Java type).
+     * @throws ProcessingException in case the request processing or subsequent I/O operation fails.
+     * @throws WebApplicationException in case the response status code of the response returned by the server is not
+     * {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and the specified generic response type does
+     * not represent {@link javax.ws.rs.core.Response}
      */
     <T> T get(GenericType<T> responseType);
 
@@ -82,60 +74,49 @@ public interface SyncInvoker {
     /**
      * Invoke HTTP PUT method for the current request synchronously.
      *
-     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information.
-     *               Any variant-related HTTP headers previously set (namely {@code Content-Type},
-     *               {@code Content-Language} and {@code Content-Encoding}) will be overwritten using
-     *               the entity variant information.
+     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information. Any variant-related
+     * HTTP headers previously set (namely {@code Content-Type}, {@code Content-Language} and {@code Content-Encoding}) will
+     * be overwritten using the entity variant information.
      * @return invocation response.
-     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter
-     *                                     or during conversion of the response entity data to an instance
-     *                                     of a particular Java type).
-     * @throws ProcessingException         in case the request processing or subsequent I/O operation fails.
+     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter or during
+     * conversion of the response entity data to an instance of a particular Java type).
+     * @throws ProcessingException in case the request processing or subsequent I/O operation fails.
      */
     Response put(Entity<?> entity);
 
     /**
      * Invoke HTTP PUT method for the current request synchronously.
      *
-     * @param <T>          response entity type.
-     * @param entity       request entity, including it's full {@link javax.ws.rs.core.Variant} information.
-     *                     Any variant-related HTTP headers previously set (namely {@code Content-Type},
-     *                     {@code Content-Language} and {@code Content-Encoding}) will be overwritten using
-     *                     the entity variant information.
+     * @param <T> response entity type.
+     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information. Any variant-related
+     * HTTP headers previously set (namely {@code Content-Type}, {@code Content-Language} and {@code Content-Encoding}) will
+     * be overwritten using the entity variant information.
      * @param responseType Java type the response entity will be converted to.
      * @return invocation response.
-     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter
-     *                                     or during conversion of the response entity data to an instance
-     *                                     of a particular Java type).
-     * @throws ProcessingException         in case the request processing or subsequent I/O operation fails.
-     * @throws WebApplicationException     in case the response status code of the response
-     *                                     returned by the server is not
-     *                                     {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     *                                     successful} and the specified response type is not
-     *                                     {@link javax.ws.rs.core.Response}.
+     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter or during
+     * conversion of the response entity data to an instance of a particular Java type).
+     * @throws ProcessingException in case the request processing or subsequent I/O operation fails.
+     * @throws WebApplicationException in case the response status code of the response returned by the server is not
+     * {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and the specified response type is not
+     * {@link javax.ws.rs.core.Response}.
      */
     <T> T put(Entity<?> entity, Class<T> responseType);
 
     /**
      * Invoke HTTP PUT method for the current request synchronously.
      *
-     * @param <T>          generic response entity type.
-     * @param entity       request entity, including it's full {@link javax.ws.rs.core.Variant} information.
-     *                     Any variant-related HTTP headers previously set (namely {@code Content-Type},
-     *                     {@code Content-Language} and {@code Content-Encoding}) will be overwritten using
-     *                     the entity variant information.
-     * @param responseType representation of a generic Java type the response
-     *                     entity will be converted to.
+     * @param <T> generic response entity type.
+     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information. Any variant-related
+     * HTTP headers previously set (namely {@code Content-Type}, {@code Content-Language} and {@code Content-Encoding}) will
+     * be overwritten using the entity variant information.
+     * @param responseType representation of a generic Java type the response entity will be converted to.
      * @return invocation response.
-     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter
-     *                                     or during conversion of the response entity data to an instance
-     *                                     of a particular Java type).
-     * @throws ProcessingException         in case the request processing or subsequent I/O operation fails.
-     * @throws WebApplicationException     in case the response status code of the response
-     *                                     returned by the server is not
-     *                                     {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     *                                     successful} and the specified generic response type does not represent
-     *                                     {@link javax.ws.rs.core.Response}.
+     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter or during
+     * conversion of the response entity data to an instance of a particular Java type).
+     * @throws ProcessingException in case the request processing or subsequent I/O operation fails.
+     * @throws WebApplicationException in case the response status code of the response returned by the server is not
+     * {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and the specified generic response type does
+     * not represent {@link javax.ws.rs.core.Response}.
      */
     <T> T put(Entity<?> entity, GenericType<T> responseType);
 
@@ -144,60 +125,49 @@ public interface SyncInvoker {
     /**
      * Invoke HTTP POST method for the current request synchronously.
      *
-     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information.
-     *               Any variant-related HTTP headers previously set (namely {@code Content-Type},
-     *               {@code Content-Language} and {@code Content-Encoding}) will be overwritten using
-     *               the entity variant information.
+     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information. Any variant-related
+     * HTTP headers previously set (namely {@code Content-Type}, {@code Content-Language} and {@code Content-Encoding}) will
+     * be overwritten using the entity variant information.
      * @return invocation response.
-     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter
-     *                                     or during conversion of the response entity data to an instance
-     *                                     of a particular Java type).
-     * @throws ProcessingException         in case the request processing or subsequent I/O operation fails.
+     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter or during
+     * conversion of the response entity data to an instance of a particular Java type).
+     * @throws ProcessingException in case the request processing or subsequent I/O operation fails.
      */
     Response post(Entity<?> entity);
 
     /**
      * Invoke HTTP POST method for the current request synchronously.
      *
-     * @param <T>          response entity type.
-     * @param entity       request entity, including it's full {@link javax.ws.rs.core.Variant} information.
-     *                     Any variant-related HTTP headers previously set (namely {@code Content-Type},
-     *                     {@code Content-Language} and {@code Content-Encoding}) will be overwritten using
-     *                     the entity variant information.
+     * @param <T> response entity type.
+     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information. Any variant-related
+     * HTTP headers previously set (namely {@code Content-Type}, {@code Content-Language} and {@code Content-Encoding}) will
+     * be overwritten using the entity variant information.
      * @param responseType Java type the response entity will be converted to.
      * @return invocation response.
-     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter
-     *                                     or during conversion of the response entity data to an instance
-     *                                     of a particular Java type).
-     * @throws ProcessingException         in case the request processing or subsequent I/O operation fails.
-     * @throws WebApplicationException     in case the response status code of the response
-     *                                     returned by the server is not
-     *                                     {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     *                                     successful} and the specified response type is not
-     *                                     {@link javax.ws.rs.core.Response}.
+     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter or during
+     * conversion of the response entity data to an instance of a particular Java type).
+     * @throws ProcessingException in case the request processing or subsequent I/O operation fails.
+     * @throws WebApplicationException in case the response status code of the response returned by the server is not
+     * {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and the specified response type is not
+     * {@link javax.ws.rs.core.Response}.
      */
     <T> T post(Entity<?> entity, Class<T> responseType);
 
     /**
      * Invoke HTTP POST method for the current request synchronously.
      *
-     * @param <T>          generic response entity type.
-     * @param entity       request entity, including it's full {@link javax.ws.rs.core.Variant} information.
-     *                     Any variant-related HTTP headers previously set (namely {@code Content-Type},
-     *                     {@code Content-Language} and {@code Content-Encoding}) will be overwritten using
-     *                     the entity variant information.
-     * @param responseType representation of a generic Java type the response
-     *                     entity will be converted to.
+     * @param <T> generic response entity type.
+     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information. Any variant-related
+     * HTTP headers previously set (namely {@code Content-Type}, {@code Content-Language} and {@code Content-Encoding}) will
+     * be overwritten using the entity variant information.
+     * @param responseType representation of a generic Java type the response entity will be converted to.
      * @return invocation response.
-     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter
-     *                                     or during conversion of the response entity data to an instance
-     *                                     of a particular Java type).
-     * @throws ProcessingException         in case the request processing or subsequent I/O operation fails.
-     * @throws WebApplicationException     in case the response status code of the response
-     *                                     returned by the server is not
-     *                                     {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     *                                     successful} and the specified generic response type does not represent
-     *                                     {@link javax.ws.rs.core.Response}.
+     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter or during
+     * conversion of the response entity data to an instance of a particular Java type).
+     * @throws ProcessingException in case the request processing or subsequent I/O operation fails.
+     * @throws WebApplicationException in case the response status code of the response returned by the server is not
+     * {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and the specified generic response type does
+     * not represent {@link javax.ws.rs.core.Response}.
      */
     <T> T post(Entity<?> entity, GenericType<T> responseType);
 
@@ -207,47 +177,39 @@ public interface SyncInvoker {
      * Invoke HTTP DELETE method for the current request synchronously.
      *
      * @return invocation response.
-     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter
-     *                                     or during conversion of the response entity data to an instance
-     *                                     of a particular Java type).
-     * @throws ProcessingException         in case the request processing or subsequent I/O operation fails.
+     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter or during
+     * conversion of the response entity data to an instance of a particular Java type).
+     * @throws ProcessingException in case the request processing or subsequent I/O operation fails.
      */
     Response delete();
 
     /**
      * Invoke HTTP DELETE method for the current request synchronously.
      *
-     * @param <T>          response entity type.
+     * @param <T> response entity type.
      * @param responseType Java type the response entity will be converted to.
      * @return invocation response.
-     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter
-     *                                     or during conversion of the response entity data to an instance
-     *                                     of a particular Java type).
-     * @throws ProcessingException         in case the request processing or subsequent I/O operation fails.
-     * @throws WebApplicationException     in case the response status code of the response
-     *                                     returned by the server is not
-     *                                     {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     *                                     successful} and the specified response type is not
-     *                                     {@link javax.ws.rs.core.Response}.
+     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter or during
+     * conversion of the response entity data to an instance of a particular Java type).
+     * @throws ProcessingException in case the request processing or subsequent I/O operation fails.
+     * @throws WebApplicationException in case the response status code of the response returned by the server is not
+     * {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and the specified response type is not
+     * {@link javax.ws.rs.core.Response}.
      */
     <T> T delete(Class<T> responseType);
 
     /**
      * Invoke HTTP DELETE method for the current request synchronously.
      *
-     * @param <T>          generic response entity type.
-     * @param responseType representation of a generic Java type the response
-     *                     entity will be converted to.
+     * @param <T> generic response entity type.
+     * @param responseType representation of a generic Java type the response entity will be converted to.
      * @return invocation response.
-     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter
-     *                                     or during conversion of the response entity data to an instance
-     *                                     of a particular Java type).
-     * @throws ProcessingException         in case the request processing or subsequent I/O operation fails.
-     * @throws WebApplicationException     in case the response status code of the response
-     *                                     returned by the server is not
-     *                                     {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     *                                     successful} and the specified generic response type does not represent
-     *                                     {@link javax.ws.rs.core.Response}.
+     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter or during
+     * conversion of the response entity data to an instance of a particular Java type).
+     * @throws ProcessingException in case the request processing or subsequent I/O operation fails.
+     * @throws WebApplicationException in case the response status code of the response returned by the server is not
+     * {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and the specified generic response type does
+     * not represent {@link javax.ws.rs.core.Response}.
      */
     <T> T delete(GenericType<T> responseType);
 
@@ -257,10 +219,9 @@ public interface SyncInvoker {
      * Invoke HTTP HEAD method for the current request synchronously.
      *
      * @return invocation response.
-     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter
-     *                                     or during conversion of the response entity data to an instance
-     *                                     of a particular Java type).
-     * @throws ProcessingException         in case the request processing or subsequent I/O operation fails.
+     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter or during
+     * conversion of the response entity data to an instance of a particular Java type).
+     * @throws ProcessingException in case the request processing or subsequent I/O operation fails.
      */
     Response head();
 
@@ -270,47 +231,39 @@ public interface SyncInvoker {
      * Invoke HTTP OPTIONS method for the current request synchronously.
      *
      * @return invocation response.
-     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter
-     *                                     or during conversion of the response entity data to an instance
-     *                                     of a particular Java type).
-     * @throws ProcessingException         in case the request processing or subsequent I/O operation fails.
+     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter or during
+     * conversion of the response entity data to an instance of a particular Java type).
+     * @throws ProcessingException in case the request processing or subsequent I/O operation fails.
      */
     Response options();
 
     /**
      * Invoke HTTP OPTIONS method for the current request synchronously.
      *
-     * @param <T>          response entity type.
+     * @param <T> response entity type.
      * @param responseType Java type the response entity will be converted to.
      * @return invocation response.
-     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter
-     *                                     or during conversion of the response entity data to an instance
-     *                                     of a particular Java type).
-     * @throws ProcessingException         in case the request processing or subsequent I/O operation fails.
-     * @throws WebApplicationException     in case the response status code of the response
-     *                                     returned by the server is not
-     *                                     {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     *                                     successful} and the specified response type is not
-     *                                     {@link javax.ws.rs.core.Response}.
+     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter or during
+     * conversion of the response entity data to an instance of a particular Java type).
+     * @throws ProcessingException in case the request processing or subsequent I/O operation fails.
+     * @throws WebApplicationException in case the response status code of the response returned by the server is not
+     * {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and the specified response type is not
+     * {@link javax.ws.rs.core.Response}.
      */
     <T> T options(Class<T> responseType);
 
     /**
      * Invoke HTTP OPTIONS method for the current request synchronously.
      *
-     * @param <T>          generic response entity type.
-     * @param responseType representation of a generic Java type the response
-     *                     entity will be converted to.
+     * @param <T> generic response entity type.
+     * @param responseType representation of a generic Java type the response entity will be converted to.
      * @return invocation response.
-     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter
-     *                                     or during conversion of the response entity data to an instance
-     *                                     of a particular Java type).
-     * @throws ProcessingException         in case the request processing or subsequent I/O operation fails.
-     * @throws WebApplicationException     in case the response status code of the response
-     *                                     returned by the server is not
-     *                                     {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     *                                     successful} and the specified generic response type does not represent
-     *                                     {@link javax.ws.rs.core.Response}.
+     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter or during
+     * conversion of the response entity data to an instance of a particular Java type).
+     * @throws ProcessingException in case the request processing or subsequent I/O operation fails.
+     * @throws WebApplicationException in case the response status code of the response returned by the server is not
+     * {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and the specified generic response type does
+     * not represent {@link javax.ws.rs.core.Response}.
      */
     <T> T options(GenericType<T> responseType);
 
@@ -320,47 +273,39 @@ public interface SyncInvoker {
      * Invoke HTTP TRACE method for the current request synchronously.
      *
      * @return invocation response.
-     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter
-     *                                     or during conversion of the response entity data to an instance
-     *                                     of a particular Java type).
-     * @throws ProcessingException         in case the request processing or subsequent I/O operation fails.
+     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter or during
+     * conversion of the response entity data to an instance of a particular Java type).
+     * @throws ProcessingException in case the request processing or subsequent I/O operation fails.
      */
     Response trace();
 
     /**
      * Invoke HTTP TRACE method for the current request synchronously.
      *
-     * @param <T>          response entity type.
+     * @param <T> response entity type.
      * @param responseType Java type the response entity will be converted to.
      * @return invocation response.
-     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter
-     *                                     or during conversion of the response entity data to an instance
-     *                                     of a particular Java type).
-     * @throws ProcessingException         in case the request processing or subsequent I/O operation fails.
-     * @throws WebApplicationException     in case the response status code of the response
-     *                                     returned by the server is not
-     *                                     {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     *                                     successful} and the specified response type is not
-     *                                     {@link javax.ws.rs.core.Response}.
+     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter or during
+     * conversion of the response entity data to an instance of a particular Java type).
+     * @throws ProcessingException in case the request processing or subsequent I/O operation fails.
+     * @throws WebApplicationException in case the response status code of the response returned by the server is not
+     * {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and the specified response type is not
+     * {@link javax.ws.rs.core.Response}.
      */
     <T> T trace(Class<T> responseType);
 
     /**
      * Invoke HTTP TRACE method for the current request synchronously.
      *
-     * @param <T>          generic response entity type.
-     * @param responseType representation of a generic Java type the response
-     *                     entity will be converted to.
+     * @param <T> generic response entity type.
+     * @param responseType representation of a generic Java type the response entity will be converted to.
      * @return invocation response.
-     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter
-     *                                     or during conversion of the response entity data to an instance
-     *                                     of a particular Java type).
-     * @throws ProcessingException         in case the request processing or subsequent I/O operation fails.
-     * @throws WebApplicationException     in case the response status code of the response
-     *                                     returned by the server is not
-     *                                     {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     *                                     successful} and the specified generic response type does not represent
-     *                                     {@link javax.ws.rs.core.Response}.
+     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter or during
+     * conversion of the response entity data to an instance of a particular Java type).
+     * @throws ProcessingException in case the request processing or subsequent I/O operation fails.
+     * @throws WebApplicationException in case the response status code of the response returned by the server is not
+     * {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and the specified generic response type does
+     * not represent {@link javax.ws.rs.core.Response}.
      */
     <T> T trace(GenericType<T> responseType);
 
@@ -371,112 +316,93 @@ public interface SyncInvoker {
      *
      * @param name method name.
      * @return invocation response.
-     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter
-     *                                     or during conversion of the response entity data to an instance
-     *                                     of a particular Java type).
-     * @throws ProcessingException         in case the request processing or subsequent I/O operation fails.
+     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter or during
+     * conversion of the response entity data to an instance of a particular Java type).
+     * @throws ProcessingException in case the request processing or subsequent I/O operation fails.
      */
     Response method(String name);
 
     /**
      * Invoke an arbitrary method for the current request synchronously.
      *
-     * @param <T>          response entity type.
-     * @param name         method name.
+     * @param <T> response entity type.
+     * @param name method name.
      * @param responseType Java type the response entity will be converted to.
      * @return invocation response.
-     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter
-     *                                     or during conversion of the response entity data to an instance
-     *                                     of a particular Java type).
-     * @throws ProcessingException         in case the request processing or subsequent I/O operation fails.
-     * @throws WebApplicationException     in case the response status code of the response
-     *                                     returned by the server is not
-     *                                     {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     *                                     successful} and the specified response type is not
-     *                                     {@link javax.ws.rs.core.Response}.
+     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter or during
+     * conversion of the response entity data to an instance of a particular Java type).
+     * @throws ProcessingException in case the request processing or subsequent I/O operation fails.
+     * @throws WebApplicationException in case the response status code of the response returned by the server is not
+     * {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and the specified response type is not
+     * {@link javax.ws.rs.core.Response}.
      */
     <T> T method(String name, Class<T> responseType);
 
     /**
      * Invoke an arbitrary method for the current request synchronously.
      *
-     * @param <T>          generic response entity type.
-     * @param name         method name.
-     * @param responseType representation of a generic Java type the response
-     *                     entity will be converted to.
+     * @param <T> generic response entity type.
+     * @param name method name.
+     * @param responseType representation of a generic Java type the response entity will be converted to.
      * @return invocation response.
-     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter
-     *                                     or during conversion of the response entity data to an instance
-     *                                     of a particular Java type).
-     * @throws ProcessingException         in case the request processing or subsequent I/O operation fails.
-     * @throws WebApplicationException     in case the response status code of the response
-     *                                     returned by the server is not
-     *                                     {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     *                                     successful} and the specified generic response type does not represent
-     *                                     {@link javax.ws.rs.core.Response}.
+     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter or during
+     * conversion of the response entity data to an instance of a particular Java type).
+     * @throws ProcessingException in case the request processing or subsequent I/O operation fails.
+     * @throws WebApplicationException in case the response status code of the response returned by the server is not
+     * {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and the specified generic response type does
+     * not represent {@link javax.ws.rs.core.Response}.
      */
     <T> T method(String name, GenericType<T> responseType);
 
     /**
      * Invoke an arbitrary method for the current request synchronously.
      *
-     * @param name   method name.
-     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information.
-     *               Any variant-related HTTP headers previously set (namely {@code Content-Type},
-     *               {@code Content-Language} and {@code Content-Encoding}) will be overwritten using
-     *               the entity variant information.
+     * @param name method name.
+     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information. Any variant-related
+     * HTTP headers previously set (namely {@code Content-Type}, {@code Content-Language} and {@code Content-Encoding}) will
+     * be overwritten using the entity variant information.
      * @return invocation response.
-     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter
-     *                                     or during conversion of the response entity data to an instance
-     *                                     of a particular Java type).
-     * @throws ProcessingException         in case the request processing or subsequent I/O operation fails.
+     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter or during
+     * conversion of the response entity data to an instance of a particular Java type).
+     * @throws ProcessingException in case the request processing or subsequent I/O operation fails.
      */
     Response method(String name, Entity<?> entity);
 
     /**
      * Invoke an arbitrary method for the current request synchronously.
      *
-     * @param <T>          response entity type.
-     * @param name         method name.
-     * @param entity       request entity, including it's full {@link javax.ws.rs.core.Variant} information.
-     *                     Any variant-related HTTP headers previously set (namely {@code Content-Type},
-     *                     {@code Content-Language} and {@code Content-Encoding}) will be overwritten using
-     *                     the entity variant information.
+     * @param <T> response entity type.
+     * @param name method name.
+     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information. Any variant-related
+     * HTTP headers previously set (namely {@code Content-Type}, {@code Content-Language} and {@code Content-Encoding}) will
+     * be overwritten using the entity variant information.
      * @param responseType Java type the response entity will be converted to.
      * @return invocation response.
-     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter
-     *                                     or during conversion of the response entity data to an instance
-     *                                     of a particular Java type).
-     * @throws ProcessingException         in case the request processing or subsequent I/O operation fails.
-     * @throws WebApplicationException     in case the response status code of the response
-     *                                     returned by the server is not
-     *                                     {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     *                                     successful} and the specified response type is not
-     *                                     {@link javax.ws.rs.core.Response}.
+     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter or during
+     * conversion of the response entity data to an instance of a particular Java type).
+     * @throws ProcessingException in case the request processing or subsequent I/O operation fails.
+     * @throws WebApplicationException in case the response status code of the response returned by the server is not
+     * {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and the specified response type is not
+     * {@link javax.ws.rs.core.Response}.
      */
     <T> T method(String name, Entity<?> entity, Class<T> responseType);
 
     /**
      * Invoke an arbitrary method for the current request synchronously.
      *
-     * @param <T>          generic response entity type.
-     * @param name         method name.
-     * @param entity       request entity, including it's full {@link javax.ws.rs.core.Variant} information.
-     *                     Any variant-related HTTP headers previously set (namely {@code Content-Type},
-     *                     {@code Content-Language} and {@code Content-Encoding}) will be overwritten using
-     *                     the entity variant information.
-     * @param responseType representation of a generic Java type the response
-     *                     entity will be converted to.
+     * @param <T> generic response entity type.
+     * @param name method name.
+     * @param entity request entity, including it's full {@link javax.ws.rs.core.Variant} information. Any variant-related
+     * HTTP headers previously set (namely {@code Content-Type}, {@code Content-Language} and {@code Content-Encoding}) will
+     * be overwritten using the entity variant information.
+     * @param responseType representation of a generic Java type the response entity will be converted to.
      * @return invocation response.
-     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter
-     *                                     or during conversion of the response entity data to an instance
-     *                                     of a particular Java type).
-     * @throws ProcessingException         in case the request processing or subsequent I/O operation fails.
-     * @throws WebApplicationException     in case the response status code of the response
-     *                                     returned by the server is not
-     *                                     {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL
-     *                                     successful} and the specified generic response type does not represent
-     *                                     {@link javax.ws.rs.core.Response}.
+     * @throws ResponseProcessingException in case processing of a received HTTP response fails (e.g. in a filter or during
+     * conversion of the response entity data to an instance of a particular Java type).
+     * @throws ProcessingException in case the request processing or subsequent I/O operation fails.
+     * @throws WebApplicationException in case the response status code of the response returned by the server is not
+     * {@link javax.ws.rs.core.Response.Status.Family#SUCCESSFUL successful} and the specified generic response type does
+     * not represent {@link javax.ws.rs.core.Response}.
      */
     <T> T method(String name, Entity<?> entity, GenericType<T> responseType);
 }

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/WebTarget.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/WebTarget.java
@@ -39,27 +39,23 @@ public interface WebTarget extends Configurable<WebTarget> {
     public URI getUri();
 
     /**
-     * Get the URI builder initialized with the {@link URI} of the current
-     * resource target. The returned URI builder is detached from the target,
-     * i.e. any updates in the URI builder MUST NOT have any effects on the
-     * URI of the originating target.
+     * Get the URI builder initialized with the {@link URI} of the current resource target. The returned URI builder is
+     * detached from the target, i.e. any updates in the URI builder MUST NOT have any effects on the URI of the originating
+     * target.
      *
      * @return the initialized URI builder.
      */
     public UriBuilder getUriBuilder();
 
     /**
-     * Create a new {@code WebTarget} instance by appending path to the URI of
-     * the current target instance.
+     * Create a new {@code WebTarget} instance by appending path to the URI of the current target instance.
      * <p>
-     * When constructing the final path, a '/' separator will be inserted between
-     * the existing path and the supplied path if necessary. Existing '/' characters
-     * are preserved thus a single value can represent multiple URI path segments.
+     * When constructing the final path, a '/' separator will be inserted between the existing path and the supplied path if
+     * necessary. Existing '/' characters are preserved thus a single value can represent multiple URI path segments.
      * </p>
      * <p>
-     * A snapshot of the present configuration of the current (parent) target
-     * instance is taken and is inherited by the newly constructed (child) target
-     * instance.
+     * A snapshot of the present configuration of the current (parent) target instance is taken and is inherited by the
+     * newly constructed (child) target instance.
      * </p>
      *
      * @param path the path, may contain URI template parameters.
@@ -69,18 +65,16 @@ public interface WebTarget extends Configurable<WebTarget> {
     public WebTarget path(String path);
 
     /**
-     * Create a new {@code WebTarget} instance by resolving a URI template with a given {@code name}
-     * in the URI of the current target instance using a supplied value.
+     * Create a new {@code WebTarget} instance by resolving a URI template with a given {@code name} in the URI of the
+     * current target instance using a supplied value.
      *
-     * In case a {@code null} template name or value is entered a {@link NullPointerException}
-     * is thrown.
+     * In case a {@code null} template name or value is entered a {@link NullPointerException} is thrown.
      * <p>
-     * A snapshot of the present configuration of the current (parent) target
-     * instance is taken and is inherited by the newly constructed (child) target
-     * instance.
+     * A snapshot of the present configuration of the current (parent) target instance is taken and is inherited by the
+     * newly constructed (child) target instance.
      * </p>
      *
-     * @param name  name of the URI template.
+     * @param name name of the URI template.
      * @param value value to be used to resolve the template.
      * @return a new target instance.
      * @throws NullPointerException if the resolved template name or value is {@code null}.
@@ -88,46 +82,40 @@ public interface WebTarget extends Configurable<WebTarget> {
     public WebTarget resolveTemplate(String name, Object value);
 
     /**
-     * Create a new {@code WebTarget} instance by resolving a URI template with a given {@code name}
-     * in the URI of the current target instance using a supplied value.
+     * Create a new {@code WebTarget} instance by resolving a URI template with a given {@code name} in the URI of the
+     * current target instance using a supplied value.
      *
-     * In case a {@code null} template name or value is entered a {@link NullPointerException}
-     * is thrown.
+     * In case a {@code null} template name or value is entered a {@link NullPointerException} is thrown.
      * <p>
-     * A snapshot of the present configuration of the current (parent) target
-     * instance is taken and is inherited by the newly constructed (child) target
-     * instance.
+     * A snapshot of the present configuration of the current (parent) target instance is taken and is inherited by the
+     * newly constructed (child) target instance.
      * </p>
      *
-     * @param name  name of the URI template.
+     * @param name name of the URI template.
      * @param value value to be used to resolve the template.
-     * @param encodeSlashInPath if {@code true}, the slash ({@code '/'}) characters
-     *                          in template values will be encoded if the template
-     *                          is placed in the URI path component, otherwise the slash
-     *                          characters will not be encoded in path templates.
+     * @param encodeSlashInPath if {@code true}, the slash ({@code '/'}) characters in template values will be encoded if
+     * the template is placed in the URI path component, otherwise the slash characters will not be encoded in path
+     * templates.
      * @return a new target instance.
      * @throws NullPointerException if the resolved template name or value is {@code null}.
      */
     public WebTarget resolveTemplate(String name, Object value, boolean encodeSlashInPath);
 
     /**
-     * Create a new {@code WebTarget} instance by resolving a URI template with a given {@code name}
-     * in the URI of the current target instance using a supplied encoded value.
+     * Create a new {@code WebTarget} instance by resolving a URI template with a given {@code name} in the URI of the
+     * current target instance using a supplied encoded value.
      *
-     * A template with a matching name will be replaced by the supplied value.
-     * Value is converted to {@code String} using its {@code toString()} method and is then
-     * encoded to match the rules of the URI component to which they pertain.  All % characters in
-     * the stringified values that are not followed by two hexadecimal numbers will be encoded.
+     * A template with a matching name will be replaced by the supplied value. Value is converted to {@code String} using
+     * its {@code toString()} method and is then encoded to match the rules of the URI component to which they pertain. All
+     * % characters in the stringified values that are not followed by two hexadecimal numbers will be encoded.
      *
-     * In case a {@code null} template name or value is entered a {@link NullPointerException}
-     * is thrown.
+     * In case a {@code null} template name or value is entered a {@link NullPointerException} is thrown.
      * <p>
-     * A snapshot of the present configuration of the current (parent) target
-     * instance is taken and is inherited by the newly constructed (child) target
-     * instance.
+     * A snapshot of the present configuration of the current (parent) target instance is taken and is inherited by the
+     * newly constructed (child) target instance.
      * </p>
      *
-     * @param name  name of the URI template.
+     * @param name name of the URI template.
      * @param value encoded value to be used to resolve the template.
      * @return a new target instance.
      * @throws NullPointerException if the resolved template name or value is {@code null}.
@@ -135,127 +123,105 @@ public interface WebTarget extends Configurable<WebTarget> {
     public WebTarget resolveTemplateFromEncoded(String name, Object value);
 
     /**
-     * Create a new {@code WebTarget} instance by resolving one or more URI templates
-     * in the URI of the current target instance using supplied name-value pairs.
+     * Create a new {@code WebTarget} instance by resolving one or more URI templates in the URI of the current target
+     * instance using supplied name-value pairs.
      *
-     * A call to the method with an empty parameter map is ignored, i.e. same {@code WebTarget}
-     * instance is returned.
+     * A call to the method with an empty parameter map is ignored, i.e. same {@code WebTarget} instance is returned.
      * <p>
-     * A snapshot of the present configuration of the current (parent) target
-     * instance is taken and is inherited by the newly constructed (child) target
-     * instance.
+     * A snapshot of the present configuration of the current (parent) target instance is taken and is inherited by the
+     * newly constructed (child) target instance.
      * </p>
      *
      * @param templateValues a map of URI template names and their values.
-     * @return a new target instance or the same target instance in case the input name-value map
-     *         is empty.
-     * @throws NullPointerException if the name-value map or any of the names or values in the map
-     *                              is {@code null}.
+     * @return a new target instance or the same target instance in case the input name-value map is empty.
+     * @throws NullPointerException if the name-value map or any of the names or values in the map is {@code null}.
      */
     public WebTarget resolveTemplates(Map<String, Object> templateValues);
+
     /**
-     * Create a new {@code WebTarget} instance by resolving one or more URI templates
-     * in the URI of the current target instance using supplied name-value pairs.
+     * Create a new {@code WebTarget} instance by resolving one or more URI templates in the URI of the current target
+     * instance using supplied name-value pairs.
      *
-     * A call to the method with an empty parameter map is ignored, i.e. same {@code WebTarget}
-     * instance is returned.
+     * A call to the method with an empty parameter map is ignored, i.e. same {@code WebTarget} instance is returned.
      * <p>
-     * A snapshot of the present configuration of the current (parent) target
-     * instance is taken and is inherited by the newly constructed (child) target
-     * instance.
+     * A snapshot of the present configuration of the current (parent) target instance is taken and is inherited by the
+     * newly constructed (child) target instance.
      * </p>
      *
      *
      * @param templateValues a map of URI template names and their values.
-     * @param encodeSlashInPath if {@code true}, the slash ({@code '/'}) characters
-     *                          in template values will be encoded if the template
-     *                          is placed in the URI path component, otherwise the slash
-     *                          characters will not be encoded in path templates.
-     * @return a new target instance or the same target instance in case the input name-value map
-     *         is empty.
-     * @throws NullPointerException if the name-value map or any of the names or values in the map
-     *                              is {@code null}.
+     * @param encodeSlashInPath if {@code true}, the slash ({@code '/'}) characters in template values will be encoded if
+     * the template is placed in the URI path component, otherwise the slash characters will not be encoded in path
+     * templates.
+     * @return a new target instance or the same target instance in case the input name-value map is empty.
+     * @throws NullPointerException if the name-value map or any of the names or values in the map is {@code null}.
      */
     public WebTarget resolveTemplates(Map<String, Object> templateValues, boolean encodeSlashInPath);
 
     /**
-     * Create a new {@code WebTarget} instance by resolving one or more URI templates
-     * in the URI of the current target instance using supplied name-encoded value pairs.
+     * Create a new {@code WebTarget} instance by resolving one or more URI templates in the URI of the current target
+     * instance using supplied name-encoded value pairs.
      *
-     * All templates  with their name matching one of the keys in the supplied map will be replaced
-     * by the value in the supplied map. Values are converted to {@code String} using
-     * their {@code toString()} method and are then encoded to match the
-     * rules of the URI component to which they pertain.  All % characters in
-     * the stringified values that are not followed by two hexadecimal numbers
-     * will be encoded.
+     * All templates with their name matching one of the keys in the supplied map will be replaced by the value in the
+     * supplied map. Values are converted to {@code String} using their {@code toString()} method and are then encoded to
+     * match the rules of the URI component to which they pertain. All % characters in the stringified values that are not
+     * followed by two hexadecimal numbers will be encoded.
      *
-     * A call to the method with an empty parameter map is ignored, i.e. same {@code WebTarget}
-     * instance is returned.
+     * A call to the method with an empty parameter map is ignored, i.e. same {@code WebTarget} instance is returned.
      * <p>
-     * A snapshot of the present configuration of the current (parent) target
-     * instance is taken and is inherited by the newly constructed (child) target
-     * instance.
+     * A snapshot of the present configuration of the current (parent) target instance is taken and is inherited by the
+     * newly constructed (child) target instance.
      * </p>
      *
      * @param templateValues a map of URI template names and their encoded values.
-     * @return a new target instance or the same target instance in case the input name-value map
-     *         is empty.
-     * @throws NullPointerException if the name-value map or any of the names or encoded values in the map
-     *                              is {@code null}.
+     * @return a new target instance or the same target instance in case the input name-value map is empty.
+     * @throws NullPointerException if the name-value map or any of the names or encoded values in the map is {@code null}.
      */
     public WebTarget resolveTemplatesFromEncoded(Map<String, Object> templateValues);
 
     /**
-     * Create a new {@code WebTarget} instance by appending a matrix parameter to
-     * the existing set of matrix parameters of the current final segment of the
-     * URI of the current target instance.
+     * Create a new {@code WebTarget} instance by appending a matrix parameter to the existing set of matrix parameters of
+     * the current final segment of the URI of the current target instance.
      *
-     * If multiple values are supplied the parameter will be added once per value. In case a single
-     * {@code null} value is entered, all parameters with that name in the current final path segment
-     * are removed (if present) from the collection of last segment matrix parameters inherited from
-     * the current target.
+     * If multiple values are supplied the parameter will be added once per value. In case a single {@code null} value is
+     * entered, all parameters with that name in the current final path segment are removed (if present) from the collection
+     * of last segment matrix parameters inherited from the current target.
      * <p>
-     * Note that the matrix parameters are tied to a particular path segment; appending
-     * a value to an existing matrix parameter name will not affect the position of
-     * the matrix parameter in the URI path.
+     * Note that the matrix parameters are tied to a particular path segment; appending a value to an existing matrix
+     * parameter name will not affect the position of the matrix parameter in the URI path.
      * </p>
      * <p>
-     * A snapshot of the present configuration of the current (parent) target
-     * instance is taken and is inherited by the newly constructed (child) target
-     * instance.
+     * A snapshot of the present configuration of the current (parent) target instance is taken and is inherited by the
+     * newly constructed (child) target instance.
      * </p>
      *
-     * @param name   the matrix parameter name, may contain URI template parameters.
-     * @param values the matrix parameter value(s), each object will be converted
-     *               to a {@code String} using its {@code toString()} method. Stringified
-     *               values may contain URI template parameters.
+     * @param name the matrix parameter name, may contain URI template parameters.
+     * @param values the matrix parameter value(s), each object will be converted to a {@code String} using its
+     * {@code toString()} method. Stringified values may contain URI template parameters.
      * @return a new target instance.
-     * @throws NullPointerException if the parameter name is {@code null} or if there are multiple
-     *                              values present and any of those values is {@code null}.
+     * @throws NullPointerException if the parameter name is {@code null} or if there are multiple values present and any of
+     * those values is {@code null}.
      * @see <a href="http://www.w3.org/DesignIssues/MatrixURIs.html">Matrix URIs</a>
      */
     public WebTarget matrixParam(String name, Object... values);
 
     /**
-     * Create a new {@code WebTarget} instance by configuring a query parameter on the URI
-     * of the current target instance.
+     * Create a new {@code WebTarget} instance by configuring a query parameter on the URI of the current target instance.
      *
-     * If multiple values are supplied the parameter will be added once per value. In case a single
-     * {@code null} value is entered, all parameters with that name are removed (if present) from
-     * the collection of query parameters inherited from the current target.
+     * If multiple values are supplied the parameter will be added once per value. In case a single {@code null} value is
+     * entered, all parameters with that name are removed (if present) from the collection of query parameters inherited
+     * from the current target.
      * <p>
-     * A snapshot of the present configuration of the current (parent) target
-     * instance is taken and is inherited by the newly constructed (child) target
-     * instance.
+     * A snapshot of the present configuration of the current (parent) target instance is taken and is inherited by the
+     * newly constructed (child) target instance.
      * </p>
      *
-     * @param name   the query parameter name, may contain URI template parameters
-     * @param values the query parameter value(s), each object will be converted
-     *               to a {@code String} using its {@code toString()} method. Stringified
-     *               values may contain URI template parameters.
+     * @param name the query parameter name, may contain URI template parameters
+     * @param values the query parameter value(s), each object will be converted to a {@code String} using its
+     * {@code toString()} method. Stringified values may contain URI template parameters.
      * @return a new target instance.
-     * @throws NullPointerException if the parameter name is {@code null} or if there are multiple
-     *                              values present and any of those values is {@code null}.
+     * @throws NullPointerException if the parameter name is {@code null} or if there are multiple values present and any of
+     * those values is {@code null}.
      */
     public WebTarget queryParam(String name, Object... values);
 
@@ -267,11 +233,11 @@ public interface WebTarget extends Configurable<WebTarget> {
     public Invocation.Builder request();
 
     /**
-     * Start building a request to the targeted web resource and define the accepted
-     * response media types.
+     * Start building a request to the targeted web resource and define the accepted response media types.
      * <p>
      * Invoking this method is identical to:
      * </p>
+     *
      * <pre>
      * webTarget.request().accept(types);
      * </pre>
@@ -282,11 +248,11 @@ public interface WebTarget extends Configurable<WebTarget> {
     public Invocation.Builder request(String... acceptedResponseTypes);
 
     /**
-     * Start building a request to the targeted web resource and define the accepted
-     * response media types.
+     * Start building a request to the targeted web resource and define the accepted response media types.
      * <p>
      * Invoking this method is identical to:
      * </p>
+     *
      * <pre>
      * webTarget.request().accept(types);
      * </pre>

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/package-info.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/package-info.java
@@ -17,77 +17,70 @@
 /**
  * <h1>The JAX-RS client API</h1>
  * <p>
- * The JAX-RS client API is a Java based API used to access Web resources.
- * It is not restricted to resources implemented using JAX-RS.
- * It provides a higher-level abstraction compared to a {@link java.net.HttpURLConnection
- * plain HTTP communication API} as well as integration with the JAX-RS extension
- * providers, in order to enable concise and efficient implementation of
- * reusable client-side solutions that leverage existing and well
- * established client-side implementations of HTTP-based communication.
+ * The JAX-RS client API is a Java based API used to access Web resources. It is not restricted to resources implemented
+ * using JAX-RS. It provides a higher-level abstraction compared to a {@link java.net.HttpURLConnection plain HTTP
+ * communication API} as well as integration with the JAX-RS extension providers, in order to enable concise and
+ * efficient implementation of reusable client-side solutions that leverage existing and well established client-side
+ * implementations of HTTP-based communication.
  * </p>
- * The JAX-RS Client API encapsulates the Uniform Interface Constraint &ndash;
- * a key constraint of the REST architectural style &ndash; and associated data
- * elements as client-side Java artifacts and supports a pluggable architecture
- * by defining multiple extension points.
+ * The JAX-RS Client API encapsulates the Uniform Interface Constraint &ndash; a key constraint of the REST
+ * architectural style &ndash; and associated data elements as client-side Java artifacts and supports a pluggable
+ * architecture by defining multiple extension points.
  *
- * <h2>Client API Bootstrapping and Configuration</h2>
- * The main entry point to the API is a {@link javax.ws.rs.client.ClientBuilder}
- * that is used to bootstrap {@link javax.ws.rs.client.Client} instances -
- * {@link javax.ws.rs.core.Configurable configurable}, heavy-weight objects
- * that manage the underlying communication infrastructure and serve as the root
- * objects for accessing any Web resource. The following example illustrates the
+ * <h2>Client API Bootstrapping and Configuration</h2> The main entry point to the API is a
+ * {@link javax.ws.rs.client.ClientBuilder} that is used to bootstrap {@link javax.ws.rs.client.Client} instances -
+ * {@link javax.ws.rs.core.Configurable configurable}, heavy-weight objects that manage the underlying communication
+ * infrastructure and serve as the root objects for accessing any Web resource. The following example illustrates the
  * bootstrapping and configuration of a {@code Client} instance:
- * <pre>
- *   Client client = ClientBuilder.newClient();
  *
- *   client.property("MyProperty", "MyValue")
+ * <pre>
+ * Client client = ClientBuilder.newClient();
+ *
+ * client.property("MyProperty", "MyValue")
  *         .register(MyProvider.class)
  *         .register(MyFeature.class);
  * </pre>
  *
- * <h2>Accessing Web Resources</h2>
- * A Web resource can be accessed using a fluent API in which method invocations
- * are chained to configure and ultimately submit an HTTP request. The following
- * example gets a {@code text/plain} representation of the resource identified by
- * {@code "http://example.org/hello"}:
+ * <h2>Accessing Web Resources</h2> A Web resource can be accessed using a fluent API in which method invocations are
+ * chained to configure and ultimately submit an HTTP request. The following example gets a {@code text/plain}
+ * representation of the resource identified by {@code "http://example.org/hello"}:
+ *
  * <pre>
- *   Client client = ClientBuilder.newClient();
- *   Response res = client.target("http://example.org/hello").request("text/plain").get();
+ * Client client = ClientBuilder.newClient();
+ * Response res = client.target("http://example.org/hello").request("text/plain").get();
  * </pre>
+ *
  * Conceptually, the steps required to submit a request are the following:
  * <ol>
- *   <li>obtain an {@link javax.ws.rs.client.Client} instance</li>
- *   <li>create a {@link javax.ws.rs.client.WebTarget WebTarget} pointing at a Web resource</li>
- *   <li>{@link javax.ws.rs.client.Invocation.Builder build} a request</li>
- *   <li>submit a request to directly retrieve a response or get a prepared
- *       {@link javax.ws.rs.client.Invocation} for later submission</li>
+ * <li>obtain an {@link javax.ws.rs.client.Client} instance</li>
+ * <li>create a {@link javax.ws.rs.client.WebTarget WebTarget} pointing at a Web resource</li>
+ * <li>{@link javax.ws.rs.client.Invocation.Builder build} a request</li>
+ * <li>submit a request to directly retrieve a response or get a prepared {@link javax.ws.rs.client.Invocation} for
+ * later submission</li>
  * </ol>
  *
- * As illustrated above, individual Web resources are in the JAX-RS Client API
- * represented as resource targets. Each {@code WebTarget} instance is bound to a
- * concrete URI, e.g. {@code "http://example.org/messages/123"},
- * or a URI template, e.g. {@code "http://example.org/messages/{id}"}.
- * That way a single target can either point at a particular resource or represent
- * a larger group of resources (that e.g. share a common configuration) from which
- * concrete resources can be later derived:
+ * As illustrated above, individual Web resources are in the JAX-RS Client API represented as resource targets. Each
+ * {@code WebTarget} instance is bound to a concrete URI, e.g. {@code "http://example.org/messages/123"}, or a URI
+ * template, e.g. {@code "http://example.org/messages/{id}"}. That way a single target can either point at a particular
+ * resource or represent a larger group of resources (that e.g. share a common configuration) from which concrete
+ * resources can be later derived:
+ *
  * <pre>
- *   // Parent target for all messages
- *   WebTarget messages = client.target("http://example.org/messages/{id}");
+ * // Parent target for all messages
+ * WebTarget messages = client.target("http://example.org/messages/{id}");
  *
- *   // New target for http://example.org/messages/123
- *   WebTarget msg123 = messages.resolveTemplate("id", 123);
+ * // New target for http://example.org/messages/123
+ * WebTarget msg123 = messages.resolveTemplate("id", 123);
  *
- *   // New target for http://example.org/messages/456
- *   WebTarget msg456 = messages.resolveTemplate("id", 456);
+ * // New target for http://example.org/messages/456
+ * WebTarget msg456 = messages.resolveTemplate("id", 456);
  * </pre>
  *
- *<h2>Generic Invocations</h2>
- * An {@link javax.ws.rs.client.Invocation} is a request that has been prepared
- * and is ready for execution.
- * Invocations provide a generic interface that enables a separation of concerns
- * between the creator and the submitter. In particular, the submitter does not
- * need to know how the invocation was prepared, but only whether it should be
- * executed synchronously or asynchronously.
+ * <h2>Generic Invocations</h2> An {@link javax.ws.rs.client.Invocation} is a request that has been prepared and is
+ * ready for execution. Invocations provide a generic interface that enables a separation of concerns between the
+ * creator and the submitter. In particular, the submitter does not need to know how the invocation was prepared, but
+ * only whether it should be executed synchronously or asynchronously.
+ *
  * <pre>
  *   Invocation inv1 = client.target("http://example.org/atm/balance")
  *       .queryParam("card", "111122223333").queryParam("pin", "9876")

--- a/jaxrs-api/src/main/java/javax/ws/rs/container/AsyncResponse.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/container/AsyncResponse.java
@@ -22,30 +22,26 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 /**
- * An injectable JAX-RS asynchronous response that provides means for asynchronous server side
- * response processing.
+ * An injectable JAX-RS asynchronous response that provides means for asynchronous server side response processing.
  * <p>
- * A new instance of {@code AsyncResponse} may be injected into a
- * {@link javax.ws.rs.HttpMethod resource or sub-resource method} parameter using
- * the {@link Suspended &#64;Suspended} annotation.
+ * A new instance of {@code AsyncResponse} may be injected into a {@link javax.ws.rs.HttpMethod resource or sub-resource
+ * method} parameter using the {@link Suspended &#64;Suspended} annotation.
  * </p>
- * Each asynchronous response instance is bound to the running request and can be used to
- * asynchronously provide the request processing result or otherwise manipulate the suspended
- * client connection. The available operations include:
+ * Each asynchronous response instance is bound to the running request and can be used to asynchronously provide the
+ * request processing result or otherwise manipulate the suspended client connection. The available operations include:
  * <ul>
  * <li>updating suspended state data (time-out value, response ...)</li>
  * <li>resuming the suspended request processing</li>
  * <li>canceling the suspended request processing</li>
  * </ul>
  * <p>
- * Following example demonstrates the use of the {@code AsyncResponse} for asynchronous
- * HTTP request processing:
+ * Following example demonstrates the use of the {@code AsyncResponse} for asynchronous HTTP request processing:
  * </p>
+ *
  * <pre>
  * &#64;Path("/messages/next")
  * public class MessagingResource {
- *     private static final BlockingQueue&lt;AsyncResponse&gt; suspended =
- *             new ArrayBlockingQueue&lt;AsyncResponse&gt;(5);
+ *     private static final BlockingQueue&lt;AsyncResponse&gt; suspended = new ArrayBlockingQueue&lt;AsyncResponse&gt;(5);
  *
  *     &#64;GET
  *     public void readMessage(&#64;Suspended AsyncResponse ar) throws InterruptedException {
@@ -61,16 +57,15 @@ import java.util.concurrent.TimeUnit;
  * }
  * </pre>
  * <p>
- * If the asynchronous response was suspended with a positive timeout value, and has
- * not been explicitly resumed before the timeout has expired, the processing
- * will be resumed once the specified timeout threshold is reached, provided a positive
- * timeout value was set on the response.
+ * If the asynchronous response was suspended with a positive timeout value, and has not been explicitly resumed before
+ * the timeout has expired, the processing will be resumed once the specified timeout threshold is reached, provided a
+ * positive timeout value was set on the response.
  * </p>
  * <p>
- * By default a timed-out asynchronous response is resumed with a {@link javax.ws.rs.WebApplicationException}
- * that has {@link javax.ws.rs.core.Response.Status#SERVICE_UNAVAILABLE HTTP 503 (Service unavailable)}
- * error response status code set. This default behavior may be overridden by
- * {@link AsyncResponse#setTimeoutHandler(TimeoutHandler) setting} a custom {@link TimeoutHandler time-out handler}.
+ * By default a timed-out asynchronous response is resumed with a {@link javax.ws.rs.WebApplicationException} that has
+ * {@link javax.ws.rs.core.Response.Status#SERVICE_UNAVAILABLE HTTP 503 (Service unavailable)} error response status
+ * code set. This default behavior may be overridden by {@link AsyncResponse#setTimeoutHandler(TimeoutHandler) setting}
+ * a custom {@link TimeoutHandler time-out handler}.
  * </p>
  *
  * @author Marek Potociar
@@ -85,26 +80,23 @@ public interface AsyncResponse {
     /**
      * Resume the suspended request processing using the provided response data.
      *
-     * The provided response data can be of any Java type that can be
-     * returned from a {@link javax.ws.rs.HttpMethod JAX-RS resource method}.
+     * The provided response data can be of any Java type that can be returned from a {@link javax.ws.rs.HttpMethod JAX-RS
+     * resource method}.
      * <p>
-     * The asynchronous response must be still in a {@link #isSuspended() suspended} state
-     * for this method to succeed.
+     * The asynchronous response must be still in a {@link #isSuspended() suspended} state for this method to succeed.
      * </p>
      * <p>
-     * By executing this method, the request is guaranteed to complete either successfully or
-     * with an error. The data processing by the JAX-RS runtime follows the same path
-     * as it would for the response data returned synchronously by a JAX-RS resource,
-     * except that unmapped exceptions are not re-thrown by JAX-RS runtime to be handled by
-     * a hosting I/O container. Instead, any unmapped exceptions are propagated to the hosting
-     * I/O container via a container-specific callback mechanism. Depending on the container
-     * implementation, propagated unmapped exceptions typically result in an error status
-     * being sent to the client and/or the connection being closed.
+     * By executing this method, the request is guaranteed to complete either successfully or with an error. The data
+     * processing by the JAX-RS runtime follows the same path as it would for the response data returned synchronously by a
+     * JAX-RS resource, except that unmapped exceptions are not re-thrown by JAX-RS runtime to be handled by a hosting I/O
+     * container. Instead, any unmapped exceptions are propagated to the hosting I/O container via a container-specific
+     * callback mechanism. Depending on the container implementation, propagated unmapped exceptions typically result in an
+     * error status being sent to the client and/or the connection being closed.
      * </p>
      *
      * @param response data to be sent back in response to the suspended request.
-     * @return {@code true} if the request processing has been resumed, returns {@code false} in case
-     *         the request processing is not {@link #isSuspended() suspended} and could not be resumed.
+     * @return {@code true} if the request processing has been resumed, returns {@code false} in case the request processing
+     * is not {@link #isSuspended() suspended} and could not be resumed.
      * @see #resume(Throwable)
      */
     public boolean resume(Object response);
@@ -112,23 +104,20 @@ public interface AsyncResponse {
     /**
      * Resume the suspended request processing using the provided throwable.
      *
-     * For the provided throwable same rules apply as for an exception thrown
-     * by a {@link javax.ws.rs.HttpMethod JAX-RS resource method}.
+     * For the provided throwable same rules apply as for an exception thrown by a {@link javax.ws.rs.HttpMethod JAX-RS
+     * resource method}.
      * <p>
-     * By executing this method, the request is guaranteed to complete either successfully or
-     * with an error. The throwable processing by the JAX-RS runtime follows the same path
-     * as it would for the response data returned synchronously by a JAX-RS resource,
-     * except that unmapped exceptions are not re-thrown by JAX-RS runtime to be handled by
-     * a hosting I/O container. Instead, any unmapped exceptions are propagated to the hosting
-     * I/O container via a container-specific callback mechanism. Depending on the container
-     * implementation, propagated unmapped exceptions typically result in an error status
-     * being sent to the client and/or the connection being closed.
+     * By executing this method, the request is guaranteed to complete either successfully or with an error. The throwable
+     * processing by the JAX-RS runtime follows the same path as it would for the response data returned synchronously by a
+     * JAX-RS resource, except that unmapped exceptions are not re-thrown by JAX-RS runtime to be handled by a hosting I/O
+     * container. Instead, any unmapped exceptions are propagated to the hosting I/O container via a container-specific
+     * callback mechanism. Depending on the container implementation, propagated unmapped exceptions typically result in an
+     * error status being sent to the client and/or the connection being closed.
      * </p>
      *
-     * @param response an exception to be raised in response to the suspended
-     *                 request.
-     * @return {@code true} if the response has been resumed, returns {@code false} in case
-     *         the response is not {@link #isSuspended() suspended} and could not be resumed.
+     * @param response an exception to be raised in response to the suspended request.
+     * @return {@code true} if the response has been resumed, returns {@code false} in case the response is not
+     * {@link #isSuspended() suspended} and could not be resumed.
      * @see #resume(Object)
      */
     public boolean resume(Throwable response);
@@ -136,23 +125,21 @@ public interface AsyncResponse {
     /**
      * Cancel the suspended request processing.
      * <p>
-     * When a request processing is cancelled using this method, the JAX-RS implementation
-     * MUST indicate to the client that the request processing has been cancelled by sending
-     * back a {@link javax.ws.rs.core.Response.Status#SERVICE_UNAVAILABLE HTTP 503 (Service unavailable)}
-     * error response.
+     * When a request processing is cancelled using this method, the JAX-RS implementation MUST indicate to the client that
+     * the request processing has been cancelled by sending back a
+     * {@link javax.ws.rs.core.Response.Status#SERVICE_UNAVAILABLE HTTP 503 (Service unavailable)} error response.
      * </p>
      * <p>
-     * Invoking a {@code cancel(...)} method multiple times to cancel request processing has the same
-     * effect as canceling the request processing only once. Invoking a {@code cancel(...)} method on
-     * an asynchronous response instance that has already been cancelled or resumed has no effect and the
-     * method call is ignored while returning {@code true}, in case the request has been cancelled previously.
-     * Otherwise, in case the request has been resumed regularly (using a {@code resume(...) method}) or
-     * resumed due to a time-out, method returns {@code false}.
+     * Invoking a {@code cancel(...)} method multiple times to cancel request processing has the same effect as canceling
+     * the request processing only once. Invoking a {@code cancel(...)} method on an asynchronous response instance that has
+     * already been cancelled or resumed has no effect and the method call is ignored while returning {@code true}, in case
+     * the request has been cancelled previously. Otherwise, in case the request has been resumed regularly (using a
+     * {@code resume(...) method}) or resumed due to a time-out, method returns {@code false}.
      * </p>
      *
-     * @return {@code true} if the request processing has been cancelled, returns {@code false} in case
-     *         the request processing is not {@link #isSuspended() suspended} and could not be cancelled
-     *         and is not {@link #isCancelled() cancelled} already.
+     * @return {@code true} if the request processing has been cancelled, returns {@code false} in case the request
+     * processing is not {@link #isSuspended() suspended} and could not be cancelled and is not {@link #isCancelled()
+     * cancelled} already.
      * @see #cancel(int)
      * @see #cancel(java.util.Date)
      */
@@ -161,27 +148,24 @@ public interface AsyncResponse {
     /**
      * Cancel the suspended request processing.
      * <p>
-     * When a request processing is cancelled using this method, the JAX-RS implementation
-     * MUST indicate to the client that the request processing has been cancelled by sending
-     * back a {@link javax.ws.rs.core.Response.Status#SERVICE_UNAVAILABLE HTTP 503 (Service unavailable)}
-     * error response with a {@code Retry-After} header set to the value provided by the method
-     * parameter.
+     * When a request processing is cancelled using this method, the JAX-RS implementation MUST indicate to the client that
+     * the request processing has been cancelled by sending back a
+     * {@link javax.ws.rs.core.Response.Status#SERVICE_UNAVAILABLE HTTP 503 (Service unavailable)} error response with a
+     * {@code Retry-After} header set to the value provided by the method parameter.
      * </p>
      * <p>
-     * Invoking a {@code cancel(...)} method multiple times to cancel request processing has the same
-     * effect as canceling the request processing only once. Invoking a {@code cancel(...)} method on
-     * an asynchronous response instance that has already been cancelled or resumed has no effect and the
-     * method call is ignored while returning {@code true}, in case the request has been cancelled previously.
-     * Otherwise, in case the request has been resumed regularly (using a {@code resume(...) method}) or
-     * resumed due to a time-out, method returns {@code false}.
+     * Invoking a {@code cancel(...)} method multiple times to cancel request processing has the same effect as canceling
+     * the request processing only once. Invoking a {@code cancel(...)} method on an asynchronous response instance that has
+     * already been cancelled or resumed has no effect and the method call is ignored while returning {@code true}, in case
+     * the request has been cancelled previously. Otherwise, in case the request has been resumed regularly (using a
+     * {@code resume(...) method}) or resumed due to a time-out, method returns {@code false}.
      * </p>
      *
-     * @param retryAfter a decimal integer number of seconds after the response is sent to the client that
-     *                   indicates how long the service is expected to be unavailable to the requesting
-     *                   client.
-     * @return {@code true} if the request processing has been cancelled, returns {@code false} in case
-     *         the request processing is not {@link #isSuspended() suspended} and could not be cancelled
-     *         and is not {@link #isCancelled() cancelled} already.
+     * @param retryAfter a decimal integer number of seconds after the response is sent to the client that indicates how
+     * long the service is expected to be unavailable to the requesting client.
+     * @return {@code true} if the request processing has been cancelled, returns {@code false} in case the request
+     * processing is not {@link #isSuspended() suspended} and could not be cancelled and is not {@link #isCancelled()
+     * cancelled} already.
      * @see #cancel
      * @see #cancel(java.util.Date)
      */
@@ -190,26 +174,23 @@ public interface AsyncResponse {
     /**
      * Cancel the suspended request processing.
      * <p>
-     * When a request processing is cancelled using this method, the JAX-RS implementation
-     * MUST indicate to the client that the request processing has been cancelled by sending
-     * back a {@link javax.ws.rs.core.Response.Status#SERVICE_UNAVAILABLE HTTP 503 (Service unavailable)}
-     * error response with a {@code Retry-After} header set to the value provided by the method
-     * parameter.
+     * When a request processing is cancelled using this method, the JAX-RS implementation MUST indicate to the client that
+     * the request processing has been cancelled by sending back a
+     * {@link javax.ws.rs.core.Response.Status#SERVICE_UNAVAILABLE HTTP 503 (Service unavailable)} error response with a
+     * {@code Retry-After} header set to the value provided by the method parameter.
      * </p>
      * <p>
-     * Invoking a {@code cancel(...)} method multiple times to cancel request processing has the same
-     * effect as canceling the request processing only once. Invoking a {@code cancel(...)} method on
-     * an asynchronous response instance that has already been cancelled or resumed has no effect and the
-     * method call is ignored while returning {@code true}, in case the request has been cancelled previously.
-     * Otherwise, in case the request has been resumed regularly (using a {@code resume(...) method}) or
-     * resumed due to a time-out, method returns {@code false}.
+     * Invoking a {@code cancel(...)} method multiple times to cancel request processing has the same effect as canceling
+     * the request processing only once. Invoking a {@code cancel(...)} method on an asynchronous response instance that has
+     * already been cancelled or resumed has no effect and the method call is ignored while returning {@code true}, in case
+     * the request has been cancelled previously. Otherwise, in case the request has been resumed regularly (using a
+     * {@code resume(...) method}) or resumed due to a time-out, method returns {@code false}.
      * </p>
      *
-     * @param retryAfter a date that indicates how long the service is expected to be unavailable to the
-     *                   requesting client.
-     * @return {@code true} if the request processing has been cancelled, returns {@code false} in case
-     *         the request processing is not {@link #isSuspended() suspended} and could not be cancelled
-     *         and is not {@link #isCancelled() cancelled} already.
+     * @param retryAfter a date that indicates how long the service is expected to be unavailable to the requesting client.
+     * @return {@code true} if the request processing has been cancelled, returns {@code false} in case the request
+     * processing is not {@link #isSuspended() suspended} and could not be cancelled and is not {@link #isCancelled()
+     * cancelled} already.
      * @see #cancel
      * @see #cancel(int)
      */
@@ -218,11 +199,10 @@ public interface AsyncResponse {
     /**
      * Check if the asynchronous response instance is in a suspended state.
      *
-     * Method returns {@code true} if this asynchronous response is still suspended and has
-     * not finished processing yet (either by resuming or canceling the response).
+     * Method returns {@code true} if this asynchronous response is still suspended and has not finished processing yet
+     * (either by resuming or canceling the response).
      *
-     * @return {@code true} if this asynchronous response is in a suspend state, {@code false}
-     *         otherwise.
+     * @return {@code true} if this asynchronous response is in a suspend state, {@code false} otherwise.
      * @see #isCancelled()
      * @see #isDone()
      */
@@ -231,8 +211,7 @@ public interface AsyncResponse {
     /**
      * Check if the asynchronous response instance has been cancelled.
      *
-     * Method returns {@code true} if this asynchronous response has been canceled before
-     * completion.
+     * Method returns {@code true} if this asynchronous response has been canceled before completion.
      *
      * @return {@code true} if this task was canceled before completion.
      * @see #isSuspended()
@@ -241,14 +220,12 @@ public interface AsyncResponse {
     public boolean isCancelled();
 
     /**
-     * Check if the processing of a request this asynchronous response instance belongs to
-     * has finished.
+     * Check if the processing of a request this asynchronous response instance belongs to has finished.
      *
-     * Method returns {@code true} if the processing of a request this asynchronous response
-     * is bound to is finished.
+     * Method returns {@code true} if the processing of a request this asynchronous response is bound to is finished.
      * <p>
-     * The request processing may be finished due to a normal termination, a suspend timeout, or
-     * cancellation -- in all of these cases, this method will return {@code true}.
+     * The request processing may be finished due to a normal termination, a suspend timeout, or cancellation -- in all of
+     * these cases, this method will return {@code true}.
      * </p>
      *
      * @return {@code true} if this execution context has finished processing.
@@ -260,25 +237,23 @@ public interface AsyncResponse {
     /**
      * Set/update the suspend timeout.
      * <p>
-     * The new suspend timeout values override any timeout value previously specified.
-     * The asynchronous response must be still in a {@link #isSuspended() suspended} state
-     * for this method to succeed.
+     * The new suspend timeout values override any timeout value previously specified. The asynchronous response must be
+     * still in a {@link #isSuspended() suspended} state for this method to succeed.
      * </p>
      *
-     * @param time suspend timeout value in the give time {@code unit}. Value lower
-     *             or equal to 0 causes the context to suspend indefinitely.
+     * @param time suspend timeout value in the give time {@code unit}. Value lower or equal to 0 causes the context to
+     * suspend indefinitely.
      * @param unit suspend timeout value time unit.
-     * @return {@code true} if the suspend time out has been set, returns {@code false} in case
-     *         the request processing is not in the {@link #isSuspended() suspended} state.
+     * @return {@code true} if the suspend time out has been set, returns {@code false} in case the request processing is
+     * not in the {@link #isSuspended() suspended} state.
      */
     public boolean setTimeout(long time, TimeUnit unit);
 
     /**
      * Set/replace a time-out handler for the suspended asynchronous response.
      * <p>
-     * The time-out handler will be invoked when the suspend period of this
-     * asynchronous response times out. The job of the time-out handler is to
-     * resolve the time-out situation by either
+     * The time-out handler will be invoked when the suspend period of this asynchronous response times out. The job of the
+     * time-out handler is to resolve the time-out situation by either
      * </p>
      * <ul>
      * <li>resuming the suspended response</li>
@@ -286,8 +261,8 @@ public interface AsyncResponse {
      * <li>extending the suspend period by setting a new suspend time-out</li>
      * </ul>
      * <p>
-     * Note that in case the response is suspended {@link #NO_TIMEOUT indefinitely},
-     * the time-out handler may never be invoked.
+     * Note that in case the response is suspended {@link #NO_TIMEOUT indefinitely}, the time-out handler may never be
+     * invoked.
      * </p>
      *
      * @param handler response time-out handler.
@@ -295,52 +270,49 @@ public interface AsyncResponse {
     public void setTimeoutHandler(TimeoutHandler handler);
 
     /**
-     * Register an asynchronous processing lifecycle callback class to receive lifecycle
-     * events for the asynchronous response based on the implemented callback interfaces.
+     * Register an asynchronous processing lifecycle callback class to receive lifecycle events for the asynchronous
+     * response based on the implemented callback interfaces.
      *
      * @param callback callback class.
-     * @return collection of registered callback interfaces. If the callback class does not
-     *         implement any recognized callback interfaces, the returned collection will be
-     *         empty.
+     * @return collection of registered callback interfaces. If the callback class does not implement any recognized
+     * callback interfaces, the returned collection will be empty.
      * @throws NullPointerException in case the callback class is {@code null}.
      */
     public Collection<Class<?>> register(Class<?> callback);
 
     /**
-     * Register asynchronous processing lifecycle callback classes to receive lifecycle
-     * events for the asynchronous response based on the implemented callback interfaces.
+     * Register asynchronous processing lifecycle callback classes to receive lifecycle events for the asynchronous response
+     * based on the implemented callback interfaces.
      *
-     * @param callback  callback class.
+     * @param callback callback class.
      * @param callbacks additional callback classes.
-     * @return map of registered classes and the callback interfaces registered for each class.
-     *         If a callback class does not implement any recognized callback interfaces, the
-     *         associated collection of registered interfaces for the class will be empty.
+     * @return map of registered classes and the callback interfaces registered for each class. If a callback class does not
+     * implement any recognized callback interfaces, the associated collection of registered interfaces for the class will
+     * be empty.
      * @throws NullPointerException in case any of the callback classes is {@code null}.
      */
     public Map<Class<?>, Collection<Class<?>>> register(Class<?> callback, Class<?>... callbacks);
 
     /**
-     * Register an asynchronous processing lifecycle callback instance to receive lifecycle
-     * events for the asynchronous response based on the implemented callback interfaces.
+     * Register an asynchronous processing lifecycle callback instance to receive lifecycle events for the asynchronous
+     * response based on the implemented callback interfaces.
      *
-     * @param callback callback instance implementing one or more of the recognized callback
-     *                 interfaces.
-     * @return collection of registered callback interfaces. If the callback class does not
-     *         implement any recognized callback interfaces, the returned collection will be
-     *         empty.
+     * @param callback callback instance implementing one or more of the recognized callback interfaces.
+     * @return collection of registered callback interfaces. If the callback class does not implement any recognized
+     * callback interfaces, the returned collection will be empty.
      * @throws NullPointerException in case the callback instance is {@code null}.
      */
     public Collection<Class<?>> register(Object callback);
 
     /**
-     * Register an asynchronous processing lifecycle callback instances to receive lifecycle
-     * events for the asynchronous response based on the implemented callback interfaces.
+     * Register an asynchronous processing lifecycle callback instances to receive lifecycle events for the asynchronous
+     * response based on the implemented callback interfaces.
      *
-     * @param callback  callback instance.
+     * @param callback callback instance.
      * @param callbacks additional callback instances.
-     * @return map of registered classes and the callback interfaces registered for each class.
-     *         If a callback class does not implement any recognized callback interfaces, the
-     *         associated collection of registered interfaces for the class will be empty.
+     * @return map of registered classes and the callback interfaces registered for each class. If a callback class does not
+     * implement any recognized callback interfaces, the associated collection of registered interfaces for the class will
+     * be empty.
      * @throws NullPointerException in case any of the callback instances is {@code null}.
      */
     public Map<Class<?>, Collection<Class<?>>> register(Object callback, Object... callbacks);

--- a/jaxrs-api/src/main/java/javax/ws/rs/container/CompletionCallback.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/container/CompletionCallback.java
@@ -19,9 +19,9 @@ package javax.ws.rs.container;
 /**
  * A request processing callback that receives request processing completion events.
  * <p>
- * A completion callback is invoked when the whole request processing is over, i.e.
- * once a response for the request has been processed and sent back to the client
- * or in when an unmapped exception or error is being propagated to the container.
+ * A completion callback is invoked when the whole request processing is over, i.e. once a response for the request has
+ * been processed and sent back to the client or in when an unmapped exception or error is being propagated to the
+ * container.
  * </p>
  *
  * @author Marek Potociar
@@ -29,24 +29,20 @@ package javax.ws.rs.container;
  */
 public interface CompletionCallback {
     /**
-     * A completion callback notification method that will be invoked when the request
-     * processing is finished, after a response is processed and is sent back to the
-     * client or when an unmapped throwable has been propagated to the hosting I/O
-     * container.
+     * A completion callback notification method that will be invoked when the request processing is finished, after a
+     * response is processed and is sent back to the client or when an unmapped throwable has been propagated to the hosting
+     * I/O container.
      * <p>
-     * An unmapped throwable is propagated to the hosting I/O container in case no
-     * {@link javax.ws.rs.ext.ExceptionMapper exception mapper} has been found for
-     * a throwable indicating a request processing failure.
-     * In this case a non-{@code null} unmapped throwable instance is passed to the method.
-     * Note that the throwable instance represents the actual unmapped exception thrown
-     * during the request processing, before it has been wrapped into an I/O container-specific
-     * exception that was used to propagate the throwable to the hosting I/O container.
+     * An unmapped throwable is propagated to the hosting I/O container in case no {@link javax.ws.rs.ext.ExceptionMapper
+     * exception mapper} has been found for a throwable indicating a request processing failure. In this case a
+     * non-{@code null} unmapped throwable instance is passed to the method. Note that the throwable instance represents the
+     * actual unmapped exception thrown during the request processing, before it has been wrapped into an I/O
+     * container-specific exception that was used to propagate the throwable to the hosting I/O container.
      * </p>
      *
-     * @param throwable is {@code null}, if the request processing has completed with a response
-     *                  that has been sent to the client. In case the request processing resulted
-     *                  in an unmapped exception or error that has been propagated to the hosting
-     *                  I/O container, this parameter contains the unmapped exception instance.
+     * @param throwable is {@code null}, if the request processing has completed with a response that has been sent to the
+     * client. In case the request processing resulted in an unmapped exception or error that has been propagated to the
+     * hosting I/O container, this parameter contains the unmapped exception instance.
      */
     public void onComplete(Throwable throwable);
 }

--- a/jaxrs-api/src/main/java/javax/ws/rs/container/ConnectionCallback.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/container/ConnectionCallback.java
@@ -17,8 +17,8 @@
 package javax.ws.rs.container;
 
 /**
- * Asynchronous request processing lifecycle callback that receives connection
- * related {@link AsyncResponse asynchronous response} lifecycle events.
+ * Asynchronous request processing lifecycle callback that receives connection related {@link AsyncResponse asynchronous
+ * response} lifecycle events.
  * <p>
  * Support for this type of callback by JAX-RS runtime is OPTIONAL.
  * </p>
@@ -28,12 +28,10 @@ package javax.ws.rs.container;
  */
 public interface ConnectionCallback {
     /**
-     * This callback notification method is invoked in case the container detects
-     * that the remote client connection associated with the asynchronous response
-     * has been disconnected.
+     * This callback notification method is invoked in case the container detects that the remote client connection
+     * associated with the asynchronous response has been disconnected.
      *
-     * @param disconnected asynchronous response for which the remote client connection
-     *                     has been lost.
+     * @param disconnected asynchronous response for which the remote client connection has been lost.
      */
     public void onDisconnect(AsyncResponse disconnected);
 }

--- a/jaxrs-api/src/main/java/javax/ws/rs/container/ContainerRequestContext.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/container/ContainerRequestContext.java
@@ -35,9 +35,8 @@ import javax.ws.rs.core.UriInfo;
 /**
  * Container request filter context.
  *
- * A mutable class that provides request-specific information for the filter,
- * such as request URI, message headers, message entity or request-scoped
- * properties. The exposed setters allow modification of the exposed request-specific
+ * A mutable class that provides request-specific information for the filter, such as request URI, message headers,
+ * message entity or request-scoped properties. The exposed setters allow modification of the exposed request-specific
  * information.
  *
  * @author Marek Potociar
@@ -46,42 +45,39 @@ import javax.ws.rs.core.UriInfo;
 public interface ContainerRequestContext {
 
     /**
-     * Returns the property with the given name registered in the current request/response
-     * exchange context, or {@code null} if there is no property by that name.
+     * Returns the property with the given name registered in the current request/response exchange context, or {@code null}
+     * if there is no property by that name.
      * <p>
-     * A property allows a JAX-RS filters and interceptors to exchange
-     * additional custom information not already provided by this interface.
+     * A property allows a JAX-RS filters and interceptors to exchange additional custom information not already provided by
+     * this interface.
      * </p>
      * <p>
-     * A list of supported properties can be retrieved using {@link #getPropertyNames()}.
-     * Custom property names should follow the same convention as package names.
+     * A list of supported properties can be retrieved using {@link #getPropertyNames()}. Custom property names should
+     * follow the same convention as package names.
      * </p>
      * <p>
-     * In a Servlet container, the properties are synchronized with the {@code ServletRequest}
-     * and expose all the attributes available in the {@code ServletRequest}. Any modifications
-     * of the properties are also reflected in the set of properties of the associated
-     * {@code ServletRequest}.
+     * In a Servlet container, the properties are synchronized with the {@code ServletRequest} and expose all the attributes
+     * available in the {@code ServletRequest}. Any modifications of the properties are also reflected in the set of
+     * properties of the associated {@code ServletRequest}.
      * </p>
      *
      * @param name a {@code String} specifying the name of the property.
-     * @return an {@code Object} containing the value of the property, or
-     *         {@code null} if no property exists matching the given name.
+     * @return an {@code Object} containing the value of the property, or {@code null} if no property exists matching the
+     * given name.
      * @see #getPropertyNames()
      */
     public Object getProperty(String name);
 
     /**
-     * Returns an immutable {@link java.util.Collection collection} containing the property
-     * names available within the context of the current request/response exchange context.
+     * Returns an immutable {@link java.util.Collection collection} containing the property names available within the
+     * context of the current request/response exchange context.
      * <p>
-     * Use the {@link #getProperty} method with a property name to get the value of
-     * a property.
+     * Use the {@link #getProperty} method with a property name to get the value of a property.
      * </p>
      * <p>
-     * In a Servlet container, the properties are synchronized with the {@code ServletRequest}
-     * and expose all the attributes available in the {@code ServletRequest}. Any modifications
-     * of the properties are also reflected in the set of properties of the associated
-     * {@code ServletRequest}.
+     * In a Servlet container, the properties are synchronized with the {@code ServletRequest} and expose all the attributes
+     * available in the {@code ServletRequest}. Any modifications of the properties are also reflected in the set of
+     * properties of the associated {@code ServletRequest}.
      * </p>
      *
      * @return an immutable {@link java.util.Collection collection} of property names.
@@ -90,42 +86,37 @@ public interface ContainerRequestContext {
     public Collection<String> getPropertyNames();
 
     /**
-     * Binds an object to a given property name in the current request/response
-     * exchange context. If the name specified is already used for a property,
-     * this method will replace the value of the property with the new value.
+     * Binds an object to a given property name in the current request/response exchange context. If the name specified is
+     * already used for a property, this method will replace the value of the property with the new value.
      * <p>
-     * A property allows a JAX-RS filters and interceptors to exchange
-     * additional custom information not already provided by this interface.
+     * A property allows a JAX-RS filters and interceptors to exchange additional custom information not already provided by
+     * this interface.
      * </p>
      * <p>
-     * A list of supported properties can be retrieved using {@link #getPropertyNames()}.
-     * Custom property names should follow the same convention as package names.
+     * A list of supported properties can be retrieved using {@link #getPropertyNames()}. Custom property names should
+     * follow the same convention as package names.
      * </p>
      * <p>
-     * If a {@code null} value is passed, the effect is the same as calling the
-     * {@link #removeProperty(String)} method.
+     * If a {@code null} value is passed, the effect is the same as calling the {@link #removeProperty(String)} method.
      * </p>
      * <p>
-     * In a Servlet container, the properties are synchronized with the {@code ServletRequest}
-     * and expose all the attributes available in the {@code ServletRequest}. Any modifications
-     * of the properties are also reflected in the set of properties of the associated
-     * {@code ServletRequest}.
+     * In a Servlet container, the properties are synchronized with the {@code ServletRequest} and expose all the attributes
+     * available in the {@code ServletRequest}. Any modifications of the properties are also reflected in the set of
+     * properties of the associated {@code ServletRequest}.
      * </p>
      *
-     * @param name   a {@code String} specifying the name of the property.
+     * @param name a {@code String} specifying the name of the property.
      * @param object an {@code Object} representing the property to be bound.
      */
     public void setProperty(String name, Object object);
 
     /**
-     * Removes a property with the given name from the current request/response
-     * exchange context. After removal, subsequent calls to {@link #getProperty}
-     * to retrieve the property value will return {@code null}.
+     * Removes a property with the given name from the current request/response exchange context. After removal, subsequent
+     * calls to {@link #getProperty} to retrieve the property value will return {@code null}.
      * <p>
-     * In a Servlet container, the properties are synchronized with the {@code ServletRequest}
-     * and expose all the attributes available in the {@code ServletRequest}. Any modifications
-     * of the properties are also reflected in the set of properties of the associated
-     * {@code ServletRequest}.
+     * In a Servlet container, the properties are synchronized with the {@code ServletRequest} and expose all the attributes
+     * available in the {@code ServletRequest}. Any modifications of the properties are also reflected in the set of
+     * properties of the associated {@code ServletRequest}.
      * </p>
      *
      * @param name a {@code String} specifying the name of the property to be removed.
@@ -135,45 +126,40 @@ public interface ContainerRequestContext {
     /**
      * Get request URI information.
      *
-     * The returned object contains "live" view of the request URI information in
-     * a sense that any changes made to the request URI using one of the
-     * {@code setRequestUri(...)} methods will be reflected in the previously
-     * returned {@link UriInfo} instance.
+     * The returned object contains "live" view of the request URI information in a sense that any changes made to the
+     * request URI using one of the {@code setRequestUri(...)} methods will be reflected in the previously returned
+     * {@link UriInfo} instance.
      *
      * @return request URI information.
      */
     public UriInfo getUriInfo();
 
     /**
-     * Set a new request URI using the current base URI of the application to
-     * resolve the application-specific request URI part.
+     * Set a new request URI using the current base URI of the application to resolve the application-specific request URI
+     * part.
      * <p>
-     * Note that the method is usable only in pre-matching filters, prior to the resource
-     * matching occurs. Trying to invoke the method in a filter bound to a resource method
-     * results in an {@link IllegalStateException} being thrown.
+     * Note that the method is usable only in pre-matching filters, prior to the resource matching occurs. Trying to invoke
+     * the method in a filter bound to a resource method results in an {@link IllegalStateException} being thrown.
      * </p>
      *
      * @param requestUri new URI of the request.
-     * @throws IllegalStateException in case the method is not invoked from a {@link PreMatching pre-matching}
-     *                               request filter.
+     * @throws IllegalStateException in case the method is not invoked from a {@link PreMatching pre-matching} request
+     * filter.
      * @see #setRequestUri(java.net.URI, java.net.URI)
      */
     public void setRequestUri(URI requestUri);
 
     /**
-     * Set a new request URI using a new base URI to resolve the application-specific
-     * request URI part.
+     * Set a new request URI using a new base URI to resolve the application-specific request URI part.
      * <p>
-     * Note that the method is usable only in pre-matching filters, prior to the resource
-     * matching occurs. Trying to invoke the method in a filter bound to a resource method
-     * results in an {@link IllegalStateException} being thrown.
+     * Note that the method is usable only in pre-matching filters, prior to the resource matching occurs. Trying to invoke
+     * the method in a filter bound to a resource method results in an {@link IllegalStateException} being thrown.
      * </p>
      *
-     * @param baseUri    base URI that will be used to resolve the application-specific
-     *                   part of the request URI.
+     * @param baseUri base URI that will be used to resolve the application-specific part of the request URI.
      * @param requestUri new URI of the request.
-     * @throws IllegalStateException in case the method is not invoked from a {@link PreMatching pre-matching}
-     *                               request filter.
+     * @throws IllegalStateException in case the method is not invoked from a {@link PreMatching pre-matching} request
+     * filter.
      * @see #setRequestUri(java.net.URI)
      */
     public void setRequestUri(URI baseUri, URI requestUri);
@@ -196,14 +182,13 @@ public interface ContainerRequestContext {
     /**
      * Set the request method.
      * <p>
-     * Note that the method is usable only in pre-matching filters, prior to the resource
-     * matching occurs. Trying to invoke the method in a filter bound to a resource method
-     * results in an {@link IllegalStateException} being thrown.
+     * Note that the method is usable only in pre-matching filters, prior to the resource matching occurs. Trying to invoke
+     * the method in a filter bound to a resource method results in an {@link IllegalStateException} being thrown.
      * </p>
      *
      * @param method new request method.
-     * @throws IllegalStateException in case the method is not invoked from a {@link PreMatching pre-matching}
-     *                               request filter.
+     * @throws IllegalStateException in case the method is not invoked from a {@link PreMatching pre-matching} request
+     * filter.
      * @see javax.ws.rs.HttpMethod
      */
     public void setMethod(String method);
@@ -220,11 +205,9 @@ public interface ContainerRequestContext {
      * Get a message header as a single string value.
      *
      * @param name the message header.
-     * @return the message header value. If the message header is not present then
-     *         {@code null} is returned. If the message header is present but has no
-     *         value then the empty string is returned. If the message header is present
-     *         more than once then the values of joined together and separated by a ','
-     *         character.
+     * @return the message header value. If the message header is not present then {@code null} is returned. If the message
+     * header is present but has no value then the empty string is returned. If the message header is present more than once
+     * then the values of joined together and separated by a ',' character.
      * @see #getHeaders()
      */
     public String getHeaderString(String name);
@@ -246,32 +229,29 @@ public interface ContainerRequestContext {
     /**
      * Get Content-Length value.
      *
-     * @return Content-Length as integer if present and valid number. In other
-     *         cases returns {@code -1}.
+     * @return Content-Length as integer if present and valid number. In other cases returns {@code -1}.
      */
     public int getLength();
 
     /**
      * Get the media type of the entity.
      *
-     * @return the media type or {@code null} if not specified (e.g. there's no
-     *         request entity).
+     * @return the media type or {@code null} if not specified (e.g. there's no request entity).
      */
     public MediaType getMediaType();
 
     /**
      * Get a list of media types that are acceptable for the response.
      *
-     * @return a read-only list of requested response media types sorted according
-     *         to their q-value, with highest preference first.
+     * @return a read-only list of requested response media types sorted according to their q-value, with highest preference
+     * first.
      */
     public List<MediaType> getAcceptableMediaTypes();
 
     /**
      * Get a list of languages that are acceptable for the response.
      *
-     * @return a read-only list of acceptable languages sorted according
-     *         to their q-value, with highest preference first.
+     * @return a read-only list of acceptable languages sorted according to their q-value, with highest preference first.
      */
     public List<Locale> getAcceptableLanguages();
 
@@ -283,28 +263,23 @@ public interface ContainerRequestContext {
     public Map<String, Cookie> getCookies();
 
     /**
-     * Check if there is a non-empty entity input stream  available in the request
-     * message.
+     * Check if there is a non-empty entity input stream available in the request message.
      *
-     * The method returns {@code true} if the entity is present, returns
-     * {@code false} otherwise.
+     * The method returns {@code true} if the entity is present, returns {@code false} otherwise.
      *
-     * @return {@code true} if there is an entity present in the message,
-     *         {@code false} otherwise.
+     * @return {@code true} if there is an entity present in the message, {@code false} otherwise.
      */
     public boolean hasEntity();
 
     /**
-     * Get the entity input stream. The JAX-RS runtime is responsible for
-     * closing the input stream.
+     * Get the entity input stream. The JAX-RS runtime is responsible for closing the input stream.
      *
      * @return entity input stream.
      */
     public InputStream getEntityStream();
 
     /**
-     * Set a new entity input stream. The JAX-RS runtime is responsible for
-     * closing the input stream.
+     * Set a new entity input stream. The JAX-RS runtime is responsible for closing the input stream.
      *
      * @param input new entity input stream.
      * @throws IllegalStateException in case the method is invoked from a response filter.
@@ -314,8 +289,8 @@ public interface ContainerRequestContext {
     /**
      * Get the injectable security context information for the current request.
      *
-     * The {@link SecurityContext#getUserPrincipal()} must return {@code null}
-     * if the current request has not been authenticated.
+     * The {@link SecurityContext#getUserPrincipal()} must return {@code null} if the current request has not been
+     * authenticated.
      *
      * @return injectable request security context information.
      */
@@ -324,8 +299,8 @@ public interface ContainerRequestContext {
     /**
      * Set a new injectable security context information for the current request.
      *
-     * The {@link SecurityContext#getUserPrincipal()} must return {@code null}
-     * if the current request has not been authenticated.
+     * The {@link SecurityContext#getUserPrincipal()} must return {@code null} if the current request has not been
+     * authenticated.
      *
      * @param context new injectable request security context information.
      * @throws IllegalStateException in case the method is invoked from a response filter.
@@ -335,9 +310,8 @@ public interface ContainerRequestContext {
     /**
      * Abort the filter chain with a response.
      *
-     * This method breaks the filter chain processing and returns the provided
-     * response back to the client. The provided response goes through the
-     * chain of applicable response filters.
+     * This method breaks the filter chain processing and returns the provided response back to the client. The provided
+     * response goes through the chain of applicable response filters.
      *
      * @param response response to be sent back to the client.
      * @throws IllegalStateException in case the method is invoked from a response filter.

--- a/jaxrs-api/src/main/java/javax/ws/rs/container/ContainerRequestFilter.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/container/ContainerRequestFilter.java
@@ -21,31 +21,26 @@ import java.io.IOException;
 /**
  * An extension interface implemented by container request filters.
  * <p>
- * By default, i.e. if no {@link javax.ws.rs.NameBinding name binding} is applied
- * to the filter implementation class, the filter instance is applied globally,
- * however only after the incoming request has been matched to a particular resource
- * by JAX-RS runtime.
- * If there is a {@link javax.ws.rs.NameBinding &#64;NameBinding} annotation
- * applied to the filter, the filter will also be executed at the <i>post-match</i>
- * request extension point, but only in case the matched {@link javax.ws.rs.HttpMethod
- * resource or sub-resource method} is bound to the same name-binding annotation.
+ * By default, i.e. if no {@link javax.ws.rs.NameBinding name binding} is applied to the filter implementation class,
+ * the filter instance is applied globally, however only after the incoming request has been matched to a particular
+ * resource by JAX-RS runtime. If there is a {@link javax.ws.rs.NameBinding &#64;NameBinding} annotation applied to the
+ * filter, the filter will also be executed at the <i>post-match</i> request extension point, but only in case the
+ * matched {@link javax.ws.rs.HttpMethod resource or sub-resource method} is bound to the same name-binding annotation.
  * </p>
  * <p>
- * In case the filter should be applied at the <i>pre-match</i> extension point,
- * i.e. before any request matching has been performed by JAX-RS runtime, the
- * filter MUST be annotated with a {@link PreMatching &#64;PreMatching} annotation.
+ * In case the filter should be applied at the <i>pre-match</i> extension point, i.e. before any request matching has
+ * been performed by JAX-RS runtime, the filter MUST be annotated with a {@link PreMatching &#64;PreMatching}
+ * annotation.
  * </p>
  * <p>
- * Use a pre-match request filter to update the input to the JAX-RS matching algorithm,
- * e.g., the HTTP method, Accept header, return cached responses etc. Otherwise,
- * the use of a request filter invoked at the <i>post-match</i> request extension point
- * (after a successful resource method matching) is recommended.
+ * Use a pre-match request filter to update the input to the JAX-RS matching algorithm, e.g., the HTTP method, Accept
+ * header, return cached responses etc. Otherwise, the use of a request filter invoked at the <i>post-match</i> request
+ * extension point (after a successful resource method matching) is recommended.
  * </p>
  * <p>
- * Filters implementing this interface must be annotated with
- * {@link javax.ws.rs.ext.Provider &#64;Provider} to be discovered by the JAX-RS
- * runtime. Container request filter instances may also be discovered and
- * bound {@link DynamicFeature dynamically} to particular resource methods.
+ * Filters implementing this interface must be annotated with {@link javax.ws.rs.ext.Provider &#64;Provider} to be
+ * discovered by the JAX-RS runtime. Container request filter instances may also be discovered and bound
+ * {@link DynamicFeature dynamically} to particular resource methods.
  * </p>
  *
  * @author Marek Potociar
@@ -60,16 +55,13 @@ public interface ContainerRequestFilter {
      * Filter method called before a request has been dispatched to a resource.
      *
      * <p>
-     * Filters in the filter chain are ordered according to their {@code javax.annotation.Priority}
-     * class-level annotation value.
-     * If a request filter produces a response by calling {@link ContainerRequestContext#abortWith}
-     * method, the execution of the (either pre-match or post-match) request filter
-     * chain is stopped and the response is passed to the corresponding response
-     * filter chain (either pre-match or post-match). For example, a pre-match
-     * caching filter may produce a response in this way, which would effectively
-     * skip any post-match request filters as well as post-match response filters.
-     * Note however that a responses produced in this manner would still be processed
-     * by the pre-match response filter chain.
+     * Filters in the filter chain are ordered according to their {@code javax.annotation.Priority} class-level annotation
+     * value. If a request filter produces a response by calling {@link ContainerRequestContext#abortWith} method, the
+     * execution of the (either pre-match or post-match) request filter chain is stopped and the response is passed to the
+     * corresponding response filter chain (either pre-match or post-match). For example, a pre-match caching filter may
+     * produce a response in this way, which would effectively skip any post-match request filters as well as post-match
+     * response filters. Note however that a responses produced in this manner would still be processed by the pre-match
+     * response filter chain.
      * </p>
      *
      * @param requestContext request context.

--- a/jaxrs-api/src/main/java/javax/ws/rs/container/ContainerResponseContext.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/container/ContainerResponseContext.java
@@ -36,10 +36,8 @@ import javax.ws.rs.ext.MessageBodyWriter;
 /**
  * Container response filter context.
  *
- * A mutable class that provides response-specific information for the filter,
- * such as message headers, message entity or request-scoped properties.
- * The exposed setters allow modification of the exposed response-specific
- * information.
+ * A mutable class that provides response-specific information for the filter, such as message headers, message entity
+ * or request-scoped properties. The exposed setters allow modification of the exposed response-specific information.
  *
  * @author Marek Potociar
  * @since 2.0
@@ -63,14 +61,12 @@ public interface ContainerResponseContext {
     /**
      * Get the complete status information associated with the response.
      *
-     * @return the response status information or {@code null} if the status was
-     *         not set.
+     * @return the response status information or {@code null} if the status was not set.
      */
     public Response.StatusType getStatusInfo();
 
     /**
-     * Set the complete status information (status code and reason phrase) associated
-     * with the response.
+     * Set the complete status information (status code and reason phrase) associated with the response.
      *
      * @param statusInfo the response status information.
      */
@@ -88,14 +84,12 @@ public interface ContainerResponseContext {
     /**
      * Get a string view of header values associated with the message.
      *
-     * Changes in the underlying {@link #getHeaders() headers map} are reflected
-     * in this view.
+     * Changes in the underlying {@link #getHeaders() headers map} are reflected in this view.
      * <p>
      * The method converts the non-string header values to strings using a
      * {@link javax.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one is available via
-     * {@link javax.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the
-     * class of the value or using the values {@code toString} method if a header delegate is
-     * not available.
+     * {@link javax.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the class of the value or using the
+     * values {@code toString} method if a header delegate is not available.
      * </p>
      *
      * @return response headers as a string view of header values.
@@ -107,18 +101,14 @@ public interface ContainerResponseContext {
     /**
      * Get a message header as a single string value.
      *
-     * Each single header value is converted to String using a
-     * {@link javax.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one is available
-     * via {@link javax.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)}
-     * for the header value class or using its {@code toString} method  if a header
-     * delegate is not available.
+     * Each single header value is converted to String using a {@link javax.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one
+     * is available via {@link javax.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the header value
+     * class or using its {@code toString} method if a header delegate is not available.
      *
      * @param name the message header.
-     * @return the message header value. If the message header is not present then
-     *         {@code null} is returned. If the message header is present but has no
-     *         value then the empty string is returned. If the message header is present
-     *         more than once then the values of joined together and separated by a ','
-     *         character.
+     * @return the message header value. If the message header is not present then {@code null} is returned. If the message
+     * header is present but has no value then the empty string is returned. If the message header is present more than once
+     * then the values of joined together and separated by a ',' character.
      * @see #getHeaders()
      * @see #getStringHeaders()
      */
@@ -127,8 +117,7 @@ public interface ContainerResponseContext {
     /**
      * Get the allowed HTTP methods from the Allow HTTP header.
      *
-     * @return the allowed HTTP methods, all methods will returned as upper case
-     *         strings.
+     * @return the allowed HTTP methods, all methods will returned as upper case strings.
      */
     public Set<String> getAllowedMethods();
 
@@ -149,16 +138,14 @@ public interface ContainerResponseContext {
     /**
      * Get Content-Length value.
      *
-     * @return Content-Length as integer if present and valid number. In other
-     *         cases returns -1.
+     * @return Content-Length as integer if present and valid number. In other cases returns -1.
      */
     public int getLength();
 
     /**
      * Get the media type of the entity.
      *
-     * @return the media type or {@code null} if not specified (e.g. there's no
-     *         response entity).
+     * @return the media type or {@code null} if not specified (e.g. there's no response entity).
      */
     public MediaType getMediaType();
 
@@ -193,8 +180,7 @@ public interface ContainerResponseContext {
     /**
      * Get the links attached to the message as header.
      *
-     * @return links, may return empty {@link Set} if no links are present. Never
-     *         returns {@code null}.
+     * @return links, may return empty {@link Set} if no links are present. Never returns {@code null}.
      */
     public Set<Link> getLinks();
 
@@ -202,8 +188,7 @@ public interface ContainerResponseContext {
      * Check if link for relation exists.
      *
      * @param relation link relation.
-     * @return {@code true} if the for the relation link exists, {@code false}
-     *         otherwise.
+     * @return {@code true} if the for the relation link exists, {@code false} otherwise.
      */
     boolean hasLink(String relation);
 
@@ -216,23 +201,19 @@ public interface ContainerResponseContext {
     public Link getLink(String relation);
 
     /**
-     * Convenience method that returns a {@link javax.ws.rs.core.Link.Builder Link.Builder}
-     * for the relation.
+     * Convenience method that returns a {@link javax.ws.rs.core.Link.Builder Link.Builder} for the relation.
      *
      * @param relation link relation.
-     * @return the link builder for the relation, otherwise {@code null} if not
-     *         present.
+     * @return the link builder for the relation, otherwise {@code null} if not present.
      */
     public Link.Builder getLinkBuilder(String relation);
 
     /**
      * Check if there is an entity available in the response.
      *
-     * The method returns {@code true} if the entity is present, returns
-     * {@code false} otherwise.
+     * The method returns {@code true} if the entity is present, returns {@code false} otherwise.
      *
-     * @return {@code true} if there is an entity present in the message,
-     *         {@code false} otherwise.
+     * @return {@code true} if there is an entity present in the message, {@code false} otherwise.
      */
     public boolean hasEntity();
 
@@ -241,8 +222,7 @@ public interface ContainerResponseContext {
      *
      * Returns {@code null} if the message does not contain an entity.
      *
-     * @return the message entity or {@code null} if message does not contain an
-     *         entity body.
+     * @return the message entity or {@code null} if message does not contain an entity body.
      */
     public Object getEntity();
 
@@ -261,12 +241,11 @@ public interface ContainerResponseContext {
     public Type getEntityType();
 
     /**
-     * Set a new message entity. The existing entity {@link #getEntityAnnotations() annotations}
-     * and {@link #getMediaType() media type} are preserved.
+     * Set a new message entity. The existing entity {@link #getEntityAnnotations() annotations} and {@link #getMediaType()
+     * media type} are preserved.
      * <p>
-     * It is the callers responsibility to wrap the actual entity with
-     * {@link javax.ws.rs.core.GenericEntity} if preservation of its generic
-     * type is required.
+     * It is the callers responsibility to wrap the actual entity with {@link javax.ws.rs.core.GenericEntity} if
+     * preservation of its generic type is required.
      * </p>
      *
      * @param entity entity object.
@@ -278,14 +257,13 @@ public interface ContainerResponseContext {
     /**
      * Set a new message entity, including the attached annotations and the media type.
      * <p>
-     * It is the callers responsibility to wrap the actual entity with
-     * {@link javax.ws.rs.core.GenericEntity} if preservation of its generic
-     * type is required.
+     * It is the callers responsibility to wrap the actual entity with {@link javax.ws.rs.core.GenericEntity} if
+     * preservation of its generic type is required.
      * </p>
      *
-     * @param entity      entity object.
+     * @param entity entity object.
      * @param annotations annotations attached to the entity instance.
-     * @param mediaType   entity media type.
+     * @param mediaType entity media type.
      * @see #setEntity(Object)
      * @see MessageBodyWriter
      */
@@ -297,21 +275,21 @@ public interface ContainerResponseContext {
     /**
      * Get the annotations attached to the entity instance.
      * <p>
-     * Note that the returned annotations array contains only those annotations
-     * explicitly attached to entity instance (such as the ones attached using
-     * {@link javax.ws.rs.core.Response.ResponseBuilder#entity(Object, java.lang.annotation.Annotation[])} method
-     * as well as the ones attached to the resource method that has returned the response).
-     * The entity instance annotations array does not include annotations declared on the entity
-     * implementation class or its ancestors.
+     * Note that the returned annotations array contains only those annotations explicitly attached to entity instance (such
+     * as the ones attached using
+     * {@link javax.ws.rs.core.Response.ResponseBuilder#entity(Object, java.lang.annotation.Annotation[])} method as well as
+     * the ones attached to the resource method that has returned the response). The entity instance annotations array does
+     * not include annotations declared on the entity implementation class or its ancestors.
      * </p>
      * <p>
-     * Note that container response filters invoked earlier in the filter chain may modify the entity annotations value,
-     * in which case this getter method would return the last annotations value set by a container response filter invoked
+     * Note that container response filters invoked earlier in the filter chain may modify the entity annotations value, in
+     * which case this getter method would return the last annotations value set by a container response filter invoked
      * earlier in the filter chain.
      * </p>
      * <p>
      * For example:
      * </p>
+     *
      * <pre>
      * &#64;Path("my-resource")
      * public class MyResource {
@@ -326,14 +304,15 @@ public interface ContainerResponseContext {
      * }
      * </pre>
      * <p>
-     * The container response context for a response returned from the {@code getMe()} method above would contain all
-     * the annotations declared on the {@code getAnnotatedMe()} method (<tt>&#64;GET, &#64;Custom</tt>) as well as all
-     * the annotations from the {@code extras} field, provided this value has not been replaced by any container response filter
+     * The container response context for a response returned from the {@code getMe()} method above would contain all the
+     * annotations declared on the {@code getAnnotatedMe()} method (<tt>&#64;GET, &#64;Custom</tt>) as well as all the
+     * annotations from the {@code extras} field, provided this value has not been replaced by any container response filter
      * invoked earlier.
      * </p>
      * <p>
      * Similarly:
      * </p>
+     *
      * <pre>
      * &#64;Custom
      * public class AnnotatedMe { ... }
@@ -350,10 +329,10 @@ public interface ContainerResponseContext {
      * }
      * </pre>
      * <p>
-     * Provided that the value has not been replaced by any container response filter invoked earlier,
-     * the container response context for a response returned from the {@code getMe()} method above would contain all
-     * the annotations on the {@code getMe()} method (<tt>&#64;GET</tt>) as well as all the annotations from the
-     * {@code extras} field. It would however not contain any annotations declared on the {@code AnnotatedMe} class.
+     * Provided that the value has not been replaced by any container response filter invoked earlier, the container
+     * response context for a response returned from the {@code getMe()} method above would contain all the annotations on
+     * the {@code getMe()} method (<tt>&#64;GET</tt>) as well as all the annotations from the {@code extras} field. It would
+     * however not contain any annotations declared on the {@code AnnotatedMe} class.
      * </p>
      *
      * @return annotations attached to the entity instance.
@@ -361,16 +340,14 @@ public interface ContainerResponseContext {
     public Annotation[] getEntityAnnotations();
 
     /**
-     * Get the entity output stream. The JAX-RS runtime is responsible for
-     * closing the output stream.
+     * Get the entity output stream. The JAX-RS runtime is responsible for closing the output stream.
      *
      * @return entity output stream.
      */
     public OutputStream getEntityStream();
 
     /**
-     * Set a new entity output stream. The JAX-RS runtime is responsible for
-     * closing the output stream.
+     * Set a new entity output stream. The JAX-RS runtime is responsible for closing the output stream.
      *
      * @param outputStream new entity output stream.
      */

--- a/jaxrs-api/src/main/java/javax/ws/rs/container/ContainerResponseFilter.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/container/ContainerResponseFilter.java
@@ -21,26 +21,21 @@ import java.io.IOException;
 /**
  * An extension interface implemented by container response filters.
  * <p>
- * By default, i.e. if no {@link javax.ws.rs.NameBinding name binding} is applied
- * to the filter implementation class, the filter instance is applied globally to
- * any outgoing response.
- * If there is a {@code @NameBinding} annotation applied to the filter, the filter
- * will only be executed for a response for which the request has been matched to
- * a {@link javax.ws.rs.HttpMethod resource or sub-resource method} AND the method
- * or the whole custom {@link javax.ws.rs.core.Application JAX-RS Application} class
- * is bound to the same name-binding annotation.
+ * By default, i.e. if no {@link javax.ws.rs.NameBinding name binding} is applied to the filter implementation class,
+ * the filter instance is applied globally to any outgoing response. If there is a {@code @NameBinding} annotation
+ * applied to the filter, the filter will only be executed for a response for which the request has been matched to a
+ * {@link javax.ws.rs.HttpMethod resource or sub-resource method} AND the method or the whole custom
+ * {@link javax.ws.rs.core.Application JAX-RS Application} class is bound to the same name-binding annotation.
  * </p>
  * <p>
- * Implement a name-bound response filter in cases when you want limit the filter
- * functionality to a matched resource or resource method. In other cases,
- * when the filter should be applied globally to any outgoing response, implement an
+ * Implement a name-bound response filter in cases when you want limit the filter functionality to a matched resource or
+ * resource method. In other cases, when the filter should be applied globally to any outgoing response, implement an
  * unbound, global response filter.
  * </p>
  * <p>
- * Filters implementing this interface must be annotated with
- * {@link javax.ws.rs.ext.Provider &#64;Provider} to be discovered by the JAX-RS
- * runtime. Container response filter instances may also be discovered and
- * bound {@link DynamicFeature dynamically} to particular resource methods.
+ * Filters implementing this interface must be annotated with {@link javax.ws.rs.ext.Provider &#64;Provider} to be
+ * discovered by the JAX-RS runtime. Container response filter instances may also be discovered and bound
+ * {@link DynamicFeature dynamically} to particular resource methods.
  * </p>
  *
  * @author Marek Potociar
@@ -51,15 +46,14 @@ import java.io.IOException;
 public interface ContainerResponseFilter {
 
     /**
-     * Filter method called after a response has been provided for a request
-     * (either by a {@link ContainerRequestFilter request filter} or by a
-     * matched resource method.
+     * Filter method called after a response has been provided for a request (either by a {@link ContainerRequestFilter
+     * request filter} or by a matched resource method.
      * <p>
-     * Filters in the filter chain are ordered according to their {@code javax.annotation.Priority}
-     * class-level annotation value.
+     * Filters in the filter chain are ordered according to their {@code javax.annotation.Priority} class-level annotation
+     * value.
      * </p>
      *
-     * @param requestContext  request context.
+     * @param requestContext request context.
      * @param responseContext response context.
      * @throws IOException if an I/O exception occurs.
      */

--- a/jaxrs-api/src/main/java/javax/ws/rs/container/DynamicFeature.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/container/DynamicFeature.java
@@ -21,17 +21,16 @@ import javax.ws.rs.ext.ReaderInterceptor;
 import javax.ws.rs.ext.WriterInterceptor;
 
 /**
- * A JAX-RS meta-provider for dynamic registration of <i>post-matching</i> providers
- * during a JAX-RS application setup at deployment time.
+ * A JAX-RS meta-provider for dynamic registration of <i>post-matching</i> providers during a JAX-RS application setup
+ * at deployment time.
  *
- * Dynamic feature is used by JAX-RS runtime to register providers that shall be applied
- * to a particular resource class and method and overrides any annotation-based binding
- * definitions defined on any registered resource filter or interceptor instance.
+ * Dynamic feature is used by JAX-RS runtime to register providers that shall be applied to a particular resource class
+ * and method and overrides any annotation-based binding definitions defined on any registered resource filter or
+ * interceptor instance.
  * <p>
- * Providers implementing this interface MAY be annotated with
- * {@link javax.ws.rs.ext.Provider &#64;Provider} annotation in order to be
- * discovered by JAX-RS runtime when scanning for resources and providers.
- * This provider types is supported only as part of the Server API.
+ * Providers implementing this interface MAY be annotated with {@link javax.ws.rs.ext.Provider &#64;Provider} annotation
+ * in order to be discovered by JAX-RS runtime when scanning for resources and providers. This provider types is
+ * supported only as part of the Server API.
  * </p>
  *
  * @author Santiago Pericas-Geertsen
@@ -43,14 +42,12 @@ import javax.ws.rs.ext.WriterInterceptor;
 public interface DynamicFeature {
 
     /**
-     * A callback method called by the JAX-RS runtime during the application
-     * deployment to register provider instances or classes in a
-     * {@link javax.ws.rs.core.Configuration runtime configuration} scope of a particular {@link javax.ws.rs.HttpMethod
-     * resource or sub-resource method}; i.e. the providers that should be dynamically bound
+     * A callback method called by the JAX-RS runtime during the application deployment to register provider instances or
+     * classes in a {@link javax.ws.rs.core.Configuration runtime configuration} scope of a particular
+     * {@link javax.ws.rs.HttpMethod resource or sub-resource method}; i.e. the providers that should be dynamically bound
      * to the method.
      * <p>
-     * The registered provider instances or classes are expected to be implementing one
-     * or more of the following interfaces:
+     * The registered provider instances or classes are expected to be implementing one or more of the following interfaces:
      * </p>
      * <ul>
      * <li>{@link ContainerRequestFilter}</li>
@@ -60,25 +57,21 @@ public interface DynamicFeature {
      * <li>{@link javax.ws.rs.core.Feature}</li>
      * </ul>
      * <p>
-     * A provider instance or class that does not implement any of the interfaces
-     * above may be ignored by the JAX-RS implementation. In such case a
-     * {@link java.util.logging.Level#WARNING warning} message must be logged.
-     * JAX-RS implementations may support additional provider contracts that
-     * can be registered using a dynamic feature concept.
+     * A provider instance or class that does not implement any of the interfaces above may be ignored by the JAX-RS
+     * implementation. In such case a {@link java.util.logging.Level#WARNING warning} message must be logged. JAX-RS
+     * implementations may support additional provider contracts that can be registered using a dynamic feature concept.
      * </p>
      * <p>
-     * Conceptually, this callback method is called during a {@link javax.ws.rs.HttpMethod
-     * resource or sub-resource method} discovery phase (typically once per each discovered
-     * resource or sub-resource method) to register provider instances or classes in a
-     * {@code configuration} scope of each particular method identified by the supplied
-     * {@link ResourceInfo resource information}.
-     * The responsibility of the feature is to properly update the supplied {@code configuration}
+     * Conceptually, this callback method is called during a {@link javax.ws.rs.HttpMethod resource or sub-resource method}
+     * discovery phase (typically once per each discovered resource or sub-resource method) to register provider instances
+     * or classes in a {@code configuration} scope of each particular method identified by the supplied {@link ResourceInfo
+     * resource information}. The responsibility of the feature is to properly update the supplied {@code configuration}
      * context.
      * </p>
      *
      * @param resourceInfo resource class and method information.
-     * @param context      configurable resource or sub-resource method-level runtime context
-     *                     associated with the {@code resourceInfo} in which the feature
+     * @param context configurable resource or sub-resource method-level runtime context associated with the
+     * {@code resourceInfo} in which the feature
      */
     public void configure(ResourceInfo resourceInfo, FeatureContext context);
 }

--- a/jaxrs-api/src/main/java/javax/ws/rs/container/PreMatching.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/container/PreMatching.java
@@ -23,20 +23,18 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Global binding annotation that can be applied to a {@link ContainerRequestFilter
- * container request filter} to indicate that such filter should be applied globally
- * on all resources in the application before the actual resource matching occurs.
+ * Global binding annotation that can be applied to a {@link ContainerRequestFilter container request filter} to
+ * indicate that such filter should be applied globally on all resources in the application before the actual resource
+ * matching occurs.
  * <p>
- * The JAX-RS runtime will apply the filters marked with the {@code @PreMatching}
- * annotation globally to all resources, before the incoming request has been matched
- * to a particular resource method.
- * Any {@link javax.ws.rs.NameBinding named binding annotations} will be ignored on
- * a component annotated with the {@code @PreMatching} annotation.
+ * The JAX-RS runtime will apply the filters marked with the {@code @PreMatching} annotation globally to all resources,
+ * before the incoming request has been matched to a particular resource method. Any {@link javax.ws.rs.NameBinding
+ * named binding annotations} will be ignored on a component annotated with the {@code @PreMatching} annotation.
  * </p>
  *
  * @author Marek Potociar
  */
-@Target({ElementType.TYPE})
+@Target({ ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface PreMatching {

--- a/jaxrs-api/src/main/java/javax/ws/rs/container/ResourceContext.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/container/ResourceContext.java
@@ -24,10 +24,9 @@ import javax.ws.rs.core.Context;
  * This interface can be injected using the {@link Context} annotation.
  * </p>
  * <p>
- * The resource context can be utilized when instances of managed resource
- * classes are to be returned by sub-resource locator methods. Such instances
- * will be injected and managed within the declared scope just like instances
- * of root resource classes.
+ * The resource context can be utilized when instances of managed resource classes are to be returned by sub-resource
+ * locator methods. Such instances will be injected and managed within the declared scope just like instances of root
+ * resource classes.
  * </p>
  *
  * @author Marek Potociar
@@ -37,13 +36,12 @@ public interface ResourceContext {
     /**
      * Get a resolved instance of a resource or sub-resource class.
      * <p>
-     * The resolved resource instance is properly initialized in the context of the
-     * current request processing scope. The scope of the resolved resource instance
-     * depends on the managing container. For resources managed by JAX-RS container
+     * The resolved resource instance is properly initialized in the context of the current request processing scope. The
+     * scope of the resolved resource instance depends on the managing container. For resources managed by JAX-RS container
      * the default scope is per-request.
      * </p>
      *
-     * @param <T>           the type of the resource class.
+     * @param <T> the type of the resource class.
      * @param resourceClass the resource class.
      * @return an instance if it could be resolved, otherwise {@code null}.
      */
@@ -52,10 +50,10 @@ public interface ResourceContext {
     /**
      * Initialize the resource or sub-resource instance.
      *
-     * All JAX-RS injectable fields in the resource instance will be properly initialized in
-     * the context of the current request processing scope.
+     * All JAX-RS injectable fields in the resource instance will be properly initialized in the context of the current
+     * request processing scope.
      *
-     * @param <T>      resource instance type.
+     * @param <T> resource instance type.
      * @param resource resource instance.
      * @return initialized (same) resource instance.
      */

--- a/jaxrs-api/src/main/java/javax/ws/rs/container/ResourceInfo.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/container/ResourceInfo.java
@@ -19,11 +19,9 @@ package javax.ws.rs.container;
 import java.lang.reflect.Method;
 
 /**
- * An injectable class to access the resource class and resource method
- * matched by the current request. Methods in this class MAY return
- * <code>null</code> if a resource class and method have not been matched,
- * e.g. in a standalone, pre-matching {@link ContainerRequestFilter} that was
- * not provided by a post-matching {@link PreMatching}.
+ * An injectable class to access the resource class and resource method matched by the current request. Methods in this
+ * class MAY return <code>null</code> if a resource class and method have not been matched, e.g. in a standalone,
+ * pre-matching {@link ContainerRequestFilter} that was not provided by a post-matching {@link PreMatching}.
  *
  * @author Santiago Pericas-Geertsen
  * @since 2.0
@@ -31,8 +29,7 @@ import java.lang.reflect.Method;
 public interface ResourceInfo {
 
     /**
-     * Get the resource method that is the target of a request,
-     * or <code>null</code> if this information is not available.
+     * Get the resource method that is the target of a request, or <code>null</code> if this information is not available.
      *
      * @return resource method instance or null
      * @see #getResourceClass()
@@ -40,8 +37,7 @@ public interface ResourceInfo {
     Method getResourceMethod();
 
     /**
-     * Get the resource class that is the target of a request,
-     * or <code>null</code> if this information is not available.
+     * Get the resource class that is the target of a request, or <code>null</code> if this information is not available.
      *
      * @return resource class instance or null
      * @see #getResourceMethod()

--- a/jaxrs-api/src/main/java/javax/ws/rs/container/Suspended.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/container/Suspended.java
@@ -24,19 +24,18 @@ import java.lang.annotation.Target;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Inject a suspended {@link AsyncResponse} into a parameter of an invoked
- * JAX-RS {@link javax.ws.rs.HttpMethod resource or sub-resource method}.
+ * Inject a suspended {@link AsyncResponse} into a parameter of an invoked JAX-RS {@link javax.ws.rs.HttpMethod resource
+ * or sub-resource method}.
  *
- * The injected {@code AsyncResponse} instance is bound to the processing
- * of the active request and can be used to resume the request processing when
- * a response is available.
+ * The injected {@code AsyncResponse} instance is bound to the processing of the active request and can be used to
+ * resume the request processing when a response is available.
  * <p>
- * By default there is {@link AsyncResponse#NO_TIMEOUT no suspend timeout set} and
- * the asynchronous response is suspended indefinitely. The suspend timeout as well
- * as a custom {@link TimeoutHandler timeout handler} can be specified programmatically
- * using the {@link AsyncResponse#setTimeout(long, TimeUnit)} and
+ * By default there is {@link AsyncResponse#NO_TIMEOUT no suspend timeout set} and the asynchronous response is
+ * suspended indefinitely. The suspend timeout as well as a custom {@link TimeoutHandler timeout handler} can be
+ * specified programmatically using the {@link AsyncResponse#setTimeout(long, TimeUnit)} and
  * {@link AsyncResponse#setTimeoutHandler(TimeoutHandler)} methods. For example:
  * </p>
+ *
  * <pre>
  *  &#64;Stateless
  *  &#64;Path("/")
@@ -55,14 +54,13 @@ import java.util.concurrent.TimeUnit;
  *  }
  * </pre>
  * <p>
- * A resource or sub-resource method that injects a suspended instance of an
- * {@code AsyncResponse} using the {@code @Suspended} annotation is expected
- * be declared to return {@code void} type. Methods that inject asynchronous
- * response instance using the {@code @Suspended} annotation and declare a
- * return type other than {@code void} MUST be detected by the JAX-RS runtime and
- * a warning message MUST be logged. Any response value returned from such resource
+ * A resource or sub-resource method that injects a suspended instance of an {@code AsyncResponse} using the
+ * {@code @Suspended} annotation is expected be declared to return {@code void} type. Methods that inject asynchronous
+ * response instance using the {@code @Suspended} annotation and declare a return type other than {@code void} MUST be
+ * detected by the JAX-RS runtime and a warning message MUST be logged. Any response value returned from such resource
  * or sub-resource method MUST be ignored by the framework:
  * </p>
+ *
  * <pre>
  * &#64;Path("/messages/next")
  * public class MessagingResource {
@@ -79,7 +77,7 @@ import java.util.concurrent.TimeUnit;
  * @author Marek Potociar
  * @since 2.0
  */
-@Target({ElementType.PARAMETER})
+@Target({ ElementType.PARAMETER })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface Suspended {

--- a/jaxrs-api/src/main/java/javax/ws/rs/container/TimeoutHandler.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/container/TimeoutHandler.java
@@ -19,36 +19,32 @@ package javax.ws.rs.container;
 /**
  * Asynchronous response suspend time-out handler.
  *
- * JAX-RS users may utilize this callback interface to provide
- * custom resolution of time-out events.
+ * JAX-RS users may utilize this callback interface to provide custom resolution of time-out events.
  * <p>
- * By default, JAX-RS runtime generates a {@link javax.ws.rs.WebApplicationException}
- * with a {@link javax.ws.rs.core.Response.Status#SERVICE_UNAVAILABLE HTTP 503
- * (Service unavailable)} error response status code. A custom time-out handler
- * may be {@link AsyncResponse#setTimeoutHandler(TimeoutHandler) set} on an
- * asynchronous response instance to provide custom time-out event resolution.
+ * By default, JAX-RS runtime generates a {@link javax.ws.rs.WebApplicationException} with a
+ * {@link javax.ws.rs.core.Response.Status#SERVICE_UNAVAILABLE HTTP 503 (Service unavailable)} error response status
+ * code. A custom time-out handler may be {@link AsyncResponse#setTimeoutHandler(TimeoutHandler) set} on an asynchronous
+ * response instance to provide custom time-out event resolution.
  * </p>
  * <p>
- * In case of a suspend time-out event, a custom time-out handler takes typically one
- * of the following actions:
+ * In case of a suspend time-out event, a custom time-out handler takes typically one of the following actions:
  * </p>
  * <ul>
- * <li>Resumes the suspended asynchronous response using a {@link AsyncResponse#resume(Object)
- * custom response} or a {@link AsyncResponse#resume(Throwable) custom exception}</li>
- * <li>Cancels the response by calling one of the {@link AsyncResponse} {@code cancel(...)}
- * methods.</li>
+ * <li>Resumes the suspended asynchronous response using a {@link AsyncResponse#resume(Object) custom response} or a
+ * {@link AsyncResponse#resume(Throwable) custom exception}</li>
+ * <li>Cancels the response by calling one of the {@link AsyncResponse} {@code cancel(...)} methods.</li>
  * <li>Extends the suspend period of the response by
- * {@link AsyncResponse#setTimeout(long, java.util.concurrent.TimeUnit)
- * setting a new suspend time-out}</li>
+ * {@link AsyncResponse#setTimeout(long, java.util.concurrent.TimeUnit) setting a new suspend time-out}</li>
  * </ul>
  * <p>
- * If the registered time-out handler does not take any of the actions above, the
- * default time-out event processing continues and the response is resumed with
- * a generated {@code WebApplicationException} containing the HTTP 503 status code.
+ * If the registered time-out handler does not take any of the actions above, the default time-out event processing
+ * continues and the response is resumed with a generated {@code WebApplicationException} containing the HTTP 503 status
+ * code.
  * </p>
  * <p>
  * Following example illustrates the use of a custom {@code TimeoutHandler}:
  * </p>
+ *
  * <pre>
  * public class MyTimeoutHandler implements TimeoutHandler {
  *     &hellip;
@@ -84,20 +80,19 @@ public interface TimeoutHandler {
     /**
      * Invoked when the suspended asynchronous response is about to time out.
      *
-     * Implementing time-out handlers may use the callback method to change the
-     * default time-out strategy defined by JAX-RS specification (see
-     * {@link javax.ws.rs.container.AsyncResponse} API documentation).
+     * Implementing time-out handlers may use the callback method to change the default time-out strategy defined by JAX-RS
+     * specification (see {@link javax.ws.rs.container.AsyncResponse} API documentation).
      * <p>
      * A custom time-out handler may decide to either
      * </p>
      * <ul>
      * <li>resume the suspended response using one of it's {@code resume(...)} methods,</li>
      * <li>cancel the suspended response using one of it's {@code cancel(...)} methods, or</li>
-     * <li>extend the suspend period by {@link AsyncResponse#setTimeout(long, java.util.concurrent.TimeUnit)
-     * setting a new suspend time-out}</li>
+     * <li>extend the suspend period by {@link AsyncResponse#setTimeout(long, java.util.concurrent.TimeUnit) setting a new
+     * suspend time-out}</li>
      * </ul>
-     * In case the time-out handler does not take any of the actions mentioned above,
-     * a default time-out strategy is executed by the JAX-RS runtime.
+     * In case the time-out handler does not take any of the actions mentioned above, a default time-out strategy is
+     * executed by the JAX-RS runtime.
      *
      * @param asyncResponse suspended asynchronous response that is timing out.
      */

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/AbstractMultivaluedMap.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/AbstractMultivaluedMap.java
@@ -24,8 +24,8 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Abstract skeleton implementation of a {@link MultivaluedMap} that is backed
- * by a [key, multi-value] store represented as a {@link Map Map&lt;K, List&lt;V&gt;&gt;}.
+ * Abstract skeleton implementation of a {@link MultivaluedMap} that is backed by a [key, multi-value] store represented
+ * as a {@link Map Map&lt;K, List&lt;V&gt;&gt;}.
  *
  * @param <K> the type of keys maintained by this map.
  * @param <V> the type of mapped values.
@@ -39,13 +39,10 @@ public abstract class AbstractMultivaluedMap<K, V> implements MultivaluedMap<K, 
     protected final Map<K, List<V>> store;
 
     /**
-     * Initialize the backing store in the abstract parent multivalued map
-     * implementation.
+     * Initialize the backing store in the abstract parent multivalued map implementation.
      *
-     * @param store the backing {@link Map} to be used as a [key, multi-value]
-     *              store. Must not be {@code null}.
-     * @throws NullPointerException in case the underlying {@code store} parameter
-     *                              is {@code null}.
+     * @param store the backing {@link Map} to be used as a [key, multi-value] store. Must not be {@code null}.
+     * @throws NullPointerException in case the underlying {@code store} parameter is {@code null}.
      */
     public AbstractMultivaluedMap(final Map<K, List<V>> store) {
         if (store == null) {
@@ -55,18 +52,16 @@ public abstract class AbstractMultivaluedMap<K, V> implements MultivaluedMap<K, 
     }
 
     /**
-     * <p>Set the value for the key to be a one item list consisting of the supplied
-     * value. Any existing values will be replaced.
+     * <p>
+     * Set the value for the key to be a one item list consisting of the supplied value. Any existing values will be
+     * replaced.
      * </p>
-     * NOTE: This implementation ignores {@code null} values; A supplied value
-     * of {@code null} is ignored and not added to the purged value list.
-     * As a result of such operation, empty value list would  be registered for
-     * the supplied key. Overriding implementations may modify this behavior by
-     * redefining the {@link #addNull(java.util.List)} method.
+     * NOTE: This implementation ignores {@code null} values; A supplied value of {@code null} is ignored and not added to
+     * the purged value list. As a result of such operation, empty value list would be registered for the supplied key.
+     * Overriding implementations may modify this behavior by redefining the {@link #addNull(java.util.List)} method.
      *
-     * @param key   the key
-     * @param value the single value of the key. If the value is {@code null} it
-     *              will be ignored.
+     * @param key the key
+     * @param value the single value of the key. If the value is {@code null} it will be ignored.
      */
     @Override
     public final void putSingle(final K key, final V value) {
@@ -81,14 +76,13 @@ public abstract class AbstractMultivaluedMap<K, V> implements MultivaluedMap<K, 
     }
 
     /**
-     * <p>Define the behavior for adding a {@code null} values to the value list.
+     * <p>
+     * Define the behavior for adding a {@code null} values to the value list.
      * </p>
-     * Default implementation is a no-op, i.e. the {@code null} values are ignored.
-     * Overriding implementations may modify this behavior by providing their
-     * own definitions of this method.
+     * Default implementation is a no-op, i.e. the {@code null} values are ignored. Overriding implementations may modify
+     * this behavior by providing their own definitions of this method.
      *
-     * @param values value list where the {@code null} value addition is being
-     *               requested.
+     * @param values value list where the {@code null} value addition is being requested.
      */
     @SuppressWarnings("UnusedParameters")
     protected void addNull(final List<V> values) {
@@ -96,15 +90,13 @@ public abstract class AbstractMultivaluedMap<K, V> implements MultivaluedMap<K, 
     }
 
     /**
-     * <p>Define the behavior for adding a {@code null} values to the first position
-     * in the value list.
+     * <p>
+     * Define the behavior for adding a {@code null} values to the first position in the value list.
      * </p>
-     * Default implementation is a no-op, i.e. the {@code null} values are ignored.
-     * Overriding implementations may modify this behavior by providing their
-     * own definitions of this method.
+     * Default implementation is a no-op, i.e. the {@code null} values are ignored. Overriding implementations may modify
+     * this behavior by providing their own definitions of this method.
      *
-     * @param values value list where the {@code null} value addition is being
-     *               requested.
+     * @param values value list where the {@code null} value addition is being requested.
      */
     @SuppressWarnings("UnusedParameters")
     protected void addFirstNull(final List<V> values) {
@@ -112,14 +104,14 @@ public abstract class AbstractMultivaluedMap<K, V> implements MultivaluedMap<K, 
     }
 
     /**
-     * <p>Add a value to the current list of values for the supplied key.
+     * <p>
+     * Add a value to the current list of values for the supplied key.
      * </p>
-     * NOTE: This implementation ignores {@code null} values; A supplied value
-     * of {@code null} is ignored and not added to the value list. Overriding
-     * implementations may modify this behavior by redefining the
+     * NOTE: This implementation ignores {@code null} values; A supplied value of {@code null} is ignored and not added to
+     * the value list. Overriding implementations may modify this behavior by redefining the
      * {@link #addNull(java.util.List)} method.
      *
-     * @param key   the key
+     * @param key the key
      * @param value the value to be added.
      */
     @Override
@@ -134,17 +126,16 @@ public abstract class AbstractMultivaluedMap<K, V> implements MultivaluedMap<K, 
     }
 
     /**
-     * <p>Add multiple values to the current list of values for the supplied key. If
-     * the supplied array of new values is empty, method returns immediately.
-     * Method throws a {@code NullPointerException} if the supplied array of values
-     * is {@code null}.
+     * <p>
+     * Add multiple values to the current list of values for the supplied key. If the supplied array of new values is empty,
+     * method returns immediately. Method throws a {@code NullPointerException} if the supplied array of values is
+     * {@code null}.
      * </p>
-     * NOTE: This implementation ignores {@code null} values; Any of the supplied values
-     * of {@code null} is ignored and not added to the value list. Overriding
-     * implementations may modify this behavior by redefining the
+     * NOTE: This implementation ignores {@code null} values; Any of the supplied values of {@code null} is ignored and not
+     * added to the value list. Overriding implementations may modify this behavior by redefining the
      * {@link #addNull(java.util.List)} method.
      *
-     * @param key       the key.
+     * @param key the key.
      * @param newValues the values to be added.
      * @throws NullPointerException if the supplied array of new values is {@code null}.
      */
@@ -169,17 +160,16 @@ public abstract class AbstractMultivaluedMap<K, V> implements MultivaluedMap<K, 
     }
 
     /**
-     * <p>Add all the values from the supplied value list to the current list of
-     * values for the supplied key. If the supplied value list is empty, method
-     * returns immediately. Method throws a {@code NullPointerException} if the
-     * supplied array of values is {@code null}.
+     * <p>
+     * Add all the values from the supplied value list to the current list of values for the supplied key. If the supplied
+     * value list is empty, method returns immediately. Method throws a {@code NullPointerException} if the supplied array
+     * of values is {@code null}.
      * </p>
-     * NOTE: This implementation ignores {@code null} values; Any {@code null} value
-     * in the supplied value list is ignored and not added to the value list. Overriding
-     * implementations may modify this behavior by redefining the
+     * NOTE: This implementation ignores {@code null} values; Any {@code null} value in the supplied value list is ignored
+     * and not added to the value list. Overriding implementations may modify this behavior by redefining the
      * {@link #addNull(java.util.List)} method.
      *
-     * @param key       the key.
+     * @param key the key.
      * @param valueList the list of values to be added.
      * @throws NullPointerException if the supplied value list is {@code null}.
      */
@@ -214,15 +204,14 @@ public abstract class AbstractMultivaluedMap<K, V> implements MultivaluedMap<K, 
     }
 
     /**
-     * <p>Add a value to the first position in the current list of values for the
-     * supplied key.
+     * <p>
+     * Add a value to the first position in the current list of values for the supplied key.
      * </p>
-     * NOTE: This implementation ignores {@code null} values; A supplied value
-     * of {@code null} is ignored and not added to the purged value list. Overriding
-     * implementations may modify this behavior by redefining the
+     * NOTE: This implementation ignores {@code null} values; A supplied value of {@code null} is ignored and not added to
+     * the purged value list. Overriding implementations may modify this behavior by redefining the
      * {@link #addFirstNull(java.util.List)} method.
      *
-     * @param key   the key
+     * @param key the key
      * @param value the value to be added.
      */
     @Override
@@ -237,16 +226,14 @@ public abstract class AbstractMultivaluedMap<K, V> implements MultivaluedMap<K, 
     }
 
     /**
-     * <p>Return a non-null list of values for a given key. The returned list may be
-     * empty.
+     * <p>
+     * Return a non-null list of values for a given key. The returned list may be empty.
      * </p>
-     * If there is no entry for the key in the map, a new empty {@link List}
-     * instance is created, registered within the map to hold the values of
-     * the key and returned from the method.
+     * If there is no entry for the key in the map, a new empty {@link List} instance is created, registered within the map
+     * to hold the values of the key and returned from the method.
      *
      * @param key the key.
-     * @return value list registered with the key. The method is guaranteed to never
-     *         return {@code null}.
+     * @return value list registered with the key. The method is guaranteed to never return {@code null}.
      */
     protected final List<V> getValues(final K key) {
         List<V> l = store.get(key);
@@ -265,8 +252,8 @@ public abstract class AbstractMultivaluedMap<K, V> implements MultivaluedMap<K, 
     /**
      * {@inheritDoc }
      * <p>
-     * This implementation delegates the method call to to the the underlying
-     * [key, multi-value] store.</p>
+     * This implementation delegates the method call to to the the underlying [key, multi-value] store.
+     * </p>
      *
      * @return a hash code value for the underlying [key, multi-value] store.
      */
@@ -278,11 +265,11 @@ public abstract class AbstractMultivaluedMap<K, V> implements MultivaluedMap<K, 
     /**
      * {@inheritDoc }
      * <p>
-     * This implementation delegates the method call to to the the underlying
-     * [key, multi-value] store.</p>
+     * This implementation delegates the method call to to the the underlying [key, multi-value] store.
+     * </p>
      *
-     * @return {@code true} if the specified object is equal to the underlying
-     *         [key, multi-value] store, {@code false} otherwise.
+     * @return {@code true} if the specified object is equal to the underlying [key, multi-value] store, {@code false}
+     * otherwise.
      */
     @Override
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Application.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Application.java
@@ -21,18 +21,15 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Defines the components of a JAX-RS application and supplies additional
- * meta-data. A JAX-RS application or implementation supplies a concrete
- * subclass of this abstract class.
+ * Defines the components of a JAX-RS application and supplies additional meta-data. A JAX-RS application or
+ * implementation supplies a concrete subclass of this abstract class.
  * <p>
- * The implementation-created instance of an Application subclass may be
- * injected into resource classes and providers using
- * {@link javax.ws.rs.core.Context}.
+ * The implementation-created instance of an Application subclass may be injected into resource classes and providers
+ * using {@link javax.ws.rs.core.Context}.
  * </p>
  * <p>
- * In case any of the {@code Application} subclass methods or it's constructor
- * throws a {@link RuntimeException}, the deployment of the application SHOULD
- * be aborted with a failure.
+ * In case any of the {@code Application} subclass methods or it's constructor throws a {@link RuntimeException}, the
+ * deployment of the application SHOULD be aborted with a failure.
  * </p>
  *
  * @author Paul Sandoz
@@ -45,21 +42,18 @@ public class Application {
     /**
      * Get a set of root resource, provider and {@link Feature feature} classes.
      *
-     * The default life-cycle for resource class instances is per-request. The default
-     * life-cycle for providers (registered directly or via a feature) is singleton.
+     * The default life-cycle for resource class instances is per-request. The default life-cycle for providers (registered
+     * directly or via a feature) is singleton.
      * <p>
-     * Implementations should warn about and ignore classes that do not
-     * conform to the requirements of root resource or provider/feature classes.
-     * Implementations should warn about and ignore classes for which
-     * {@link #getSingletons()} returns an instance. Implementations MUST
-     * NOT modify the returned set.
+     * Implementations should warn about and ignore classes that do not conform to the requirements of root resource or
+     * provider/feature classes. Implementations should warn about and ignore classes for which {@link #getSingletons()}
+     * returns an instance. Implementations MUST NOT modify the returned set.
      * </p>
      * <p>
      * The default implementation returns an empty set.
      * </p>
      *
-     * @return a set of root resource and provider classes. Returning {@code null}
-     *         is equivalent to returning an empty set.
+     * @return a set of root resource and provider classes. Returning {@code null} is equivalent to returning an empty set.
      */
     public Set<Class<?>> getClasses() {
         return Collections.emptySet();
@@ -68,21 +62,19 @@ public class Application {
     /**
      * Get a set of root resource, provider and {@link Feature feature} instances.
      *
-     * Fields and properties of returned instances are injected with their declared
-     * dependencies (see {@link Context}) by the runtime prior to use.
+     * Fields and properties of returned instances are injected with their declared dependencies (see {@link Context}) by
+     * the runtime prior to use.
      * <p>
-     * Implementations should warn about and ignore classes that do not
-     * conform to the requirements of root resource or provider classes.
-     * Implementations should flag an error if the returned set includes
-     * more than one instance of the same class. Implementations MUST
-     * NOT modify the returned set.
+     * Implementations should warn about and ignore classes that do not conform to the requirements of root resource or
+     * provider classes. Implementations should flag an error if the returned set includes more than one instance of the
+     * same class. Implementations MUST NOT modify the returned set.
      * </p>
      * <p>
      * The default implementation returns an empty set.
      * </p>
      *
-     * @return a set of root resource and provider instances. Returning {@code null}
-     *         is equivalent to returning an empty set.
+     * @return a set of root resource and provider instances. Returning {@code null} is equivalent to returning an empty
+     * set.
      */
     public Set<Object> getSingletons() {
         return Collections.emptySet();
@@ -91,22 +83,20 @@ public class Application {
     /**
      * Get a map of custom application-wide properties.
      * <p>
-     * The returned properties are reflected in the application {@link Configuration configuration}
-     * passed to the server-side features or injected into server-side JAX-RS components.
+     * The returned properties are reflected in the application {@link Configuration configuration} passed to the
+     * server-side features or injected into server-side JAX-RS components.
      * </p>
      * <p>
-     * The set of returned properties may be further extended or customized at deployment time
-     * using container-specific features and deployment descriptors. For example, in a Servlet-based
-     * deployment scenario, web application's {@code <context-param>} and Servlet {@code <init-param>}
-     * values may be used to extend or override values of the properties programmatically returned
-     * by this method.
+     * The set of returned properties may be further extended or customized at deployment time using container-specific
+     * features and deployment descriptors. For example, in a Servlet-based deployment scenario, web application's
+     * {@code <context-param>} and Servlet {@code <init-param>} values may be used to extend or override values of the
+     * properties programmatically returned by this method.
      * </p>
      * <p>
      * The default implementation returns an empty set.
      * </p>
      *
-     * @return a map of custom application-wide properties. Returning {@code null}
-     *         is equivalent to returning an empty set.
+     * @return a map of custom application-wide properties. Returning {@code null} is equivalent to returning an empty set.
      * @since 2.0
      */
     public Map<String, Object> getProperties() {

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/CacheControl.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/CacheControl.java
@@ -39,8 +39,7 @@ public class CacheControl {
      * @deprecated This field will be removed in a future version. See https://github.com/eclipse-ee4j/jaxrs-api/issues/607
      */
     @Deprecated
-    private static final HeaderDelegate<CacheControl> HEADER_DELEGATE =
-            RuntimeDelegate.getInstance().createHeaderDelegate(CacheControl.class);
+    private static final HeaderDelegate<CacheControl> HEADER_DELEGATE = RuntimeDelegate.getInstance().createHeaderDelegate(CacheControl.class);
     private List<String> privateFields;
     private List<String> noCacheFields;
     private Map<String, String> cacheExtension;
@@ -55,8 +54,7 @@ public class CacheControl {
     private int sMaxAge = -1;
 
     /**
-     * Create a new instance of CacheControl. The new instance will have the
-     * following default settings:
+     * Create a new instance of CacheControl. The new instance will have the following default settings:
      *
      * <ul>
      * <li>private = false</li>
@@ -85,10 +83,9 @@ public class CacheControl {
      * @param value the cache control string
      * @return the newly created CacheControl
      *
-     * @throws IllegalArgumentException if the supplied string cannot be parsed
-     *                                  or is null
+     * @throws IllegalArgumentException if the supplied string cannot be parsed or is null
      * @deprecated This method will be removed in a future version. Please use
-     *   RuntimeDelegate.getInstance().createHeaderDelegate(CacheControl.class).fromString(value) instead.
+     * RuntimeDelegate.getInstance().createHeaderDelegate(CacheControl.class).fromString(value) instead.
      */
     @Deprecated
     public static CacheControl valueOf(final String value) {
@@ -98,8 +95,7 @@ public class CacheControl {
     /**
      * Corresponds to the must-revalidate cache control directive.
      *
-     * @return true if the must-revalidate cache control directive will be included in the
-     * response, false otherwise.
+     * @return true if the must-revalidate cache control directive will be included in the response, false otherwise.
      *
      * @see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.4">HTTP/1.1 section 14.9.4</a>
      */
@@ -110,8 +106,8 @@ public class CacheControl {
     /**
      * Corresponds to the must-revalidate cache control directive.
      *
-     * @param mustRevalidate true if the must-revalidate cache control directive should be included in the
-     *                       response, false otherwise.
+     * @param mustRevalidate true if the must-revalidate cache control directive should be included in the response, false
+     * otherwise.
      * @see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.4">HTTP/1.1 section 14.9.4</a>
      */
     public void setMustRevalidate(final boolean mustRevalidate) {
@@ -121,8 +117,7 @@ public class CacheControl {
     /**
      * Corresponds to the proxy-revalidate cache control directive.
      *
-     * @return true if the proxy-revalidate cache control directive will be included in the
-     * response, false otherwise.
+     * @return true if the proxy-revalidate cache control directive will be included in the response, false otherwise.
      *
      * @see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.4">HTTP/1.1 section 14.9.4</a>
      */
@@ -133,8 +128,8 @@ public class CacheControl {
     /**
      * Corresponds to the must-revalidate cache control directive.
      *
-     * @param proxyRevalidate true if the proxy-revalidate cache control directive should be included in the
-     *                        response, false otherwise.
+     * @param proxyRevalidate true if the proxy-revalidate cache control directive should be included in the response, false
+     * otherwise.
      * @see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.4">HTTP/1.1 section 14.9.4</a>
      */
     public void setProxyRevalidate(final boolean proxyRevalidate) {
@@ -186,8 +181,8 @@ public class CacheControl {
     /**
      * Corresponds to the value of the no-cache cache control directive.
      *
-     * @return a mutable list of field-names that will form the value of the no-cache cache control directive.
-     * An empty list results in a bare no-cache directive.
+     * @return a mutable list of field-names that will form the value of the no-cache cache control directive. An empty list
+     * results in a bare no-cache directive.
      *
      * @see #isNoCache()
      * @see #setNoCache(boolean)
@@ -203,8 +198,7 @@ public class CacheControl {
     /**
      * Corresponds to the no-cache cache control directive.
      *
-     * @param noCache true if the no-cache cache control directive should be included in the
-     *                response, false otherwise.
+     * @param noCache true if the no-cache cache control directive should be included in the response, false otherwise.
      * @see #getNoCacheFields()
      * @see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.1">HTTP/1.1 section 14.9.1</a>
      */
@@ -215,8 +209,7 @@ public class CacheControl {
     /**
      * Corresponds to the no-cache cache control directive.
      *
-     * @return true if the no-cache cache control directive will be included in the
-     * response, false otherwise.
+     * @return true if the no-cache cache control directive will be included in the response, false otherwise.
      *
      * @see #getNoCacheFields()
      * @see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.1">HTTP/1.1 section 14.9.1</a>
@@ -228,8 +221,7 @@ public class CacheControl {
     /**
      * Corresponds to the private cache control directive.
      *
-     * @return true if the private cache control directive will be included in the
-     * response, false otherwise.
+     * @return true if the private cache control directive will be included in the response, false otherwise.
      *
      * @see #getPrivateFields()
      * @see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.1">HTTP/1.1 section 14.9.1</a>
@@ -241,8 +233,8 @@ public class CacheControl {
     /**
      * Corresponds to the value of the private cache control directive.
      *
-     * @return a mutable list of field-names that will form the value of the private cache control directive.
-     * An empty list results in a bare no-cache directive.
+     * @return a mutable list of field-names that will form the value of the private cache control directive. An empty list
+     * results in a bare no-cache directive.
      *
      * @see #isPrivate()
      * @see #setPrivate(boolean)
@@ -258,8 +250,7 @@ public class CacheControl {
     /**
      * Corresponds to the private cache control directive.
      *
-     * @param flag true if the private cache control directive should be included in the
-     *             response, false otherwise.
+     * @param flag true if the private cache control directive should be included in the response, false otherwise.
      * @see #getPrivateFields()
      * @see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.1">HTTP/1.1 section 14.9.1</a>
      */
@@ -270,8 +261,7 @@ public class CacheControl {
     /**
      * Corresponds to the no-transform cache control directive.
      *
-     * @return true if the no-transform cache control directive will be included in the
-     * response, false otherwise.
+     * @return true if the no-transform cache control directive will be included in the response, false otherwise.
      *
      * @see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.5">HTTP/1.1 section 14.9.5</a>
      */
@@ -282,8 +272,8 @@ public class CacheControl {
     /**
      * Corresponds to the no-transform cache control directive.
      *
-     * @param noTransform true if the no-transform cache control directive should be included in the
-     *                    response, false otherwise.
+     * @param noTransform true if the no-transform cache control directive should be included in the response, false
+     * otherwise.
      * @see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.5">HTTP/1.1 section 14.9.5</a>
      */
     public void setNoTransform(final boolean noTransform) {
@@ -293,8 +283,7 @@ public class CacheControl {
     /**
      * Corresponds to the no-store cache control directive.
      *
-     * @return true if the no-store cache control directive will be included in the
-     * response, false otherwise.
+     * @return true if the no-store cache control directive will be included in the response, false otherwise.
      *
      * @see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.2">HTTP/1.1 section 14.9.2</a>
      */
@@ -305,8 +294,7 @@ public class CacheControl {
     /**
      * Corresponds to the no-store cache control directive.
      *
-     * @param noStore true if the no-store cache control directive should be included in the
-     *                response, false otherwise.
+     * @param noStore true if the no-store cache control directive should be included in the response, false otherwise.
      * @see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.2">HTTP/1.1 section 14.9.2</a>
      */
     public void setNoStore(final boolean noStore) {
@@ -316,11 +304,10 @@ public class CacheControl {
     /**
      * Corresponds to a set of extension cache control directives.
      *
-     * @return a mutable map of cache control extension names and their values.
-     * If a key has a null value, it will appear as a bare directive. If a key has
-     * a value that contains no whitespace then the directive will appear as
-     * a simple name=value pair. If a key has a value that contains whitespace
-     * then the directive will appear as a quoted name="value" pair.
+     * @return a mutable map of cache control extension names and their values. If a key has a null value, it will appear as
+     * a bare directive. If a key has a value that contains no whitespace then the directive will appear as a simple
+     * name=value pair. If a key has a value that contains whitespace then the directive will appear as a quoted
+     * name="value" pair.
      *
      * @see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.6">HTTP/1.1 section 14.9.6</a>
      */
@@ -332,13 +319,12 @@ public class CacheControl {
     }
 
     /**
-     * Convert the cache control to a string suitable for use as the value of the
-     * corresponding HTTP header.
+     * Convert the cache control to a string suitable for use as the value of the corresponding HTTP header.
      *
      * @return a stringified cache control
      * @deprecated The format of the toString() method is subject to change in a future version. Please use
-     * RuntimeDelegate.getInstance().createHeaderDelegate(CacheControl.class).toString(value) instead if you rely on
-     * the format of this method.
+     * RuntimeDelegate.getInstance().createHeaderDelegate(CacheControl.class).toString(value) instead if you rely on the
+     * format of this method.
      */
     @Override
     @Deprecated
@@ -369,8 +355,7 @@ public class CacheControl {
     }
 
     /**
-     * Compares object argument to this cache control to see if they are the same
-     * considering all property values.
+     * Compares object argument to this cache control to see if they are the same considering all property values.
      *
      * @param obj the object to compare to
      * @return true if the two cache controls are the same, false otherwise.
@@ -425,10 +410,10 @@ public class CacheControl {
      *
      * If one of the collections is {@code null} and the other is empty, consider the collections to be equal.
      *
-     * @param first  first collection. May be {@code null}.
+     * @param first first collection. May be {@code null}.
      * @param second second collection. May be {@code null}.
-     * @return {@code true} if the two collections are not equal, {@code false} if the two collections are equal
-     * (or one of them is {@code null} and the other one is empty).
+     * @return {@code true} if the two collections are not equal, {@code false} if the two collections are equal (or one of
+     * them is {@code null} and the other one is empty).
      */
     private static boolean notEqual(final Collection<?> first, final Collection<?> second) {
         if (first == second) {
@@ -451,10 +436,10 @@ public class CacheControl {
      *
      * If one of the maps is {@code null} and the other is empty, consider the maps to be equal.
      *
-     * @param first  first collection. May be {@code null}.
+     * @param first first collection. May be {@code null}.
      * @param second second collection. May be {@code null}.
-     * @return {@code true} if the two maps are not equal, {@code false} if the two maps are equal
-     * (or one of them is {@code null} and the other one is empty).
+     * @return {@code true} if the two maps are not equal, {@code false} if the two maps are equal (or one of them is
+     * {@code null} and the other one is empty).
      */
     private static boolean notEqual(final Map<?, ?> first, final Map<?, ?> second) {
         if (first == second) {

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Configurable.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Configurable.java
@@ -21,57 +21,53 @@ import java.util.Map;
 /**
  * Represents a client or server-side configurable context in JAX-RS.
  *
- * A configurable context can be used to define the JAX-RS components as well as
- * additional meta-data that should be used in the scope of the configured context.
- * The modification of the context typically involves setting properties or registering
- * custom JAX-RS components, such as providers and/or features.
- * All modifications of a {@code Configurable} context are reflected in the associated
- * {@link Configuration} state which is exposed via {@link #getConfiguration()} method.
+ * A configurable context can be used to define the JAX-RS components as well as additional meta-data that should be
+ * used in the scope of the configured context. The modification of the context typically involves setting properties or
+ * registering custom JAX-RS components, such as providers and/or features. All modifications of a {@code Configurable}
+ * context are reflected in the associated {@link Configuration} state which is exposed via {@link #getConfiguration()}
+ * method.
  * <p>
- * A configurable context can be either indirectly associated with a particular JAX-RS component
- * (such as application or resource method configurable context passed to a {@link Feature}
- * or {@link javax.ws.rs.container.DynamicFeature} meta-providers) or can be directly represented
- * by a concrete JAX-RS component implementing the {@code Configurable} interface
- * (such as {@link javax.ws.rs.client.Client} or {@link javax.ws.rs.client.WebTarget}).
- * As such, the exact scope of a configuration context is typically determined by a use case
- * scenario in which the context is accessed.
+ * A configurable context can be either indirectly associated with a particular JAX-RS component (such as application or
+ * resource method configurable context passed to a {@link Feature} or {@link javax.ws.rs.container.DynamicFeature}
+ * meta-providers) or can be directly represented by a concrete JAX-RS component implementing the {@code Configurable}
+ * interface (such as {@link javax.ws.rs.client.Client} or {@link javax.ws.rs.client.WebTarget}). As such, the exact
+ * scope of a configuration context is typically determined by a use case scenario in which the context is accessed.
  * </p>
  * <h3>Setting properties.</h3>
  * <p>
- * New properties can be set using the {@link #property} method. Similarly, updating a value of
- * an existing property can be achieved using the same method. Information about the configured set of
- * properties is available via the underlying {@code Configuration} object. An existing property
- * can be removed by assigning a {@code null} value to the property.
+ * New properties can be set using the {@link #property} method. Similarly, updating a value of an existing property can
+ * be achieved using the same method. Information about the configured set of properties is available via the underlying
+ * {@code Configuration} object. An existing property can be removed by assigning a {@code null} value to the property.
  * </p>
  * <h3>Registering JAX-RS components.</h3>
  * <p>
- * Registered custom JAX-RS component classes and instances are important part of the contextual
- * configuration information as these are the main factors that determine the capabilities of
- * a configured runtime.
- * Implementations SHOULD warn about and ignore registrations that do not conform to the requirements
- * of supported JAX-RS components in a given configurable context.
+ * Registered custom JAX-RS component classes and instances are important part of the contextual configuration
+ * information as these are the main factors that determine the capabilities of a configured runtime. Implementations
+ * SHOULD warn about and ignore registrations that do not conform to the requirements of supported JAX-RS components in
+ * a given configurable context.
  * </p>
  * <p>
- * In most cases, when registering a JAX-RS component, the simplest form of methods
- * ({@link #register(Class)} or {@link #register(Object)}) of the available registration API
- * is sufficient.
+ * In most cases, when registering a JAX-RS component, the simplest form of methods ({@link #register(Class)} or
+ * {@link #register(Object)}) of the available registration API is sufficient.
  * </p>
  * <p>
  * For example:
  * </p>
+ *
  * <pre>
  * config.register(HtmlDocumentReader.class);
  * config.register(new HtmlDocumentWriter(writerConfig));
  * </pre>
  * <p>
- * In some situations a JAX-RS component class or instance may implement multiple
- * provider contracts recognized by a JAX-RS implementation (e.g. filter, interceptor or entity provider).
- * By default, the JAX-RS implementation MUST register the new component class or instance as
- * a provider for all the recognized provider contracts implemented by the component class.
+ * In some situations a JAX-RS component class or instance may implement multiple provider contracts recognized by a
+ * JAX-RS implementation (e.g. filter, interceptor or entity provider). By default, the JAX-RS implementation MUST
+ * register the new component class or instance as a provider for all the recognized provider contracts implemented by
+ * the component class.
  * </p>
  * <p>
  * For example:
  * </p>
+ *
  * <pre>
  * &#64;Priority(ENTITY_CODER)
  * public class GzipInterceptor
@@ -84,15 +80,15 @@ import java.util.Map;
  * config.register(GzipInterceptor.class);
  * </pre>
  * <p>
- * There are however situations when the default registration of a JAX-RS component to all the
- * recognized provider contracts is not desirable. In such cases users may use other versions of the
- * {@code register(...)} method to explicitly specify the collection of the provider contracts
- * for which the JAX-RS component should be registered and/or the priority of each registered
- * provider contract.
+ * There are however situations when the default registration of a JAX-RS component to all the recognized provider
+ * contracts is not desirable. In such cases users may use other versions of the {@code register(...)} method to
+ * explicitly specify the collection of the provider contracts for which the JAX-RS component should be registered
+ * and/or the priority of each registered provider contract.
  * </p>
  * <p>
  * For example:
  * </p>
+ *
  * <pre>
  * &#64;Priority(USER)
  * public class ClientLoggingFilter
@@ -112,27 +108,27 @@ import java.util.Map;
  * config.register(GzipInterceptor.class, 6500);
  * </pre>
  * <p>
- * As a general rule, for each JAX-RS component class there can be at most one registration
- * &mdash; class-based or instance-based &mdash; configured at any given moment. Implementations
- * MUST reject any attempts to configure a new registration for a provider class that has been
- * already registered in the given configurable context earlier. Implementations SHOULD also raise
- * a warning to inform the user about the rejected component registration.
+ * As a general rule, for each JAX-RS component class there can be at most one registration &mdash; class-based or
+ * instance-based &mdash; configured at any given moment. Implementations MUST reject any attempts to configure a new
+ * registration for a provider class that has been already registered in the given configurable context earlier.
+ * Implementations SHOULD also raise a warning to inform the user about the rejected component registration.
  * </p>
  * <p>
  * For example:
  * </p>
+ *
  * <pre>
  * config.register(GzipInterceptor.class, WriterInterceptor.class);
- * config.register(GzipInterceptor.class);       // Rejected by runtime.
- * config.register(new GzipInterceptor());       // Rejected by runtime.
+ * config.register(GzipInterceptor.class); // Rejected by runtime.
+ * config.register(new GzipInterceptor()); // Rejected by runtime.
  * config.register(GzipInterceptor.class, 6500); // Rejected by runtime.
  *
  * config.register(new ClientLoggingFilter());
- * config.register(ClientLoggingFilter.class);   // rejected by runtime.
+ * config.register(ClientLoggingFilter.class); // rejected by runtime.
  * config.register(ClientLoggingFilter.class,
- *                 ClientResponseFilter.class);  // Rejected by runtime.
+ *         ClientResponseFilter.class); // Rejected by runtime.
  * </pre>
- * 
+ *
  * @param <C> generic configurable Java type
  * @author Marek Potociar
  * @since 2.0
@@ -142,11 +138,11 @@ public interface Configurable<C extends Configurable> {
     /**
      * Get a live view of an internal configuration state of this configurable instance.
      *
-     * Any changes made using methods of this {@code Configurable} instance will be reflected
-     * in the returned {@code Configuration} instance.
+     * Any changes made using methods of this {@code Configurable} instance will be reflected in the returned
+     * {@code Configuration} instance.
      * <p>
-     * The returned {@code Configuration} instance and the collection data it provides are not
-     * thread-safe wrt. modification made using methods on the parent configurable object.
+     * The returned {@code Configuration} instance and the collection data it provides are not thread-safe wrt. modification
+     * made using methods on the parent configurable object.
      * </p>
      *
      * @return configuration live view of the internal configuration state.
@@ -154,235 +150,184 @@ public interface Configurable<C extends Configurable> {
     public Configuration getConfiguration();
 
     /**
-     * Set the new configuration property, if already set, the existing value of
-     * the property will be updated. Setting a {@code null} value into a property
-     * effectively removes the property from the property bag.
+     * Set the new configuration property, if already set, the existing value of the property will be updated. Setting a
+     * {@code null} value into a property effectively removes the property from the property bag.
      *
-     * @param name  property name.
-     * @param value (new) property value. {@code null} value removes the property
-     *              with the given name.
+     * @param name property name.
+     * @param value (new) property value. {@code null} value removes the property with the given name.
      * @return the updated configurable instance.
      */
     public C property(String name, Object value);
 
     /**
-     * Register a class of a custom JAX-RS component (such as an extension provider or
-     * a {@link javax.ws.rs.core.Feature feature} meta-provider) to be instantiated
-     * and used in the scope of this configurable context.
+     * Register a class of a custom JAX-RS component (such as an extension provider or a {@link javax.ws.rs.core.Feature
+     * feature} meta-provider) to be instantiated and used in the scope of this configurable context.
      *
-     * Implementations SHOULD warn about and ignore registrations that do not
-     * conform to the requirements of supported JAX-RS component types in the
-     * given configurable context. Any subsequent registration attempts for a component
-     * type, for which a class or instance-based registration already exists in the system
-     * MUST be rejected by the JAX-RS implementation and a warning SHOULD be raised to
-     * inform the user about the rejected registration.
+     * Implementations SHOULD warn about and ignore registrations that do not conform to the requirements of supported
+     * JAX-RS component types in the given configurable context. Any subsequent registration attempts for a component type,
+     * for which a class or instance-based registration already exists in the system MUST be rejected by the JAX-RS
+     * implementation and a warning SHOULD be raised to inform the user about the rejected registration.
      *
-     * The registered JAX-RS component class is registered as a contract provider of
-     * all the recognized JAX-RS or implementation-specific extension contracts including
-     * meta-provider contracts, such as {@code Feature} or {@link javax.ws.rs.container.DynamicFeature}.
+     * The registered JAX-RS component class is registered as a contract provider of all the recognized JAX-RS or
+     * implementation-specific extension contracts including meta-provider contracts, such as {@code Feature} or
+     * {@link javax.ws.rs.container.DynamicFeature}.
      * <p>
-     * As opposed to component instances registered via {@link #register(Object)} method,
-     * the lifecycle of components registered using this class-based {@code register(...)}
-     * method is fully managed by the JAX-RS implementation or any underlying IoC
-     * container supported by the implementation.
+     * As opposed to component instances registered via {@link #register(Object)} method, the lifecycle of components
+     * registered using this class-based {@code register(...)} method is fully managed by the JAX-RS implementation or any
+     * underlying IoC container supported by the implementation.
      * </p>
      *
-     * @param componentClass JAX-RS component class to be configured in the scope of this
-     *                       configurable context.
+     * @param componentClass JAX-RS component class to be configured in the scope of this configurable context.
      * @return the updated configurable context.
      */
     public C register(Class<?> componentClass);
 
     /**
-     * Register a class of a custom JAX-RS component (such as an extension provider or
-     * a {@link javax.ws.rs.core.Feature feature} meta-provider) to be instantiated
-     * and used in the scope of this configurable context.
+     * Register a class of a custom JAX-RS component (such as an extension provider or a {@link javax.ws.rs.core.Feature
+     * feature} meta-provider) to be instantiated and used in the scope of this configurable context.
      * <p>
-     * This registration method provides the same functionality as {@link #register(Class)}
-     * except that any priority specified on the registered JAX-RS component class via
-     * {@code javax.annotation.Priority} annotation is overridden with the supplied
-     * {@code priority} value.
+     * This registration method provides the same functionality as {@link #register(Class)} except that any priority
+     * specified on the registered JAX-RS component class via {@code javax.annotation.Priority} annotation is overridden
+     * with the supplied {@code priority} value.
      * </p>
      * <p>
-     * Note that in case the priority is not applicable to a particular
-     * provider contract implemented by the class of the registered component, the supplied
-     * {@code priority} value will be ignored for that contract.
+     * Note that in case the priority is not applicable to a particular provider contract implemented by the class of the
+     * registered component, the supplied {@code priority} value will be ignored for that contract.
      * </p>
      *
-     * @param componentClass JAX-RS component class to be configured in the scope of this
-     *                       configurable context.
-     * @param priority       the overriding priority for the registered component
-     *                       and all the provider contracts the component implements.
+     * @param componentClass JAX-RS component class to be configured in the scope of this configurable context.
+     * @param priority the overriding priority for the registered component and all the provider contracts the component
+     * implements.
      * @return the updated configurable context.
      */
     public C register(Class<?> componentClass, int priority);
 
     /**
-     * Register a class of a custom JAX-RS component (such as an extension provider or
-     * a {@link javax.ws.rs.core.Feature feature} meta-provider) to be instantiated
-     * and used in the scope of this configurable context.
+     * Register a class of a custom JAX-RS component (such as an extension provider or a {@link javax.ws.rs.core.Feature
+     * feature} meta-provider) to be instantiated and used in the scope of this configurable context.
      * <p>
-     * This registration method provides the same functionality as {@link #register(Class)}
-     * except the JAX-RS component class is only registered as a provider of the listed
-     * extension provider or meta-provider {@code contracts}.
-     * All explicitly enumerated contract types must represent a class or an interface
-     * implemented or extended by the registered component. Contracts that are not
-     * {@link Class#isAssignableFrom(Class) assignable from} the registered component class
-     * MUST be ignored and implementations SHOULD raise a warning to inform users about the
-     * ignored contract(s).
+     * This registration method provides the same functionality as {@link #register(Class)} except the JAX-RS component
+     * class is only registered as a provider of the listed extension provider or meta-provider {@code contracts}. All
+     * explicitly enumerated contract types must represent a class or an interface implemented or extended by the registered
+     * component. Contracts that are not {@link Class#isAssignableFrom(Class) assignable from} the registered component
+     * class MUST be ignored and implementations SHOULD raise a warning to inform users about the ignored contract(s).
      * </p>
      *
-     * @param componentClass JAX-RS component class to be configured in the scope of this
-     *                       configurable context.
-     * @param contracts      the specific extension provider or meta-provider contracts
-     *                       implemented by the component for which the component should
-     *                       be registered.
-     *                       Implementations MUST ignore attempts to register a component
-     *                       class for an empty or {@code null} collection of contracts via
-     *                       this method and SHOULD raise a warning about such event.
+     * @param componentClass JAX-RS component class to be configured in the scope of this configurable context.
+     * @param contracts the specific extension provider or meta-provider contracts implemented by the component for which
+     * the component should be registered. Implementations MUST ignore attempts to register a component class for an empty
+     * or {@code null} collection of contracts via this method and SHOULD raise a warning about such event.
      * @return the updated configurable context.
      */
     public C register(Class<?> componentClass, Class<?>... contracts);
 
     /**
-     * Register a class of a custom JAX-RS component (such as an extension provider or
-     * a {@link javax.ws.rs.core.Feature feature} meta-provider) to be instantiated
-     * and used in the scope of this configurable context.
+     * Register a class of a custom JAX-RS component (such as an extension provider or a {@link javax.ws.rs.core.Feature
+     * feature} meta-provider) to be instantiated and used in the scope of this configurable context.
      * <p>
-     * This registration method provides same functionality as {@link #register(Class, Class[])}
-     * except that any priority specified on the registered JAX-RS component class via
-     * {@code javax.annotation.Priority} annotation is overridden
-     * for each extension provider contract type separately with an integer priority value
-     * specified as a value in the supplied map of [contract type, priority] pairs.
+     * This registration method provides same functionality as {@link #register(Class, Class[])} except that any priority
+     * specified on the registered JAX-RS component class via {@code javax.annotation.Priority} annotation is overridden for
+     * each extension provider contract type separately with an integer priority value specified as a value in the supplied
+     * map of [contract type, priority] pairs.
      * </p>
      * <p>
-     * Note that in case a priority is not applicable to a provider contract registered
-     * for the JAX-RS component, the supplied priority value is ignored for such
-     * contract.
+     * Note that in case a priority is not applicable to a provider contract registered for the JAX-RS component, the
+     * supplied priority value is ignored for such contract.
      * </p>
      *
-     * @param componentClass JAX-RS component class to be configured in the scope of this
-     *                       configurable context.
-     * @param contracts      map of the specific extension provider and meta-provider contracts
-     *                       and their associated priorities for which the JAX-RS component
-     *                       is registered.
-     *                       All contracts in the map must represent a class or an interface
-     *                       implemented or extended by the JAX-RS component. Contracts that are
-     *                       not {@link Class#isAssignableFrom(Class) assignable from} the registered
-     *                       component class MUST be ignored and implementations SHOULD raise a warning
-     *                       to inform users about the ignored contract(s).
+     * @param componentClass JAX-RS component class to be configured in the scope of this configurable context.
+     * @param contracts map of the specific extension provider and meta-provider contracts and their associated priorities
+     * for which the JAX-RS component is registered. All contracts in the map must represent a class or an interface
+     * implemented or extended by the JAX-RS component. Contracts that are not {@link Class#isAssignableFrom(Class)
+     * assignable from} the registered component class MUST be ignored and implementations SHOULD raise a warning to inform
+     * users about the ignored contract(s).
      * @return the updated configurable context.
      */
     public C register(Class<?> componentClass, Map<Class<?>, Integer> contracts);
 
     /**
-     * Register an instance of a custom JAX-RS component (such as an extension provider or
-     * a {@link javax.ws.rs.core.Feature feature} meta-provider) to be instantiated
-     * and used in the scope of this configurable context.
+     * Register an instance of a custom JAX-RS component (such as an extension provider or a {@link javax.ws.rs.core.Feature
+     * feature} meta-provider) to be instantiated and used in the scope of this configurable context.
      *
-     * Implementations SHOULD warn about and ignore registrations that do not
-     * conform to the requirements of supported JAX-RS component types in the
-     * given configurable context. Any subsequent registration attempts for a component
-     * type, for which a class or instance-based registration already exists in the system
-     * MUST be rejected by the JAX-RS implementation and a warning SHOULD be raised to
-     * inform the user about the rejected registration.
+     * Implementations SHOULD warn about and ignore registrations that do not conform to the requirements of supported
+     * JAX-RS component types in the given configurable context. Any subsequent registration attempts for a component type,
+     * for which a class or instance-based registration already exists in the system MUST be rejected by the JAX-RS
+     * implementation and a warning SHOULD be raised to inform the user about the rejected registration.
      *
-     * The registered JAX-RS component is registered as a contract provider of
-     * all the recognized JAX-RS or implementation-specific extension contracts including
-     * meta-provider contracts, such as {@code Feature} or {@link javax.ws.rs.container.DynamicFeature}.
+     * The registered JAX-RS component is registered as a contract provider of all the recognized JAX-RS or
+     * implementation-specific extension contracts including meta-provider contracts, such as {@code Feature} or
+     * {@link javax.ws.rs.container.DynamicFeature}.
      * <p>
-     * As opposed to components registered via {@link #register(Class)} method,
-     * the lifecycle of providers registered using this instance-based {@code register(...)}
-     * is not managed by JAX-RS runtime. The same registered component instance is used during
-     * the whole lifespan of the configurable context.
-     * Fields and properties of all registered JAX-RS component instances are injected with their
-     * declared dependencies (see {@link Context}) by the JAX-RS runtime prior to use.
+     * As opposed to components registered via {@link #register(Class)} method, the lifecycle of providers registered using
+     * this instance-based {@code register(...)} is not managed by JAX-RS runtime. The same registered component instance is
+     * used during the whole lifespan of the configurable context. Fields and properties of all registered JAX-RS component
+     * instances are injected with their declared dependencies (see {@link Context}) by the JAX-RS runtime prior to use.
      * </p>
      *
-     * @param component JAX-RS component instance to be configured in the scope of this
-     *                  configurable context.
+     * @param component JAX-RS component instance to be configured in the scope of this configurable context.
      * @return the updated configurable context.
      */
     public C register(Object component);
 
     /**
-     * Register an instance of a custom JAX-RS component (such as an extension provider or
-     * a {@link javax.ws.rs.core.Feature feature} meta-provider) to be instantiated
-     * and used in the scope of this configurable context.
+     * Register an instance of a custom JAX-RS component (such as an extension provider or a {@link javax.ws.rs.core.Feature
+     * feature} meta-provider) to be instantiated and used in the scope of this configurable context.
      * <p>
-     * This registration method provides the same functionality as {@link #register(Object)}
-     * except that any priority specified on the registered JAX-RS component class via
-     * {@code javax.annotation.Priority} annotation is overridden with the supplied
-     * {@code priority} value.
+     * This registration method provides the same functionality as {@link #register(Object)} except that any priority
+     * specified on the registered JAX-RS component class via {@code javax.annotation.Priority} annotation is overridden
+     * with the supplied {@code priority} value.
      * </p>
      * <p>
-     * Note that in case the priority is not applicable to a particular
-     * provider contract implemented by the class of the registered component, the supplied
-     * {@code priority} value will be ignored for that contract.
+     * Note that in case the priority is not applicable to a particular provider contract implemented by the class of the
+     * registered component, the supplied {@code priority} value will be ignored for that contract.
      * </p>
      *
-     * @param component JAX-RS component instance to be configured in the scope of this
-     *                  configurable context.
-     * @param priority  the overriding priority for the registered component
-     *                  and all the provider contracts the component implements.
+     * @param component JAX-RS component instance to be configured in the scope of this configurable context.
+     * @param priority the overriding priority for the registered component and all the provider contracts the component
+     * implements.
      * @return the updated configurable context.
      */
     public C register(Object component, int priority);
 
     /**
-     * Register an instance of a custom JAX-RS component (such as an extension provider or
-     * a {@link javax.ws.rs.core.Feature feature} meta-provider) to be instantiated
-     * and used in the scope of this configurable context.
+     * Register an instance of a custom JAX-RS component (such as an extension provider or a {@link javax.ws.rs.core.Feature
+     * feature} meta-provider) to be instantiated and used in the scope of this configurable context.
      * <p>
-     * This registration method provides the same functionality as {@link #register(Object)}
-     * except the JAX-RS component class is only registered as a provider of the listed
-     * extension provider or meta-provider {@code contracts}.
-     * All explicitly enumerated contract types must represent a class or an interface
-     * implemented or extended by the registered component. Contracts that are not
-     * {@link Class#isAssignableFrom(Class) assignable from} the registered component class
-     * MUST be ignored and implementations SHOULD raise a warning to inform users about the
-     * ignored contract(s).
+     * This registration method provides the same functionality as {@link #register(Object)} except the JAX-RS component
+     * class is only registered as a provider of the listed extension provider or meta-provider {@code contracts}. All
+     * explicitly enumerated contract types must represent a class or an interface implemented or extended by the registered
+     * component. Contracts that are not {@link Class#isAssignableFrom(Class) assignable from} the registered component
+     * class MUST be ignored and implementations SHOULD raise a warning to inform users about the ignored contract(s).
      * </p>
      *
-     * @param component JAX-RS component instance to be configured in the scope of this
-     *                  configurable context.
-     * @param contracts the specific extension provider or meta-provider contracts
-     *                  implemented by the component for which the component should
-     *                  be registered.
-     *                  Implementations MUST ignore attempts to register a component
-     *                  class for an empty or {@code null} collection of contracts via
-     *                  this method and SHOULD raise a warning about such event.
+     * @param component JAX-RS component instance to be configured in the scope of this configurable context.
+     * @param contracts the specific extension provider or meta-provider contracts implemented by the component for which
+     * the component should be registered. Implementations MUST ignore attempts to register a component class for an empty
+     * or {@code null} collection of contracts via this method and SHOULD raise a warning about such event.
      * @return the updated configurable context.
      */
     public C register(Object component, Class<?>... contracts);
 
     /**
-     * Register an instance of a custom JAX-RS component (such as an extension provider or
-     * a {@link javax.ws.rs.core.Feature feature} meta-provider) to be instantiated
-     * and used in the scope of this configurable context.
+     * Register an instance of a custom JAX-RS component (such as an extension provider or a {@link javax.ws.rs.core.Feature
+     * feature} meta-provider) to be instantiated and used in the scope of this configurable context.
      * <p>
-     * This registration method provides same functionality as {@link #register(Object, Class[])}
-     * except that any priority specified on the registered JAX-RS component class via
-     * {@code javax.annotation.Priority} annotation is overridden
-     * for each extension provider contract type separately with an integer priority value
-     * specified as a value in the supplied map of [contract type, priority] pairs.
+     * This registration method provides same functionality as {@link #register(Object, Class[])} except that any priority
+     * specified on the registered JAX-RS component class via {@code javax.annotation.Priority} annotation is overridden for
+     * each extension provider contract type separately with an integer priority value specified as a value in the supplied
+     * map of [contract type, priority] pairs.
      * </p>
      * <p>
-     * Note that in case a priority is not applicable to a provider contract registered
-     * for the JAX-RS component, the supplied priority value is ignored for such
-     * contract.
+     * Note that in case a priority is not applicable to a provider contract registered for the JAX-RS component, the
+     * supplied priority value is ignored for such contract.
      * </p>
      *
-     * @param component JAX-RS component instance to be configured in the scope of this
-     *                  configurable context.
-     * @param contracts map of the specific extension provider and meta-provider contracts
-     *                  and their associated priorities for which the JAX-RS component
-     *                  is registered.
-     *                  All contracts in the map must represent a class or an interface
-     *                  implemented or extended by the JAX-RS component. Contracts that are
-     *                  not {@link Class#isAssignableFrom(Class) assignable from} the registered
-     *                  component class MUST be ignored and implementations SHOULD raise a warning
-     *                  to inform users about the ignored contract(s).
+     * @param component JAX-RS component instance to be configured in the scope of this configurable context.
+     * @param contracts map of the specific extension provider and meta-provider contracts and their associated priorities
+     * for which the JAX-RS component is registered. All contracts in the map must represent a class or an interface
+     * implemented or extended by the JAX-RS component. Contracts that are not {@link Class#isAssignableFrom(Class)
+     * assignable from} the registered component class MUST be ignored and implementations SHOULD raise a warning to inform
+     * users about the ignored contract(s).
      * @return the updated configurable context.
      */
     public C register(Object component, Map<Class<?>, Integer> contracts);

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Configuration.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Configuration.java
@@ -23,14 +23,13 @@ import java.util.Set;
 import javax.ws.rs.RuntimeType;
 
 /**
- * A configuration state associated with a {@link Configurable configurable} JAX-RS context.
- * Defines the components as well as additional meta-data for the configured context.
+ * A configuration state associated with a {@link Configurable configurable} JAX-RS context. Defines the components as
+ * well as additional meta-data for the configured context.
  * <p>
- * A configuration state may be used to retrieve configuration information about
- * of the associated JAX-RS context (e.g. application, resource method, etc.) or component
- * (e.g. {@link javax.ws.rs.client.Client}, {@link javax.ws.rs.client.WebTarget}, etc.).
- * Configuration information consists of properties, registered JAX-RS component classes
- * and/or instances.
+ * A configuration state may be used to retrieve configuration information about of the associated JAX-RS context (e.g.
+ * application, resource method, etc.) or component (e.g. {@link javax.ws.rs.client.Client},
+ * {@link javax.ws.rs.client.WebTarget}, etc.). Configuration information consists of properties, registered JAX-RS
+ * component classes and/or instances.
  * </p>
  * <p>
  * This interface can be injected using the {@link Context} annotation.
@@ -59,17 +58,16 @@ public interface Configuration {
      * Get the value for the property with a given name.
      *
      * @param name property name.
-     * @return the property value for the specified property name or {@code null}
-     *         if the property with such name is not configured.
+     * @return the property value for the specified property name or {@code null} if the property with such name is not
+     * configured.
      */
     public Object getProperty(String name);
 
     /**
-     * Returns an immutable {@link java.util.Collection collection} containing the
-     * property names available within the context of the current configuration instance.
+     * Returns an immutable {@link java.util.Collection collection} containing the property names available within the
+     * context of the current configuration instance.
      * <p>
-     * Use the {@link #getProperty} method with a property name to get the value of
-     * a property.
+     * Use the {@link #getProperty} method with a property name to get the value of a property.
      * </p>
      *
      * @return an immutable {@link java.util.Collection collection} of property names.
@@ -78,63 +76,59 @@ public interface Configuration {
     public Collection<String> getPropertyNames();
 
     /**
-     * Check if a particular {@link Feature feature} instance has been previously
-     * enabled in the runtime configuration context.
+     * Check if a particular {@link Feature feature} instance has been previously enabled in the runtime configuration
+     * context.
      * <p>
-     * Method returns {@code true} only in case an instance equal to the {@code feature}
-     * instance is already present among the features previously successfully enabled in
-     * the configuration context.
+     * Method returns {@code true} only in case an instance equal to the {@code feature} instance is already present among
+     * the features previously successfully enabled in the configuration context.
      * </p>
      *
      * @param feature a feature instance to test for.
-     * @return {@code true} if the feature instance has been previously enabled in this
-     *         configuration context, {@code false} otherwise.
+     * @return {@code true} if the feature instance has been previously enabled in this configuration context, {@code false}
+     * otherwise.
      */
     public boolean isEnabled(Feature feature);
 
     /**
-     * Check if a {@link Feature feature} instance of {@code featureClass} class has been
-     * previously enabled in the runtime configuration context.
+     * Check if a {@link Feature feature} instance of {@code featureClass} class has been previously enabled in the runtime
+     * configuration context.
      * <p>
-     * Method returns {@code true} in case any instance of the {@code featureClass} class is
-     * already present among the features previously successfully enabled in the configuration
-     * context.
+     * Method returns {@code true} in case any instance of the {@code featureClass} class is already present among the
+     * features previously successfully enabled in the configuration context.
      * </p>
      *
      * @param featureClass a feature class to test for.
-     * @return {@code true} if a feature of a given class has been previously enabled in this
-     *         configuration context, {@code false} otherwise.
+     * @return {@code true} if a feature of a given class has been previously enabled in this configuration context,
+     * {@code false} otherwise.
      */
     public boolean isEnabled(Class<? extends Feature> featureClass);
 
     /**
-     * Check if a particular JAX-RS {@code component} instance (such as providers or
-     * {@link Feature features}) has been previously registered in the runtime configuration context.
+     * Check if a particular JAX-RS {@code component} instance (such as providers or {@link Feature features}) has been
+     * previously registered in the runtime configuration context.
      * <p>
-     * Method returns {@code true} only in case an instance equal to the {@code component}
-     * instance is already present among the components previously registered in the configuration
-     * context.
+     * Method returns {@code true} only in case an instance equal to the {@code component} instance is already present among
+     * the components previously registered in the configuration context.
      * </p>
      *
      * @param component a component instance to test for.
-     * @return {@code true} if the component instance has been previously registered in this
-     *         configuration context, {@code false} otherwise.
+     * @return {@code true} if the component instance has been previously registered in this configuration context,
+     * {@code false} otherwise.
      * @see #isEnabled(Feature)
      */
     public boolean isRegistered(Object component);
 
     /**
-     * Check if a JAX-RS component of the supplied {@code componentClass} class has been previously
-     * registered in the runtime configuration context.
+     * Check if a JAX-RS component of the supplied {@code componentClass} class has been previously registered in the
+     * runtime configuration context.
      * <p>
-     * Method returns {@code true} in case a component of the supplied {@code componentClass} class
-     * is already present among the previously registered component classes or instances
-     * in the configuration context.
+     * Method returns {@code true} in case a component of the supplied {@code componentClass} class is already present among
+     * the previously registered component classes or instances in the configuration context.
      * </p>
      *
      * @param componentClass a component class to test for.
-     * @return {@code true} if a component of a given class has been previously registered in this
-     *         configuration context, {@code false} otherwise.
+     * @return {@code true} if a component of a given class has been previously registered in this configuration context,
+     * {@code false} otherwise.
      * @see #isEnabled(Class)
      */
     public boolean isRegistered(Class<?> componentClass);
@@ -142,45 +136,42 @@ public interface Configuration {
     /**
      * Get the extension contract registration information for a component of a given class.
      *
-     * For component classes that are not configured in this configuration context the method returns
-     * an empty {@code Map}. Method does not return {@code null}.
+     * For component classes that are not configured in this configuration context the method returns an empty {@code Map}.
+     * Method does not return {@code null}.
      *
      * @param componentClass a component class for which to get contracts.
-     * @return map of extension contracts and their priorities for which the component class
-     *         is registered.
-     *         May return an empty map in case the component has not been registered for any
-     *         extension contract supported by the implementation.
+     * @return map of extension contracts and their priorities for which the component class is registered. May return an
+     * empty map in case the component has not been registered for any extension contract supported by the implementation.
      */
     public Map<Class<?>, Integer> getContracts(Class<?> componentClass);
 
     /**
-     * Get the immutable set of registered JAX-RS component (such as provider, root resource or
-     * {@link Feature feature}) classes to be instantiated, injected and utilized in the scope
-     * of the configurable instance. In contrast to {@link Application#getClasses()} this method
-     * returns a complete runtime view and therefore also includes auto-discovered components.
+     * Get the immutable set of registered JAX-RS component (such as provider, root resource or {@link Feature feature})
+     * classes to be instantiated, injected and utilized in the scope of the configurable instance. In contrast to
+     * {@link Application#getClasses()} this method returns a complete runtime view and therefore also includes
+     * auto-discovered components.
      * <p>
-     * For each component type, there can be only a single class-based or instance-based registration
-     * present in the configuration context at any given time.
+     * For each component type, there can be only a single class-based or instance-based registration present in the
+     * configuration context at any given time.
      * </p>
      *
-     * @return the immutable set of registered JAX-RS component classes. The returned
-     *         value may be empty but will never be {@code null}.
+     * @return the immutable set of registered JAX-RS component classes. The returned value may be empty but will never be
+     * {@code null}.
      * @see #getInstances
      */
     public Set<Class<?>> getClasses();
 
     /**
-     * Get the immutable set of registered JAX-RS component (such as provider or
-     * {@link Feature feature}) instances to be utilized by the configurable instance.
-     * Fields and properties of returned instances are injected with their declared dependencies
-     * (see {@link Context}) by the runtime prior to use.
+     * Get the immutable set of registered JAX-RS component (such as provider or {@link Feature feature}) instances to be
+     * utilized by the configurable instance. Fields and properties of returned instances are injected with their declared
+     * dependencies (see {@link Context}) by the runtime prior to use.
      * <p>
-     * For each component type, there can be only a single class-based or instance-based registration
-     * present in the configuration context at any given time.
+     * For each component type, there can be only a single class-based or instance-based registration present in the
+     * configuration context at any given time.
      * </p>
      *
-     * @return the immutable set of registered JAX-RS component instances. The returned
-     *         value may be empty but will never be {@code null}.
+     * @return the immutable set of registered JAX-RS component instances. The returned value may be empty but will never be
+     * {@code null}.
      * @see #getClasses
      */
     public Set<Object> getInstances();

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Context.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Context.java
@@ -23,8 +23,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * This annotation is used to inject information into a class
- * field, bean property or method parameter.
+ * This annotation is used to inject information into a class field, bean property or method parameter.
  *
  * @author Paul Sandoz
  * @author Marc Hadley
@@ -36,7 +35,7 @@ import java.lang.annotation.Target;
  * @see javax.ws.rs.ext.Providers
  * @since 1.0
  */
-@Target({ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD})
+@Target({ ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface Context {

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Cookie.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Cookie.java
@@ -20,8 +20,7 @@ import javax.ws.rs.ext.RuntimeDelegate;
 import javax.ws.rs.ext.RuntimeDelegate.HeaderDelegate;
 
 /**
- * Represents the value of a HTTP cookie, transferred in a request.
- * RFC 2109 specifies the legal characters for name,
+ * Represents the value of a HTTP cookie, transferred in a request. RFC 2109 specifies the legal characters for name,
  * value, path and domain. The default version of 1 corresponds to RFC 2109.
  *
  * @author Paul Sandoz
@@ -39,8 +38,7 @@ public class Cookie {
      * @deprecated This field will be removed in a future version. See https://github.com/eclipse-ee4j/jaxrs-api/issues/607
      */
     @Deprecated
-    private static final HeaderDelegate<Cookie> HEADER_DELEGATE =
-            RuntimeDelegate.getInstance().createHeaderDelegate(Cookie.class);
+    private static final HeaderDelegate<Cookie> HEADER_DELEGATE = RuntimeDelegate.getInstance().createHeaderDelegate(Cookie.class);
     private final String name;
     private final String value;
     private final int version;
@@ -50,10 +48,10 @@ public class Cookie {
     /**
      * Create a new instance.
      *
-     * @param name    the name of the cookie.
-     * @param value   the value of the cookie.
-     * @param path    the URI path for which the cookie is valid.
-     * @param domain  the host domain for which the cookie is valid.
+     * @param name the name of the cookie.
+     * @param value the value of the cookie.
+     * @param path the URI path for which the cookie is valid.
+     * @param domain the host domain for which the cookie is valid.
      * @param version the version of the specification to which the cookie complies.
      * @throws IllegalArgumentException if name is {@code null}.
      */
@@ -72,9 +70,9 @@ public class Cookie {
     /**
      * Create a new instance.
      *
-     * @param name   the name of the cookie.
-     * @param value  the value of the cookie.
-     * @param path   the URI path for which the cookie is valid.
+     * @param name the name of the cookie.
+     * @param value the value of the cookie.
+     * @param path the URI path for which the cookie is valid.
      * @param domain the host domain for which the cookie is valid.
      * @throws IllegalArgumentException if name is {@code null}.
      */
@@ -86,7 +84,7 @@ public class Cookie {
     /**
      * Create a new instance.
      *
-     * @param name  the name of the cookie.
+     * @param name the name of the cookie.
      * @param value the value of the cookie.
      * @throws IllegalArgumentException if name is {@code null}.
      */
@@ -100,10 +98,9 @@ public class Cookie {
      *
      * @param value the cookie string.
      * @return the newly created {@code Cookie}.
-     * @throws IllegalArgumentException if the supplied string cannot be parsed
-     *                                  or is {@code null}.
+     * @throws IllegalArgumentException if the supplied string cannot be parsed or is {@code null}.
      * @deprecated This method will be removed in a future version. Please use
-     *   RuntimeDelegate.getInstance().createHeaderDelegate(Cookie.class).fromString(value) instead.
+     * RuntimeDelegate.getInstance().createHeaderDelegate(Cookie.class).fromString(value) instead.
      */
     @Deprecated
     public static Cookie valueOf(final String value) {
@@ -156,13 +153,12 @@ public class Cookie {
     }
 
     /**
-     * Convert the cookie to a string suitable for use as the value of the
-     * corresponding HTTP header.
+     * Convert the cookie to a string suitable for use as the value of the corresponding HTTP header.
      *
      * @return a stringified cookie.
      * @deprecated The format of the toString() method is subject to change in a future version. Please use
-     * RuntimeDelegate.getInstance().createHeaderDelegate(Cookie.class).toString(value) instead if you rely on
-     * the format of this method.
+     * RuntimeDelegate.getInstance().createHeaderDelegate(Cookie.class).toString(value) instead if you rely on the format of
+     * this method.
      */
     @Override
     @Deprecated
@@ -190,10 +186,10 @@ public class Cookie {
      * Compare for equality.
      *
      * @param obj the object to compare to.
-     * @return {@code true}, if the object is a {@code Cookie} with the same
-     *         value for all properties, {@code false} otherwise.
+     * @return {@code true}, if the object is a {@code Cookie} with the same value for all properties, {@code false}
+     * otherwise.
      */
-    @SuppressWarnings({"StringEquality", "RedundantIfStatement"})
+    @SuppressWarnings({ "StringEquality", "RedundantIfStatement" })
     @Override
     public boolean equals(final Object obj) {
         if (obj == null) {

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/EntityTag.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/EntityTag.java
@@ -21,8 +21,7 @@ import javax.ws.rs.ext.RuntimeDelegate.HeaderDelegate;
 import java.util.Objects;
 
 /**
- * An abstraction for the value of a HTTP Entity Tag, used as the value
- * of an ETag response header.
+ * An abstraction for the value of a HTTP Entity Tag, used as the value of an ETag response header.
  *
  * @author Paul Sandoz
  * @author Marc Hadley
@@ -34,8 +33,7 @@ public class EntityTag {
      * @deprecated This field will be removed in a future version. See https://github.com/eclipse-ee4j/jaxrs-api/issues/607
      */
     @Deprecated
-    private static final HeaderDelegate<EntityTag> HEADER_DELEGATE =
-            RuntimeDelegate.getInstance().createHeaderDelegate(EntityTag.class);
+    private static final HeaderDelegate<EntityTag> HEADER_DELEGATE = RuntimeDelegate.getInstance().createHeaderDelegate(EntityTag.class);
     private String value;
     private boolean weak;
 
@@ -53,7 +51,7 @@ public class EntityTag {
      * Creates a new instance of an {@code EntityTag}.
      *
      * @param value the value of the tag, quotes not included.
-     * @param weak  {@code true} if this represents a weak tag, {@code false} otherwise.
+     * @param weak {@code true} if this represents a weak tag, {@code false} otherwise.
      * @throws IllegalArgumentException if value is {@code null}.
      */
     public EntityTag(final String value, final boolean weak) {
@@ -69,10 +67,9 @@ public class EntityTag {
      *
      * @param value the entity tag string.
      * @return the newly created entity tag.
-     * @throws IllegalArgumentException if the supplied string cannot be parsed
-     *                                  or is {@code null}.
+     * @throws IllegalArgumentException if the supplied string cannot be parsed or is {@code null}.
      * @deprecated This method will be removed in a future version. Please use
-     *   RuntimeDelegate.getInstance().createHeaderDelegate(EntityTag.class).fromString(value) instead.
+     * RuntimeDelegate.getInstance().createHeaderDelegate(EntityTag.class).fromString(value) instead.
      */
     @Deprecated
     public static EntityTag valueOf(final String value) {
@@ -98,8 +95,7 @@ public class EntityTag {
     }
 
     /**
-     * Compares {@code obj} to this tag to see if they are the same considering
-     * weakness and value.
+     * Compares {@code obj} to this tag to see if they are the same considering weakness and value.
      *
      * @param obj the object to compare to.
      * @return {@code true} if the two tags are the same, {@code false} otherwise.
@@ -109,7 +105,7 @@ public class EntityTag {
         if (!(obj instanceof EntityTag)) {
             return false;
         }
-        
+
         EntityTag other = (EntityTag) obj;
         return Objects.equals(value, other.getValue()) && weak == other.isWeak();
     }
@@ -125,13 +121,12 @@ public class EntityTag {
     }
 
     /**
-     * Convert the entity tag to a string suitable for use as the value of the
-     * corresponding HTTP header.
+     * Convert the entity tag to a string suitable for use as the value of the corresponding HTTP header.
      *
      * @return a string version of the entity tag.
      * @deprecated The format of the toString() method is subject to change in a future version. Please use
-     * RuntimeDelegate.getInstance().createHeaderDelegate(EntityTag.class).toString(value) instead if you rely on
-     * the format of this method.
+     * RuntimeDelegate.getInstance().createHeaderDelegate(EntityTag.class).toString(value) instead if you rely on the format
+     * of this method.
      */
     @Override
     @Deprecated

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Feature.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Feature.java
@@ -19,21 +19,21 @@ package javax.ws.rs.core;
 /**
  * A feature extension contract.
  *
- * Typically encapsulates a concept or facility that involves configuration of multiple providers
- * (e.g. filters or interceptors) and/or properties.
+ * Typically encapsulates a concept or facility that involves configuration of multiple providers (e.g. filters or
+ * interceptors) and/or properties.
  * <p>
- * A {@code Feature} is a special type of JAX-RS configuration meta-provider. Once a feature is registered,
- * its {@link #configure(FeatureContext)} method is invoked during JAX-RS runtime configuration and bootstrapping
- * phase allowing the feature to further configure the runtime context in which it has been registered.
- * From within the invoked {@code configure(...)} method a feature may provide additional runtime configuration
- * for the facility or conceptual domain it represents, such as registering additional contract providers,
- * including nested features and/or specifying domain-specific properties.
+ * A {@code Feature} is a special type of JAX-RS configuration meta-provider. Once a feature is registered, its
+ * {@link #configure(FeatureContext)} method is invoked during JAX-RS runtime configuration and bootstrapping phase
+ * allowing the feature to further configure the runtime context in which it has been registered. From within the
+ * invoked {@code configure(...)} method a feature may provide additional runtime configuration for the facility or
+ * conceptual domain it represents, such as registering additional contract providers, including nested features and/or
+ * specifying domain-specific properties.
  * </p>
  * <p>
  * Features implementing this interface MAY be annotated with the {@link javax.ws.rs.ext.Provider &#64;Provider}
- * annotation in order to be discovered by the JAX-RS runtime when scanning for resources and providers.
- * Please note that this will only work for server side features. Features for the JAX-RS client must
- * be registered programmatically.
+ * annotation in order to be discovered by the JAX-RS runtime when scanning for resources and providers. Please note
+ * that this will only work for server side features. Features for the JAX-RS client must be registered
+ * programmatically.
  * </p>
  *
  * @author Marek Potociar
@@ -42,22 +42,19 @@ package javax.ws.rs.core;
 public interface Feature {
 
     /**
-     * A call-back method called when the feature is to be enabled in a given
-     * runtime configuration scope.
+     * A call-back method called when the feature is to be enabled in a given runtime configuration scope.
      *
-     * The responsibility of the feature is to properly update the supplied runtime configuration context
-     * and return {@code true} if the feature was successfully enabled or {@code false} otherwise.
+     * The responsibility of the feature is to properly update the supplied runtime configuration context and return
+     * {@code true} if the feature was successfully enabled or {@code false} otherwise.
      * <p>
-     * Note that under some circumstances the feature may decide not to enable itself, which
-     * is indicated by returning {@code false}. In such case the configuration context does
-     * not add the feature to the collection of enabled features and a subsequent call to
-     * {@link Configuration#isEnabled(Feature)} or {@link Configuration#isEnabled(Class)} method
+     * Note that under some circumstances the feature may decide not to enable itself, which is indicated by returning
+     * {@code false}. In such case the configuration context does not add the feature to the collection of enabled features
+     * and a subsequent call to {@link Configuration#isEnabled(Feature)} or {@link Configuration#isEnabled(Class)} method
      * would return {@code false}.
      * </p>
      *
      * @param context configurable context in which the feature should be enabled.
-     * @return {@code true} if the feature was successfully enabled, {@code false}
-     *         otherwise.
+     * @return {@code true} if the feature was successfully enabled, {@code false} otherwise.
      */
     public boolean configure(FeatureContext context);
 }

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/FeatureContext.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/FeatureContext.java
@@ -17,8 +17,8 @@
 package javax.ws.rs.core;
 
 /**
- * A configurable context passed to {@link Feature} and {@link javax.ws.rs.container.DynamicFeature}
- * instances by JAX-RS runtime during the phase of their configuration.
+ * A configurable context passed to {@link Feature} and {@link javax.ws.rs.container.DynamicFeature} instances by JAX-RS
+ * runtime during the phase of their configuration.
  *
  * @author Marek Potociar (marek.potociar at oracle.com)
  */

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Form.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Form.java
@@ -20,8 +20,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 
 /**
- * Represents the the HTML form data request entity encoded using the
- * {@code "application/x-www-form-urlencoded"} content type.
+ * Represents the the HTML form data request entity encoded using the {@code "application/x-www-form-urlencoded"}
+ * content type.
  *
  * @author Marek Potociar
  * @since 2.0
@@ -32,9 +32,8 @@ public class Form {
     /**
      * Create a new form data instance.
      * <p>
-     * The underlying form parameter store is configured to preserve the insertion order
-     * of the parameters. I.e. parameters can be iterated in the same order as they were
-     * inserted into the {@code Form}.
+     * The underlying form parameter store is configured to preserve the insertion order of the parameters. I.e. parameters
+     * can be iterated in the same order as they were inserted into the {@code Form}.
      * </p>
      */
     public Form() {
@@ -46,12 +45,11 @@ public class Form {
     /**
      * Create a new form data instance with a single parameter entry.
      * <p>
-     * The underlying form parameter store is configured to preserve the insertion order
-     * of the parameters. I.e. parameters can be iterated in the same order as they were
-     * inserted into the {@code Form}.
+     * The underlying form parameter store is configured to preserve the insertion order of the parameters. I.e. parameters
+     * can be iterated in the same order as they were inserted into the {@code Form}.
      * </p>
      *
-     * @param parameterName  form parameter name.
+     * @param parameterName form parameter name.
      * @param parameterValue form parameter value.
      */
     public Form(final String parameterName, final String parameterValue) {
@@ -63,9 +61,8 @@ public class Form {
     /**
      * Create a new form data instance and register a custom underlying parameter store.
      * <p>
-     * This method is useful in situations when a custom parameter store is needed
-     * in order to change the default parameter iteration order, improve performance
-     * or facilitate other custom requirements placed on the parameter store.
+     * This method is useful in situations when a custom parameter store is needed in order to change the default parameter
+     * iteration order, improve performance or facilitate other custom requirements placed on the parameter store.
      * </p>
      *
      * @param store form data store used by the created form instance.
@@ -77,7 +74,7 @@ public class Form {
     /**
      * Adds a new value to the specified form parameter.
      *
-     * @param name  name of the parameter.
+     * @param name name of the parameter.
      * @param value new parameter value to be added.
      * @return updated {@code Form} instance.
      */

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/GenericEntity.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/GenericEntity.java
@@ -27,40 +27,45 @@ import java.lang.reflect.Type;
 /**
  * Represents a message entity of a generic type {@code T}.
  * <p>
- * Normally type erasure removes generic type information such that a
- * {@link Response} instance that contains, e.g., an entity of type
- * {@code List<String>} appears to contain a raw {@code List<?>} at runtime.
- * When the generic type is required to select a suitable
- * {@link javax.ws.rs.ext.MessageBodyWriter}, this class may be used to wrap the
- * entity and capture its generic type.
+ * Normally type erasure removes generic type information such that a {@link Response} instance that contains, e.g., an
+ * entity of type {@code List<String>} appears to contain a raw {@code List<?>} at runtime. When the generic type is
+ * required to select a suitable {@link javax.ws.rs.ext.MessageBodyWriter}, this class may be used to wrap the entity
+ * and capture its generic type.
  * </p>
  * <p>
  * There are two ways to create an instance:
  * </p>
  * <ol>
- * <li>Create a (typically anonymous) subclass of this
- * class which enables retrieval of the type information at runtime despite
- * type erasure. For example, the following code shows how to create a
- * {@link Response} containing an entity of type {@code List<String>} whose
- * generic type will be available at runtime for selection of a suitable
+ * <li>Create a (typically anonymous) subclass of this class which enables retrieval of the type information at runtime
+ * despite type erasure. For example, the following code shows how to create a {@link Response} containing an entity of
+ * type {@code List<String>} whose generic type will be available at runtime for selection of a suitable
  * {@link javax.ws.rs.ext.MessageBodyWriter}:
  *
- * <pre>List&lt;String&gt; list = new ArrayList&lt;String&gt;();
- * GenericEntity&lt;List&lt;String&gt;&gt; entity = new GenericEntity&lt;List&lt;String&gt;&gt;(list) {};
- * Response response = Response.ok(entity).build();</pre>
+ * <pre>
+ * List&lt;String&gt; list = new ArrayList&lt;String&gt;();
+ * GenericEntity&lt;List&lt;String&gt;&gt; entity = new GenericEntity&lt;List&lt;String&gt;&gt;(list) {
+ * };
+ * Response response = Response.ok(entity).build();
+ * </pre>
  *
- * <p>where {@code list} is the instance of {@code List<String>}
- * that will form the response body and entity is an instance of an anonymous
- * subclass of {@code GenericEntity}.</p></li>
- * <li>Create an instance directly by supplying the generic type information
- * with the entity. For example the following code shows how to create
- * a response containing the result of a method invoked via reflection:
- * <pre>Method method = ...;
+ * <p>
+ * where {@code list} is the instance of {@code List<String>} that will form the response body and entity is an instance
+ * of an anonymous subclass of {@code GenericEntity}.
+ * </p>
+ * </li>
+ * <li>Create an instance directly by supplying the generic type information with the entity. For example the following
+ * code shows how to create a response containing the result of a method invoked via reflection:
+ *
+ * <pre>
+ * Method method = ...;
  * GenericEntity&lt;Object&gt; entity = new GenericEntity&lt;Object&gt;(
  *    method.invoke(...), method.getGenericReturnType());
- * Response response = Response.ok(entity).build();</pre>
- * <p>The above obtains the generic type from the return type of the method,
- * the raw type is the class of entity.</p></li>
+ * Response response = Response.ok(entity).build();
+ * </pre>
+ * <p>
+ * The above obtains the generic type from the return type of the method, the raw type is the class of entity.
+ * </p>
+ * </li>
  * </ol>
  *
  * @param <T> response entity instance type
@@ -76,9 +81,8 @@ public class GenericEntity<T> {
     private final T entity;
 
     /**
-     * Constructs a new generic entity. Derives represented class from type
-     * parameter. Note that this constructor is protected, users should create
-     * a (usually anonymous) subclass as shown above.
+     * Constructs a new generic entity. Derives represented class from type parameter. Note that this constructor is
+     * protected, users should create a (usually anonymous) subclass as shown above.
      *
      * @param entity the entity instance, must not be {@code null}.
      * @throws IllegalArgumentException if entity is {@code null}.
@@ -93,18 +97,15 @@ public class GenericEntity<T> {
     }
 
     /**
-     * Create a new instance of GenericEntity, supplying the generic type information.
-     * The entity must be assignable to a variable of the
-     * supplied generic type, e.g. if {@code entity} is an instance of
-     * {@code ArrayList<String>} then {@code genericType} could
-     * be the same or a superclass of {@code ArrayList} with the same generic
-     * type like {@code List<String>}.
+     * Create a new instance of GenericEntity, supplying the generic type information. The entity must be assignable to a
+     * variable of the supplied generic type, e.g. if {@code entity} is an instance of {@code ArrayList<String>} then
+     * {@code genericType} could be the same or a superclass of {@code ArrayList} with the same generic type like
+     * {@code List<String>}.
      *
-     * @param entity      the entity instance, must not be {@code null}.
+     * @param entity the entity instance, must not be {@code null}.
      * @param genericType the generic type, must not be {@code null}.
-     * @throws IllegalArgumentException if the entity is not assignable to
-     *                                  a variable of the supplied generic type or if entity or genericType
-     *                                  is null.
+     * @throws IllegalArgumentException if the entity is not assignable to a variable of the supplied generic type or if
+     * entity or genericType is null.
      */
     public GenericEntity(final T entity, final Type genericType) {
         if (entity == null || genericType == null) {
@@ -137,9 +138,8 @@ public class GenericEntity<T> {
     }
 
     /**
-     * Gets the raw type of the enclosed entity. Note that this is the raw type of
-     * the instance, not the raw type of the type parameter. I.e. in the example
-     * in the introduction, the raw type is {@code ArrayList} not {@code List}.
+     * Gets the raw type of the enclosed entity. Note that this is the raw type of the instance, not the raw type of the
+     * type parameter. I.e. in the example in the introduction, the raw type is {@code ArrayList} not {@code List}.
      *
      * @return the raw type.
      */
@@ -148,10 +148,8 @@ public class GenericEntity<T> {
     }
 
     /**
-     * Gets underlying {@code Type} instance. Note that this is derived from the
-     * type parameter, not the enclosed instance. I.e. in the example
-     * in the introduction, the type is {@code List<String>} not
-     * {@code ArrayList<String>}.
+     * Gets underlying {@code Type} instance. Note that this is derived from the type parameter, not the enclosed instance.
+     * I.e. in the example in the introduction, the type is {@code List<String>} not {@code ArrayList<String>}.
      *
      * @return the type
      */

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/GenericType.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/GenericType.java
@@ -27,21 +27,22 @@ import java.util.Stack;
 /**
  * Represents a generic message entity type {@code T}.
  *
- * Supports in-line instantiation of objects that represent generic types with
- * actual type parameters. An object that represents any parameterized type may
- * be obtained by sub-classing {@code GenericType}. Alternatively, an object
- * representing a concrete parameterized type can be created using a
- * {@link #GenericType(java.lang.reflect.Type)} and manually specifying
- * the {@link #getType() actual (parameterized) type}.
+ * Supports in-line instantiation of objects that represent generic types with actual type parameters. An object that
+ * represents any parameterized type may be obtained by sub-classing {@code GenericType}. Alternatively, an object
+ * representing a concrete parameterized type can be created using a {@link #GenericType(java.lang.reflect.Type)} and
+ * manually specifying the {@link #getType() actual (parameterized) type}.
  * <p>
  * For example:
  * </p>
+ *
  * <pre>
- *  GenericType&lt;List&lt;String&gt;&gt; stringListType = new GenericType&lt;List&lt;String&gt;&gt;() {};
+ * GenericType&lt;List&lt;String&gt;&gt; stringListType = new GenericType&lt;List&lt;String&gt;&gt;() {
+ * };
  * </pre>
  * <p>
  * Or:
  * </p>
+ *
  * <pre>
  *  public class MyGenericType extends GenericType&lt;List&lt;String&gt;&gt; { ... }
  *
@@ -50,10 +51,11 @@ import java.util.Stack;
  *  MyGenericType stringListType = new MyGenericType();
  * </pre>
  * <p>
- * Note that due to the Java type erasure limitations the parameterized type information
- * must be specified on a subclass, not just during the instance creation. For example,
- * the following case would throw an {@link IllegalArgumentException}:
+ * Note that due to the Java type erasure limitations the parameterized type information must be specified on a
+ * subclass, not just during the instance creation. For example, the following case would throw an
+ * {@link IllegalArgumentException}:
  * </p>
+ *
  * <pre>
  *  public class MyGenericType&lt;T&gt; extends GenericType&lt;T&gt; { ... }
  *
@@ -82,12 +84,10 @@ public class GenericType<T> {
     private final Class<?> rawType;
 
     /**
-     * Create a {@link javax.ws.rs.core.GenericType generic type} from a
-     * Java {@code instance}.
+     * Create a {@link javax.ws.rs.core.GenericType generic type} from a Java {@code instance}.
      * <p>
-     * If the supplied instance is a {@link javax.ws.rs.core.GenericEntity}, the generic type
-     * will be computed using the {@link javax.ws.rs.core.GenericEntity#getType()}.
-     * Otherwise {@code instance.getClass()} will be used.
+     * If the supplied instance is a {@link javax.ws.rs.core.GenericEntity}, the generic type will be computed using the
+     * {@link javax.ws.rs.core.GenericEntity#getType()}. Otherwise {@code instance.getClass()} will be used.
      * </p>
      *
      * @param instance Java instance for which the {@code GenericType} description should be created.
@@ -105,12 +105,10 @@ public class GenericType<T> {
     }
 
     /**
-     * Constructs a new generic type, deriving the generic type and class from
-     * type parameter. Note that this constructor is protected, users should create
-     * a (usually anonymous) subclass as shown above.
+     * Constructs a new generic type, deriving the generic type and class from type parameter. Note that this constructor is
+     * protected, users should create a (usually anonymous) subclass as shown above.
      *
-     * @throws IllegalArgumentException in case the generic type parameter value is not
-     *                                  provided by any of the subclasses.
+     * @throws IllegalArgumentException in case the generic type parameter value is not provided by any of the subclasses.
      */
     protected GenericType() {
         // Get the type parameter of GenericType<T> (aka the T value)
@@ -119,13 +117,11 @@ public class GenericType<T> {
     }
 
     /**
-     * Constructs a new generic type, supplying the generic type
-     * information and deriving the class.
+     * Constructs a new generic type, supplying the generic type information and deriving the class.
      *
      * @param genericType the generic type.
-     * @throws IllegalArgumentException if genericType is {@code null} or not an instance of
-     *                                  {@code Class} or {@link ParameterizedType} whose raw
-     *                                  type is an instance of {@code Class}.
+     * @throws IllegalArgumentException if genericType is {@code null} or not an instance of {@code Class} or
+     * {@link ParameterizedType} whose raw type is an instance of {@code Class}.
      */
     public GenericType(final Type genericType) {
         if (genericType == null) {
@@ -146,19 +142,17 @@ public class GenericType<T> {
     }
 
     /**
-     * Returns the object representing the class or interface that declared
-     * the type represented by this generic type instance.
+     * Returns the object representing the class or interface that declared the type represented by this generic type
+     * instance.
      *
-     * @return the class or interface that declared the type represented by this
-     *         generic type instance.
+     * @return the class or interface that declared the type represented by this generic type instance.
      */
     public final Class<?> getRawType() {
         return rawType;
     }
 
     /**
-     * Returns the object representing the class or interface that declared
-     * the supplied {@code type}.
+     * Returns the object representing the class or interface that declared the supplied {@code type}.
      *
      * @param type {@code Type} to inspect.
      * @return the class or interface that declared the supplied {@code type}.
@@ -198,7 +192,7 @@ public class GenericType<T> {
     /**
      * Return the value of the type parameter of {@code GenericType<T>}.
      *
-     * @param clazz     subClass of {@code baseClass} to analyze.
+     * @param clazz subClass of {@code baseClass} to analyze.
      * @param baseClass base class having the type parameter the value of which we need to retrieve
      * @return the parameterized type of {@code GenericType<T>} (aka T)
      */

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/HttpHeaders.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/HttpHeaders.java
@@ -22,9 +22,8 @@ import java.util.Locale;
 import java.util.Map;
 
 /**
- * An injectable interface that provides access to HTTP header information.
- * All methods throw {@link java.lang.IllegalStateException} if called outside the
- * scope of a request (e.g. from a provider constructor).
+ * An injectable interface that provides access to HTTP header information. All methods throw
+ * {@link java.lang.IllegalStateException} if called outside the scope of a request (e.g. from a provider constructor).
  *
  * @author Paul Sandoz
  * @author Marc Hadley
@@ -34,72 +33,63 @@ import java.util.Map;
 public interface HttpHeaders {
 
     /**
-     * Get the values of a HTTP request header. The returned List is read-only.
-     * This is a shortcut for {@code getRequestHeaders().get(name)}.
+     * Get the values of a HTTP request header. The returned List is read-only. This is a shortcut for
+     * {@code getRequestHeaders().get(name)}.
      *
      * @param name the header name, case insensitive.
      * @return a read-only list of header values.
-     * @throws java.lang.IllegalStateException
-     *          if called outside the scope of a request.
+     * @throws java.lang.IllegalStateException if called outside the scope of a request.
      */
     public List<String> getRequestHeader(String name);
 
     /**
-     * <p>Get a HTTP header as a single string value.
+     * <p>
+     * Get a HTTP header as a single string value.
      * </p>
-     * Each single header value is converted to String using a
-     * {@link javax.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one is available
-     * via {@link javax.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)}
-     * for the header value class or using its {@code toString} method  if a header
-     * delegate is not available.
+     * Each single header value is converted to String using a {@link javax.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one
+     * is available via {@link javax.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the header value
+     * class or using its {@code toString} method if a header delegate is not available.
      *
      * @param name the HTTP header.
-     * @return the HTTP header value. If the HTTP header is not present then
-     *         {@code null} is returned. If the HTTP header is present but has no
-     *         value then the empty string is returned. If the HTTP header is present
-     *         more than once then the values of joined together and separated by a ','
-     *         character.
+     * @return the HTTP header value. If the HTTP header is not present then {@code null} is returned. If the HTTP header is
+     * present but has no value then the empty string is returned. If the HTTP header is present more than once then the
+     * values of joined together and separated by a ',' character.
      * @see #getRequestHeader(java.lang.String)
      * @since 2.0
      */
     public String getHeaderString(String name);
 
-
     /**
-     * Get the values of HTTP request headers. The returned Map is case-insensitive
-     * wrt. keys and is read-only. The method never returns {@code null}.
+     * Get the values of HTTP request headers. The returned Map is case-insensitive wrt. keys and is read-only. The method
+     * never returns {@code null}.
      *
      * @return a read-only map of header names and values.
-     * @throws java.lang.IllegalStateException
-     *          if called outside the scope of a request.
+     * @throws java.lang.IllegalStateException if called outside the scope of a request.
      */
     public MultivaluedMap<String, String> getRequestHeaders();
 
     /**
-     * <p>Get a list of media types that are acceptable for the response.
+     * <p>
+     * Get a list of media types that are acceptable for the response.
      * </p>
-     * If no acceptable media types are specified, a read-only list containing
-     * a single {@link javax.ws.rs.core.MediaType#WILDCARD_TYPE wildcard media type}
-     * instance is returned.
+     * If no acceptable media types are specified, a read-only list containing a single
+     * {@link javax.ws.rs.core.MediaType#WILDCARD_TYPE wildcard media type} instance is returned.
      *
-     * @return a read-only list of requested response media types sorted according
-     *         to their q-value, with highest preference first.
-     * @throws java.lang.IllegalStateException
-     *          if called outside the scope of a request.
+     * @return a read-only list of requested response media types sorted according to their q-value, with highest preference
+     * first.
+     * @throws java.lang.IllegalStateException if called outside the scope of a request.
      */
     public List<MediaType> getAcceptableMediaTypes();
 
     /**
-     * <p>Get a list of languages that are acceptable for the response.
+     * <p>
+     * Get a list of languages that are acceptable for the response.
      * </p>
-     * If no acceptable languages are specified, a read-only list containing
-     * a single wildcard {@link java.util.Locale} instance (with language field
-     * set to "{@code *}") is returned.
+     * If no acceptable languages are specified, a read-only list containing a single wildcard {@link java.util.Locale}
+     * instance (with language field set to "{@code *}") is returned.
      *
-     * @return a read-only list of acceptable languages sorted according
-     *         to their q-value, with highest preference first.
-     * @throws java.lang.IllegalStateException
-     *          if called outside the scope of a request.
+     * @return a read-only list of acceptable languages sorted according to their q-value, with highest preference first.
+     * @throws java.lang.IllegalStateException if called outside the scope of a request.
      */
     public List<Locale> getAcceptableLanguages();
 
@@ -107,8 +97,7 @@ public interface HttpHeaders {
      * Get the media type of the request entity.
      *
      * @return the media type or {@code null} if there is no request entity.
-     * @throws java.lang.IllegalStateException
-     *          if called outside the scope of a request.
+     * @throws java.lang.IllegalStateException if called outside the scope of a request.
      */
     public MediaType getMediaType();
 
@@ -116,8 +105,7 @@ public interface HttpHeaders {
      * Get the language of the request entity.
      *
      * @return the language of the entity or {@code null} if not specified.
-     * @throws java.lang.IllegalStateException
-     *          if called outside the scope of a request.
+     * @throws java.lang.IllegalStateException if called outside the scope of a request.
      */
     public Locale getLanguage();
 
@@ -125,8 +113,7 @@ public interface HttpHeaders {
      * Get any cookies that accompanied the request.
      *
      * @return a read-only map of cookie name (String) to Cookie.
-     * @throws java.lang.IllegalStateException
-     *          if called outside the scope of a request
+     * @throws java.lang.IllegalStateException if called outside the scope of a request
      */
     public Map<String, Cookie> getCookies();
 
@@ -141,8 +128,7 @@ public interface HttpHeaders {
     /**
      * Get Content-Length value.
      *
-     * @return Content-Length as integer if present and valid number. In other
-     *         cases returns -1.
+     * @return Content-Length as integer if present and valid number. In other cases returns -1.
      * @since 2.0
      */
     public int getLength();

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Link.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Link.java
@@ -29,14 +29,17 @@ import javax.xml.bind.annotation.adapters.XmlAdapter;
 import javax.xml.namespace.QName;
 
 /**
- * <p>Class representing hypermedia links. A hypermedia link may include additional
- * parameters beyond its underlying URI. Parameters such as {@code rel} or {@code type}
- * provide additional meta-data. Links in responses can be <em>followed</em> by
- * creating an {@link javax.ws.rs.client.Invocation.Builder} or a
- * {@link javax.ws.rs.client.WebTarget}.</p>
+ * <p>
+ * Class representing hypermedia links. A hypermedia link may include additional parameters beyond its underlying URI.
+ * Parameters such as {@code rel} or {@code type} provide additional meta-data. Links in responses can be
+ * <em>followed</em> by creating an {@link javax.ws.rs.client.Invocation.Builder} or a
+ * {@link javax.ws.rs.client.WebTarget}.
+ * </p>
  *
- * <p>The methods {@link #toString} and {@link #valueOf} can be used to serialize
- * and de-serialize a link into a link header (RFC 5988).</p>
+ * <p>
+ * The methods {@link #toString} and {@link #valueOf} can be used to serialize and de-serialize a link into a link
+ * header (RFC 5988).
+ * </p>
  *
  * @author Marek Potociar
  * @author Santiago Pericas-Geertsen
@@ -70,58 +73,52 @@ public abstract class Link {
     public abstract URI getUri();
 
     /**
-     * Convenience method that returns a {@link javax.ws.rs.core.UriBuilder}
-     * initialized with this link's underlying URI.
+     * Convenience method that returns a {@link javax.ws.rs.core.UriBuilder} initialized with this link's underlying URI.
      *
      * @return UriBuilder initialized using underlying URI.
      */
     public abstract UriBuilder getUriBuilder();
 
     /**
-     * Returns the value associated with the link {@code rel} param, or
-     * {@code null} if this param is not specified.
+     * Returns the value associated with the link {@code rel} param, or {@code null} if this param is not specified.
      *
      * @return relation types as string or {@code null}.
      */
     public abstract String getRel();
 
     /**
-     * Returns the value associated with the link {@code rel} param as a list
-     * of strings or the empty list if {@code rel} is not defined.
+     * Returns the value associated with the link {@code rel} param as a list of strings or the empty list if {@code rel} is
+     * not defined.
      *
      * @return relation types as list of strings or empty list.
      */
     public abstract List<String> getRels();
 
     /**
-     * Returns the value associated with the link {@code title} param, or
-     * {@code null} if this param is not specified.
+     * Returns the value associated with the link {@code title} param, or {@code null} if this param is not specified.
      *
      * @return value of title parameter or {@code null}.
      */
     public abstract String getTitle();
 
     /**
-     * Returns the value associated with the link {@code type} param, or
-     * {@code null} if this param is not specified.
+     * Returns the value associated with the link {@code type} param, or {@code null} if this param is not specified.
      *
      * @return value of type parameter or {@code null}.
      */
     public abstract String getType();
 
     /**
-     * Returns an immutable map that includes all the link parameters
-     * defined on this link. If defined, this map will include entries
-     * for {@code rel}, {@code title} and {@code type}.
+     * Returns an immutable map that includes all the link parameters defined on this link. If defined, this map will
+     * include entries for {@code rel}, {@code title} and {@code type}.
      *
      * @return immutable map of link parameters.
      */
     public abstract Map<String, String> getParams();
 
     /**
-     * Returns a string representation as a link header (RFC 5988).
-     * All link params are serialized as link-param="value" where value
-     * is a quoted-string. For example,
+     * Returns a string representation as a link header (RFC 5988). All link params are serialized as link-param="value"
+     * where value is a quoted-string. For example,
      *
      * &lt;http://foo.bar/employee/john&gt;; title="employee"; rel="manager friend"
      *
@@ -132,6 +129,7 @@ public abstract class Link {
 
     /**
      * Simple parser to convert link header string representations into a link.
+     *
      * <pre>
      * link ::= '&lt;' uri 'gt;' (';' link-param)*
      * link-param ::= name '=' quoted-string
@@ -201,11 +199,9 @@ public abstract class Link {
     }
 
     /**
-     * Convenience method to build a link from a path. Equivalent to
-     * {@code fromUriBuilder(UriBuilder.fromPath(path))}.
+     * Convenience method to build a link from a path. Equivalent to {@code fromUriBuilder(UriBuilder.fromPath(path))}.
      *
-     * @param path a URI path that will be used to initialize the Link, may contain
-     *             URI template parameters.
+     * @param path a URI path that will be used to initialize the Link, may contain URI template parameters.
      * @return a new Link.Builder.
      * @throws IllegalArgumentException if path is {@code null}.
      */
@@ -215,18 +211,16 @@ public abstract class Link {
 
     /**
      * Convenience method to build a link from a resource. Equivalent to
-     * <tt>Link.fromUriBuilder({@link UriBuilder#fromResource UriBuilder.fromResource(resource)})</tt>.
-     * Note that the link URI passed to the {@code Link.Builder} instance returned by this
-     * method is relative. Should the link be built as absolute, a {@link Link.Builder#baseUri(URI)
-     * base URI} has to be specified in the builder prior to building the new link instance.
-     * For example, on a server side a {@link UriInfo#getBaseUri()} may be typically used to define
-     * the base URI of a link created using this method.
+     * <tt>Link.fromUriBuilder({@link UriBuilder#fromResource UriBuilder.fromResource(resource)})</tt>. Note that the link
+     * URI passed to the {@code Link.Builder} instance returned by this method is relative. Should the link be built as
+     * absolute, a {@link Link.Builder#baseUri(URI) base URI} has to be specified in the builder prior to building the new
+     * link instance. For example, on a server side a {@link UriInfo#getBaseUri()} may be typically used to define the base
+     * URI of a link created using this method.
      *
-     * @param resource a root resource whose {@link javax.ws.rs.Path} value will be used
-     *                 to initialize the builder.
+     * @param resource a root resource whose {@link javax.ws.rs.Path} value will be used to initialize the builder.
      * @return a new {@link Link.Builder link builder} instance.
-     * @throws IllegalArgumentException if resource is not annotated with {@link javax.ws.rs.Path}
-     *                                  or resource is {@code null}.
+     * @throws IllegalArgumentException if resource is not annotated with {@link javax.ws.rs.Path} or resource is
+     * {@code null}.
      * @see UriInfo#getBaseUri()
      */
     public static Builder fromResource(final Class<?> resource) {
@@ -236,19 +230,16 @@ public abstract class Link {
     /**
      * Convenience method to build a link from a resource. Equivalent to
      * <tt>Link.fromUriBuilder({@link UriBuilder#fromMethod(Class, String) UriBuilder.fromMethod(resource, method)})</tt>.
-     * Note that the link URI passed to the {@code Link.Builder} instance returned by this
-     * method is relative. Should the link be built as absolute, a {@link Link.Builder#baseUri(URI)
-     * base URI} has to be specified in the builder prior to building the new link instance.
-     * For example, on a server side a {@link UriInfo#getBaseUri()} may be typically used to define
-     * the base URI of a link created using this method.
+     * Note that the link URI passed to the {@code Link.Builder} instance returned by this method is relative. Should the
+     * link be built as absolute, a {@link Link.Builder#baseUri(URI) base URI} has to be specified in the builder prior to
+     * building the new link instance. For example, on a server side a {@link UriInfo#getBaseUri()} may be typically used to
+     * define the base URI of a link created using this method.
      *
      * @param resource the resource containing the method.
-     * @param method   the name of the method whose {@link javax.ws.rs.Path} value will be used
-     *                 to obtain the path to append.
+     * @param method the name of the method whose {@link javax.ws.rs.Path} value will be used to obtain the path to append.
      * @return the updated Link.Builder.
-     * @throws IllegalArgumentException if resource or method is {@code null}, or there is more
-     *                                  than or less than one variant of the method annotated with
-     *                                  {@link javax.ws.rs.Path}.
+     * @throws IllegalArgumentException if resource or method is {@code null}, or there is more than or less than one
+     * variant of the method annotated with {@link javax.ws.rs.Path}.
      * @see UriInfo#getBaseUri()
      */
     public static Builder fromMethod(final Class<?> resource, final String method) {
@@ -264,8 +255,7 @@ public abstract class Link {
     public interface Builder {
 
         /**
-         * Initialize builder using another link. Sets underlying URI and copies
-         * all parameters.
+         * Initialize builder using another link. Sets underlying URI and copies all parameters.
          *
          * @param link other link from which to initialize.
          * @return the updated builder.
@@ -273,8 +263,9 @@ public abstract class Link {
         public Builder link(Link link);
 
         /**
-         * Initialize builder using another link represented as a string. Uses
-         * simple parser to convert string representation into a link.
+         * Initialize builder using another link represented as a string. Uses simple parser to convert string representation
+         * into a link.
+         *
          * <pre>
          * link ::= '&lt;' uri 'gt;' (';' link-param)*
          * link-param ::= name '=' quoted-string
@@ -306,8 +297,7 @@ public abstract class Link {
         public Builder uri(String uri);
 
         /**
-         * Set the base URI for resolution of relative URIs. If the underlying URI is already
-         * absolute, the base URI is ignored.
+         * Set the base URI for resolution of relative URIs. If the underlying URI is already absolute, the base URI is ignored.
          *
          * @param uri base URI for relative links.
          * @return the updated builder.
@@ -318,8 +308,8 @@ public abstract class Link {
         public Builder baseUri(URI uri);
 
         /**
-         * Set the base URI as a string for resolution of relative URIs. If the underlying URI
-         * is already absolute, the base URI is ignored.
+         * Set the base URI as a string for resolution of relative URIs. If the underlying URI is already absolute, the base URI
+         * is ignored.
          *
          * @param uri base URI for relative links.
          * @return the updated builder.
@@ -339,10 +329,9 @@ public abstract class Link {
         public Builder uriBuilder(UriBuilder uriBuilder);
 
         /**
-         * Convenience method to set a link relation. More than one {@code rel} value can
-         * be specified by using one or more whitespace characters as delimiters
-         * according to RFC 5988. The effect of calling this method is cumulative;
-         * relations are appended using a single space character as separator.
+         * Convenience method to set a link relation. More than one {@code rel} value can be specified by using one or more
+         * whitespace characters as delimiters according to RFC 5988. The effect of calling this method is cumulative; relations
+         * are appended using a single space character as separator.
          *
          * @param rel relation name.
          * @return the updated builder.
@@ -369,11 +358,10 @@ public abstract class Link {
         public Builder type(String type);
 
         /**
-         * Set an arbitrary parameter on this link. Note that link parameters are those
-         * defined in RFC 5988 and should not be confused with URI parameters which can
-         * be specified when calling {@link #build(Object...)}.
+         * Set an arbitrary parameter on this link. Note that link parameters are those defined in RFC 5988 and should not be
+         * confused with URI parameters which can be specified when calling {@link #build(Object...)}.
          *
-         * @param name  the name of the parameter.
+         * @param name the name of the parameter.
          * @param value the value set for the parameter.
          * @return the updated builder.
          * @throws IllegalArgumentException if either the name or value are {@code null}.
@@ -383,36 +371,31 @@ public abstract class Link {
         /**
          * Finish building this link using the supplied values as URI parameters.
          *
-         * The state of the builder is unaffected; this method may be called
-         * multiple times on the same builder instance.
+         * The state of the builder is unaffected; this method may be called multiple times on the same builder instance.
          *
          * @param values parameters used to build underlying URI.
          * @return newly built link.
-         * @throws IllegalArgumentException if there are any URI template parameters
-         *                                  without a supplied value, or if a value is {@code null}.
-         * @throws UriBuilderException      if a URI cannot be constructed based on the
-         *                                  current state of the underlying URI builder.
+         * @throws IllegalArgumentException if there are any URI template parameters without a supplied value, or if a value is
+         * {@code null}.
+         * @throws UriBuilderException if a URI cannot be constructed based on the current state of the underlying URI builder.
          */
         public Link build(Object... values);
 
         /**
-         * Finish building this link using the supplied values as URI parameters
-         * and relativize the result with respect to the supplied URI.
+         * Finish building this link using the supplied values as URI parameters and relativize the result with respect to the
+         * supplied URI.
          *
-         * If the underlying link is already relative or if it is absolute but does
-         * not share a prefix with the supplied URI, this method is equivalent to calling
-         * {@link Link.Builder#build(java.lang.Object[])}. Note that a base URI can
-         * be set on a relative link using {@link Link.Builder#baseUri(java.net.URI)}.
-         * The state of the builder is unaffected; this method may be called
-         * multiple times on the same builder instance.
+         * If the underlying link is already relative or if it is absolute but does not share a prefix with the supplied URI,
+         * this method is equivalent to calling {@link Link.Builder#build(java.lang.Object[])}. Note that a base URI can be set
+         * on a relative link using {@link Link.Builder#baseUri(java.net.URI)}. The state of the builder is unaffected; this
+         * method may be called multiple times on the same builder instance.
          *
-         * @param uri    URI used for relativization.
+         * @param uri URI used for relativization.
          * @param values parameters used to build underlying URI.
          * @return newly built link.
-         * @throws IllegalArgumentException if there are any URI template parameters
-         *                                  without a supplied value, or if a value is {@code null}.
-         * @throws UriBuilderException      if a URI cannot be constructed based on the current
-         *                                  state of the underlying URI builder.
+         * @throws IllegalArgumentException if there are any URI template parameters without a supplied value, or if a value is
+         * {@code null}.
+         * @throws UriBuilderException if a URI cannot be constructed based on the current state of the underlying URI builder.
          * @see #baseUri(java.lang.String)
          * @see #baseUri(java.net.URI)
          */
@@ -420,8 +403,7 @@ public abstract class Link {
     }
 
     /**
-     * Value type for {@link javax.ws.rs.core.Link} that can be marshalled and
-     * unmarshalled by JAXB.
+     * Value type for {@link javax.ws.rs.core.Link} that can be marshalled and unmarshalled by JAXB.
      *
      * @see javax.ws.rs.core.Link.JaxbAdapter
      * @since 2.0
@@ -449,7 +431,7 @@ public abstract class Link {
         /**
          * Construct an instance from a URI and some parameters.
          *
-         * @param uri    underlying URI.
+         * @param uri underlying URI.
          * @param params parameters of this link.
          */
         public JaxbLink(final URI uri, final Map<QName, Object> params) {
@@ -500,8 +482,10 @@ public abstract class Link {
 
         @Override
         public boolean equals(final Object o) {
-            if (this == o) return true;
-            if (!(o instanceof JaxbLink)) return false;
+            if (this == o)
+                return true;
+            if (!(o instanceof JaxbLink))
+                return false;
 
             JaxbLink jaxbLink = (JaxbLink) o;
 
@@ -534,10 +518,9 @@ public abstract class Link {
     }
 
     /**
-     * An implementation of JAXB {@link javax.xml.bind.annotation.adapters.XmlAdapter}
-     * that maps the JAX-RS {@link javax.ws.rs.core.Link} type to a value that can be
-     * marshalled and unmarshalled by JAXB. The following example shows how to use
-     * this adapter on a JAXB bean class:
+     * An implementation of JAXB {@link javax.xml.bind.annotation.adapters.XmlAdapter} that maps the JAX-RS
+     * {@link javax.ws.rs.core.Link} type to a value that can be marshalled and unmarshalled by JAXB. The following example
+     * shows how to use this adapter on a JAXB bean class:
      *
      * <pre>
      * &#64;XmlRootElement

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/MediaType.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/MediaType.java
@@ -165,10 +165,9 @@ public class MediaType {
      *
      * @param type the media type string.
      * @return the newly created MediaType.
-     * @throws IllegalArgumentException if the supplied string cannot be parsed
-     *                                  or is {@code null}.
+     * @throws IllegalArgumentException if the supplied string cannot be parsed or is {@code null}.
      */
-    public static MediaType valueOf(final String type){
+    public static MediaType valueOf(final String type) {
         return RuntimeDelegate.getInstance().createHeaderDelegate(MediaType.class).fromString(type);
     }
 
@@ -189,15 +188,11 @@ public class MediaType {
     }
 
     /**
-     * Creates a new instance of {@code MediaType} with the supplied type, subtype and
-     * parameters.
+     * Creates a new instance of {@code MediaType} with the supplied type, subtype and parameters.
      *
-     * @param type       the primary type, {@code null} is equivalent to
-     *                   {@link #MEDIA_TYPE_WILDCARD}.
-     * @param subtype    the subtype, {@code null} is equivalent to
-     *                   {@link #MEDIA_TYPE_WILDCARD}.
-     * @param parameters a map of media type parameters, {@code null} is the same as an
-     *                   empty map.
+     * @param type the primary type, {@code null} is equivalent to {@link #MEDIA_TYPE_WILDCARD}.
+     * @param subtype the subtype, {@code null} is equivalent to {@link #MEDIA_TYPE_WILDCARD}.
+     * @param parameters a map of media type parameters, {@code null} is the same as an empty map.
      */
     public MediaType(final String type, final String subtype, final Map<String, String> parameters) {
         this(type, subtype, null, createParametersMap(parameters));
@@ -206,33 +201,29 @@ public class MediaType {
     /**
      * Creates a new instance of {@code MediaType} with the supplied type and subtype.
      *
-     * @param type    the primary type, {@code null} is equivalent to
-     *                {@link #MEDIA_TYPE_WILDCARD}
-     * @param subtype the subtype, {@code null} is equivalent to
-     *                {@link #MEDIA_TYPE_WILDCARD}
+     * @param type the primary type, {@code null} is equivalent to {@link #MEDIA_TYPE_WILDCARD}
+     * @param subtype the subtype, {@code null} is equivalent to {@link #MEDIA_TYPE_WILDCARD}
      */
     public MediaType(final String type, final String subtype) {
         this(type, subtype, null, null);
     }
 
     /**
-     * Creates a new instance of {@code MediaType} with the supplied type, subtype and
-     * {@value #CHARSET_PARAMETER} parameter.
+     * Creates a new instance of {@code MediaType} with the supplied type, subtype and {@value #CHARSET_PARAMETER}
+     * parameter.
      *
-     * @param type    the primary type, {@code null} is equivalent to
-     *                {@link #MEDIA_TYPE_WILDCARD}
-     * @param subtype the subtype, {@code null} is equivalent to
-     *                {@link #MEDIA_TYPE_WILDCARD}
-     * @param charset the {@value #CHARSET_PARAMETER} parameter value. If {@code null} or empty
-     *                the {@value #CHARSET_PARAMETER} parameter will not be set.
+     * @param type the primary type, {@code null} is equivalent to {@link #MEDIA_TYPE_WILDCARD}
+     * @param subtype the subtype, {@code null} is equivalent to {@link #MEDIA_TYPE_WILDCARD}
+     * @param charset the {@value #CHARSET_PARAMETER} parameter value. If {@code null} or empty the
+     * {@value #CHARSET_PARAMETER} parameter will not be set.
      */
     public MediaType(final String type, final String subtype, final String charset) {
         this(type, subtype, charset, null);
     }
 
     /**
-     * Creates a new instance of {@code MediaType}, both type and subtype are wildcards.
-     * Consider using the constant {@link #WILDCARD_TYPE} instead.
+     * Creates a new instance of {@code MediaType}, both type and subtype are wildcards. Consider using the constant
+     * {@link #WILDCARD_TYPE} instead.
      */
     public MediaType() {
         this(MEDIA_TYPE_WILDCARD, MEDIA_TYPE_WILDCARD, null, null);
@@ -305,13 +296,13 @@ public class MediaType {
     }
 
     /**
-     * Create a new {@code MediaType} instance with the same type, subtype and parameters
-     * copied from the original instance and the supplied {@value #CHARSET_PARAMETER} parameter.
+     * Create a new {@code MediaType} instance with the same type, subtype and parameters copied from the original instance
+     * and the supplied {@value #CHARSET_PARAMETER} parameter.
      *
-     * @param charset the {@value #CHARSET_PARAMETER} parameter value. If {@code null} or empty
-     *                the {@value #CHARSET_PARAMETER} parameter will not be set or updated.
-     * @return copy of the current {@code MediaType} instance with the {@value #CHARSET_PARAMETER}
-     *         parameter set to the supplied value.
+     * @param charset the {@value #CHARSET_PARAMETER} parameter value. If {@code null} or empty the
+     * {@value #CHARSET_PARAMETER} parameter will not be set or updated.
+     * @return copy of the current {@code MediaType} instance with the {@value #CHARSET_PARAMETER} parameter set to the
+     * supplied value.
      * @since 2.0
      */
     public MediaType withCharset(final String charset) {
@@ -319,9 +310,8 @@ public class MediaType {
     }
 
     /**
-     * Check if this media type is compatible with another media type. E.g.
-     * image/* is compatible with image/jpeg, image/png, etc. Media type
-     * parameters are ignored. The function is commutative.
+     * Check if this media type is compatible with another media type. E.g. image/* is compatible with image/jpeg,
+     * image/png, etc. Media type parameters are ignored. The function is commutative.
      *
      * @param other the media type to compare with.
      * @return true if the types are compatible, false otherwise.
@@ -330,24 +320,22 @@ public class MediaType {
         return other != null && // return false if other is null, else
                 (type.equals(MEDIA_TYPE_WILDCARD) || other.type.equals(MEDIA_TYPE_WILDCARD) || // both are wildcard types, or
                         (type.equalsIgnoreCase(other.type) && (subtype.equals(MEDIA_TYPE_WILDCARD)
-                                || other.subtype.equals(MEDIA_TYPE_WILDCARD))) || // same types, wildcard sub-types, or
+                                || other.subtype.equals(MEDIA_TYPE_WILDCARD)))
+                        || // same types, wildcard sub-types, or
                         (type.equalsIgnoreCase(other.type) && this.subtype.equalsIgnoreCase(other.subtype))); // same types & sub-types
     }
 
     /**
-     * <p>Compares {@code obj} to this media type to see if they are the same by comparing
-     * type, subtype and parameters. Note that the case-sensitivity of parameter
-     * values is dependent on the semantics of the parameter name, see
-     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.7">HTTP/1.1</a>.
-     * This method assumes that values are case-sensitive.
+     * <p>
+     * Compares {@code obj} to this media type to see if they are the same by comparing type, subtype and parameters. Note
+     * that the case-sensitivity of parameter values is dependent on the semantics of the parameter name, see
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.7">HTTP/1.1</a>. This method assumes that values
+     * are case-sensitive.
      * </p>
-     * Note that the {@code equals(...)} implementation does not perform
-     * a class equality check ({@code this.getClass() == obj.getClass()}). Therefore
-     * any class that extends from {@code MediaType} class and needs to override
-     * one of the {@code equals(...)} and {@link #hashCode()} methods must
-     * always override both methods to ensure the contract between
-     * {@link Object#equals(java.lang.Object)} and {@link Object#hashCode()} does
-     * not break.
+     * Note that the {@code equals(...)} implementation does not perform a class equality check
+     * ({@code this.getClass() == obj.getClass()}). Therefore any class that extends from {@code MediaType} class and needs
+     * to override one of the {@code equals(...)} and {@link #hashCode()} methods must always override both methods to
+     * ensure the contract between {@link Object#equals(java.lang.Object)} and {@link Object#hashCode()} does not break.
      *
      * @param obj the object to compare to.
      * @return true if the two media types are the same, false otherwise.
@@ -366,15 +354,13 @@ public class MediaType {
     }
 
     /**
-     * <p>Generate a hash code from the type, subtype and parameters.
+     * <p>
+     * Generate a hash code from the type, subtype and parameters.
      * </p>
-     * Note that the {@link #equals(java.lang.Object)} implementation does not perform
-     * a class equality check ({@code this.getClass() == obj.getClass()}). Therefore
-     * any class that extends from {@code MediaType} class and needs to override
-     * one of the {@link #equals(Object)} and {@code hashCode()} methods must
-     * always override both methods to ensure the contract between
-     * {@link Object#equals(java.lang.Object)} and {@link Object#hashCode()} does
-     * not break.
+     * Note that the {@link #equals(java.lang.Object)} implementation does not perform a class equality check
+     * ({@code this.getClass() == obj.getClass()}). Therefore any class that extends from {@code MediaType} class and needs
+     * to override one of the {@link #equals(Object)} and {@code hashCode()} methods must always override both methods to
+     * ensure the contract between {@link Object#equals(java.lang.Object)} and {@link Object#hashCode()} does not break.
      *
      * @return a generated hash code.
      */
@@ -385,8 +371,7 @@ public class MediaType {
     }
 
     /**
-     * Convert the media type to a string suitable for use as the value of a
-     * corresponding HTTP header.
+     * Convert the media type to a string suitable for use as the value of a corresponding HTTP header.
      *
      * @return a string version of the media type.
      */

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/MultivaluedHashMap.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/MultivaluedHashMap.java
@@ -26,72 +26,60 @@ import java.util.Map;
 /**
  * A hash table based implementation of {@link MultivaluedMap} interface.
  *
- * <p>This implementation provides all of the optional map operations. This class
- * makes no guarantees as to the order of the map; in particular, it does not
- * guarantee that the order will remain constant over time. The implementation
- * permits {@code null} key. By default the implementation does also permit
- * {@code null} values, but ignores them. This behavior can be customized
- * by overriding the protected {@link #addNull(List) addNull(...)} and
+ * <p>
+ * This implementation provides all of the optional map operations. This class makes no guarantees as to the order of
+ * the map; in particular, it does not guarantee that the order will remain constant over time. The implementation
+ * permits {@code null} key. By default the implementation does also permit {@code null} values, but ignores them. This
+ * behavior can be customized by overriding the protected {@link #addNull(List) addNull(...)} and
  * {@link #addFirstNull(List) addFirstNull(...)} methods.
  * </p>
- * <p>This implementation provides constant-time performance for the basic
- * operations (<tt>get</tt> and <tt>put</tt>), assuming the hash function
- * disperses the elements properly among the buckets. Iteration over
- * collection views requires time proportional to the "capacity" of the
- * map instance (the number of buckets) plus its size (the number
- * of key-value mappings).  Thus, it's very important not to set the initial
- * capacity too high (or the load factor too low) if iteration performance is
- * important.
+ * <p>
+ * This implementation provides constant-time performance for the basic operations (<tt>get</tt> and <tt>put</tt>),
+ * assuming the hash function disperses the elements properly among the buckets. Iteration over collection views
+ * requires time proportional to the "capacity" of the map instance (the number of buckets) plus its size (the number of
+ * key-value mappings). Thus, it's very important not to set the initial capacity too high (or the load factor too low)
+ * if iteration performance is important.
  * </p>
- * <p>An instance of <tt>MultivaluedHashMap</tt> has two parameters that affect its
- * performance: <i>initial capacity</i> and <i>load factor</i>. The <i>capacity</i>
- * is the number of buckets in the hash table, and the initial capacity is simply
- * the capacity at the time the hash table is created. The <i>load factor</i> is
- * a measure of how full the hash table is allowed to get before its capacity is
- * automatically increased. When the number of entries in the hash table exceeds
- * the product of the load factor and the current capacity, the hash table is
- * <i>rehashed</i> (that is, internal data structures are rebuilt) so that the
- * hash table has approximately twice the number of buckets.
+ * <p>
+ * An instance of <tt>MultivaluedHashMap</tt> has two parameters that affect its performance: <i>initial capacity</i>
+ * and <i>load factor</i>. The <i>capacity</i> is the number of buckets in the hash table, and the initial capacity is
+ * simply the capacity at the time the hash table is created. The <i>load factor</i> is a measure of how full the hash
+ * table is allowed to get before its capacity is automatically increased. When the number of entries in the hash table
+ * exceeds the product of the load factor and the current capacity, the hash table is <i>rehashed</i> (that is, internal
+ * data structures are rebuilt) so that the hash table has approximately twice the number of buckets.
  * </p>
- * <p>As a general rule, the default load factor (.75) offers a good tradeoff
- * between time and space costs. Higher values decrease the space overhead
- * but increase the lookup cost (reflected in most of the operations of the
- * <tt>HashMap</tt> class, including <tt>get</tt> and <tt>put</tt>). The
- * expected number of entries in the map and its load factor should be taken
- * into account when setting its initial capacity, so as to minimize the
- * number of rehash operations. If the initial capacity is greater
- * than the maximum number of entries divided by the load factor, no
- * rehash operations will ever occur.
+ * <p>
+ * As a general rule, the default load factor (.75) offers a good tradeoff between time and space costs. Higher values
+ * decrease the space overhead but increase the lookup cost (reflected in most of the operations of the <tt>HashMap</tt>
+ * class, including <tt>get</tt> and <tt>put</tt>). The expected number of entries in the map and its load factor should
+ * be taken into account when setting its initial capacity, so as to minimize the number of rehash operations. If the
+ * initial capacity is greater than the maximum number of entries divided by the load factor, no rehash operations will
+ * ever occur.
  * </p>
- * <p>If many mappings are to be stored in a <tt>MultivaluedHashMap</tt> instance,
- * creating it with a sufficiently large capacity will allow the mappings to
- * be stored more efficiently than letting it perform automatic rehashing as
- * needed to grow the table.
+ * <p>
+ * If many mappings are to be stored in a <tt>MultivaluedHashMap</tt> instance, creating it with a sufficiently large
+ * capacity will allow the mappings to be stored more efficiently than letting it perform automatic rehashing as needed
+ * to grow the table.
  * </p>
- * <p><strong>Note that this implementation is not guaranteed to be synchronized.</strong>
- * If multiple threads access a hash map concurrently, and at least one of
- * the threads modifies the map structurally, it <i>must</i> be
- * synchronized externally. (A structural modification is any operation
- * that adds or deletes one or more mappings; merely changing the value
- * associated with a key that an instance already contains is not a
- * structural modification.) This is typically accomplished by
- * synchronizing on some object that naturally encapsulates the map.
+ * <p>
+ * <strong>Note that this implementation is not guaranteed to be synchronized.</strong> If multiple threads access a
+ * hash map concurrently, and at least one of the threads modifies the map structurally, it <i>must</i> be synchronized
+ * externally. (A structural modification is any operation that adds or deletes one or more mappings; merely changing
+ * the value associated with a key that an instance already contains is not a structural modification.) This is
+ * typically accomplished by synchronizing on some object that naturally encapsulates the map.
  * </p>
- * <p>The iterators returned by all of this class's "collection view methods"
- * are <i>fail-fast</i>: if the map is structurally modified at any time after
- * the iterator is created, in any way except through the iterator's own
- * <tt>remove</tt> method, the iterator will throw a {@link ConcurrentModificationException}.
- * Thus, in the face of concurrent modification, the iterator fails quickly and
- * cleanly, rather than risking arbitrary, non-deterministic behavior at an
- * undetermined time in the future.
+ * <p>
+ * The iterators returned by all of this class's "collection view methods" are <i>fail-fast</i>: if the map is
+ * structurally modified at any time after the iterator is created, in any way except through the iterator's own
+ * <tt>remove</tt> method, the iterator will throw a {@link ConcurrentModificationException}. Thus, in the face of
+ * concurrent modification, the iterator fails quickly and cleanly, rather than risking arbitrary, non-deterministic
+ * behavior at an undetermined time in the future.
  * </p>
- * Note that the fail-fast behavior of an iterator cannot be guaranteed
- * as it is, generally speaking, impossible to make any hard guarantees in the
- * presence of unsynchronized concurrent modification. Fail-fast iterators
- * throw <tt>ConcurrentModificationException</tt> on a best-effort basis.
- * Therefore, it would be wrong to write a program that depended on this
- * exception for its correctness: <i>the fail-fast behavior of iterators
- * should be used only to detect bugs.</i>
+ * Note that the fail-fast behavior of an iterator cannot be guaranteed as it is, generally speaking, impossible to make
+ * any hard guarantees in the presence of unsynchronized concurrent modification. Fail-fast iterators throw
+ * <tt>ConcurrentModificationException</tt> on a best-effort basis. Therefore, it would be wrong to write a program that
+ * depended on this exception for its correctness: <i>the fail-fast behavior of iterators should be used only to detect
+ * bugs.</i>
  *
  * @param <K> the type of keys maintained by this map.
  * @param <V> the type of mapped values.
@@ -104,16 +92,16 @@ public class MultivaluedHashMap<K, V> extends AbstractMultivaluedMap<K, V> imple
     private static final long serialVersionUID = -6052320403766368902L;
 
     /**
-     * Constructs an empty multivalued hash map with the default initial capacity
-     * ({@code 16}) and the default load factor ({@code 0.75}).
+     * Constructs an empty multivalued hash map with the default initial capacity ({@code 16}) and the default load factor
+     * ({@code 0.75}).
      */
     public MultivaluedHashMap() {
         super(new HashMap<K, List<V>>());
     }
 
     /**
-     * Constructs an empty multivalued hash map with the specified initial
-     * capacity and the default load factor ({@code 0.75}).
+     * Constructs an empty multivalued hash map with the specified initial capacity and the default load factor
+     * ({@code 0.75}).
      *
      * @param initialCapacity the initial capacity.
      * @throws IllegalArgumentException if the initial capacity is negative.
@@ -123,25 +111,21 @@ public class MultivaluedHashMap<K, V> extends AbstractMultivaluedMap<K, V> imple
     }
 
     /**
-     * Constructs an empty multivalued hash map with the specified initial
-     * capacity and load factor.
+     * Constructs an empty multivalued hash map with the specified initial capacity and load factor.
      *
      * @param initialCapacity the initial capacity
-     * @param loadFactor      the load factor
-     * @throws IllegalArgumentException if the initial capacity is negative
-     *                                  or the load factor is nonpositive
+     * @param loadFactor the load factor
+     * @throws IllegalArgumentException if the initial capacity is negative or the load factor is nonpositive
      */
     public MultivaluedHashMap(final int initialCapacity, final float loadFactor) {
         super(new HashMap<K, List<V>>(initialCapacity, loadFactor));
     }
 
     /**
-     * Constructs a new multivalued hash map with the same mappings as the
-     * specified {@link MultivaluedMap }. The {@link List} instances holding
-     * the values of each key are created anew instead of being reused.
+     * Constructs a new multivalued hash map with the same mappings as the specified {@link MultivaluedMap }. The
+     * {@link List} instances holding the values of each key are created anew instead of being reused.
      *
-     * @param map the multivalued map whose mappings are to be placed in this
-     *            multivalued map.
+     * @param map the multivalued map whose mappings are to be placed in this multivalued map.
      * @throws NullPointerException if the specified map is {@code null}
      */
     public MultivaluedHashMap(final MultivaluedMap<? extends K, ? extends V> map) {
@@ -150,8 +134,8 @@ public class MultivaluedHashMap<K, V> extends AbstractMultivaluedMap<K, V> imple
     }
 
     /**
-     * This private method is used by the copy constructor to avoid exposing
-     * additional generic parameters through the public API documentation.
+     * This private method is used by the copy constructor to avoid exposing additional generic parameters through the
+     * public API documentation.
      *
      * @param <T> any subclass of K
      * @param <U> any subclass of V
@@ -164,11 +148,9 @@ public class MultivaluedHashMap<K, V> extends AbstractMultivaluedMap<K, V> imple
     }
 
     /**
-     * Constructs a new multivalued hash map with the same mappings as the
-     * specified single-valued {@link Map }.
+     * Constructs a new multivalued hash map with the same mappings as the specified single-valued {@link Map }.
      *
-     * @param map the single-valued map whose mappings are to be placed in this
-     *            multivalued map.
+     * @param map the single-valued map whose mappings are to be placed in this multivalued map.
      * @throws NullPointerException if the specified map is {@code null}
      */
     public MultivaluedHashMap(final Map<? extends K, ? extends V> map) {

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/MultivaluedMap.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/MultivaluedMap.java
@@ -32,10 +32,9 @@ import java.util.Map;
 public interface MultivaluedMap<K, V> extends Map<K, List<V>> {
 
     /**
-     * Set the key's value to be a one item list consisting of the supplied value.
-     * Any existing values will be replaced.
+     * Set the key's value to be a one item list consisting of the supplied value. Any existing values will be replaced.
      *
-     * @param key   the key
+     * @param key the key
      * @param value the single value of the key
      */
     void putSingle(K key, V value);
@@ -43,7 +42,7 @@ public interface MultivaluedMap<K, V> extends Map<K, List<V>> {
     /**
      * Add a value to the current list of values for the supplied key.
      *
-     * @param key   the key
+     * @param key the key
      * @param value the value to be added.
      */
     void add(K key, V value);
@@ -52,18 +51,16 @@ public interface MultivaluedMap<K, V> extends Map<K, List<V>> {
      * A shortcut to get the first value of the supplied key.
      *
      * @param key the key
-     * @return the first value for the specified key or null if the key is
-     *         not in the map.
+     * @return the first value for the specified key or null if the key is not in the map.
      */
     V getFirst(K key);
 
     /**
-     * Add multiple values to the current list of values for the supplied key. If
-     * the supplied array of new values is empty, method returns immediately.
-     * Method throws a {@code NullPointerException} if the supplied array of values
-     * is {@code null}.
+     * Add multiple values to the current list of values for the supplied key. If the supplied array of new values is empty,
+     * method returns immediately. Method throws a {@code NullPointerException} if the supplied array of values is
+     * {@code null}.
      *
-     * @param key       the key.
+     * @param key the key.
      * @param newValues the values to be added.
      * @throws NullPointerException if the supplied array of new values is {@code null}.
      * @since 2.0
@@ -71,12 +68,11 @@ public interface MultivaluedMap<K, V> extends Map<K, List<V>> {
     void addAll(K key, V... newValues);
 
     /**
-     * Add all the values from the supplied value list to the current list of
-     * values for the supplied key. If the supplied value list is empty, method
-     * returns immediately. Method throws a {@code NullPointerException} if the
-     * supplied array of values is {@code null}.
+     * Add all the values from the supplied value list to the current list of values for the supplied key. If the supplied
+     * value list is empty, method returns immediately. Method throws a {@code NullPointerException} if the supplied array
+     * of values is {@code null}.
      *
-     * @param key       the key.
+     * @param key the key.
      * @param valueList the list of values to be added.
      * @throws NullPointerException if the supplied value list is {@code null}.
      * @since 2.0
@@ -84,19 +80,17 @@ public interface MultivaluedMap<K, V> extends Map<K, List<V>> {
     void addAll(K key, List<V> valueList);
 
     /**
-     * Add a value to the first position in the current list of values for the
-     * supplied key.
+     * Add a value to the first position in the current list of values for the supplied key.
      *
-     * @param key   the key
+     * @param key the key
      * @param value the value to be added.
      * @since 2.0
      */
     void addFirst(K key, V value);
 
     /**
-     * Compare the specified map with this map for equality modulo the order
-     * of values for each key. Specifically, the values associated with
-     * each key are compared as if they were ordered lists.
+     * Compare the specified map with this map for equality modulo the order of values for each key. Specifically, the
+     * values associated with each key are compared as if they were ordered lists.
      *
      * @param otherMap map to be compared to this one.
      * @return true if the maps are equal modulo value ordering.

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/NewCookie.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/NewCookie.java
@@ -40,8 +40,7 @@ public class NewCookie extends Cookie {
      * @deprecated This field will be removed in a future version. See https://github.com/eclipse-ee4j/jaxrs-api/issues/607
      */
     @Deprecated
-    private static final HeaderDelegate<NewCookie> delegate =
-            RuntimeDelegate.getInstance().createHeaderDelegate(NewCookie.class);
+    private static final HeaderDelegate<NewCookie> delegate = RuntimeDelegate.getInstance().createHeaderDelegate(NewCookie.class);
 
     private final String comment;
     private final int maxAge;
@@ -52,7 +51,7 @@ public class NewCookie extends Cookie {
     /**
      * Create a new instance.
      *
-     * @param name  the name of the cookie.
+     * @param name the name of the cookie.
      * @param value the value of the cookie.
      * @throws IllegalArgumentException if name is {@code null}.
      */
@@ -63,100 +62,100 @@ public class NewCookie extends Cookie {
     /**
      * Create a new instance.
      *
-     * @param name    the name of the cookie.
-     * @param value   the value of the cookie.
-     * @param path    the URI path for which the cookie is valid.
-     * @param domain  the host domain for which the cookie is valid.
+     * @param name the name of the cookie.
+     * @param value the value of the cookie.
+     * @param path the URI path for which the cookie is valid.
+     * @param domain the host domain for which the cookie is valid.
      * @param comment the comment.
-     * @param maxAge  the maximum age of the cookie in seconds.
-     * @param secure  specifies whether the cookie will only be sent over a secure connection.
+     * @param maxAge the maximum age of the cookie in seconds.
+     * @param secure specifies whether the cookie will only be sent over a secure connection.
      * @throws IllegalArgumentException if name is {@code null}.
      */
     public NewCookie(final String name,
-                     final String value,
-                     final String path,
-                     final String domain,
-                     final String comment,
-                     final int maxAge,
-                     final boolean secure) {
+            final String value,
+            final String path,
+            final String domain,
+            final String comment,
+            final int maxAge,
+            final boolean secure) {
         this(name, value, path, domain, DEFAULT_VERSION, comment, maxAge, null, secure, false);
     }
 
     /**
      * Create a new instance.
      *
-     * @param name     the name of the cookie.
-     * @param value    the value of the cookie.
-     * @param path     the URI path for which the cookie is valid.
-     * @param domain   the host domain for which the cookie is valid.
-     * @param comment  the comment.
-     * @param maxAge   the maximum age of the cookie in seconds.
-     * @param secure   specifies whether the cookie will only be sent over a secure connection.
+     * @param name the name of the cookie.
+     * @param value the value of the cookie.
+     * @param path the URI path for which the cookie is valid.
+     * @param domain the host domain for which the cookie is valid.
+     * @param comment the comment.
+     * @param maxAge the maximum age of the cookie in seconds.
+     * @param secure specifies whether the cookie will only be sent over a secure connection.
      * @param httpOnly if {@code true} make the cookie HTTP only, i.e. only visible as part of an HTTP request.
      * @throws IllegalArgumentException if name is {@code null}.
      * @since 2.0
      */
     public NewCookie(final String name,
-                     final String value,
-                     final String path,
-                     final String domain,
-                     final String comment,
-                     final int maxAge,
-                     final boolean secure,
-                     final boolean httpOnly) {
+            final String value,
+            final String path,
+            final String domain,
+            final String comment,
+            final int maxAge,
+            final boolean secure,
+            final boolean httpOnly) {
         this(name, value, path, domain, DEFAULT_VERSION, comment, maxAge, null, secure, httpOnly);
     }
 
     /**
      * Create a new instance.
      *
-     * @param name    the name of the cookie
-     * @param value   the value of the cookie
-     * @param path    the URI path for which the cookie is valid
-     * @param domain  the host domain for which the cookie is valid
+     * @param name the name of the cookie
+     * @param value the value of the cookie
+     * @param path the URI path for which the cookie is valid
+     * @param domain the host domain for which the cookie is valid
      * @param version the version of the specification to which the cookie complies
      * @param comment the comment
-     * @param maxAge  the maximum age of the cookie in seconds
-     * @param secure  specifies whether the cookie will only be sent over a secure connection
+     * @param maxAge the maximum age of the cookie in seconds
+     * @param secure specifies whether the cookie will only be sent over a secure connection
      * @throws IllegalArgumentException if name is {@code null}.
      */
     public NewCookie(final String name,
-                     final String value,
-                     final String path,
-                     final String domain,
-                     final int version,
-                     final String comment,
-                     final int maxAge,
-                     final boolean secure) {
+            final String value,
+            final String path,
+            final String domain,
+            final int version,
+            final String comment,
+            final int maxAge,
+            final boolean secure) {
         this(name, value, path, domain, version, comment, maxAge, null, secure, false);
     }
 
     /**
      * Create a new instance.
      *
-     * @param name     the name of the cookie
-     * @param value    the value of the cookie
-     * @param path     the URI path for which the cookie is valid
-     * @param domain   the host domain for which the cookie is valid
-     * @param version  the version of the specification to which the cookie complies
-     * @param comment  the comment
-     * @param maxAge   the maximum age of the cookie in seconds
-     * @param expiry   the cookie expiry date.
-     * @param secure   specifies whether the cookie will only be sent over a secure connection
+     * @param name the name of the cookie
+     * @param value the value of the cookie
+     * @param path the URI path for which the cookie is valid
+     * @param domain the host domain for which the cookie is valid
+     * @param version the version of the specification to which the cookie complies
+     * @param comment the comment
+     * @param maxAge the maximum age of the cookie in seconds
+     * @param expiry the cookie expiry date.
+     * @param secure specifies whether the cookie will only be sent over a secure connection
      * @param httpOnly if {@code true} make the cookie HTTP only, i.e. only visible as part of an HTTP request.
      * @throws IllegalArgumentException if name is {@code null}.
      * @since 2.0
      */
     public NewCookie(final String name,
-                     final String value,
-                     final String path,
-                     final String domain,
-                     final int version,
-                     final String comment,
-                     final int maxAge,
-                     final Date expiry,
-                     final boolean secure,
-                     final boolean httpOnly) {
+            final String value,
+            final String path,
+            final String domain,
+            final int version,
+            final String comment,
+            final int maxAge,
+            final Date expiry,
+            final boolean secure,
+            final boolean httpOnly) {
         super(name, value, path, domain, version);
         this.comment = comment;
         this.maxAge = maxAge;
@@ -178,10 +177,10 @@ public class NewCookie extends Cookie {
     /**
      * Create a new instance supplementing the information in the supplied cookie.
      *
-     * @param cookie  the cookie to clone.
+     * @param cookie the cookie to clone.
      * @param comment the comment.
-     * @param maxAge  the maximum age of the cookie in seconds.
-     * @param secure  specifies whether the cookie will only be sent over a secure connection.
+     * @param maxAge the maximum age of the cookie in seconds.
+     * @param secure specifies whether the cookie will only be sent over a secure connection.
      * @throws IllegalArgumentException if cookie is {@code null}.
      */
     public NewCookie(final Cookie cookie, final String comment, final int maxAge, final boolean secure) {
@@ -191,11 +190,11 @@ public class NewCookie extends Cookie {
     /**
      * Create a new instance supplementing the information in the supplied cookie.
      *
-     * @param cookie   the cookie to clone.
-     * @param comment  the comment.
-     * @param maxAge   the maximum age of the cookie in seconds.
-     * @param expiry   the cookie expiry date.
-     * @param secure   specifies whether the cookie will only be sent over a secure connection.
+     * @param cookie the cookie to clone.
+     * @param comment the comment.
+     * @param maxAge the maximum age of the cookie in seconds.
+     * @param expiry the cookie expiry date.
+     * @param secure specifies whether the cookie will only be sent over a secure connection.
      * @param httpOnly if {@code true} make the cookie HTTP only, i.e. only visible as part of an HTTP request.
      * @throws IllegalArgumentException if cookie is {@code null}.
      * @since 2.0
@@ -218,10 +217,9 @@ public class NewCookie extends Cookie {
      *
      * @param value the cookie string.
      * @return the newly created {@code NewCookie}.
-     * @throws IllegalArgumentException if the supplied string cannot be parsed
-     *                                  or is {@code null}.
+     * @throws IllegalArgumentException if the supplied string cannot be parsed or is {@code null}.
      * @deprecated This method will be removed in a future version. Please use
-     *   RuntimeDelegate.getInstance().createHeaderDelegate(NewCookie.class).fromString(value) instead.
+     * RuntimeDelegate.getInstance().createHeaderDelegate(NewCookie.class).fromString(value) instead.
      */
     @Deprecated
     public static NewCookie valueOf(final String value) {
@@ -238,15 +236,13 @@ public class NewCookie extends Cookie {
     }
 
     /**
-     * Get the maximum age of the the cookie in seconds. Cookies older than
-     * the maximum age are discarded. A cookie can be unset by sending a new
-     * cookie with maximum age of 0 since it will overwrite any existing cookie
-     * and then be immediately discarded. The default value of {@code -1} indicates
-     * that the cookie will be discarded at the end of the browser/application session.
+     * Get the maximum age of the the cookie in seconds. Cookies older than the maximum age are discarded. A cookie can be
+     * unset by sending a new cookie with maximum age of 0 since it will overwrite any existing cookie and then be
+     * immediately discarded. The default value of {@code -1} indicates that the cookie will be discarded at the end of the
+     * browser/application session.
      * <p>
-     * Note that it is recommended to use {@code Max-Age} to control cookie
-     * expiration, however some browsers do not understand {@code Max-Age}, in which case
-     * setting {@link #getExpiry()} Expires} parameter may be necessary.
+     * Note that it is recommended to use {@code Max-Age} to control cookie expiration, however some browsers do not
+     * understand {@code Max-Age}, in which case setting {@link #getExpiry()} Expires} parameter may be necessary.
      * </p>
      *
      * @return the maximum age in seconds.
@@ -257,13 +253,11 @@ public class NewCookie extends Cookie {
     }
 
     /**
-     * Get the cookie expiry date. Cookies whose expiry date has passed are discarded.
-     * A cookie can be unset by setting a new cookie with an expiry date in the past,
-     * typically the lowest possible date that can be set.
+     * Get the cookie expiry date. Cookies whose expiry date has passed are discarded. A cookie can be unset by setting a
+     * new cookie with an expiry date in the past, typically the lowest possible date that can be set.
      * <p>
-     * Note that it is recommended to use {@link #getMaxAge() Max-Age} to control cookie
-     * expiration, however some browsers do not understand {@code Max-Age}, in which case
-     * setting {@code Expires} parameter may be necessary.
+     * Note that it is recommended to use {@link #getMaxAge() Max-Age} to control cookie expiration, however some browsers
+     * do not understand {@code Max-Age}, in which case setting {@code Expires} parameter may be necessary.
      * </p>
      *
      * @return cookie expiry date or {@code null} if no expiry date was set.
@@ -275,23 +269,19 @@ public class NewCookie extends Cookie {
     }
 
     /**
-     * Whether the cookie will only be sent over a secure connection. Defaults
-     * to {@code false}.
+     * Whether the cookie will only be sent over a secure connection. Defaults to {@code false}.
      *
-     * @return {@code true} if the cookie will only be sent over a secure connection,
-     *         {@code false} otherwise.
+     * @return {@code true} if the cookie will only be sent over a secure connection, {@code false} otherwise.
      */
     public boolean isSecure() {
         return secure;
     }
 
     /**
-     * Returns {@code true} if this cookie contains the {@code HttpOnly} attribute.
-     * This means that the cookie should not be accessible to scripting engines,
-     * like javascript.
+     * Returns {@code true} if this cookie contains the {@code HttpOnly} attribute. This means that the cookie should not be
+     * accessible to scripting engines, like javascript.
      *
-     * @return {@code true} if this cookie should be considered http only, {@code false}
-     *         otherwise.
+     * @return {@code true} if this cookie should be considered http only, {@code false} otherwise.
      * @since 2.0
      */
     public boolean isHttpOnly() {
@@ -299,10 +289,9 @@ public class NewCookie extends Cookie {
     }
 
     /**
-     * Obtain a new instance of a {@link Cookie} with the same name, value, path,
-     * domain and version as this {@code NewCookie}. This method can be used to
-     * obtain an object that can be compared for equality with another {@code Cookie};
-     * since a {@code Cookie} will never compare equal to a {@code NewCookie}.
+     * Obtain a new instance of a {@link Cookie} with the same name, value, path, domain and version as this
+     * {@code NewCookie}. This method can be used to obtain an object that can be compared for equality with another
+     * {@code Cookie}; since a {@code Cookie} will never compare equal to a {@code NewCookie}.
      *
      * @return a {@link Cookie}
      */
@@ -312,13 +301,12 @@ public class NewCookie extends Cookie {
     }
 
     /**
-     * Convert the cookie to a string suitable for use as the value of the
-     * corresponding HTTP header.
+     * Convert the cookie to a string suitable for use as the value of the corresponding HTTP header.
      *
      * @return a stringified cookie.
      * @deprecated The format of the toString() method is subject to change in a future version. Please use
-     * RuntimeDelegate.getInstance().createHeaderDelegate(NewCookie.class).toString(value) instead if you rely on
-     * the format of this method.
+     * RuntimeDelegate.getInstance().createHeaderDelegate(NewCookie.class).toString(value) instead if you rely on the format
+     * of this method.
      */
     @Override
     @Deprecated
@@ -343,15 +331,13 @@ public class NewCookie extends Cookie {
     }
 
     /**
-     * Compare for equality. Use {@link #toCookie()} to compare a
-     * {@code NewCookie} to a {@code Cookie} considering only the common
-     * properties.
+     * Compare for equality. Use {@link #toCookie()} to compare a {@code NewCookie} to a {@code Cookie} considering only the
+     * common properties.
      *
      * @param obj the object to compare to
-     * @return true if the object is a {@code NewCookie} with the same value for
-     *         all properties, false otherwise.
+     * @return true if the object is a {@code NewCookie} with the same value for all properties, false otherwise.
      */
-    @SuppressWarnings({"StringEquality", "RedundantIfStatement"})
+    @SuppressWarnings({ "StringEquality", "RedundantIfStatement" })
     @Override
     public boolean equals(final Object obj) {
         if (obj == null) {

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/NoContentException.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/NoContentException.java
@@ -19,14 +19,13 @@ package javax.ws.rs.core;
 import java.io.IOException;
 
 /**
- * An I/O exception thrown by {@link javax.ws.rs.ext.MessageBodyReader} implementations
- * when reading a zero-length message content to indicate that the message body reader
- * is not able to produce an instance representing an zero-length message content.
+ * An I/O exception thrown by {@link javax.ws.rs.ext.MessageBodyReader} implementations when reading a zero-length
+ * message content to indicate that the message body reader is not able to produce an instance representing an
+ * zero-length message content.
  * <p>
- * This exception, when thrown while reading a server request entity, is automatically
- * translated by JAX-RS server runtime into a {@link javax.ws.rs.BadRequestException}
- * wrapping the original {@code NoContentException} and rethrown for a standard processing by
- * the registered {@link javax.ws.rs.ext.ExceptionMapper exception mappers}.
+ * This exception, when thrown while reading a server request entity, is automatically translated by JAX-RS server
+ * runtime into a {@link javax.ws.rs.BadRequestException} wrapping the original {@code NoContentException} and rethrown
+ * for a standard processing by the registered {@link javax.ws.rs.ext.ExceptionMapper exception mappers}.
  * </p>
  *
  * @author Marek Potociar (marek.potociar at oracle.com)
@@ -38,8 +37,7 @@ public class NoContentException extends IOException {
     /**
      * Construct a new {@code NoContentException} instance.
      *
-     * @param message the detail message (which is saved for later retrieval
-     *                by the {@link #getMessage()} method).
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
      */
     public NoContentException(final String message) {
         super(message);
@@ -48,9 +46,8 @@ public class NoContentException extends IOException {
     /**
      * Construct a new {@code NoContentException} instance.
      *
-     * @param message the detail message (which is saved for later retrieval
-     *                by the {@link #getMessage()} method).
-     * @param cause   the underlying cause of the exception.
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param cause the underlying cause of the exception.
      */
     public NoContentException(final String message, final Throwable cause) {
         super(message, cause);

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/PathSegment.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/PathSegment.java
@@ -17,12 +17,10 @@
 package javax.ws.rs.core;
 
 /**
- * Represents a URI path segment and any associated matrix parameters. When an
- * instance of this type is injected with {@link javax.ws.rs.PathParam}, the
- * value of the annotation identifies which path segment is selected and the
- * presence of an {@link javax.ws.rs.Encoded} annotation will result in an
- * instance that supplies the path and matrix parameter values in
- * URI encoded form.
+ * Represents a URI path segment and any associated matrix parameters. When an instance of this type is injected with
+ * {@link javax.ws.rs.PathParam}, the value of the annotation identifies which path segment is selected and the presence
+ * of an {@link javax.ws.rs.Encoded} annotation will result in an instance that supplies the path and matrix parameter
+ * values in URI encoded form.
  *
  * @author Paul Sandoz
  * @author Marc Hadley
@@ -41,9 +39,8 @@ public interface PathSegment {
     String getPath();
 
     /**
-     * Get a map of the matrix parameters associated with the path segment.
-     * The map keys are the names of the matrix parameters with any
-     * percent-escaped octets decoded.
+     * Get a map of the matrix parameters associated with the path segment. The map keys are the names of the matrix
+     * parameters with any percent-escaped octets decoded.
      *
      * @return the map of matrix parameters
      * @see <a href="http://www.w3.org/DesignIssues/MatrixURIs.html">Matrix URIs</a>

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Request.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Request.java
@@ -22,22 +22,17 @@ import java.util.List;
 import javax.ws.rs.core.Response.ResponseBuilder;
 
 /**
- * An injectable helper for request processing, all methods throw an
- * {@link IllegalStateException} if called outside the scope of a request
- * (e.g. from a provider constructor).
+ * An injectable helper for request processing, all methods throw an {@link IllegalStateException} if called outside the
+ * scope of a request (e.g. from a provider constructor).
  *
- * Precondition processing (see the {@code evaluatePreconditions} methods)
- * can result in either a {@code null} return value to indicate that
- * preconditions have been met and that the request should continue, or
- * a non-{@code null} return value to indicate that preconditions were not met. In the
- * event that preconditions were not met, the returned {@code ResponseBuilder}
- * instance will have an appropriate status and will also include a {@code Vary}
- * header if the {@link #selectVariant(List)} method was called prior to to calling
- * {@code evaluatePreconditions}. It is the responsibility of the caller
- * to check the status and add additional metadata if required. E.g., see
- * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.5">HTTP/1.1, section 10.3.5</a>
- * for details of the headers that are expected to accompany a {@code 304 Not Modified}
- * response.
+ * Precondition processing (see the {@code evaluatePreconditions} methods) can result in either a {@code null} return
+ * value to indicate that preconditions have been met and that the request should continue, or a non-{@code null} return
+ * value to indicate that preconditions were not met. In the event that preconditions were not met, the returned
+ * {@code ResponseBuilder} instance will have an appropriate status and will also include a {@code Vary} header if the
+ * {@link #selectVariant(List)} method was called prior to to calling {@code evaluatePreconditions}. It is the
+ * responsibility of the caller to check the status and add additional metadata if required. E.g., see
+ * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.5">HTTP/1.1, section 10.3.5</a> for details
+ * of the headers that are expected to accompany a {@code 304 Not Modified} response.
  *
  * @author Paul Sandoz
  * @author Marc Hadley
@@ -55,20 +50,17 @@ public interface Request {
     public String getMethod();
 
     /**
-     * Select the representation variant that best matches the request. Returns
-     * {@code null} in case there is no matching variant in the list.
+     * Select the representation variant that best matches the request. Returns {@code null} in case there is no matching
+     * variant in the list.
      * <p>
-     * More explicit variants are chosen ahead of less explicit ones. A vary header
-     * is computed from the supplied list and automatically added to the  response.
+     * More explicit variants are chosen ahead of less explicit ones. A vary header is computed from the supplied list and
+     * automatically added to the response.
      * </p>
      *
-     * @param variants a list of Variant that describe all of the available representation
-     *                 variants.
+     * @param variants a list of Variant that describe all of the available representation variants.
      * @return the variant that best matches the request or {@code null} if there's no match.
-     * @throws java.lang.IllegalArgumentException
-     *          if variants is empty or {@code null}.
-     * @throws java.lang.IllegalStateException
-     *          if called outside the scope of a request.
+     * @throws java.lang.IllegalArgumentException if variants is empty or {@code null}.
+     * @throws java.lang.IllegalStateException if called outside the scope of a request.
      * @see Variant.VariantListBuilder
      */
     public Variant selectVariant(List<Variant> variants);
@@ -77,16 +69,12 @@ public interface Request {
      * Evaluate request preconditions based on the passed in value.
      *
      * @param eTag an ETag for the current state of the resource
-     * @return {@code null} if the preconditions are met or a {@code ResponseBuilder} set with
-     *         the appropriate status if the preconditions are not met. A returned
-     *         {@code ResponseBuilder} will include an ETag header set with the value of eTag,
-     *         provided none of the precondition evaluation has failed, in which case
-     *         the ETag header would not be included and the status code of the returned
-     *         {@code ResponseBuilder} would be set to {@link Response.Status#PRECONDITION_FAILED}.
-     * @throws java.lang.IllegalArgumentException
-     *          if eTag is {@code null}.
-     * @throws java.lang.IllegalStateException
-     *          if called outside the scope of a request.
+     * @return {@code null} if the preconditions are met or a {@code ResponseBuilder} set with the appropriate status if the
+     * preconditions are not met. A returned {@code ResponseBuilder} will include an ETag header set with the value of eTag,
+     * provided none of the precondition evaluation has failed, in which case the ETag header would not be included and the
+     * status code of the returned {@code ResponseBuilder} would be set to {@link Response.Status#PRECONDITION_FAILED}.
+     * @throws java.lang.IllegalArgumentException if eTag is {@code null}.
+     * @throws java.lang.IllegalStateException if called outside the scope of a request.
      */
     public ResponseBuilder evaluatePreconditions(EntityTag eTag);
 
@@ -94,12 +82,10 @@ public interface Request {
      * Evaluate request preconditions based on the passed in value.
      *
      * @param lastModified a date that specifies the modification date of the resource
-     * @return {@code null} if the preconditions are met or a {@code ResponseBuilder} set with
-     *         the appropriate status if the preconditions are not met.
-     * @throws java.lang.IllegalArgumentException
-     *          if lastModified is {@code null}.
-     * @throws java.lang.IllegalStateException
-     *          if called outside the scope of a request.
+     * @return {@code null} if the preconditions are met or a {@code ResponseBuilder} set with the appropriate status if the
+     * preconditions are not met.
+     * @throws java.lang.IllegalArgumentException if lastModified is {@code null}.
+     * @throws java.lang.IllegalStateException if called outside the scope of a request.
      */
     public ResponseBuilder evaluatePreconditions(Date lastModified);
 
@@ -107,39 +93,31 @@ public interface Request {
      * Evaluate request preconditions based on the passed in value.
      *
      * @param lastModified a date that specifies the modification date of the resource
-     * @param eTag         an ETag for the current state of the resource
-     * @return {@code null} if the preconditions are met or a {@code ResponseBuilder} set with
-     *         the appropriate status if the preconditions are not met. A returned
-     *         {@code ResponseBuilder} will include an ETag header set with the value of eTag,
-     *         provided none of the precondition evaluation has failed, in which case
-     *         the ETag header would not be included and the status code of the returned
-     *         {@code ResponseBuilder} would be set to {@link Response.Status#PRECONDITION_FAILED}.
-     * @throws java.lang.IllegalArgumentException
-     *          if lastModified or eTag is {@code null}.
-     * @throws java.lang.IllegalStateException
-     *          if called outside the scope of a request.
+     * @param eTag an ETag for the current state of the resource
+     * @return {@code null} if the preconditions are met or a {@code ResponseBuilder} set with the appropriate status if the
+     * preconditions are not met. A returned {@code ResponseBuilder} will include an ETag header set with the value of eTag,
+     * provided none of the precondition evaluation has failed, in which case the ETag header would not be included and the
+     * status code of the returned {@code ResponseBuilder} would be set to {@link Response.Status#PRECONDITION_FAILED}.
+     * @throws java.lang.IllegalArgumentException if lastModified or eTag is {@code null}.
+     * @throws java.lang.IllegalStateException if called outside the scope of a request.
      */
     public ResponseBuilder evaluatePreconditions(Date lastModified, EntityTag eTag);
 
     /**
-     * Evaluate request preconditions for a resource that does not currently
-     * exist. The primary use of this method is to support the <a
-     * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.24">
-     * If-Match: *</a> and <a
-     * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.26">
-     * If-None-Match: *</a> preconditions.
+     * Evaluate request preconditions for a resource that does not currently exist. The primary use of this method is to
+     * support the <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.24"> If-Match: *</a> and
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.26"> If-None-Match: *</a> preconditions.
      *
-     * <p>Note that both preconditions {@code If-None-Match: *} and
-     * <code>If-None-Match: <i>something</i></code> will always be considered to
-     * have been met and it is the applications responsibility
-     * to enforce any additional method-specific semantics. E.g. a
-     * {@code PUT} on a resource that does not exist might succeed whereas
-     * a {@code GET} on a resource that does not exist would likely result
-     * in a 404 response. It would be the responsibility of the application to
-     * generate the 404 response.</p>
+     * <p>
+     * Note that both preconditions {@code If-None-Match: *} and <code>If-None-Match: <i>something</i></code> will always be
+     * considered to have been met and it is the applications responsibility to enforce any additional method-specific
+     * semantics. E.g. a {@code PUT} on a resource that does not exist might succeed whereas a {@code GET} on a resource
+     * that does not exist would likely result in a 404 response. It would be the responsibility of the application to
+     * generate the 404 response.
+     * </p>
      *
-     * @return {@code null} if the preconditions are met or a {@code ResponseBuilder} set with
-     *         the appropriate status if the preconditions are not met.
+     * @return {@code null} if the preconditions are met or a {@code ResponseBuilder} set with the appropriate status if the
+     * preconditions are not met.
      * @throws IllegalStateException if called outside the scope of a request.
      * @since 1.1
      */

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Response.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Response.java
@@ -31,16 +31,16 @@ import javax.ws.rs.ext.MessageBodyWriter;
 import javax.ws.rs.ext.RuntimeDelegate;
 
 /**
- * Defines the contract between a returned instance and the runtime when
- * an application needs to provide meta-data to the runtime.
+ * Defines the contract between a returned instance and the runtime when an application needs to provide meta-data to
+ * the runtime.
  * <p>
- * An application class should not extend this class directly. {@code Response} class is
- * reserved for an extension by a JAX-RS implementation providers. An application should use one
- * of the static methods to create a {@code Response} instance using a ResponseBuilder.
+ * An application class should not extend this class directly. {@code Response} class is reserved for an extension by a
+ * JAX-RS implementation providers. An application should use one of the static methods to create a {@code Response}
+ * instance using a ResponseBuilder.
  * </p>
  * <p>
- * Several methods have parameters of type URI, {@link UriBuilder} provides
- * convenient methods to create such values as does {@link URI#create(java.lang.String)}.
+ * Several methods have parameters of type URI, {@link UriBuilder} provides convenient methods to create such values as
+ * does {@link URI#create(java.lang.String)}.
  * </p>
  *
  * @author Paul Sandoz
@@ -52,8 +52,8 @@ import javax.ws.rs.ext.RuntimeDelegate;
 public abstract class Response implements AutoCloseable {
 
     /**
-     * Protected constructor, use one of the static methods to obtain a
-     * {@link ResponseBuilder} instance and obtain a Response from that.
+     * Protected constructor, use one of the static methods to obtain a {@link ResponseBuilder} instance and obtain a
+     * Response from that.
      */
     protected Response() {
     }
@@ -68,197 +68,164 @@ public abstract class Response implements AutoCloseable {
     /**
      * Get the complete status information associated with the response.
      *
-     * @return the response status information. The returned value is never
-     *         {@code null}.
+     * @return the response status information. The returned value is never {@code null}.
      * @since 2.0
      */
     public abstract StatusType getStatusInfo();
 
     /**
-     * Get the message entity Java instance. Returns {@code null} if the message
-     * does not contain an entity body.
+     * Get the message entity Java instance. Returns {@code null} if the message does not contain an entity body.
      * <p>
-     * If the entity is represented by an un-consumed {@link InputStream input stream}
-     * the method will return the input stream.
+     * If the entity is represented by an un-consumed {@link InputStream input stream} the method will return the input
+     * stream.
      * </p>
      *
-     * @return the message entity or {@code null} if message does not contain an
-     *         entity body (i.e. when {@link #hasEntity()} returns {@code false}).
-     * @throws IllegalStateException if the entity was previously fully consumed
-     *                               as an {@link InputStream input stream}, or
-     *                               if the response has been {@link #close() closed}.
+     * @return the message entity or {@code null} if message does not contain an entity body (i.e. when {@link #hasEntity()}
+     * returns {@code false}).
+     * @throws IllegalStateException if the entity was previously fully consumed as an {@link InputStream input stream}, or
+     * if the response has been {@link #close() closed}.
      */
     public abstract Object getEntity();
 
     /**
-     * Read the message entity input stream as an instance of specified Java type
-     * using a {@link javax.ws.rs.ext.MessageBodyReader} that supports mapping the
-     * message entity stream onto the requested type.
+     * Read the message entity input stream as an instance of specified Java type using a
+     * {@link javax.ws.rs.ext.MessageBodyReader} that supports mapping the message entity stream onto the requested type.
      * <p>
-     * Method throws an {@link ProcessingException} if the content of the
-     * message cannot be mapped to an entity of the requested type and
-     * {@link IllegalStateException} in case the entity is not backed by an input
-     * stream or if the original entity input stream has already been consumed
-     * without {@link #bufferEntity() buffering} the entity data prior consuming.
+     * Method throws an {@link ProcessingException} if the content of the message cannot be mapped to an entity of the
+     * requested type and {@link IllegalStateException} in case the entity is not backed by an input stream or if the
+     * original entity input stream has already been consumed without {@link #bufferEntity() buffering} the entity data
+     * prior consuming.
      * </p>
      * <p>
-     * A message instance returned from this method will be cached for
-     * subsequent retrievals via {@link #getEntity()}. Unless the supplied entity
-     * type is an {@link java.io.InputStream input stream}, this method automatically
-     * {@link #close() closes} the an unconsumed original response entity data stream
-     * if open. In case the entity data has been buffered, the buffer will be reset
-     * prior consuming the buffered data to enable subsequent invocations of
+     * A message instance returned from this method will be cached for subsequent retrievals via {@link #getEntity()}.
+     * Unless the supplied entity type is an {@link java.io.InputStream input stream}, this method automatically
+     * {@link #close() closes} the an unconsumed original response entity data stream if open. In case the entity data has
+     * been buffered, the buffer will be reset prior consuming the buffered data to enable subsequent invocations of
      * {@code readEntity(...)} methods on this response.
      * </p>
      *
-     * @param <T>        entity instance Java type.
+     * @param <T> entity instance Java type.
      * @param entityType the type of entity.
-     * @return the message entity; for a zero-length response entities returns a corresponding
-     *         Java object that represents zero-length data. In case no zero-length representation
-     *         is defined for the Java type, a {@link ProcessingException} wrapping the
-     *         underlying {@link NoContentException} is thrown.
-     * @throws ProcessingException   if the content of the message cannot be
-     *                               mapped to an entity of the requested type.
-     * @throws IllegalStateException if the entity is not backed by an input stream,
-     *                               the response has been {@link #close() closed} already,
-     *                               or if the entity input stream has been fully consumed already and has
-     *                               not been buffered prior consuming.
+     * @return the message entity; for a zero-length response entities returns a corresponding Java object that represents
+     * zero-length data. In case no zero-length representation is defined for the Java type, a {@link ProcessingException}
+     * wrapping the underlying {@link NoContentException} is thrown.
+     * @throws ProcessingException if the content of the message cannot be mapped to an entity of the requested type.
+     * @throws IllegalStateException if the entity is not backed by an input stream, the response has been {@link #close()
+     * closed} already, or if the entity input stream has been fully consumed already and has not been buffered prior
+     * consuming.
      * @see javax.ws.rs.ext.MessageBodyReader
      * @since 2.0
      */
     public abstract <T> T readEntity(Class<T> entityType);
 
     /**
-     * Read the message entity input stream as an instance of specified Java type
-     * using a {@link javax.ws.rs.ext.MessageBodyReader} that supports mapping the
-     * message entity stream onto the requested type.
+     * Read the message entity input stream as an instance of specified Java type using a
+     * {@link javax.ws.rs.ext.MessageBodyReader} that supports mapping the message entity stream onto the requested type.
      * <p>
-     * Method throws an {@link ProcessingException} if the content of the
-     * message cannot be mapped to an entity of the requested type and
-     * {@link IllegalStateException} in case the entity is not backed by an input
-     * stream or if the original entity input stream has already been consumed
-     * without {@link #bufferEntity() buffering} the entity data prior consuming.
+     * Method throws an {@link ProcessingException} if the content of the message cannot be mapped to an entity of the
+     * requested type and {@link IllegalStateException} in case the entity is not backed by an input stream or if the
+     * original entity input stream has already been consumed without {@link #bufferEntity() buffering} the entity data
+     * prior consuming.
      * </p>
      * <p>
-     * A message instance returned from this method will be cached for
-     * subsequent retrievals via {@link #getEntity()}. Unless the supplied entity
-     * type is an {@link java.io.InputStream input stream}, this method automatically
-     * {@link #close() closes} the an unconsumed original response entity data stream
-     * if open. In case the entity data has been buffered, the buffer will be reset
-     * prior consuming the buffered data to enable subsequent invocations of
+     * A message instance returned from this method will be cached for subsequent retrievals via {@link #getEntity()}.
+     * Unless the supplied entity type is an {@link java.io.InputStream input stream}, this method automatically
+     * {@link #close() closes} the an unconsumed original response entity data stream if open. In case the entity data has
+     * been buffered, the buffer will be reset prior consuming the buffered data to enable subsequent invocations of
      * {@code readEntity(...)} methods on this response.
      * </p>
      *
-     * @param <T>        entity instance Java type.
+     * @param <T> entity instance Java type.
      * @param entityType the type of entity; may be generic.
-     * @return the message entity; for a zero-length response entities returns a corresponding
-     *         Java object that represents zero-length data. In case no zero-length representation
-     *         is defined for the Java type, a {@link ProcessingException} wrapping the
-     *         underlying {@link NoContentException} is thrown.
-     * @throws ProcessingException   if the content of the message cannot be
-     *                               mapped to an entity of the requested type.
-     * @throws IllegalStateException if the entity is not backed by an input stream,
-     *                               the response has been {@link #close() closed} already,
-     *                               or if the entity input stream has been fully consumed already and has
-     *                               not been buffered prior consuming.
+     * @return the message entity; for a zero-length response entities returns a corresponding Java object that represents
+     * zero-length data. In case no zero-length representation is defined for the Java type, a {@link ProcessingException}
+     * wrapping the underlying {@link NoContentException} is thrown.
+     * @throws ProcessingException if the content of the message cannot be mapped to an entity of the requested type.
+     * @throws IllegalStateException if the entity is not backed by an input stream, the response has been {@link #close()
+     * closed} already, or if the entity input stream has been fully consumed already and has not been buffered prior
+     * consuming.
      * @see javax.ws.rs.ext.MessageBodyReader
      * @since 2.0
      */
     public abstract <T> T readEntity(GenericType<T> entityType);
 
     /**
-     * Read the message entity input stream as an instance of specified Java type
-     * using a {@link javax.ws.rs.ext.MessageBodyReader} that supports mapping the
-     * message entity stream onto the requested type.
+     * Read the message entity input stream as an instance of specified Java type using a
+     * {@link javax.ws.rs.ext.MessageBodyReader} that supports mapping the message entity stream onto the requested type.
      * <p>
-     * Method throws an {@link ProcessingException} if the content of the
-     * message cannot be mapped to an entity of the requested type and
-     * {@link IllegalStateException} in case the entity is not backed by an input
-     * stream or if the original entity input stream has already been consumed
-     * without {@link #bufferEntity() buffering} the entity data prior consuming.
+     * Method throws an {@link ProcessingException} if the content of the message cannot be mapped to an entity of the
+     * requested type and {@link IllegalStateException} in case the entity is not backed by an input stream or if the
+     * original entity input stream has already been consumed without {@link #bufferEntity() buffering} the entity data
+     * prior consuming.
      * </p>
      * <p>
-     * A message instance returned from this method will be cached for
-     * subsequent retrievals via {@link #getEntity()}. Unless the supplied entity
-     * type is an {@link java.io.InputStream input stream}, this method automatically
-     * {@link #close() closes} the an unconsumed original response entity data stream
-     * if open. In case the entity data has been buffered, the buffer will be reset
-     * prior consuming the buffered data to enable subsequent invocations of
+     * A message instance returned from this method will be cached for subsequent retrievals via {@link #getEntity()}.
+     * Unless the supplied entity type is an {@link java.io.InputStream input stream}, this method automatically
+     * {@link #close() closes} the an unconsumed original response entity data stream if open. In case the entity data has
+     * been buffered, the buffer will be reset prior consuming the buffered data to enable subsequent invocations of
      * {@code readEntity(...)} methods on this response.
      * </p>
      *
-     * @param <T>         entity instance Java type.
-     * @param entityType  the type of entity.
+     * @param <T> entity instance Java type.
+     * @param entityType the type of entity.
      * @param annotations annotations that will be passed to the {@link MessageBodyReader}.
-     * @return the message entity; for a zero-length response entities returns a corresponding
-     *         Java object that represents zero-length data. In case no zero-length representation
-     *         is defined for the Java type, a {@link ProcessingException} wrapping the
-     *         underlying {@link NoContentException} is thrown.
-     * @throws ProcessingException   if the content of the message cannot be
-     *                               mapped to an entity of the requested type.
-     * @throws IllegalStateException if the entity is not backed by an input stream,
-     *                               the response has been {@link #close() closed} already,
-     *                               or if the entity input stream has been fully consumed already and has
-     *                               not been buffered prior consuming.
+     * @return the message entity; for a zero-length response entities returns a corresponding Java object that represents
+     * zero-length data. In case no zero-length representation is defined for the Java type, a {@link ProcessingException}
+     * wrapping the underlying {@link NoContentException} is thrown.
+     * @throws ProcessingException if the content of the message cannot be mapped to an entity of the requested type.
+     * @throws IllegalStateException if the entity is not backed by an input stream, the response has been {@link #close()
+     * closed} already, or if the entity input stream has been fully consumed already and has not been buffered prior
+     * consuming.
      * @see javax.ws.rs.ext.MessageBodyReader
      * @since 2.0
      */
     public abstract <T> T readEntity(Class<T> entityType, Annotation[] annotations);
 
     /**
-     * Read the message entity input stream as an instance of specified Java type
-     * using a {@link javax.ws.rs.ext.MessageBodyReader} that supports mapping the
-     * message entity stream onto the requested type.
+     * Read the message entity input stream as an instance of specified Java type using a
+     * {@link javax.ws.rs.ext.MessageBodyReader} that supports mapping the message entity stream onto the requested type.
      * <p>
-     * Method throws an {@link ProcessingException} if the content of the
-     * message cannot be mapped to an entity of the requested type and
-     * {@link IllegalStateException} in case the entity is not backed by an input
-     * stream or if the original entity input stream has already been consumed
-     * without {@link #bufferEntity() buffering} the entity data prior consuming.
+     * Method throws an {@link ProcessingException} if the content of the message cannot be mapped to an entity of the
+     * requested type and {@link IllegalStateException} in case the entity is not backed by an input stream or if the
+     * original entity input stream has already been consumed without {@link #bufferEntity() buffering} the entity data
+     * prior consuming.
      * </p>
      * <p>
-     * A message instance returned from this method will be cached for
-     * subsequent retrievals via {@link #getEntity()}. Unless the supplied entity
-     * type is an {@link java.io.InputStream input stream}, this method automatically
-     * {@link #close() closes} the an unconsumed original response entity data stream
-     * if open. In case the entity data has been buffered, the buffer will be reset
-     * prior consuming the buffered data to enable subsequent invocations of
+     * A message instance returned from this method will be cached for subsequent retrievals via {@link #getEntity()}.
+     * Unless the supplied entity type is an {@link java.io.InputStream input stream}, this method automatically
+     * {@link #close() closes} the an unconsumed original response entity data stream if open. In case the entity data has
+     * been buffered, the buffer will be reset prior consuming the buffered data to enable subsequent invocations of
      * {@code readEntity(...)} methods on this response.
      * </p>
      *
-     * @param <T>         entity instance Java type.
-     * @param entityType  the type of entity; may be generic.
+     * @param <T> entity instance Java type.
+     * @param entityType the type of entity; may be generic.
      * @param annotations annotations that will be passed to the {@link MessageBodyReader}.
-     * @return the message entity; for a zero-length response entities returns a corresponding
-     *         Java object that represents zero-length data. In case no zero-length representation
-     *         is defined for the Java type, a {@link ProcessingException} wrapping the
-     *         underlying {@link NoContentException} is thrown.
-     * @throws ProcessingException   if the content of the message cannot be
-     *                               mapped to an entity of the requested type.
-     * @throws IllegalStateException if the entity is not backed by an input stream,
-     *                               the response has been {@link #close() closed} already,
-     *                               or if the entity input stream has been fully consumed already and has
-     *                               not been buffered prior consuming.
+     * @return the message entity; for a zero-length response entities returns a corresponding Java object that represents
+     * zero-length data. In case no zero-length representation is defined for the Java type, a {@link ProcessingException}
+     * wrapping the underlying {@link NoContentException} is thrown.
+     * @throws ProcessingException if the content of the message cannot be mapped to an entity of the requested type.
+     * @throws IllegalStateException if the entity is not backed by an input stream, the response has been {@link #close()
+     * closed} already, or if the entity input stream has been fully consumed already and has not been buffered prior
+     * consuming.
      * @see javax.ws.rs.ext.MessageBodyReader
      * @since 2.0
      */
     public abstract <T> T readEntity(GenericType<T> entityType, Annotation[] annotations);
 
     /**
-     * Check if there is an entity available in the response. The method returns
-     * {@code true} if the entity is present, returns {@code false} otherwise.
+     * Check if there is an entity available in the response. The method returns {@code true} if the entity is present,
+     * returns {@code false} otherwise.
      * <p>
-     * Note that the method may return {@code true} also for response messages with
-     * a zero-length content, in case the <tt>{@value javax.ws.rs.core.HttpHeaders#CONTENT_LENGTH}</tt> and
-     * <tt>{@value javax.ws.rs.core.HttpHeaders#CONTENT_TYPE}</tt> headers are specified in the message.
-     * In such case, an attempt to read the entity using one of the {@code readEntity(...)}
-     * methods will return a corresponding instance representing a zero-length entity for a
-     * given Java type or produce a {@link ProcessingException} in case no such instance
-     * is available for the Java type.
+     * Note that the method may return {@code true} also for response messages with a zero-length content, in case the
+     * <tt>{@value javax.ws.rs.core.HttpHeaders#CONTENT_LENGTH}</tt> and
+     * <tt>{@value javax.ws.rs.core.HttpHeaders#CONTENT_TYPE}</tt> headers are specified in the message. In such case, an
+     * attempt to read the entity using one of the {@code readEntity(...)} methods will return a corresponding instance
+     * representing a zero-length entity for a given Java type or produce a {@link ProcessingException} in case no such
+     * instance is available for the Java type.
      * </p>
      *
-     * @return {@code true} if there is an entity present in the message,
-     *         {@code false} otherwise.
+     * @return {@code true} if there is an entity present in the message, {@code false} otherwise.
      * @throws IllegalStateException in case the response has been {@link #close() closed}.
      * @since 2.0
      */
@@ -267,62 +234,51 @@ public abstract class Response implements AutoCloseable {
     /**
      * Buffer the message entity data.
      * <p>
-     * In case the message entity is backed by an unconsumed entity input stream,
-     * all the bytes of the original entity input stream are read and stored in a
-     * local buffer. The original entity input stream is consumed and automatically
-     * closed as part of the operation and the method returns {@code true}.
+     * In case the message entity is backed by an unconsumed entity input stream, all the bytes of the original entity input
+     * stream are read and stored in a local buffer. The original entity input stream is consumed and automatically closed
+     * as part of the operation and the method returns {@code true}.
      * </p>
      * <p>
-     * In case the response entity instance is not backed by an unconsumed input stream
-     * an invocation of {@code bufferEntity} method is ignored and the method returns
-     * {@code false}.
+     * In case the response entity instance is not backed by an unconsumed input stream an invocation of
+     * {@code bufferEntity} method is ignored and the method returns {@code false}.
      * </p>
      * <p>
-     * This operation is idempotent, i.e. it can be invoked multiple times with
-     * the same effect which also means that calling the {@code bufferEntity()}
-     * method on an already buffered (and thus closed) message instance is legal
-     * and has no further effect. Also, the result returned by the {@code bufferEntity()}
-     * method is consistent across all invocations of the method on the same
-     * {@code Response} instance.
+     * This operation is idempotent, i.e. it can be invoked multiple times with the same effect which also means that
+     * calling the {@code bufferEntity()} method on an already buffered (and thus closed) message instance is legal and has
+     * no further effect. Also, the result returned by the {@code bufferEntity()} method is consistent across all
+     * invocations of the method on the same {@code Response} instance.
      * </p>
      * <p>
-     * Buffering the message entity data allows for multiple invocations of
-     * {@code readEntity(...)} methods on the response instance. Note however, that
-     * once the response instance itself is {@link #close() closed}, the implementations
-     * are expected to release the buffered message entity data too. Therefore any subsequent
-     * attempts to read a message entity stream on such closed response will result in an
-     * {@link IllegalStateException} being thrown.
+     * Buffering the message entity data allows for multiple invocations of {@code readEntity(...)} methods on the response
+     * instance. Note however, that once the response instance itself is {@link #close() closed}, the implementations are
+     * expected to release the buffered message entity data too. Therefore any subsequent attempts to read a message entity
+     * stream on such closed response will result in an {@link IllegalStateException} being thrown.
      * </p>
      *
-     * @return {@code true} if the message entity input stream was available and
-     *         was buffered successfully, returns {@code false} if the entity stream
-     *         was not available.
-     * @throws ProcessingException   if there was an error while buffering the entity
-     *                               input stream.
+     * @return {@code true} if the message entity input stream was available and was buffered successfully, returns
+     * {@code false} if the entity stream was not available.
+     * @throws ProcessingException if there was an error while buffering the entity input stream.
      * @throws IllegalStateException in case the response has been {@link #close() closed}.
      * @since 2.0
      */
     public abstract boolean bufferEntity();
 
     /**
-     * Close the underlying message entity input stream (if available and open)
-     * as well as releases any other resources associated with the response
-     * (e.g. {@link #bufferEntity() buffered message entity data}).
+     * Close the underlying message entity input stream (if available and open) as well as releases any other resources
+     * associated with the response (e.g. {@link #bufferEntity() buffered message entity data}).
      * <p>
-     * This operation is idempotent, i.e. it can be invoked multiple times with the
-     * same effect which also means that calling the {@code close()} method on an
-     * already closed message instance is legal and has no further effect.
+     * This operation is idempotent, i.e. it can be invoked multiple times with the same effect which also means that
+     * calling the {@code close()} method on an already closed message instance is legal and has no further effect.
      * </p>
      * <p>
-     * The {@code close()} method should be invoked on all instances that
-     * contain an un-consumed entity input stream to ensure the resources associated
-     * with the instance are properly cleaned-up and prevent potential memory leaks.
-     * This is typical for client-side scenarios where application layer code
-     * processes only the response headers and ignores the response entity.
+     * The {@code close()} method should be invoked on all instances that contain an un-consumed entity input stream to
+     * ensure the resources associated with the instance are properly cleaned-up and prevent potential memory leaks. This is
+     * typical for client-side scenarios where application layer code processes only the response headers and ignores the
+     * response entity.
      * </p>
      * <p>
-     * Any attempts to manipulate (read, get, buffer) a message entity on a closed response
-     * will result in an {@link IllegalStateException} being thrown.
+     * Any attempts to manipulate (read, get, buffer) a message entity on a closed response will result in an
+     * {@link IllegalStateException} being thrown.
      * </p>
      *
      * @throws ProcessingException if there is an error closing the response.
@@ -350,8 +306,7 @@ public abstract class Response implements AutoCloseable {
     /**
      * Get Content-Length value.
      *
-     * @return Content-Length as integer if present and valid number. In other
-     *         cases returns {@code -1}.
+     * @return Content-Length as integer if present and valid number. In other cases returns {@code -1}.
      * @since 2.0
      */
     public abstract int getLength();
@@ -359,8 +314,7 @@ public abstract class Response implements AutoCloseable {
     /**
      * Get the allowed HTTP methods from the Allow HTTP header.
      *
-     * @return the allowed HTTP methods, all methods will returned as upper case
-     *         strings.
+     * @return the allowed HTTP methods, all methods will returned as upper case strings.
      * @since 2.0
      */
     public abstract Set<String> getAllowedMethods();
@@ -406,14 +360,11 @@ public abstract class Response implements AutoCloseable {
     public abstract URI getLocation();
 
     /**
-     * Get the links attached to the message as headers. Any links in the message
-     * that are relative must be resolved with respect to the actual request URI
-     * that produced this response. Note that request URIs may be updated by
-     * filters, so the actual request URI may differ from that in the original
-     * invocation.
+     * Get the links attached to the message as headers. Any links in the message that are relative must be resolved with
+     * respect to the actual request URI that produced this response. Note that request URIs may be updated by filters, so
+     * the actual request URI may differ from that in the original invocation.
      *
-     * @return links, may return empty {@link Set} if no links are present. Does
-     *         not return {@code null}.
+     * @return links, may return empty {@link Set} if no links are present. Does not return {@code null}.
      * @since 2.0
      */
     public abstract Set<Link> getLinks();
@@ -422,17 +373,16 @@ public abstract class Response implements AutoCloseable {
      * Check if link for relation exists.
      *
      * @param relation link relation.
-     * @return {@code true} if the link for the relation is present in the
-     *         {@link #getHeaders() message headers}, {@code false} otherwise.
+     * @return {@code true} if the link for the relation is present in the {@link #getHeaders() message headers},
+     * {@code false} otherwise.
      * @since 2.0
      */
     public abstract boolean hasLink(String relation);
 
     /**
-     * Get the link for the relation. A relative link is resolved with respect
-     * to the actual request URI that produced this response. Note that request
-     * URIs may be updated by filters, so the actual request URI may differ from
-     * that in the original invocation.
+     * Get the link for the relation. A relative link is resolved with respect to the actual request URI that produced this
+     * response. Note that request URIs may be updated by filters, so the actual request URI may differ from that in the
+     * original invocation.
      *
      * @param relation link relation.
      * @return the link for the relation, otherwise {@code null} if not present.
@@ -441,12 +391,10 @@ public abstract class Response implements AutoCloseable {
     public abstract Link getLink(String relation);
 
     /**
-     * Convenience method that returns a {@link Link.Builder} for the relation.
-     * See {@link #getLink} for more information.
+     * Convenience method that returns a {@link Link.Builder} for the relation. See {@link #getLink} for more information.
      *
      * @param relation link relation.
-     * @return the link builder for the relation, otherwise {@code null} if not
-     *         present.
+     * @return the link builder for the relation, otherwise {@code null} if not present.
      * @since 2.0
      */
     public abstract Link.Builder getLinkBuilder(String relation);
@@ -454,9 +402,8 @@ public abstract class Response implements AutoCloseable {
     /**
      * See {@link #getHeaders()}.
      *
-     * This method is considered deprecated. Users are encouraged to switch their
-     * code to use the {@code getHeaders()} method instead. The method may be annotated
-     * as {@link Deprecated &#64;Deprecated} in a future release of JAX-RS API.
+     * This method is considered deprecated. Users are encouraged to switch their code to use the {@code getHeaders()}
+     * method instead. The method may be annotated as {@link Deprecated &#64;Deprecated} in a future release of JAX-RS API.
      *
      * @return response headers as a multivalued map.
      */
@@ -465,18 +412,16 @@ public abstract class Response implements AutoCloseable {
     /**
      * Get view of the response headers and their object values.
      *
-     * The underlying header data may be subsequently modified by the JAX-RS runtime on the
-     * server side. Changes in the underlying header data are reflected in this view.
+     * The underlying header data may be subsequently modified by the JAX-RS runtime on the server side. Changes in the
+     * underlying header data are reflected in this view.
      * <p>
-     * On the server-side, when the message is sent, the non-string values will be serialized
-     * using a {@link javax.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one is available via
-     * {@link javax.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the
-     * class of the value or using the values {@code toString} method if a header delegate is
-     * not available.
+     * On the server-side, when the message is sent, the non-string values will be serialized using a
+     * {@link javax.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one is available via
+     * {@link javax.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the class of the value or using the
+     * values {@code toString} method if a header delegate is not available.
      * </p>
      * <p>
-     * On the client side, the returned map is identical to the one returned by
-     * {@link #getStringHeaders()}.
+     * On the client side, the returned map is identical to the one returned by {@link #getStringHeaders()}.
      * </p>
      *
      * @return response headers as an object view of header values.
@@ -491,8 +436,8 @@ public abstract class Response implements AutoCloseable {
     /**
      * Get view of the response headers and their string values.
      *
-     * The underlying header data may be subsequently modified by the JAX-RS runtime on
-     * the server side. Changes in the underlying header data are reflected in this view.
+     * The underlying header data may be subsequently modified by the JAX-RS runtime on the server side. Changes in the
+     * underlying header data are reflected in this view.
      *
      * @return response headers as a string view of header values.
      * @see #getHeaders()
@@ -504,18 +449,14 @@ public abstract class Response implements AutoCloseable {
     /**
      * Get a message header as a single string value.
      *
-     * Each single header value is converted to String using a
-     * {@link javax.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one is available
-     * via {@link javax.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)}
-     * for the header value class or using its {@code toString} method  if a header
-     * delegate is not available.
+     * Each single header value is converted to String using a {@link javax.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one
+     * is available via {@link javax.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the header value
+     * class or using its {@code toString} method if a header delegate is not available.
      *
      * @param name the message header.
-     * @return the message header value. If the message header is not present then
-     *         {@code null} is returned. If the message header is present but has no
-     *         value then the empty string is returned. If the message header is present
-     *         more than once then the values of joined together and separated by a ','
-     *         character.
+     * @return the message header value. If the message header is not present then {@code null} is returned. If the message
+     * header is present but has no value then the empty string is returned. If the message header is present more than once
+     * then the values of joined together and separated by a ',' character.
      * @see #getHeaders()
      * @see #getStringHeaders()
      * @since 2.0
@@ -523,23 +464,20 @@ public abstract class Response implements AutoCloseable {
     public abstract String getHeaderString(String name);
 
     /**
-     * Create a new ResponseBuilder by performing a shallow copy of an
-     * existing Response.
+     * Create a new ResponseBuilder by performing a shallow copy of an existing Response.
      * <p>
-     * The returned builder has its own {@link #getHeaders() response headers}
-     * but the header values are shared with the original {@code Response} instance.
-     * The original response entity instance reference is set in the new response
+     * The returned builder has its own {@link #getHeaders() response headers} but the header values are shared with the
+     * original {@code Response} instance. The original response entity instance reference is set in the new response
      * builder.
      * </p>
      * <p>
-     * Note that if the entity is backed by an un-consumed input stream, the
-     * reference to the stream is copied. In such case make sure to
-     * {@link #bufferEntity() buffer} the entity stream of the original response
-     * instance before passing it to this method.
+     * Note that if the entity is backed by an un-consumed input stream, the reference to the stream is copied. In such case
+     * make sure to {@link #bufferEntity() buffer} the entity stream of the original response instance before passing it to
+     * this method.
      * </p>
      *
-     * @param response a Response from which the status code, entity and
-     *                 {@link #getHeaders() response headers} will be copied.
+     * @param response a Response from which the status code, entity and {@link #getHeaders() response headers} will be
+     * copied.
      * @return a new response builder.
      * @since 2.0
      */
@@ -584,8 +522,7 @@ public abstract class Response implements AutoCloseable {
      *
      * @param status the response status.
      * @return a new response builder.
-     * @throws IllegalArgumentException if status is less than {@code 100} or greater
-     *                                  than {@code 599}.
+     * @throws IllegalArgumentException if status is less than {@code 100} or greater than {@code 599}.
      */
     public static ResponseBuilder status(final int status) {
         return ResponseBuilder.newInstance().status(status);
@@ -594,11 +531,10 @@ public abstract class Response implements AutoCloseable {
     /**
      * Create a new ResponseBuilder with the supplied status and reason phrase.
      *
-     * @param status       the response status.
+     * @param status the response status.
      * @param reasonPhrase the reason phrase.
      * @return the updated response builder.
-     * @throws IllegalArgumentException if status is less than {@code 100} or greater
-     *                                  than {@code 599}.
+     * @throws IllegalArgumentException if status is less than {@code 100} or greater than {@code 599}.
      * @since 2.1
      */
     public static ResponseBuilder status(final int status, final String reasonPhrase) {
@@ -615,9 +551,8 @@ public abstract class Response implements AutoCloseable {
     }
 
     /**
-     * Create a new ResponseBuilder that contains a representation. It is the
-     * callers responsibility to wrap the actual entity with
-     * {@link GenericEntity} if preservation of its generic type is required.
+     * Create a new ResponseBuilder that contains a representation. It is the callers responsibility to wrap the actual
+     * entity with {@link GenericEntity} if preservation of its generic type is required.
      *
      * @param entity the representation entity data.
      * @return a new response builder.
@@ -629,12 +564,11 @@ public abstract class Response implements AutoCloseable {
     }
 
     /**
-     * Create a new ResponseBuilder that contains a representation. It is the
-     * callers responsibility to wrap the actual entity with
-     * {@link GenericEntity} if preservation of its generic type is required.
+     * Create a new ResponseBuilder that contains a representation. It is the callers responsibility to wrap the actual
+     * entity with {@link GenericEntity} if preservation of its generic type is required.
      *
      * @param entity the representation entity data.
-     * @param type   the media type of the entity.
+     * @param type the media type of the entity.
      * @return a new response builder.
      */
     public static ResponseBuilder ok(final Object entity, final MediaType type) {
@@ -642,12 +576,11 @@ public abstract class Response implements AutoCloseable {
     }
 
     /**
-     * Create a new ResponseBuilder that contains a representation. It is the
-     * callers responsibility to wrap the actual entity with
-     * {@link GenericEntity} if preservation of its generic type is required.
+     * Create a new ResponseBuilder that contains a representation. It is the callers responsibility to wrap the actual
+     * entity with {@link GenericEntity} if preservation of its generic type is required.
      *
      * @param entity the representation entity data.
-     * @param type   the media type of the entity.
+     * @param type the media type of the entity.
      * @return a new response builder.
      */
     public static ResponseBuilder ok(final Object entity, final String type) {
@@ -655,11 +588,10 @@ public abstract class Response implements AutoCloseable {
     }
 
     /**
-     * Create a new ResponseBuilder that contains a representation. It is the
-     * callers responsibility to wrap the actual entity with
-     * {@link GenericEntity} if preservation of its generic type is required.
+     * Create a new ResponseBuilder that contains a representation. It is the callers responsibility to wrap the actual
+     * entity with {@link GenericEntity} if preservation of its generic type is required.
      *
-     * @param entity  the representation entity data.
+     * @param entity the representation entity data.
      * @param variant representation metadata.
      * @return a new response builder.
      */
@@ -677,15 +609,12 @@ public abstract class Response implements AutoCloseable {
     }
 
     /**
-     * Create a new ResponseBuilder for a created resource, set the location
-     * header using the supplied value.
+     * Create a new ResponseBuilder for a created resource, set the location header using the supplied value.
      *
-     * @param location the URI of the new resource. If a relative URI is
-     *                 supplied it will be converted into an absolute URI by resolving it
-     *                 relative to the request URI (see {@link UriInfo#getRequestUri}).
+     * @param location the URI of the new resource. If a relative URI is supplied it will be converted into an absolute URI
+     * by resolving it relative to the request URI (see {@link UriInfo#getRequestUri}).
      * @return a new response builder.
-     * @throws java.lang.IllegalArgumentException
-     *          if location is {@code null}.
+     * @throws java.lang.IllegalArgumentException if location is {@code null}.
      */
     public static ResponseBuilder created(final URI location) {
         return status(Status.CREATED).location(location);
@@ -702,9 +631,8 @@ public abstract class Response implements AutoCloseable {
     }
 
     /**
-     * Create a new ResponseBuilder with an ACCEPTED status that contains
-     * a representation. It is the callers responsibility to wrap the actual entity with
-     * {@link GenericEntity} if preservation of its generic type is required.
+     * Create a new ResponseBuilder with an ACCEPTED status that contains a representation. It is the callers responsibility
+     * to wrap the actual entity with {@link GenericEntity} if preservation of its generic type is required.
      *
      * @param entity the representation entity data.
      * @return a new response builder.
@@ -737,21 +665,18 @@ public abstract class Response implements AutoCloseable {
      *
      * @param tag a tag for the unmodified entity.
      * @return a new response builder.
-     * @throws java.lang.IllegalArgumentException
-     *          if tag is {@code null}.
+     * @throws java.lang.IllegalArgumentException if tag is {@code null}.
      */
     public static ResponseBuilder notModified(final EntityTag tag) {
         return notModified().tag(tag);
     }
 
     /**
-     * Create a new ResponseBuilder with a not-modified status
-     * and a strong entity tag. This is a shortcut
-     * for <code>notModified(new EntityTag(<i>value</i>))</code>.
+     * Create a new ResponseBuilder with a not-modified status and a strong entity tag. This is a shortcut for
+     * <code>notModified(new EntityTag(<i>value</i>))</code>.
      *
-     * @param tag the string content of a strong entity tag. The JAX-RS
-     *            runtime will quote the supplied value when creating the
-     *            header.
+     * @param tag the string content of a strong entity tag. The JAX-RS runtime will quote the supplied value when creating
+     * the header.
      * @return a new response builder.
      * @throws IllegalArgumentException if tag is {@code null}.
      */
@@ -761,16 +686,12 @@ public abstract class Response implements AutoCloseable {
     }
 
     /**
-     * Create a new ResponseBuilder for a redirection. Used in the
-     * redirect-after-POST (aka POST/redirect/GET) pattern.
+     * Create a new ResponseBuilder for a redirection. Used in the redirect-after-POST (aka POST/redirect/GET) pattern.
      *
-     * @param location the redirection URI. If a relative URI is
-     *                 supplied it will be converted into an absolute URI by resolving it
-     *                 relative to the base URI of the application (see
-     *                 {@link UriInfo#getBaseUri}).
+     * @param location the redirection URI. If a relative URI is supplied it will be converted into an absolute URI by
+     * resolving it relative to the base URI of the application (see {@link UriInfo#getBaseUri}).
      * @return a new response builder.
-     * @throws java.lang.IllegalArgumentException
-     *          if location is {@code null}.
+     * @throws java.lang.IllegalArgumentException if location is {@code null}.
      */
     public static ResponseBuilder seeOther(final URI location) {
         return status(Status.SEE_OTHER).location(location);
@@ -779,13 +700,10 @@ public abstract class Response implements AutoCloseable {
     /**
      * Create a new ResponseBuilder for a temporary redirection.
      *
-     * @param location the redirection URI. If a relative URI is
-     *                 supplied it will be converted into an absolute URI by resolving it
-     *                 relative to the base URI of the application (see
-     *                 {@link UriInfo#getBaseUri}).
+     * @param location the redirection URI. If a relative URI is supplied it will be converted into an absolute URI by
+     * resolving it relative to the base URI of the application (see {@link UriInfo#getBaseUri}).
      * @return a new response builder.
-     * @throws java.lang.IllegalArgumentException
-     *          if location is {@code null}.
+     * @throws java.lang.IllegalArgumentException if location is {@code null}.
      */
     public static ResponseBuilder temporaryRedirect(final URI location) {
         return status(Status.TEMPORARY_REDIRECT).location(location);
@@ -794,8 +712,7 @@ public abstract class Response implements AutoCloseable {
     /**
      * Create a new ResponseBuilder for a not acceptable response.
      *
-     * @param variants list of variants that were available, a null value is
-     *                 equivalent to an empty list.
+     * @param variants list of variants that were available, a null value is equivalent to an empty list.
      * @return a new response builder.
      */
     public static ResponseBuilder notAcceptable(final List<Variant> variants) {
@@ -803,30 +720,33 @@ public abstract class Response implements AutoCloseable {
     }
 
     /**
-     * A class used to build Response instances that contain metadata instead
-     * of or in addition to an entity. An initial instance may be obtained via
-     * static methods of the Response class, instance methods provide the
-     * ability to set metadata. E.g. to create a response that indicates the
-     * creation of a new resource:
-     * <pre>&#64;POST
+     * A class used to build Response instances that contain metadata instead of or in addition to an entity. An initial
+     * instance may be obtained via static methods of the Response class, instance methods provide the ability to set
+     * metadata. E.g. to create a response that indicates the creation of a new resource:
+     *
+     * <pre>
+     * &#64;POST
      * Response addWidget(...) {
      *   Widget w = ...
      *   URI widgetId = UriBuilder.fromResource(Widget.class)...
      *   return Response.created(widgetId).build();
-     * }</pre>
+     * }
+     * </pre>
      *
-     * <p>Several methods have parameters of type URI, {@link UriBuilder} provides
-     * convenient methods to create such values as does {@code URI.create()}.</p>
+     * <p>
+     * Several methods have parameters of type URI, {@link UriBuilder} provides convenient methods to create such values as
+     * does {@code URI.create()}.
+     * </p>
      *
-     * <p>Where multiple variants of the same method are provided, the type of
-     * the supplied parameter is retained in the metadata of the built
-     * {@code Response}.</p>
+     * <p>
+     * Where multiple variants of the same method are provided, the type of the supplied parameter is retained in the
+     * metadata of the built {@code Response}.
+     * </p>
      */
     public static abstract class ResponseBuilder {
 
         /**
-         * Protected constructor, use one of the static methods of
-         * {@code Response} to obtain an instance.
+         * Protected constructor, use one of the static methods of {@code Response} to obtain an instance.
          */
         protected ResponseBuilder() {
         }
@@ -841,8 +761,8 @@ public abstract class Response implements AutoCloseable {
         }
 
         /**
-         * Create a Response instance from the current ResponseBuilder. The builder
-         * is reset to a blank state equivalent to calling the ok method.
+         * Create a Response instance from the current ResponseBuilder. The builder is reset to a blank state equivalent to
+         * calling the ok method.
          *
          * @return a Response instance.
          */
@@ -865,19 +785,17 @@ public abstract class Response implements AutoCloseable {
          *
          * @param status the response status.
          * @return the updated response builder.
-         * @throws IllegalArgumentException if status is less than {@code 100} or greater
-         *                                  than {@code 599}.
+         * @throws IllegalArgumentException if status is less than {@code 100} or greater than {@code 599}.
          */
         public abstract ResponseBuilder status(int status);
 
         /**
          * Set the status on the ResponseBuilder.
          *
-         * @param status       the response status.
+         * @param status the response status.
          * @param reasonPhrase the reason phrase.
          * @return the updated response builder.
-         * @throws IllegalArgumentException if status is less than {@code 100} or greater
-         *                                  than {@code 599}.
+         * @throws IllegalArgumentException if status is less than {@code 100} or greater than {@code 599}.
          * @since 2.1
          */
         public abstract ResponseBuilder status(int status, String reasonPhrase);
@@ -909,16 +827,15 @@ public abstract class Response implements AutoCloseable {
         }
 
         /**
-         * <p>Set the response entity in the builder.
+         * <p>
+         * Set the response entity in the builder.
          * </p>
-         * <p>Any Java type instance for a response entity, that is supported by the
-         * runtime can be passed. It is the callers responsibility to wrap the
-         * actual entity with {@link GenericEntity} if preservation of its generic
-         * type is required. Note that the entity can be also set as an
-         * {@link java.io.InputStream input stream}.
+         * <p>
+         * Any Java type instance for a response entity, that is supported by the runtime can be passed. It is the callers
+         * responsibility to wrap the actual entity with {@link GenericEntity} if preservation of its generic type is required.
+         * Note that the entity can be also set as an {@link java.io.InputStream input stream}.
          * </p>
-         * A specific entity media type can be set using one of the {@code type(...)}
-         * methods.
+         * A specific entity media type can be set using one of the {@code type(...)} methods.
          *
          * @param entity the request entity.
          * @return updated response builder instance.
@@ -929,21 +846,19 @@ public abstract class Response implements AutoCloseable {
         public abstract ResponseBuilder entity(Object entity);
 
         /**
-         * <p>Set the response entity in the builder.
+         * <p>
+         * Set the response entity in the builder.
          * </p>
-         * <p>Any Java type instance for a response entity, that is supported by the
-         * runtime can be passed. It is the callers responsibility to wrap the
-         * actual entity with {@link GenericEntity} if preservation of its generic
-         * type is required. Note that the entity can be also set as an
-         * {@link java.io.InputStream input stream}.
+         * <p>
+         * Any Java type instance for a response entity, that is supported by the runtime can be passed. It is the callers
+         * responsibility to wrap the actual entity with {@link GenericEntity} if preservation of its generic type is required.
+         * Note that the entity can be also set as an {@link java.io.InputStream input stream}.
          * </p>
-         * A specific entity media type can be set using one of the {@code type(...)}
-         * methods.
+         * A specific entity media type can be set using one of the {@code type(...)} methods.
          *
-         * @param entity      the request entity.
-         * @param annotations annotations that will be passed to the {@link MessageBodyWriter},
-         *                    (in addition to any annotations declared directly on a resource
-         *                    method that returns the built response).
+         * @param entity the request entity.
+         * @param annotations annotations that will be passed to the {@link MessageBodyWriter}, (in addition to any annotations
+         * declared directly on a resource method that returns the built response).
          * @return updated response builder instance.
          * @see #entity(java.lang.Object)
          * @see #type(javax.ws.rs.core.MediaType)
@@ -953,11 +868,10 @@ public abstract class Response implements AutoCloseable {
         public abstract ResponseBuilder entity(Object entity, Annotation[] annotations);
 
         /**
-         * Set the list of allowed methods for the resource. Any duplicate method
-         * names will be truncated to a single entry.
+         * Set the list of allowed methods for the resource. Any duplicate method names will be truncated to a single entry.
          *
-         * @param methods the methods to be listed as allowed for the resource,
-         *                if {@code null} any existing allowed method list will be removed.
+         * @param methods the methods to be listed as allowed for the resource, if {@code null} any existing allowed method list
+         * will be removed.
          * @return the updated response builder.
          * @since 2.0
          */
@@ -966,8 +880,8 @@ public abstract class Response implements AutoCloseable {
         /**
          * Set the list of allowed methods for the resource.
          *
-         * @param methods the methods to be listed as allowed for the resource,
-         *                if {@code null} any existing allowed method list will be removed.
+         * @param methods the methods to be listed as allowed for the resource, if {@code null} any existing allowed method list
+         * will be removed.
          * @return the updated response builder.
          * @since 2.0
          */
@@ -976,8 +890,8 @@ public abstract class Response implements AutoCloseable {
         /**
          * Set the cache control data of the message.
          *
-         * @param cacheControl the cache control directives, if {@code null}
-         *                     any existing cache control directives will be removed.
+         * @param cacheControl the cache control directives, if {@code null} any existing cache control directives will be
+         * removed.
          * @return the updated response builder.
          */
         public abstract ResponseBuilder cacheControl(CacheControl cacheControl);
@@ -985,9 +899,8 @@ public abstract class Response implements AutoCloseable {
         /**
          * Set the message entity content encoding.
          *
-         * @param encoding the content encoding of the message entity,
-         *                 if {@code null} any existing value for content encoding will be
-         *                 removed.
+         * @param encoding the content encoding of the message entity, if {@code null} any existing value for content encoding
+         * will be removed.
          * @return the updated response builder.
          * @since 2.0
          */
@@ -996,13 +909,12 @@ public abstract class Response implements AutoCloseable {
         /**
          * Add an arbitrary header.
          *
-         * @param name  the name of the header
-         * @param value the value of the header, the header will be serialized
-         *              using a {@link javax.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if
-         *              one is available via {@link javax.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)}
-         *              for the class of {@code value} or using its {@code toString} method
-         *              if a header delegate is not available. If {@code value} is {@code null}
-         *              then all current headers of the same name will be removed.
+         * @param name the name of the header
+         * @param value the value of the header, the header will be serialized using a
+         * {@link javax.ws.rs.ext.RuntimeDelegate.HeaderDelegate} if one is available via
+         * {@link javax.ws.rs.ext.RuntimeDelegate#createHeaderDelegate(java.lang.Class)} for the class of {@code value} or using
+         * its {@code toString} method if a header delegate is not available. If {@code value} is {@code null} then all current
+         * headers of the same name will be removed.
          * @return the updated response builder.
          */
         public abstract ResponseBuilder header(String name, Object value);
@@ -1010,8 +922,7 @@ public abstract class Response implements AutoCloseable {
         /**
          * Replaces all existing headers with the newly supplied headers.
          *
-         * @param headers new headers to be set, if {@code null} all existing
-         *                headers will be removed.
+         * @param headers new headers to be set, if {@code null} all existing headers will be removed.
          * @return the updated response builder.
          * @since 2.0
          */
@@ -1020,8 +931,7 @@ public abstract class Response implements AutoCloseable {
         /**
          * Set the message entity language.
          *
-         * @param language the language of the message entity, if {@code null} any
-         *                 existing value for language will be removed.
+         * @param language the language of the message entity, if {@code null} any existing value for language will be removed.
          * @return the updated response builder.
          */
         public abstract ResponseBuilder language(String language);
@@ -1029,8 +939,7 @@ public abstract class Response implements AutoCloseable {
         /**
          * Set the message entity language.
          *
-         * @param language the language of the message entity, if {@code null} any
-         *                 existing value for type will be removed.
+         * @param language the language of the message entity, if {@code null} any existing value for type will be removed.
          * @return the updated response builder.
          */
         public abstract ResponseBuilder language(Locale language);
@@ -1038,8 +947,7 @@ public abstract class Response implements AutoCloseable {
         /**
          * Set the message entity media type.
          *
-         * @param type the media type of the message entity. If {@code null}, any
-         *             existing value for type will be removed.
+         * @param type the media type of the message entity. If {@code null}, any existing value for type will be removed.
          * @return the updated response builder.
          */
         public abstract ResponseBuilder type(MediaType type);
@@ -1047,20 +955,20 @@ public abstract class Response implements AutoCloseable {
         /**
          * Set the message entity media type.
          *
-         * @param type the media type of the message entity. If {@code null}, any
-         *             existing value for type will be removed.
+         * @param type the media type of the message entity. If {@code null}, any existing value for type will be removed.
          * @return the updated response builder.
          */
         public abstract ResponseBuilder type(String type);
 
         /**
-         * <p>Set message entity representation metadata.
+         * <p>
+         * Set message entity representation metadata.
          * </p>
-         * Equivalent to setting the values of content type, content language,
-         * and content encoding separately using the values of the variant properties.
+         * Equivalent to setting the values of content type, content language, and content encoding separately using the values
+         * of the variant properties.
          *
-         * @param variant metadata of the message entity, a {@code null} value is
-         *                equivalent to a variant with all {@code null} properties.
+         * @param variant metadata of the message entity, a {@code null} value is equivalent to a variant with all {@code null}
+         * properties.
          * @return the updated response builder.
          * @see #encoding(java.lang.String)
          * @see #language(java.util.Locale)
@@ -1072,9 +980,8 @@ public abstract class Response implements AutoCloseable {
         /**
          * Set the content location.
          *
-         * @param location the content location. Relative or absolute URIs
-         *                 may be used for the value of content location. If {@code null} any
-         *                 existing value for content location will be removed.
+         * @param location the content location. Relative or absolute URIs may be used for the value of content location. If
+         * {@code null} any existing value for content location will be removed.
          * @return the updated response builder.
          */
         public abstract ResponseBuilder contentLocation(URI location);
@@ -1082,9 +989,8 @@ public abstract class Response implements AutoCloseable {
         /**
          * Add cookies to the response message.
          *
-         * @param cookies new cookies that will accompany the response. A {@code null}
-         *                value will remove all cookies, including those added via the
-         *                {@link #header(java.lang.String, java.lang.Object)} method.
+         * @param cookies new cookies that will accompany the response. A {@code null} value will remove all cookies, including
+         * those added via the {@link #header(java.lang.String, java.lang.Object)} method.
          * @return the updated response builder.
          */
         public abstract ResponseBuilder cookie(NewCookie... cookies);
@@ -1092,8 +998,7 @@ public abstract class Response implements AutoCloseable {
         /**
          * Set the response expiration date.
          *
-         * @param expires the expiration date, if {@code null} removes any existing
-         *                expires value.
+         * @param expires the expiration date, if {@code null} removes any existing expires value.
          * @return the updated response builder.
          */
         public abstract ResponseBuilder expires(Date expires);
@@ -1101,8 +1006,7 @@ public abstract class Response implements AutoCloseable {
         /**
          * Set the response entity last modification date.
          *
-         * @param lastModified the last modified date, if {@code null} any existing
-         *                     last modified value will be removed.
+         * @param lastModified the last modified date, if {@code null} any existing last modified value will be removed.
          * @return the updated response builder.
          */
         public abstract ResponseBuilder lastModified(Date lastModified);
@@ -1110,10 +1014,9 @@ public abstract class Response implements AutoCloseable {
         /**
          * Set the location.
          *
-         * @param location the location. If a relative URI is supplied it will be
-         *                 converted into an absolute URI by resolving it relative to the
-         *                 base URI of the application (see {@link UriInfo#getBaseUri}).
-         *                 If {@code null} any existing value for location will be removed.
+         * @param location the location. If a relative URI is supplied it will be converted into an absolute URI by resolving it
+         * relative to the base URI of the application (see {@link UriInfo#getBaseUri}). If {@code null} any existing value for
+         * location will be removed.
          * @return the updated response builder.
          */
         public abstract ResponseBuilder location(URI location);
@@ -1121,20 +1024,19 @@ public abstract class Response implements AutoCloseable {
         /**
          * Set a response entity tag.
          *
-         * @param tag the entity tag, if {@code null} any existing entity tag
-         *            value will be removed.
+         * @param tag the entity tag, if {@code null} any existing entity tag value will be removed.
          * @return the updated response builder.
          */
         public abstract ResponseBuilder tag(EntityTag tag);
 
         /**
-         * <p>Set a strong response entity tag.
+         * <p>
+         * Set a strong response entity tag.
          * </p>
          * This is a shortcut for <code>tag(new EntityTag(<i>value</i>))</code>.
          *
-         * @param tag the string content of a strong entity tag. The JAX-RS
-         *            runtime will quote the supplied value when creating the header.
-         *            If {@code null} any existing entity tag value will be removed.
+         * @param tag the string content of a strong entity tag. The JAX-RS runtime will quote the supplied value when creating
+         * the header. If {@code null} any existing entity tag value will be removed.
          * @return the updated response builder.
          */
         @SuppressWarnings("HtmlTagCanBeJavadocTag")
@@ -1143,8 +1045,8 @@ public abstract class Response implements AutoCloseable {
         /**
          * Add a Vary header that lists the available variants.
          *
-         * @param variants a list of available representation variants, a {@code null}
-         *                 value will remove an existing value for Vary header.
+         * @param variants a list of available representation variants, a {@code null} value will remove an existing value for
+         * Vary header.
          * @return the updated response builder.
          * @since 2.0
          */
@@ -1153,8 +1055,8 @@ public abstract class Response implements AutoCloseable {
         /**
          * Add a Vary header that lists the available variants.
          *
-         * @param variants a list of available representation variants, a {@code null}
-         *                 value will remove an existing value for Vary header.
+         * @param variants a list of available representation variants, a {@code null} value will remove an existing value for
+         * Vary header.
          * @return the updated response builder.
          */
         public abstract ResponseBuilder variants(List<Variant> variants);
@@ -1162,8 +1064,7 @@ public abstract class Response implements AutoCloseable {
         /**
          * Add one or more link headers.
          *
-         * @param links links to be added to the message as headers, a {@code null}
-         *              value will remove any existing Link headers.
+         * @param links links to be added to the message as headers, a {@code null} value will remove any existing Link headers.
          * @return the updated response builder.
          * @since 2.0
          */
@@ -1221,8 +1122,8 @@ public abstract class Response implements AutoCloseable {
         /**
          * Get the this Status Type as a {@link Status}.
          * <p>
-         * Please note that returned status contains only a status code, the reason phrase is
-         * set to default one (corresponding to the status code).
+         * Please note that returned status contains only a status code, the reason phrase is set to default one (corresponding
+         * to the status code).
          *
          * @return {@link Status} representing this status type.
          * @since 2.1
@@ -1234,9 +1135,8 @@ public abstract class Response implements AutoCloseable {
 
     /**
      * Commonly used status codes defined by HTTP, see
-     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10">HTTP/1.1 documentation</a>
-     * for the complete list. Additional status codes can be added by applications
-     * by creating an implementation of {@link StatusType}.
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10">HTTP/1.1 documentation</a> for the complete
+     * list. Additional status codes can be added by applications by creating an implementation of {@link StatusType}.
      */
     public enum Status implements StatusType {
 
@@ -1245,31 +1145,37 @@ public abstract class Response implements AutoCloseable {
          */
         OK(200, "OK"),
         /**
-         * 201 Created, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.2">HTTP/1.1 documentation</a>.
+         * 201 Created, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.2">HTTP/1.1
+         * documentation</a>.
          */
         CREATED(201, "Created"),
         /**
-         * 202 Accepted, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.3">HTTP/1.1 documentation</a>.
+         * 202 Accepted, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.3">HTTP/1.1
+         * documentation</a>.
          */
         ACCEPTED(202, "Accepted"),
         /**
-         * 204 No Content, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5">HTTP/1.1 documentation</a>.
+         * 204 No Content, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5">HTTP/1.1
+         * documentation</a>.
          */
         NO_CONTENT(204, "No Content"),
         /**
-         * 205 Reset Content, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.6">HTTP/1.1 documentation</a>.
+         * 205 Reset Content, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.6">HTTP/1.1
+         * documentation</a>.
          *
          * @since 2.0
          */
         RESET_CONTENT(205, "Reset Content"),
         /**
-         * 206 Reset Content, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.7">HTTP/1.1 documentation</a>.
+         * 206 Reset Content, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.7">HTTP/1.1
+         * documentation</a>.
          *
          * @since 2.0
          */
         PARTIAL_CONTENT(206, "Partial Content"),
         /**
-         * 301 Moved Permanently, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.2">HTTP/1.1 documentation</a>.
+         * 301 Moved Permanently, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.2">HTTP/1.1
+         * documentation</a>.
          */
         MOVED_PERMANENTLY(301, "Moved Permanently"),
         /**
@@ -1279,69 +1185,83 @@ public abstract class Response implements AutoCloseable {
          */
         FOUND(302, "Found"),
         /**
-         * 303 See Other, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.4">HTTP/1.1 documentation</a>.
+         * 303 See Other, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.4">HTTP/1.1
+         * documentation</a>.
          */
         SEE_OTHER(303, "See Other"),
         /**
-         * 304 Not Modified, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.5">HTTP/1.1 documentation</a>.
+         * 304 Not Modified, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.5">HTTP/1.1
+         * documentation</a>.
          */
         NOT_MODIFIED(304, "Not Modified"),
         /**
-         * 305 Use Proxy, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.6">HTTP/1.1 documentation</a>.
+         * 305 Use Proxy, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.6">HTTP/1.1
+         * documentation</a>.
          *
          * @since 2.0
          */
         USE_PROXY(305, "Use Proxy"),
         /**
-         * 307 Temporary Redirect, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.8">HTTP/1.1 documentation</a>.
+         * 307 Temporary Redirect, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.8">HTTP/1.1
+         * documentation</a>.
          */
         TEMPORARY_REDIRECT(307, "Temporary Redirect"),
         /**
-         * 400 Bad Request, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1">HTTP/1.1 documentation</a>.
+         * 400 Bad Request, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1">HTTP/1.1
+         * documentation</a>.
          */
         BAD_REQUEST(400, "Bad Request"),
         /**
-         * 401 Unauthorized, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2">HTTP/1.1 documentation</a>.
+         * 401 Unauthorized, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2">HTTP/1.1
+         * documentation</a>.
          */
         UNAUTHORIZED(401, "Unauthorized"),
         /**
-         * 402 Payment Required, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.3">HTTP/1.1 documentation</a>.
+         * 402 Payment Required, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.3">HTTP/1.1
+         * documentation</a>.
          *
          * @since 2.0
          */
         PAYMENT_REQUIRED(402, "Payment Required"),
         /**
-         * 403 Forbidden, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4">HTTP/1.1 documentation</a>.
+         * 403 Forbidden, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4">HTTP/1.1
+         * documentation</a>.
          */
         FORBIDDEN(403, "Forbidden"),
         /**
-         * 404 Not Found, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.5">HTTP/1.1 documentation</a>.
+         * 404 Not Found, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.5">HTTP/1.1
+         * documentation</a>.
          */
         NOT_FOUND(404, "Not Found"),
         /**
-         * 405 Method Not Allowed, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.6">HTTP/1.1 documentation</a>.
+         * 405 Method Not Allowed, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.6">HTTP/1.1
+         * documentation</a>.
          *
          * @since 2.0
          */
         METHOD_NOT_ALLOWED(405, "Method Not Allowed"),
         /**
-         * 406 Not Acceptable, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.7">HTTP/1.1 documentation</a>.
+         * 406 Not Acceptable, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.7">HTTP/1.1
+         * documentation</a>.
          */
         NOT_ACCEPTABLE(406, "Not Acceptable"),
         /**
-         * 407 Proxy Authentication Required, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.8">HTTP/1.1 documentation</a>.
+         * 407 Proxy Authentication Required, see
+         * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.8">HTTP/1.1 documentation</a>.
          *
          * @since 2.0
          */
         PROXY_AUTHENTICATION_REQUIRED(407, "Proxy Authentication Required"),
         /**
-         * 408 Request Timeout, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.9">HTTP/1.1 documentation</a>.
+         * 408 Request Timeout, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.9">HTTP/1.1
+         * documentation</a>.
          *
          * @since 2.0
          */
         REQUEST_TIMEOUT(408, "Request Timeout"),
         /**
-         * 409 Conflict, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.10">HTTP/1.1 documentation</a>.
+         * 409 Conflict, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.10">HTTP/1.1
+         * documentation</a>.
          */
         CONFLICT(409, "Conflict"),
         /**
@@ -1349,95 +1269,112 @@ public abstract class Response implements AutoCloseable {
          */
         GONE(410, "Gone"),
         /**
-         * 411 Length Required, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.12">HTTP/1.1 documentation</a>.
+         * 411 Length Required, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.12">HTTP/1.1
+         * documentation</a>.
          *
          * @since 2.0
          */
         LENGTH_REQUIRED(411, "Length Required"),
         /**
-         * 412 Precondition Failed, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.13">HTTP/1.1 documentation</a>.
+         * 412 Precondition Failed, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.13">HTTP/1.1
+         * documentation</a>.
          */
         PRECONDITION_FAILED(412, "Precondition Failed"),
         /**
-         * 413 Request Entity Too Large, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.14">HTTP/1.1 documentation</a>.
+         * 413 Request Entity Too Large, see
+         * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.14">HTTP/1.1 documentation</a>.
          *
          * @since 2.0
          */
         REQUEST_ENTITY_TOO_LARGE(413, "Request Entity Too Large"),
         /**
-         * 414 Request-URI Too Long, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.15">HTTP/1.1 documentation</a>.
+         * 414 Request-URI Too Long, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.15">HTTP/1.1
+         * documentation</a>.
          *
          * @since 2.0
          */
         REQUEST_URI_TOO_LONG(414, "Request-URI Too Long"),
         /**
-         * 415 Unsupported Media Type, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.16">HTTP/1.1 documentation</a>.
+         * 415 Unsupported Media Type, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.16">HTTP/1.1
+         * documentation</a>.
          */
         UNSUPPORTED_MEDIA_TYPE(415, "Unsupported Media Type"),
         /**
-         * 416 Requested Range Not Satisfiable, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.17">HTTP/1.1 documentation</a>.
+         * 416 Requested Range Not Satisfiable, see
+         * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.17">HTTP/1.1 documentation</a>.
          *
          * @since 2.0
          */
         REQUESTED_RANGE_NOT_SATISFIABLE(416, "Requested Range Not Satisfiable"),
         /**
-         * 417 Expectation Failed, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.18">HTTP/1.1 documentation</a>.
+         * 417 Expectation Failed, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.18">HTTP/1.1
+         * documentation</a>.
          *
          * @since 2.0
          */
         EXPECTATION_FAILED(417, "Expectation Failed"),
         /**
-         * 428 Precondition required, see <a href="https://tools.ietf.org/html/rfc6585#section-3">RFC 6585: Additional HTTP Status Codes</a>.
+         * 428 Precondition required, see <a href="https://tools.ietf.org/html/rfc6585#section-3">RFC 6585: Additional HTTP
+         * Status Codes</a>.
          *
          * @since 2.1
          */
         PRECONDITION_REQUIRED(428, "Precondition Required"),
         /**
-         * 429 Too Many Requests, see <a href="https://tools.ietf.org/html/rfc6585#section-4">RFC 6585: Additional HTTP Status Codes</a>.
+         * 429 Too Many Requests, see <a href="https://tools.ietf.org/html/rfc6585#section-4">RFC 6585: Additional HTTP Status
+         * Codes</a>.
          *
          * @since 2.1
          */
         TOO_MANY_REQUESTS(429, "Too Many Requests"),
         /**
-         * 431 Request Header Fields Too Large, see <a href="https://tools.ietf.org/html/rfc6585#section-5">RFC 6585: Additional HTTP Status Codes</a>.
+         * 431 Request Header Fields Too Large, see <a href="https://tools.ietf.org/html/rfc6585#section-5">RFC 6585: Additional
+         * HTTP Status Codes</a>.
          *
          * @since 2.1
          */
         REQUEST_HEADER_FIELDS_TOO_LARGE(431, "Request Header Fields Too Large"),
         /**
-         * 500 Internal Server Error, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1">HTTP/1.1 documentation</a>.
+         * 500 Internal Server Error, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1">HTTP/1.1
+         * documentation</a>.
          */
         INTERNAL_SERVER_ERROR(500, "Internal Server Error"),
         /**
-         * 501 Not Implemented, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.2">HTTP/1.1 documentation</a>.
+         * 501 Not Implemented, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.2">HTTP/1.1
+         * documentation</a>.
          *
          * @since 2.0
          */
         NOT_IMPLEMENTED(501, "Not Implemented"),
         /**
-         * 502 Bad Gateway, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.3">HTTP/1.1 documentation</a>.
+         * 502 Bad Gateway, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.3">HTTP/1.1
+         * documentation</a>.
          *
          * @since 2.0
          */
         BAD_GATEWAY(502, "Bad Gateway"),
         /**
-         * 503 Service Unavailable, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4">HTTP/1.1 documentation</a>.
+         * 503 Service Unavailable, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4">HTTP/1.1
+         * documentation</a>.
          */
         SERVICE_UNAVAILABLE(503, "Service Unavailable"),
         /**
-         * 504 Gateway Timeout, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.5">HTTP/1.1 documentation</a>.
+         * 504 Gateway Timeout, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.5">HTTP/1.1
+         * documentation</a>.
          *
          * @since 2.0
          */
         GATEWAY_TIMEOUT(504, "Gateway Timeout"),
         /**
-         * 505 HTTP Version Not Supported, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.6">HTTP/1.1 documentation</a>.
+         * 505 HTTP Version Not Supported, see
+         * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.6">HTTP/1.1 documentation</a>.
          *
          * @since 2.0
          */
         HTTP_VERSION_NOT_SUPPORTED(505, "HTTP Version Not Supported"),
         /**
-         * 511 Network Authentication Required, see <a href="https://tools.ietf.org/html/rfc6585#section-6">RFC 6585: Additional HTTP Status Codes</a>.
+         * 511 Network Authentication Required, see <a href="https://tools.ietf.org/html/rfc6585#section-6">RFC 6585: Additional
+         * HTTP Status Codes</a>.
          *
          * @since 2.1
          */
@@ -1448,8 +1385,7 @@ public abstract class Response implements AutoCloseable {
         private final Family family;
 
         /**
-         * An enumeration representing the class of status code. Family is used
-         * here since class is overloaded in Java.
+         * An enumeration representing the class of status code. Family is used here since class is overloaded in Java.
          */
         public enum Family {
 
@@ -1486,18 +1422,18 @@ public abstract class Response implements AutoCloseable {
              */
             public static Family familyOf(final int statusCode) {
                 switch (statusCode / 100) {
-                    case 1:
-                        return Family.INFORMATIONAL;
-                    case 2:
-                        return Family.SUCCESSFUL;
-                    case 3:
-                        return Family.REDIRECTION;
-                    case 4:
-                        return Family.CLIENT_ERROR;
-                    case 5:
-                        return Family.SERVER_ERROR;
-                    default:
-                        return Family.OTHER;
+                case 1:
+                    return Family.INFORMATIONAL;
+                case 2:
+                    return Family.SUCCESSFUL;
+                case 3:
+                    return Family.REDIRECTION;
+                case 4:
+                    return Family.CLIENT_ERROR;
+                case 5:
+                    return Family.SERVER_ERROR;
+                default:
+                    return Family.OTHER;
                 }
             }
         }

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/SecurityContext.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/SecurityContext.java
@@ -19,8 +19,7 @@ package javax.ws.rs.core;
 import java.security.Principal;
 
 /**
- * An injectable interface that provides access to security related
- * information.
+ * An injectable interface that provides access to security related information.
  *
  * @author Paul Sandoz
  * @author Marc Hadley
@@ -47,55 +46,43 @@ public interface SecurityContext {
     public static final String FORM_AUTH = "FORM";
 
     /**
-     * Returns a <code>java.security.Principal</code> object containing the
-     * name of the current authenticated user. If the user
-     * has not been authenticated, the method returns null.
+     * Returns a <code>java.security.Principal</code> object containing the name of the current authenticated user. If the
+     * user has not been authenticated, the method returns null.
      *
-     * @return a <code>java.security.Principal</code> containing the name
-     *         of the user making this request; null if the user has not been
-     *         authenticated
-     * @throws java.lang.IllegalStateException
-     *          if called outside the scope of a request
+     * @return a <code>java.security.Principal</code> containing the name of the user making this request; null if the user
+     * has not been authenticated
+     * @throws java.lang.IllegalStateException if called outside the scope of a request
      */
     public Principal getUserPrincipal();
 
     /**
-     * Returns a boolean indicating whether the authenticated user is included
-     * in the specified logical "role". If the user has not been authenticated,
-     * the method returns <code>false</code>.
+     * Returns a boolean indicating whether the authenticated user is included in the specified logical "role". If the user
+     * has not been authenticated, the method returns <code>false</code>.
      *
      * @param role a <code>String</code> specifying the name of the role
-     * @return a <code>boolean</code> indicating whether the user making
-     *         the request belongs to a given role; <code>false</code> if the user
-     *         has not been authenticated
-     * @throws java.lang.IllegalStateException
-     *          if called outside the scope of a request
+     * @return a <code>boolean</code> indicating whether the user making the request belongs to a given role;
+     * <code>false</code> if the user has not been authenticated
+     * @throws java.lang.IllegalStateException if called outside the scope of a request
      */
     public boolean isUserInRole(String role);
 
     /**
-     * Returns a boolean indicating whether this request was made
-     * using a secure channel, such as HTTPS.
+     * Returns a boolean indicating whether this request was made using a secure channel, such as HTTPS.
      *
-     * @return <code>true</code> if the request was made using a secure
-     *         channel, <code>false</code> otherwise
-     * @throws java.lang.IllegalStateException
-     *          if called outside the scope of a request
+     * @return <code>true</code> if the request was made using a secure channel, <code>false</code> otherwise
+     * @throws java.lang.IllegalStateException if called outside the scope of a request
      */
     public boolean isSecure();
 
     /**
-     * Returns the string value of the authentication scheme used to protect
-     * the resource. If the resource is not authenticated, null is returned.
+     * Returns the string value of the authentication scheme used to protect the resource. If the resource is not
+     * authenticated, null is returned.
      *
      * Values are the same as the CGI variable AUTH_TYPE
      *
-     * @return one of the static members BASIC_AUTH, FORM_AUTH,
-     *         CLIENT_CERT_AUTH, DIGEST_AUTH (suitable for == comparison) or the
-     *         container-specific string indicating the authentication scheme,
-     *         or null if the request was not authenticated.
-     * @throws java.lang.IllegalStateException
-     *          if called outside the scope of a request
+     * @return one of the static members BASIC_AUTH, FORM_AUTH, CLIENT_CERT_AUTH, DIGEST_AUTH (suitable for == comparison)
+     * or the container-specific string indicating the authentication scheme, or null if the request was not authenticated.
+     * @throws java.lang.IllegalStateException if called outside the scope of a request
      */
     public String getAuthenticationScheme();
 }

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/StreamingOutput.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/StreamingOutput.java
@@ -22,10 +22,8 @@ import java.io.OutputStream;
 import javax.ws.rs.WebApplicationException;
 
 /**
- * A type that may be used as a resource method return value or as the entity
- * in a {@link Response} when the application wishes to stream the output.
- * This is a lightweight alternative to a
- * {@link javax.ws.rs.ext.MessageBodyWriter}.
+ * A type that may be used as a resource method return value or as the entity in a {@link Response} when the application
+ * wishes to stream the output. This is a lightweight alternative to a {@link javax.ws.rs.ext.MessageBodyWriter}.
  *
  * @author Paul Sandoz
  * @author Marc Hadley
@@ -40,10 +38,8 @@ public interface StreamingOutput {
      *
      * @param output the OutputStream to write to.
      * @throws java.io.IOException if an IO error is encountered
-     * @throws javax.ws.rs.WebApplicationException
-     *                             if a specific
-     *                             HTTP error response needs to be produced. Only effective if thrown prior
-     *                             to any bytes being written to output.
+     * @throws javax.ws.rs.WebApplicationException if a specific HTTP error response needs to be produced. Only effective if
+     * thrown prior to any bytes being written to output.
      */
     void write(OutputStream output) throws IOException, WebApplicationException;
 }

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/UriBuilder.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/UriBuilder.java
@@ -23,30 +23,27 @@ import java.util.Map;
 import javax.ws.rs.ext.RuntimeDelegate;
 
 /**
- * URI template-aware utility class for building URIs from their components. See
- * {@link javax.ws.rs.Path#value} for an explanation of URI templates.
+ * URI template-aware utility class for building URIs from their components. See {@link javax.ws.rs.Path#value} for an
+ * explanation of URI templates.
  *
- * <p>Builder methods perform contextual encoding of characters not permitted in
- * the corresponding URI component following the rules of the
- * <a href="http://www.w3.org/TR/html4/interact/forms.html#h-17.13.4.1">application/x-www-form-urlencoded</a>
- * media type for query parameters and
- * <a href="http://ietf.org/rfc/rfc3986.txt">RFC 3986</a> for all other
- * components. Note that only characters not permitted in a particular component
- * are subject to encoding so, e.g., a path supplied to one of the {@code path}
- * methods may contain matrix parameters or multiple path segments since the
- * separators are legal characters and will not be encoded. Percent encoded
- * values are also recognized where allowed and will not be double encoded.</p>
+ * <p>
+ * Builder methods perform contextual encoding of characters not permitted in the corresponding URI component following
+ * the rules of the
+ * <a href="http://www.w3.org/TR/html4/interact/forms.html#h-17.13.4.1">application/x-www-form-urlencoded</a> media type
+ * for query parameters and <a href="http://ietf.org/rfc/rfc3986.txt">RFC 3986</a> for all other components. Note that
+ * only characters not permitted in a particular component are subject to encoding so, e.g., a path supplied to one of
+ * the {@code path} methods may contain matrix parameters or multiple path segments since the separators are legal
+ * characters and will not be encoded. Percent encoded values are also recognized where allowed and will not be double
+ * encoded.
+ * </p>
  *
- * <p>URI templates are allowed in most components of a URI but their value is
- * restricted to a particular component. E.g.
- * <blockquote><code>UriBuilder.fromPath("{arg1}").build("foo#bar");</code></blockquote>
- * would result in encoding of the '#' such that the resulting URI is
- * "foo%23bar". To create a URI "foo#bar" use
- * <blockquote><code>UriBuilder.fromPath("{arg1}").fragment("{arg2}").build("foo", "bar")</code></blockquote>
- * instead. URI template names and delimiters are never encoded but their
- * values are encoded when a URI is built.
- * Template parameter regular expressions are ignored when building a URI, i.e.
- * no validation is performed.
+ * <p>
+ * URI templates are allowed in most components of a URI but their value is restricted to a particular component. E.g.
+ * <blockquote><code>UriBuilder.fromPath("{arg1}").build("foo#bar");</code></blockquote> would result in encoding of the
+ * '#' such that the resulting URI is "foo%23bar". To create a URI "foo#bar" use
+ * <blockquote><code>UriBuilder.fromPath("{arg1}").fragment("{arg2}").build("foo", "bar")</code></blockquote> instead.
+ * URI template names and delimiters are never encoded but their values are encoded when a URI is built. Template
+ * parameter regular expressions are ignored when building a URI, i.e. no validation is performed.
  *
  * @author Paul Sandoz
  * @author Marc Hadley
@@ -57,8 +54,7 @@ import javax.ws.rs.ext.RuntimeDelegate;
 public abstract class UriBuilder {
 
     /**
-     * Protected constructor, use one of the static <code>from<i>Xxx</i>(...)</code>
-     * methods to obtain an instance.
+     * Protected constructor, use one of the static <code>from<i>Xxx</i>(...)</code> methods to obtain an instance.
      */
     protected UriBuilder() {
     }
@@ -87,11 +83,9 @@ public abstract class UriBuilder {
     /**
      * Create a new instance initialized from an existing URI.
      *
-     * @param uriTemplate a URI template that will be used to initialize the UriBuilder, may
-     *                    contain URI parameters.
+     * @param uriTemplate a URI template that will be used to initialize the UriBuilder, may contain URI parameters.
      * @return a new UriBuilder.
-     * @throws IllegalArgumentException if {@code uriTemplate} is not a valid URI template or
-     *                                  is {@code null}.
+     * @throws IllegalArgumentException if {@code uriTemplate} is not a valid URI template or is {@code null}.
      */
     public static UriBuilder fromUri(final String uriTemplate) {
         return newInstance().uri(uriTemplate);
@@ -100,8 +94,7 @@ public abstract class UriBuilder {
     /**
      * Create a new instance initialized from a Link.
      *
-     * @param link a Link that will be used to initialize the UriBuilder, only
-     *             its URI is used.
+     * @param link a Link that will be used to initialize the UriBuilder, only its URI is used.
      * @return a new UriBuilder
      * @throws IllegalArgumentException if link is {@code null}
      * @since 2.0
@@ -114,11 +107,9 @@ public abstract class UriBuilder {
     }
 
     /**
-     * Create a new instance representing a relative URI initialized from a
-     * URI path.
+     * Create a new instance representing a relative URI initialized from a URI path.
      *
-     * @param path a URI path that will be used to initialize the UriBuilder,
-     *             may contain URI template parameters.
+     * @param path a URI path that will be used to initialize the UriBuilder, may contain URI template parameters.
      * @return a new UriBuilder.
      * @throws IllegalArgumentException if path is {@code null}.
      */
@@ -127,33 +118,28 @@ public abstract class UriBuilder {
     }
 
     /**
-     * Create a new instance representing a relative URI initialized from a
-     * root resource class.
+     * Create a new instance representing a relative URI initialized from a root resource class.
      *
-     * @param resource a root resource whose {@link javax.ws.rs.Path} value will
-     *                 be used to initialize the UriBuilder.
+     * @param resource a root resource whose {@link javax.ws.rs.Path} value will be used to initialize the UriBuilder.
      * @return a new UriBuilder.
-     * @throws IllegalArgumentException if resource is not annotated with
-     *                                  {@link javax.ws.rs.Path} or resource is {@code null}.
+     * @throws IllegalArgumentException if resource is not annotated with {@link javax.ws.rs.Path} or resource is
+     * {@code null}.
      */
     public static UriBuilder fromResource(final Class<?> resource) {
         return newInstance().path(resource);
     }
 
     /**
-     * Create a new instance representing a relative URI initialized from a
-     * {@link javax.ws.rs.Path}-annotated method.
+     * Create a new instance representing a relative URI initialized from a {@link javax.ws.rs.Path}-annotated method.
      *
-     * This method can only be used in cases where there is a single method with the
-     * specified name that is annotated with {@link javax.ws.rs.Path}.
+     * This method can only be used in cases where there is a single method with the specified name that is annotated with
+     * {@link javax.ws.rs.Path}.
      *
      * @param resource the resource containing the method.
-     * @param method   the name of the method whose {@link javax.ws.rs.Path} value will be
-     *                 used to obtain the path to append.
+     * @param method the name of the method whose {@link javax.ws.rs.Path} value will be used to obtain the path to append.
      * @return the updated UriBuilder.
-     * @throws IllegalArgumentException if resource or method is {@code null},
-     *                                  or there is more than or less than one variant of the method annotated with
-     *                                  {@link javax.ws.rs.Path}.
+     * @throws IllegalArgumentException if resource or method is {@code null}, or there is more than or less than one
+     * variant of the method annotated with {@link javax.ws.rs.Path}.
      * @since 2.0
      */
     public static UriBuilder fromMethod(final Class<?> resource, final String method) {
@@ -161,9 +147,8 @@ public abstract class UriBuilder {
     }
 
     /**
-     * Create a copy of the UriBuilder preserving its state. This is a more
-     * efficient means of creating a copy than constructing a new UriBuilder
-     * from a URI returned by the {@link #build(Object...)} method.
+     * Create a copy of the UriBuilder preserving its state. This is a more efficient means of creating a copy than
+     * constructing a new UriBuilder from a URI returned by the {@link #build(Object...)} method.
      *
      * @return a copy of the UriBuilder.
      */
@@ -172,8 +157,8 @@ public abstract class UriBuilder {
     public abstract UriBuilder clone();
 
     /**
-     * Copies the non-null components of the supplied URI to the UriBuilder replacing
-     * any existing values for those components.
+     * Copies the non-null components of the supplied URI to the UriBuilder replacing any existing values for those
+     * components.
      *
      * @param uri the URI to copy components from.
      * @return the updated UriBuilder.
@@ -182,14 +167,12 @@ public abstract class UriBuilder {
     public abstract UriBuilder uri(URI uri);
 
     /**
-     * Parses the {@code uriTemplate} string and copies the parsed components of the supplied
-     * URI to the UriBuilder replacing any existing values for those components.
+     * Parses the {@code uriTemplate} string and copies the parsed components of the supplied URI to the UriBuilder
+     * replacing any existing values for those components.
      *
-     * @param uriTemplate a URI template that will be used to initialize the UriBuilder, may
-     *                    contain URI parameters.
+     * @param uriTemplate a URI template that will be used to initialize the UriBuilder, may contain URI parameters.
      * @return the updated UriBuilder.
-     * @throws IllegalArgumentException if {@code uriTemplate} is not a valid URI template or
-     *                                  is {@code null}.
+     * @throws IllegalArgumentException if {@code uriTemplate} is not a valid URI template or is {@code null}.
      * @since 2.0
      */
     public abstract UriBuilder uri(String uriTemplate);
@@ -197,18 +180,16 @@ public abstract class UriBuilder {
     /**
      * Set the URI scheme.
      *
-     * @param scheme the URI scheme, may contain URI template parameters.
-     *               A {@code null} value will unset the URI scheme, but will
-     *               not unset the any scheme-specific-part components.
+     * @param scheme the URI scheme, may contain URI template parameters. A {@code null} value will unset the URI scheme,
+     * but will not unset the any scheme-specific-part components.
      * @return the updated UriBuilder.
      * @throws IllegalArgumentException if scheme is invalid.
      */
     public abstract UriBuilder scheme(String scheme);
 
     /**
-     * Set the URI scheme-specific-part (see {@link java.net.URI}). This
-     * method will overwrite any existing
-     * values for authority, user-info, host, port and path.
+     * Set the URI scheme-specific-part (see {@link java.net.URI}). This method will overwrite any existing values for
+     * authority, user-info, host, port and path.
      *
      * @param ssp the URI scheme-specific-part, may contain URI template parameters.
      * @return the updated UriBuilder.
@@ -219,8 +200,8 @@ public abstract class UriBuilder {
     /**
      * Set the URI user-info.
      *
-     * @param ui the URI user-info, may contain URI template parameters.
-     *           A {@code null} value will unset userInfo component of the URI.
+     * @param ui the URI user-info, may contain URI template parameters. A {@code null} value will unset userInfo component
+     * of the URI.
      * @return the updated UriBuilder.
      */
     public abstract UriBuilder userInfo(String ui);
@@ -228,10 +209,9 @@ public abstract class UriBuilder {
     /**
      * Set the URI host.
      *
-     * @param host the URI host, may contain URI template parameters.
-     *             A {@code null} value will unset the host component of the URI, but
-     *             will not unset other authority component parts
-     *             ({@link #userInfo(String) user info} or {@link #port(int) port}).
+     * @param host the URI host, may contain URI template parameters. A {@code null} value will unset the host component of
+     * the URI, but will not unset other authority component parts ({@link #userInfo(String) user info} or {@link #port(int)
+     * port}).
      * @return the updated UriBuilder.
      * @throws IllegalArgumentException if host is invalid.
      */
@@ -247,22 +227,18 @@ public abstract class UriBuilder {
     public abstract UriBuilder port(int port);
 
     /**
-     * Set the URI path. This method will overwrite
-     * any existing path and associated matrix parameters.
-     * Existing '/' characters are preserved thus a single value can
-     * represent multiple URI path segments.
+     * Set the URI path. This method will overwrite any existing path and associated matrix parameters. Existing '/'
+     * characters are preserved thus a single value can represent multiple URI path segments.
      *
-     * @param path the path, may contain URI template parameters.
-     *             A {@code null} value will unset the path component of the URI.
+     * @param path the path, may contain URI template parameters. A {@code null} value will unset the path component of the
+     * URI.
      * @return the updated UriBuilder.
      */
     public abstract UriBuilder replacePath(String path);
 
     /**
-     * Append path to the existing path.
-     * When constructing the final path, a '/' separator will be inserted
-     * between the existing path and the supplied path if necessary.
-     * Existing '/' characters are preserved thus a single value can
+     * Append path to the existing path. When constructing the final path, a '/' separator will be inserted between the
+     * existing path and the supplied path if necessary. Existing '/' characters are preserved thus a single value can
      * represent multiple URI path segments.
      *
      * @param path the path, may contain URI template parameters.
@@ -272,78 +248,60 @@ public abstract class UriBuilder {
     public abstract UriBuilder path(String path);
 
     /**
-     * Append the path from a Path-annotated class to the
-     * existing path.
-     * When constructing the final path, a '/' separator will be inserted
-     * between the existing path and the supplied path if necessary.
+     * Append the path from a Path-annotated class to the existing path. When constructing the final path, a '/' separator
+     * will be inserted between the existing path and the supplied path if necessary.
      *
-     * @param resource a resource whose {@link javax.ws.rs.Path} value will be
-     *                 used to obtain the path to append.
+     * @param resource a resource whose {@link javax.ws.rs.Path} value will be used to obtain the path to append.
      * @return the updated UriBuilder.
-     * @throws IllegalArgumentException if resource is {@code null}, or
-     *                                  if resource is not annotated with {@link javax.ws.rs.Path}.
+     * @throws IllegalArgumentException if resource is {@code null}, or if resource is not annotated with
+     * {@link javax.ws.rs.Path}.
      */
     public abstract UriBuilder path(Class resource);
 
     /**
-     * Append the path from a Path-annotated method to the
-     * existing path.
-     * When constructing the final path, a '/' separator will be inserted
-     * between the existing path and the supplied path if necessary.
-     * This method is a convenience shortcut to {@code path(Method)}, it
-     * can only be used in cases where there is a single method with the
-     * specified name that is annotated with {@link javax.ws.rs.Path}.
+     * Append the path from a Path-annotated method to the existing path. When constructing the final path, a '/' separator
+     * will be inserted between the existing path and the supplied path if necessary. This method is a convenience shortcut
+     * to {@code path(Method)}, it can only be used in cases where there is a single method with the specified name that is
+     * annotated with {@link javax.ws.rs.Path}.
      *
      * @param resource the resource containing the method.
-     * @param method   the name of the method whose {@link javax.ws.rs.Path} value will be
-     *                 used to obtain the path to append.
+     * @param method the name of the method whose {@link javax.ws.rs.Path} value will be used to obtain the path to append.
      * @return the updated UriBuilder.
-     * @throws IllegalArgumentException if resource or method is {@code null},
-     *                                  or there is more than or less than one variant of the method annotated with
-     *                                  {@link javax.ws.rs.Path}.
+     * @throws IllegalArgumentException if resource or method is {@code null}, or there is more than or less than one
+     * variant of the method annotated with {@link javax.ws.rs.Path}.
      */
     public abstract UriBuilder path(Class resource, String method);
 
     /**
-     * Append the path from a {@link javax.ws.rs.Path}-annotated method to the
-     * existing path.
-     * When constructing the final path, a '/' separator will be inserted
-     * between the existing path and the supplied path if necessary.
+     * Append the path from a {@link javax.ws.rs.Path}-annotated method to the existing path. When constructing the final
+     * path, a '/' separator will be inserted between the existing path and the supplied path if necessary.
      *
-     * @param method a method whose {@link javax.ws.rs.Path} value will be
-     *               used to obtain the path to append to the existing path.
+     * @param method a method whose {@link javax.ws.rs.Path} value will be used to obtain the path to append to the existing
+     * path.
      * @return the updated UriBuilder.
-     * @throws IllegalArgumentException if method is {@code null} or is
-     *                                  not annotated with a {@link javax.ws.rs.Path}.
+     * @throws IllegalArgumentException if method is {@code null} or is not annotated with a {@link javax.ws.rs.Path}.
      */
     public abstract UriBuilder path(Method method);
 
     /**
-     * Append path segments to the existing path.
-     * When constructing the final path, a '/' separator will be inserted
-     * between the existing path and the first path segment if necessary and
-     * each supplied segment will also be separated by '/'.
-     * Existing '/' characters are encoded thus a single value can
-     * only represent a single URI path segment.
+     * Append path segments to the existing path. When constructing the final path, a '/' separator will be inserted between
+     * the existing path and the first path segment if necessary and each supplied segment will also be separated by '/'.
+     * Existing '/' characters are encoded thus a single value can only represent a single URI path segment.
      *
-     * @param segments the path segment values, each may contain URI template
-     *                 parameters.
+     * @param segments the path segment values, each may contain URI template parameters.
      * @return the updated UriBuilder.
-     * @throws IllegalArgumentException if segments or any element of segments
-     *                                  is {@code null}.
+     * @throws IllegalArgumentException if segments or any element of segments is {@code null}.
      */
     public abstract UriBuilder segment(String... segments);
 
     /**
-     * Set the matrix parameters of the current final segment of the current URI path.
-     * This method will overwrite any existing matrix parameters on the current final
-     * segment of the current URI path. Note that the matrix parameters
-     * are tied to a particular path segment; subsequent addition of path segments
-     * will not affect their position in the URI path.
+     * Set the matrix parameters of the current final segment of the current URI path. This method will overwrite any
+     * existing matrix parameters on the current final segment of the current URI path. Note that the matrix parameters are
+     * tied to a particular path segment; subsequent addition of path segments will not affect their position in the URI
+     * path.
      *
-     * @param matrix the matrix parameters, may contain URI template parameters.
-     *               A {@code null} value will remove all matrix parameters of the current final segment
-     *               of the current URI path.
+     * @param matrix the matrix parameters, may contain URI template parameters. A {@code null} value will remove all matrix
+     * parameters of the current final segment of the current URI path.
      * @return the updated UriBuilder.
      * @throws IllegalArgumentException if matrix cannot be parsed.
      * @see <a href="http://www.w3.org/DesignIssues/MatrixURIs.html">Matrix URIs</a>
@@ -351,16 +309,13 @@ public abstract class UriBuilder {
     public abstract UriBuilder replaceMatrix(String matrix);
 
     /**
-     * Append a matrix parameter to the existing set of matrix parameters of
-     * the current final segment of the URI path. If multiple values are supplied
-     * the parameter will be added once per value. Note that the matrix parameters
-     * are tied to a particular path segment; subsequent addition of path segments
-     * will not affect their position in the URI path.
+     * Append a matrix parameter to the existing set of matrix parameters of the current final segment of the URI path. If
+     * multiple values are supplied the parameter will be added once per value. Note that the matrix parameters are tied to
+     * a particular path segment; subsequent addition of path segments will not affect their position in the URI path.
      *
-     * @param name   the matrix parameter name, may contain URI template parameters.
-     * @param values the matrix parameter value(s), each object will be converted.
-     *               to a {@code String} using its {@code toString()} method. Stringified
-     *               values may contain URI template parameters.
+     * @param name the matrix parameter name, may contain URI template parameters.
+     * @param values the matrix parameter value(s), each object will be converted. to a {@code String} using its
+     * {@code toString()} method. Stringified values may contain URI template parameters.
      * @return the updated UriBuilder.
      * @throws IllegalArgumentException if name or values is {@code null}.
      * @see <a href="http://www.w3.org/DesignIssues/MatrixURIs.html">Matrix URIs</a>
@@ -368,17 +323,14 @@ public abstract class UriBuilder {
     public abstract UriBuilder matrixParam(String name, Object... values);
 
     /**
-     * Replace the existing value(s) of a matrix parameter on
-     * the current final segment of the URI path. If multiple values are supplied
-     * the parameter will be added once per value. Note that the matrix parameters
-     * are tied to a particular path segment; subsequent addition of path segments
-     * will not affect their position in the URI path.
+     * Replace the existing value(s) of a matrix parameter on the current final segment of the URI path. If multiple values
+     * are supplied the parameter will be added once per value. Note that the matrix parameters are tied to a particular
+     * path segment; subsequent addition of path segments will not affect their position in the URI path.
      *
-     * @param name   the matrix parameter name, may contain URI template parameters.
-     * @param values the matrix parameter value(s), each object will be converted.
-     *               to a {@code String} using its {@code toString()} method. Stringified
-     *               values may contain URI template parameters. If {@code values} is empty
-     *               or {@code null} then all current values of the parameter are removed.
+     * @param name the matrix parameter name, may contain URI template parameters.
+     * @param values the matrix parameter value(s), each object will be converted. to a {@code String} using its
+     * {@code toString()} method. Stringified values may contain URI template parameters. If {@code values} is empty or
+     * {@code null} then all current values of the parameter are removed.
      * @return the updated UriBuilder.
      * @throws IllegalArgumentException if name is {@code null}.
      * @see <a href="http://www.w3.org/DesignIssues/MatrixURIs.html">Matrix URIs</a>
@@ -386,38 +338,35 @@ public abstract class UriBuilder {
     public abstract UriBuilder replaceMatrixParam(String name, Object... values);
 
     /**
-     * Set the URI query string. This method will overwrite any existing query
-     * parameters.
+     * Set the URI query string. This method will overwrite any existing query parameters.
      *
-     * @param query the URI query string, may contain URI template parameters.
-     *              A {@code null} value will remove all query parameters.
+     * @param query the URI query string, may contain URI template parameters. A {@code null} value will remove all query
+     * parameters.
      * @return the updated UriBuilder.
      * @throws IllegalArgumentException if query cannot be parsed.
      */
     public abstract UriBuilder replaceQuery(String query);
 
     /**
-     * Append a query parameter to the existing set of query parameters. If
-     * multiple values are supplied the parameter will be added once per value.
+     * Append a query parameter to the existing set of query parameters. If multiple values are supplied the parameter will
+     * be added once per value.
      *
-     * @param name   the query parameter name, may contain URI template parameters.
-     * @param values the query parameter value(s), each object will be converted
-     *               to a {@code String} using its {@code toString()} method. Stringified
-     *               values may contain URI template parameters.
+     * @param name the query parameter name, may contain URI template parameters.
+     * @param values the query parameter value(s), each object will be converted to a {@code String} using its
+     * {@code toString()} method. Stringified values may contain URI template parameters.
      * @return the updated UriBuilder.
      * @throws IllegalArgumentException if name or values is {@code null}.
      */
     public abstract UriBuilder queryParam(String name, Object... values);
 
     /**
-     * Replace the existing value(s) of a query parameter. If
-     * multiple values are supplied the parameter will be added once per value.
+     * Replace the existing value(s) of a query parameter. If multiple values are supplied the parameter will be added once
+     * per value.
      *
-     * @param name   the query parameter name, may contain URI template parameters.
-     * @param values the query parameter value(s), each object will be converted
-     *               to a {@code String} using its {@code toString()} method. Stringified
-     *               values may contain URI template parameters. If {@code values} is empty
-     *               or {@code null} then all current values of the parameter are removed.
+     * @param name the query parameter name, may contain URI template parameters.
+     * @param values the query parameter value(s), each object will be converted to a {@code String} using its
+     * {@code toString()} method. Stringified values may contain URI template parameters. If {@code values} is empty or
+     * {@code null} then all current values of the parameter are removed.
      * @return the updated UriBuilder.
      * @throws IllegalArgumentException if name is {@code null}.
      */
@@ -426,20 +375,18 @@ public abstract class UriBuilder {
     /**
      * Set the URI fragment.
      *
-     * @param fragment the URI fragment, may contain URI template parameters.
-     *                 A {@code null} value will remove any existing fragment.
+     * @param fragment the URI fragment, may contain URI template parameters. A {@code null} value will remove any existing
+     * fragment.
      * @return the updated UriBuilder.
      */
     public abstract UriBuilder fragment(String fragment);
 
     /**
-     * Resolve a URI template with a given {@code name} in this {@code UriBuilder} instance
-     * using a supplied value.
+     * Resolve a URI template with a given {@code name} in this {@code UriBuilder} instance using a supplied value.
      *
-     * In case a {@code null} template name or value is entered a {@link IllegalArgumentException}
-     * is thrown.
+     * In case a {@code null} template name or value is entered a {@link IllegalArgumentException} is thrown.
      *
-     * @param name  name of the URI template.
+     * @param name name of the URI template.
      * @param value value to be used to resolve the template.
      * @return the updated UriBuilder.
      * @throws IllegalArgumentException if the resolved template name or value is {@code null}.
@@ -448,18 +395,15 @@ public abstract class UriBuilder {
     public abstract UriBuilder resolveTemplate(String name, Object value);
 
     /**
-     * Resolve a URI template with a given {@code name} in this {@code UriBuilder} instance
-     * using a supplied value.
+     * Resolve a URI template with a given {@code name} in this {@code UriBuilder} instance using a supplied value.
      *
-     * In case a {@code null} template name or value is entered a {@link IllegalArgumentException}
-     * is thrown.
+     * In case a {@code null} template name or value is entered a {@link IllegalArgumentException} is thrown.
      *
-     * @param name              name of the URI template.
-     * @param value             value to be used to resolve the template.
-     * @param encodeSlashInPath if {@code true}, the slash ({@code '/'}) characters
-     *                          in template values will be encoded if the template
-     *                          is placed in the URI path component, otherwise the slash
-     *                          characters will not be encoded in path templates.
+     * @param name name of the URI template.
+     * @param value value to be used to resolve the template.
+     * @param encodeSlashInPath if {@code true}, the slash ({@code '/'}) characters in template values will be encoded if
+     * the template is placed in the URI path component, otherwise the slash characters will not be encoded in path
+     * templates.
      * @return the updated UriBuilder.
      * @throws IllegalArgumentException if the resolved template name or value is {@code null}.
      * @since 2.0
@@ -467,18 +411,15 @@ public abstract class UriBuilder {
     public abstract UriBuilder resolveTemplate(String name, Object value, boolean encodeSlashInPath);
 
     /**
-     * Resolve a URI template with a given {@code name} in this {@code UriBuilder} instance
-     * using a supplied encoded value.
+     * Resolve a URI template with a given {@code name} in this {@code UriBuilder} instance using a supplied encoded value.
      *
-     * A template with a matching name will be replaced by the supplied value.
-     * Value is converted to {@code String} using its {@code toString()} method and is then
-     * encoded to match the rules of the URI component to which they pertain.  All % characters in
-     * the stringified values that are not followed by two hexadecimal numbers will be encoded.
+     * A template with a matching name will be replaced by the supplied value. Value is converted to {@code String} using
+     * its {@code toString()} method and is then encoded to match the rules of the URI component to which they pertain. All
+     * % characters in the stringified values that are not followed by two hexadecimal numbers will be encoded.
      *
-     * In case a {@code null} template name or encoded value is entered a {@link IllegalArgumentException}
-     * is thrown.
+     * In case a {@code null} template name or encoded value is entered a {@link IllegalArgumentException} is thrown.
      *
-     * @param name  name of the URI template.
+     * @param name name of the URI template.
      * @param value encoded value to be used to resolve the template.
      * @return the updated UriBuilder.
      * @throws IllegalArgumentException if the resolved template name or encoded value is {@code null}.
@@ -487,55 +428,46 @@ public abstract class UriBuilder {
     public abstract UriBuilder resolveTemplateFromEncoded(String name, Object value);
 
     /**
-     * Resolve one or more URI templates in this {@code UriBuilder} instance using supplied
-     * name-value pairs.
+     * Resolve one or more URI templates in this {@code UriBuilder} instance using supplied name-value pairs.
      *
      * A call to the method with an empty parameter map is ignored.
      *
      * @param templateValues a map of URI template names and their values.
      * @return the updated UriBuilder.
-     * @throws IllegalArgumentException if the name-value map or any of the names or values
-     *                                  in the map is {@code null}.
+     * @throws IllegalArgumentException if the name-value map or any of the names or values in the map is {@code null}.
      * @since 2.0
      */
     public abstract UriBuilder resolveTemplates(Map<String, Object> templateValues);
 
     /**
-     * Resolve one or more URI templates in this {@code UriBuilder} instance using supplied
-     * name-value pairs.
+     * Resolve one or more URI templates in this {@code UriBuilder} instance using supplied name-value pairs.
      *
      * A call to the method with an empty parameter map is ignored.
      *
-     * @param templateValues    a map of URI template names and their values.
-     * @param encodeSlashInPath if {@code true}, the slash ({@code '/'}) characters
-     *                          in template values will be encoded if the template
-     *                          is placed in the URI path component, otherwise the slash
-     *                          characters will not be encoded in path templates.
+     * @param templateValues a map of URI template names and their values.
+     * @param encodeSlashInPath if {@code true}, the slash ({@code '/'}) characters in template values will be encoded if
+     * the template is placed in the URI path component, otherwise the slash characters will not be encoded in path
+     * templates.
      * @return the updated UriBuilder.
-     * @throws IllegalArgumentException if the name-value map or any of the names or values
-     *                                  in the map is {@code null}.
+     * @throws IllegalArgumentException if the name-value map or any of the names or values in the map is {@code null}.
      * @since 2.0
      */
     public abstract UriBuilder resolveTemplates(Map<String, Object> templateValues, boolean encodeSlashInPath)
             throws IllegalArgumentException;
 
     /**
-     * Resolve one or more URI templates in this {@code UriBuilder} instance using supplied
-     * name-value pairs.
+     * Resolve one or more URI templates in this {@code UriBuilder} instance using supplied name-value pairs.
      *
-     * All templates  with their name matching one of the keys in the supplied map will be replaced
-     * by the value in the supplied map. Values are converted to {@code String} using
-     * their {@code toString()} method and are then encoded to match the
-     * rules of the URI component to which they pertain.  All % characters in
-     * the stringified values that are not followed by two hexadecimal numbers
-     * will be encoded.
+     * All templates with their name matching one of the keys in the supplied map will be replaced by the value in the
+     * supplied map. Values are converted to {@code String} using their {@code toString()} method and are then encoded to
+     * match the rules of the URI component to which they pertain. All % characters in the stringified values that are not
+     * followed by two hexadecimal numbers will be encoded.
      *
      * A call to the method with an empty parameter map is ignored.
      *
      * @param templateValues a map of URI template names and their values.
      * @return the updated UriBuilder.
-     * @throws IllegalArgumentException if the name-value map or any of the names or values
-     *                                  in the map is {@code null}.
+     * @throws IllegalArgumentException if the name-value map or any of the names or values in the map is {@code null}.
      * @since 2.0
      */
     public abstract UriBuilder resolveTemplatesFromEncoded(Map<String, Object> templateValues);
@@ -543,26 +475,21 @@ public abstract class UriBuilder {
     /**
      * Build a URI.
      *
-     * Any URI template parameters will be replaced by the value in
-     * the supplied map. Values are converted to {@code String} using
-     * their {@code toString()} method and are then encoded to match the
-     * rules of the URI component to which they pertain.  All {@code '%'} characters
-     * in the stringified values will be encoded.
-     * The state of the builder is unaffected; this method may be called
-     * multiple times on the same builder instance.
+     * Any URI template parameters will be replaced by the value in the supplied map. Values are converted to {@code String}
+     * using their {@code toString()} method and are then encoded to match the rules of the URI component to which they
+     * pertain. All {@code '%'} characters in the stringified values will be encoded. The state of the builder is
+     * unaffected; this method may be called multiple times on the same builder instance.
      * <p>
-     * NOTE: By default all {@code '/'} characters in the stringified values will be
-     * encoded in path templates, i.e. the result is identical to invoking
-     * {@link #buildFromMap(java.util.Map, boolean) buildFromMap(valueMap, true)}.
-     * To override this behavior use {@code buildFromMap(valueMap, false)} instead.
+     * NOTE: By default all {@code '/'} characters in the stringified values will be encoded in path templates, i.e. the
+     * result is identical to invoking {@link #buildFromMap(java.util.Map, boolean) buildFromMap(valueMap, true)}. To
+     * override this behavior use {@code buildFromMap(valueMap, false)} instead.
      * </p>
      *
      * @param values a map of URI template parameter names and values.
      * @return the URI built from the UriBuilder.
-     * @throws IllegalArgumentException if there are any URI template parameters
-     *                                  without a supplied value, or if a template parameter value is {@code null}.
-     * @throws UriBuilderException      if a URI cannot be constructed based on the
-     *                                  current state of the builder.
+     * @throws IllegalArgumentException if there are any URI template parameters without a supplied value, or if a template
+     * parameter value is {@code null}.
+     * @throws UriBuilderException if a URI cannot be constructed based on the current state of the builder.
      * @see #buildFromMap(java.util.Map, boolean)
      * @see #buildFromEncodedMap(java.util.Map)
      */
@@ -571,34 +498,27 @@ public abstract class UriBuilder {
     /**
      * Build a URI.
      *
-     * Any URI template parameters will be replaced by the value in
-     * the supplied map. Values are converted to {@code String} using
-     * their {@code toString()} method and are then encoded to match the
-     * rules of the URI component to which they pertain.  All {@code '%'} characters
-     * in the stringified values will be encoded.
-     * The state of the builder is unaffected; this method may be called
-     * multiple times on the same builder instance.
+     * Any URI template parameters will be replaced by the value in the supplied map. Values are converted to {@code String}
+     * using their {@code toString()} method and are then encoded to match the rules of the URI component to which they
+     * pertain. All {@code '%'} characters in the stringified values will be encoded. The state of the builder is
+     * unaffected; this method may be called multiple times on the same builder instance.
      * <p>
-     * The {@code encodeSlashInPath} parameter may be used to override the default
-     * encoding of {@code '/'} characters in the stringified template values
-     * in cases when the template is part of the URI path component when using
-     * the {@link #buildFromMap(java.util.Map)} method. If the {@code encodeSlashInPath}
-     * parameter is set to {@code true} (default), the slash ({@code '/'}) characters in
-     * parameter values will be encoded if the template is placed in the URI path component.
-     * If set to {@code false} the default encoding behavior is overridden an slash characters
-     * in template values will not be encoded when used to substitute path templates.
+     * The {@code encodeSlashInPath} parameter may be used to override the default encoding of {@code '/'} characters in the
+     * stringified template values in cases when the template is part of the URI path component when using the
+     * {@link #buildFromMap(java.util.Map)} method. If the {@code encodeSlashInPath} parameter is set to {@code true}
+     * (default), the slash ({@code '/'}) characters in parameter values will be encoded if the template is placed in the
+     * URI path component. If set to {@code false} the default encoding behavior is overridden an slash characters in
+     * template values will not be encoded when used to substitute path templates.
      * </p>
      *
-     * @param values            a map of URI template parameter names and values.
-     * @param encodeSlashInPath if {@code true}, the slash ({@code '/'}) characters
-     *                          in parameter values will be encoded if the template
-     *                          is placed in the URI path component, otherwise the slash
-     *                          characters will not be encoded in path templates.
+     * @param values a map of URI template parameter names and values.
+     * @param encodeSlashInPath if {@code true}, the slash ({@code '/'}) characters in parameter values will be encoded if
+     * the template is placed in the URI path component, otherwise the slash characters will not be encoded in path
+     * templates.
      * @return the URI built from the UriBuilder.
-     * @throws IllegalArgumentException if there are any URI template parameters
-     *                                  without a supplied value, or if a template parameter value is {@code null}.
-     * @throws UriBuilderException      if a URI cannot be constructed based on the
-     *                                  current state of the builder.
+     * @throws IllegalArgumentException if there are any URI template parameters without a supplied value, or if a template
+     * parameter value is {@code null}.
+     * @throws UriBuilderException if a URI cannot be constructed based on the current state of the builder.
      * @see #buildFromMap(java.util.Map)
      * @see #buildFromEncodedMap(java.util.Map)
      */
@@ -608,21 +528,16 @@ public abstract class UriBuilder {
     /**
      * Build a URI.
      *
-     * Any URI template parameters will be replaced by the value in
-     * the supplied map. Values are converted to {@code String} using
-     * their {@code toString()} method and are then encoded to match the
-     * rules of the URI component to which they pertain.  All % characters in
-     * the stringified values that are not followed by two hexadecimal numbers
-     * will be encoded.
-     * The state of the builder is unaffected; this method may be called
-     * multiple times on the same builder instance.
+     * Any URI template parameters will be replaced by the value in the supplied map. Values are converted to {@code String}
+     * using their {@code toString()} method and are then encoded to match the rules of the URI component to which they
+     * pertain. All % characters in the stringified values that are not followed by two hexadecimal numbers will be encoded.
+     * The state of the builder is unaffected; this method may be called multiple times on the same builder instance.
      *
      * @param values a map of URI template parameter names and values.
      * @return the URI built from the UriBuilder.
-     * @throws IllegalArgumentException if there are any URI template parameters
-     *                                  without a supplied value, or if a template parameter value is {@code null}.
-     * @throws UriBuilderException      if a URI cannot be constructed based on the
-     *                                  current state of the builder.
+     * @throws IllegalArgumentException if there are any URI template parameters without a supplied value, or if a template
+     * parameter value is {@code null}.
+     * @throws UriBuilderException if a URI cannot be constructed based on the current state of the builder.
      * @see #buildFromMap(java.util.Map)
      * @see #buildFromMap(java.util.Map, boolean)
      * @since 2.0
@@ -631,33 +546,26 @@ public abstract class UriBuilder {
             throws IllegalArgumentException, UriBuilderException;
 
     /**
-     * Build a URI, using the supplied values in order to replace any URI
-     * template parameters. Values are converted to {@code String} using
-     * their {@code toString()} method and are then encoded to match the
-     * rules of the URI component to which they pertain. All '%' characters
-     * in the stringified values will be encoded.
-     * The state of the builder is unaffected; this method may be called
-     * multiple times on the same builder instance.
+     * Build a URI, using the supplied values in order to replace any URI template parameters. Values are converted to
+     * {@code String} using their {@code toString()} method and are then encoded to match the rules of the URI component to
+     * which they pertain. All '%' characters in the stringified values will be encoded. The state of the builder is
+     * unaffected; this method may be called multiple times on the same builder instance.
      * <p>
-     * All instances of the same template parameter
-     * will be replaced by the same value that corresponds to the position of the
-     * first instance of the template parameter. e.g. the template "{a}/{b}/{a}"
-     * with values {"x", "y", "z"} will result in the the URI "x/y/x", <i>not</i>
-     * "x/y/z".
+     * All instances of the same template parameter will be replaced by the same value that corresponds to the position of
+     * the first instance of the template parameter. e.g. the template "{a}/{b}/{a}" with values {"x", "y", "z"} will result
+     * in the the URI "x/y/x", <i>not</i> "x/y/z".
      * </p>
      * <p>
-     * NOTE: By default all {@code '/'} characters in the stringified values will be
-     * encoded in path templates, i.e. the result is identical to invoking
-     * {@link #build(Object[], boolean)} build(values, true)}.
-     * To override this behavior use {@code build(values, false)} instead.
+     * NOTE: By default all {@code '/'} characters in the stringified values will be encoded in path templates, i.e. the
+     * result is identical to invoking {@link #build(Object[], boolean)} build(values, true)}. To override this behavior use
+     * {@code build(values, false)} instead.
      * </p>
      *
      * @param values a list of URI template parameter values.
      * @return the URI built from the UriBuilder.
-     * @throws IllegalArgumentException if there are any URI template parameters
-     *                                  without a supplied value, or if a value is {@code null}.
-     * @throws UriBuilderException      if a URI cannot be constructed based on the
-     *                                  current state of the builder.
+     * @throws IllegalArgumentException if there are any URI template parameters without a supplied value, or if a value is
+     * {@code null}.
+     * @throws UriBuilderException if a URI cannot be constructed based on the current state of the builder.
      * @see #build(Object[], boolean)
      * @see #buildFromEncoded(Object...)
      */
@@ -665,41 +573,32 @@ public abstract class UriBuilder {
             throws IllegalArgumentException, UriBuilderException;
 
     /**
-     * Build a URI, using the supplied values in order to replace any URI
-     * template parameters. Values are converted to {@code String} using
-     * their {@code toString()} method and are then encoded to match the
-     * rules of the URI component to which they pertain. All '%' characters
-     * in the stringified values will be encoded.
-     * The state of the builder is unaffected; this method may be called
-     * multiple times on the same builder instance.
+     * Build a URI, using the supplied values in order to replace any URI template parameters. Values are converted to
+     * {@code String} using their {@code toString()} method and are then encoded to match the rules of the URI component to
+     * which they pertain. All '%' characters in the stringified values will be encoded. The state of the builder is
+     * unaffected; this method may be called multiple times on the same builder instance.
      * <p>
-     * All instances of the same template parameter
-     * will be replaced by the same value that corresponds to the position of the
-     * first instance of the template parameter. e.g. the template "{a}/{b}/{a}"
-     * with values {"x", "y", "z"} will result in the the URI "x/y/x", <i>not</i>
-     * "x/y/z".
+     * All instances of the same template parameter will be replaced by the same value that corresponds to the position of
+     * the first instance of the template parameter. e.g. the template "{a}/{b}/{a}" with values {"x", "y", "z"} will result
+     * in the the URI "x/y/x", <i>not</i> "x/y/z".
      * </p>
      * <p>
-     * The {@code encodeSlashInPath} parameter may be used to override the default
-     * encoding of {@code '/'} characters in the stringified template values
-     * in cases when the template is part of the URI path component when using
-     * the {@link #build(Object[])} method. If the {@code encodeSlashInPath}
-     * parameter is set to {@code true} (default), the slash ({@code '/'}) characters in
-     * parameter values will be encoded if the template is placed in the URI path component.
-     * If set to {@code false} the default encoding behavior is overridden an slash characters
-     * in template values will not be encoded when used to substitute path templates.
+     * The {@code encodeSlashInPath} parameter may be used to override the default encoding of {@code '/'} characters in the
+     * stringified template values in cases when the template is part of the URI path component when using the
+     * {@link #build(Object[])} method. If the {@code encodeSlashInPath} parameter is set to {@code true} (default), the
+     * slash ({@code '/'}) characters in parameter values will be encoded if the template is placed in the URI path
+     * component. If set to {@code false} the default encoding behavior is overridden an slash characters in template values
+     * will not be encoded when used to substitute path templates.
      * </p>
      *
-     * @param values            a list of URI template parameter values.
-     * @param encodeSlashInPath if {@code true}, the slash ({@code '/'}) characters
-     *                          in parameter values will be encoded if the template
-     *                          is placed in the URI path component, otherwise the slash
-     *                          characters will not be encoded in path templates.
+     * @param values a list of URI template parameter values.
+     * @param encodeSlashInPath if {@code true}, the slash ({@code '/'}) characters in parameter values will be encoded if
+     * the template is placed in the URI path component, otherwise the slash characters will not be encoded in path
+     * templates.
      * @return the URI built from the UriBuilder.
-     * @throws IllegalArgumentException if there are any URI template parameters
-     *                                  without a supplied value, or if a value is {@code null}.
-     * @throws UriBuilderException      if a URI cannot be constructed based on the
-     *                                  current state of the builder.
+     * @throws IllegalArgumentException if there are any URI template parameters without a supplied value, or if a value is
+     * {@code null}.
+     * @throws UriBuilderException if a URI cannot be constructed based on the current state of the builder.
      * @see #build(Object[])
      * @see #buildFromEncoded(Object...)
      * @since 2.0
@@ -708,27 +607,21 @@ public abstract class UriBuilder {
             throws IllegalArgumentException, UriBuilderException;
 
     /**
-     * Build a URI.
-     * Any URI templates parameters will be replaced with the supplied values in
-     * order. Values are converted to {@code String} using
-     * their {@code toString()} method and are then encoded to match the
-     * rules of the URI component to which they pertain. All % characters in
-     * the stringified values that are not followed by two hexadecimal numbers
-     * will be encoded.
-     * The state of the builder is unaffected; this method may be called
-     * multiple times on the same builder instance.
-     * <p>All instances of the same template parameter
-     * will be replaced by the same value that corresponds to the position of the
-     * first instance of the template parameter. e.g. the template "{a}/{b}/{a}"
-     * with values {"x", "y", "z"} will result in the the URI "x/y/x", <i>not</i>
-     * "x/y/z".
+     * Build a URI. Any URI templates parameters will be replaced with the supplied values in order. Values are converted to
+     * {@code String} using their {@code toString()} method and are then encoded to match the rules of the URI component to
+     * which they pertain. All % characters in the stringified values that are not followed by two hexadecimal numbers will
+     * be encoded. The state of the builder is unaffected; this method may be called multiple times on the same builder
+     * instance.
+     * <p>
+     * All instances of the same template parameter will be replaced by the same value that corresponds to the position of
+     * the first instance of the template parameter. e.g. the template "{a}/{b}/{a}" with values {"x", "y", "z"} will result
+     * in the the URI "x/y/x", <i>not</i> "x/y/z".
      *
      * @param values a list of URI template parameter values.
      * @return the URI built from the UriBuilder.
-     * @throws IllegalArgumentException if there are any URI template parameters
-     *                                  without a supplied value, or if a value is {@code null}.
-     * @throws UriBuilderException      if a URI cannot be constructed based on the
-     *                                  current state of the builder.
+     * @throws IllegalArgumentException if there are any URI template parameters without a supplied value, or if a value is
+     * {@code null}.
+     * @throws UriBuilderException if a URI cannot be constructed based on the current state of the builder.
      * @see #build(Object[])
      * @see #build(Object[], boolean)
      */

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/UriBuilderException.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/UriBuilderException.java
@@ -17,9 +17,8 @@
 package javax.ws.rs.core;
 
 /**
- * A runtime exception thrown by {@link UriBuilder#build(Object...)} methods when
- * a {@link java.net.URI} cannot be constructed based on the current state of the
- * builder.
+ * A runtime exception thrown by {@link UriBuilder#build(Object...)} methods when a {@link java.net.URI} cannot be
+ * constructed based on the current state of the builder.
  *
  * @author Paul Sandoz
  * @author Marc Hadley
@@ -46,20 +45,22 @@ public class UriBuilderException extends java.lang.RuntimeException {
 
     /**
      * Constructs an instance of <code>UriBuilderException</code> with the specified detail message and cause.
-     * <p>Note that the detail message associated with cause is not automatically incorporated in this exception's detail message.
+     * <p>
+     * Note that the detail message associated with cause is not automatically incorporated in this exception's detail
+     * message.
      *
-     * @param msg   the detail message (which is saved for later retrieval by the Throwable.getMessage() method).
-     * @param cause the cause (which is saved for later retrieval by the Throwable.getCause() method). (A null value is permitted, and indicates that the cause is nonexistent or unknown.)
+     * @param msg the detail message (which is saved for later retrieval by the Throwable.getMessage() method).
+     * @param cause the cause (which is saved for later retrieval by the Throwable.getCause() method). (A null value is
+     * permitted, and indicates that the cause is nonexistent or unknown.)
      */
     public UriBuilderException(final String msg, final Throwable cause) {
         super(msg, cause);
     }
 
     /**
-     * Constructs a new exception with the specified cause and a detail message
-     * of (<code>cause==null ? null : cause.toString()</code>) (which typically contains
-     * the class and detail message of cause). This constructor is useful
-     * for exceptions that are little more than wrappers for other throwables.
+     * Constructs a new exception with the specified cause and a detail message of
+     * (<code>cause==null ? null : cause.toString()</code>) (which typically contains the class and detail message of
+     * cause). This constructor is useful for exceptions that are little more than wrappers for other throwables.
      *
      * @param cause the original exception
      */

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/UriInfo.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/UriInfo.java
@@ -20,12 +20,13 @@ import java.net.URI;
 import java.util.List;
 
 /**
- * An injectable interface that provides access to application and request
- * URI information. Relative URIs are relative to the base URI of the
- * application, see {@link #getBaseUri}.
+ * An injectable interface that provides access to application and request URI information. Relative URIs are relative
+ * to the base URI of the application, see {@link #getBaseUri}.
  *
- * <p>All methods throw {@code java.lang.IllegalStateException}
- * if called outside the scope of a request (e.g. from a provider constructor).</p>
+ * <p>
+ * All methods throw {@code java.lang.IllegalStateException} if called outside the scope of a request (e.g. from a
+ * provider constructor).
+ * </p>
  *
  * @author Paul Sandoz
  * @author Marc Hadley
@@ -35,39 +36,30 @@ import java.util.List;
 public interface UriInfo {
 
     /**
-     * Get the path of the current request relative to the base URI as a string.
-     * All sequences of escaped octets are decoded, equivalent to
-     * {@link #getPath(boolean) getPath(true)}.
+     * Get the path of the current request relative to the base URI as a string. All sequences of escaped octets are
+     * decoded, equivalent to {@link #getPath(boolean) getPath(true)}.
      *
      * @return the relative URI path.
-     * @throws java.lang.IllegalStateException
-     *          if called outside the scope of
-     *          a request.
+     * @throws java.lang.IllegalStateException if called outside the scope of a request.
      */
     public String getPath();
 
     /**
      * Get the path of the current request relative to the base URI as a string.
      *
-     * @param decode controls whether sequences of escaped octets are decoded
-     *               ({@code true}) or not ({@code false}).
+     * @param decode controls whether sequences of escaped octets are decoded ({@code true}) or not ({@code false}).
      * @return the relative URI path
-     * @throws java.lang.IllegalStateException
-     *          if called outside the scope of
-     *          a request.
+     * @throws java.lang.IllegalStateException if called outside the scope of a request.
      */
     public String getPath(boolean decode);
 
     /**
-     * Get the path of the current request relative to the base URI as a
-     * list of {@link PathSegment}. This method is useful when the
-     * path needs to be parsed, particularly when matrix parameters may be
-     * present in the path. All sequences of escaped octets in path segments
-     * and matrix parameter values are decoded,
-     * equivalent to {@code getPathSegments(true)}.
+     * Get the path of the current request relative to the base URI as a list of {@link PathSegment}. This method is useful
+     * when the path needs to be parsed, particularly when matrix parameters may be present in the path. All sequences of
+     * escaped octets in path segments and matrix parameter values are decoded, equivalent to {@code getPathSegments(true)}.
      *
-     * @return an unmodifiable list of {@link PathSegment}. The matrix parameter
-     *         map of each path segment is also unmodifiable.
+     * @return an unmodifiable list of {@link PathSegment}. The matrix parameter map of each path segment is also
+     * unmodifiable.
      * @throws IllegalStateException if called outside the scope of a request
      * @see PathSegment
      * @see <a href="http://www.w3.org/DesignIssues/MatrixURIs.html">Matrix URIs</a>
@@ -75,16 +67,14 @@ public interface UriInfo {
     public List<PathSegment> getPathSegments();
 
     /**
-     * Get the path of the current request relative to the base URI as a list of
-     * {@link PathSegment}. This method is useful when the path needs to be parsed,
-     * particularly when matrix parameters may be present in the path.
+     * Get the path of the current request relative to the base URI as a list of {@link PathSegment}. This method is useful
+     * when the path needs to be parsed, particularly when matrix parameters may be present in the path.
      *
-     * @param decode controls whether sequences of escaped octets in path segments
-     *               and matrix parameter values are decoded ({@code true}) or not ({@code false}).
-     * @return an unmodifiable list of {@link PathSegment}. The matrix parameter
-     *         map of each path segment is also unmodifiable.
-     * @throws java.lang.IllegalStateException
-     *          if called outside the scope of a request
+     * @param decode controls whether sequences of escaped octets in path segments and matrix parameter values are decoded
+     * ({@code true}) or not ({@code false}).
+     * @return an unmodifiable list of {@link PathSegment}. The matrix parameter map of each path segment is also
+     * unmodifiable.
+     * @throws java.lang.IllegalStateException if called outside the scope of a request
      * @see PathSegment
      * @see <a href="http://www.w3.org/DesignIssues/MatrixURIs.html">Matrix URIs</a>
      */
@@ -94,8 +84,7 @@ public interface UriInfo {
      * Get the absolute request URI including any query parameters.
      *
      * @return the absolute request URI
-     * @throws java.lang.IllegalStateException
-     *          if called outside the scope of a request
+     * @throws java.lang.IllegalStateException if called outside the scope of a request
      */
     public URI getRequestUri();
 
@@ -103,39 +92,30 @@ public interface UriInfo {
      * Get the absolute request URI in the form of a UriBuilder.
      *
      * @return a UriBuilder initialized with the absolute request URI.
-     * @throws java.lang.IllegalStateException
-     *          if called outside the scope of a
-     *          request.
+     * @throws java.lang.IllegalStateException if called outside the scope of a request.
      */
     public UriBuilder getRequestUriBuilder();
 
     /**
-     * Get the absolute path of the request. This includes everything preceding
-     * the path (host, port etc) but excludes query parameters.
-     * This is a shortcut for {@code uriInfo.getBaseUri().resolve(uriInfo.getPath(false))}.
+     * Get the absolute path of the request. This includes everything preceding the path (host, port etc) but excludes query
+     * parameters. This is a shortcut for {@code uriInfo.getBaseUri().resolve(uriInfo.getPath(false))}.
      *
      * @return the absolute path of the request.
-     * @throws java.lang.IllegalStateException
-     *          if called outside the scope of a
-     *          request.
+     * @throws java.lang.IllegalStateException if called outside the scope of a request.
      */
     public URI getAbsolutePath();
 
     /**
-     * Get the absolute path of the request in the form of a UriBuilder.
-     * This includes everything preceding the path (host, port etc) but excludes
-     * query parameters.
+     * Get the absolute path of the request in the form of a UriBuilder. This includes everything preceding the path (host,
+     * port etc) but excludes query parameters.
      *
      * @return a UriBuilder initialized with the absolute path of the request.
-     * @throws java.lang.IllegalStateException
-     *          if called outside the scope of a
-     *          request.
+     * @throws java.lang.IllegalStateException if called outside the scope of a request.
      */
     public UriBuilder getAbsolutePathBuilder();
 
     /**
-     * Get the base URI of the application. URIs of root resource classes
-     * are all relative to this base URI.
+     * Get the base URI of the application. URIs of root resource classes are all relative to this base URI.
      *
      * @return the base URI of the application.
      */
@@ -149,14 +129,11 @@ public interface UriInfo {
     public UriBuilder getBaseUriBuilder();
 
     /**
-     * Get the values of any embedded URI template parameters. All sequences of
-     * escaped octets are decoded, equivalent to
+     * Get the values of any embedded URI template parameters. All sequences of escaped octets are decoded, equivalent to
      * {@link #getPathParameters(boolean) getPathParameters(true)}.
      *
      * @return an unmodifiable map of parameter names and values.
-     * @throws java.lang.IllegalStateException
-     *          if called outside the scope of a
-     *          request.
+     * @throws java.lang.IllegalStateException if called outside the scope of a request.
      * @see javax.ws.rs.Path
      * @see javax.ws.rs.PathParam
      */
@@ -165,55 +142,45 @@ public interface UriInfo {
     /**
      * Get the values of any embedded URI template parameters.
      *
-     * @param decode controls whether sequences of escaped octets are decoded
-     *               ({@code true}) or not ({@code false}).
+     * @param decode controls whether sequences of escaped octets are decoded ({@code true}) or not ({@code false}).
      * @return an unmodifiable map of parameter names and values
-     * @throws java.lang.IllegalStateException
-     *          if called outside the scope of a
-     *          request.
+     * @throws java.lang.IllegalStateException if called outside the scope of a request.
      * @see javax.ws.rs.Path
      * @see javax.ws.rs.PathParam
      */
     public MultivaluedMap<String, String> getPathParameters(boolean decode);
 
     /**
-     * Get the URI query parameters of the current request. The map keys are the
-     * names of the query parameters with any escaped characters decoded. All sequences
-     * of escaped octets in parameter names and values are decoded, equivalent to
+     * Get the URI query parameters of the current request. The map keys are the names of the query parameters with any
+     * escaped characters decoded. All sequences of escaped octets in parameter names and values are decoded, equivalent to
      * {@link #getQueryParameters(boolean) getQueryParameters(true)}.
      *
      * @return an unmodifiable map of query parameter names and values.
-     * @throws java.lang.IllegalStateException
-     *          if called outside the scope of a
-     *          request.
+     * @throws java.lang.IllegalStateException if called outside the scope of a request.
      */
     public MultivaluedMap<String, String> getQueryParameters();
 
     /**
-     * Get the URI query parameters of the current request. The map keys are the
-     * names of the query parameters with any escaped characters decoded.
+     * Get the URI query parameters of the current request. The map keys are the names of the query parameters with any
+     * escaped characters decoded.
      *
-     * @param decode controls whether sequences of escaped octets in parameter
-     *               names and values are decoded ({@code true}) or not ({@code false}).
+     * @param decode controls whether sequences of escaped octets in parameter names and values are decoded ({@code true})
+     * or not ({@code false}).
      * @return an unmodifiable map of query parameter names and values.
-     * @throws java.lang.IllegalStateException
-     *          if called outside the scope of a
-     *          request.
+     * @throws java.lang.IllegalStateException if called outside the scope of a request.
      */
     public MultivaluedMap<String, String> getQueryParameters(boolean decode);
 
     /**
      * Get a read-only list of URIs for matched resources.
      *
-     * Each entry is a relative URI that matched a resource class, a
-     * sub-resource method or a sub-resource locator. All sequences of escaped
-     * octets are decoded, equivalent to {@code getMatchedURIs(true)}.
-     * Entries do not include query parameters but do include matrix parameters
-     * if present in the request URI. Entries are ordered in reverse request
-     * URI matching order, with the current resource URI first.  E.g. given the
-     * following resource classes:
+     * Each entry is a relative URI that matched a resource class, a sub-resource method or a sub-resource locator. All
+     * sequences of escaped octets are decoded, equivalent to {@code getMatchedURIs(true)}. Entries do not include query
+     * parameters but do include matrix parameters if present in the request URI. Entries are ordered in reverse request URI
+     * matching order, with the current resource URI first. E.g. given the following resource classes:
      *
-     * <pre>&#064;Path("foo")
+     * <pre>
+     * &#064;Path("foo")
      * public class FooResource {
      *  &#064;GET
      *  public String getFoo() {...}
@@ -228,8 +195,9 @@ public interface UriInfo {
      * }
      * </pre>
      *
-     * <p>The values returned by this method based on request uri and where
-     * the method is called from are:</p>
+     * <p>
+     * The values returned by this method based on request uri and where the method is called from are:
+     * </p>
      *
      * <table border="1">
      * <caption>Matched URIs from requests</caption>
@@ -255,8 +223,8 @@ public interface UriInfo {
      * </tr>
      * </table>
      *
-     * In case the method is invoked prior to the request matching (e.g. from a
-     * pre-matching filter), the method returns an empty list.
+     * In case the method is invoked prior to the request matching (e.g. from a pre-matching filter), the method returns an
+     * empty list.
      *
      * @return a read-only list of URI paths for matched resources.
      */
@@ -265,18 +233,15 @@ public interface UriInfo {
     /**
      * Get a read-only list of URIs for matched resources.
      *
-     * Each entry is a relative URI that matched a resource class, a sub-resource
-     * method or a sub-resource locator. Entries do not include query
-     * parameters but do include matrix parameters if present in the request URI.
-     * Entries are ordered in reverse request URI matching order, with the
-     * current resource URI first. See {@link #getMatchedURIs()} for an
+     * Each entry is a relative URI that matched a resource class, a sub-resource method or a sub-resource locator. Entries
+     * do not include query parameters but do include matrix parameters if present in the request URI. Entries are ordered
+     * in reverse request URI matching order, with the current resource URI first. See {@link #getMatchedURIs()} for an
      * example.
      *
-     * In case the method is invoked prior to the request matching (e.g. from a
-     * pre-matching filter), the method returns an empty list.
+     * In case the method is invoked prior to the request matching (e.g. from a pre-matching filter), the method returns an
+     * empty list.
      *
-     * @param decode controls whether sequences of escaped octets are decoded
-     *               ({@code true}) or not ({@code false}).
+     * @param decode controls whether sequences of escaped octets are decoded ({@code true}) or not ({@code false}).
      * @return a read-only list of URI paths for matched resources.
      */
     public List<String> getMatchedURIs(boolean decode);
@@ -284,13 +249,12 @@ public interface UriInfo {
     /**
      * Get a read-only list of the currently matched resource class instances.
      *
-     * Each entry is a resource class instance that matched the request URI
-     * either directly or via a sub-resource method or a sub-resource locator.
-     * Entries are ordered according to reverse request URI matching order,
-     * with the current resource first. E.g. given the following resource
-     * classes:
+     * Each entry is a resource class instance that matched the request URI either directly or via a sub-resource method or
+     * a sub-resource locator. Entries are ordered according to reverse request URI matching order, with the current
+     * resource first. E.g. given the following resource classes:
      *
-     * <pre>&#064;Path("foo")
+     * <pre>
+     * &#064;Path("foo")
      * public class FooResource {
      *  &#064;GET
      *  public String getFoo() {...}
@@ -305,8 +269,9 @@ public interface UriInfo {
      * }
      * </pre>
      *
-     * <p>The values returned by this method based on request uri and where
-     * the method is called from are:</p>
+     * <p>
+     * The values returned by this method based on request uri and where the method is called from are:
+     * </p>
      *
      * <table border="1">
      * <caption>Matched resources from requests</caption>
@@ -332,17 +297,16 @@ public interface UriInfo {
      * </tr>
      * </table>
      *
-     * In case the method is invoked prior to the request matching (e.g. from a
-     * pre-matching filter), the method returns an empty list.
+     * In case the method is invoked prior to the request matching (e.g. from a pre-matching filter), the method returns an
+     * empty list.
      *
      * @return a read-only list of matched resource class instances.
      */
     public List<Object> getMatchedResources();
 
     /**
-     * Resolve a relative URI with respect to the base URI of the application.
-     * The resolved URI returned by this method is normalized. If the supplied URI is
-     * already resolved, it is just returned.
+     * Resolve a relative URI with respect to the base URI of the application. The resolved URI returned by this method is
+     * normalized. If the supplied URI is already resolved, it is just returned.
      *
      * @param uri URI to resolve against the base URI of the application.
      * @return newly resolved URI or supplied URI if already resolved.
@@ -351,29 +315,29 @@ public interface UriInfo {
     public URI resolve(URI uri);
 
     /**
-     * Relativize a URI with respect to the current request URI. Relativization
-     * works as follows:
+     * Relativize a URI with respect to the current request URI. Relativization works as follows:
      * <ol>
-     * <li>If the URI to relativize is already relative, it is first resolved using
-     * {@link #resolve(java.net.URI)}.</li>
-     * <li>The resulting URI is relativized with respect to the current request
-     * URI. If the two URIs do not share a prefix, the URI computed in
-     * step 1 is returned.</li>
+     * <li>If the URI to relativize is already relative, it is first resolved using {@link #resolve(java.net.URI)}.</li>
+     * <li>The resulting URI is relativized with respect to the current request URI. If the two URIs do not share a prefix,
+     * the URI computed in step 1 is returned.</li>
      * </ol>
      *
-     * <p>Examples (for base URI {@code http://example.com:8080/app/root/}):
+     * <p>
+     * Examples (for base URI {@code http://example.com:8080/app/root/}): <br>
      * <br>
-     * <br><b>Request URI:</b> <tt>http://example.com:8080/app/root/a/b/c/resource.html</tt>
-     * <br><b>Supplied URI:</b> <tt>a/b/c/d/file.txt</tt>
-     * <br><b>Returned URI:</b> <tt>d/file.txt</tt>
+     * <b>Request URI:</b> <tt>http://example.com:8080/app/root/a/b/c/resource.html</tt> <br>
+     * <b>Supplied URI:</b> <tt>a/b/c/d/file.txt</tt> <br>
+     * <b>Returned URI:</b> <tt>d/file.txt</tt> <br>
      * <br>
-     * <br><b>Request URI:</b> <tt>http://example.com:8080/app/root/a/b/c/resource.html</tt>
-     * <br><b>Supplied URI:</b> <tt>http://example2.com:9090/app2/root2/a/d/file.txt</tt>
-     * <br><b>Returned URI:</b> <tt>http://example2.com:9090/app2/root2/a/d/file.txt</tt>
+     * <b>Request URI:</b> <tt>http://example.com:8080/app/root/a/b/c/resource.html</tt> <br>
+     * <b>Supplied URI:</b> <tt>http://example2.com:9090/app2/root2/a/d/file.txt</tt> <br>
+     * <b>Returned URI:</b> <tt>http://example2.com:9090/app2/root2/a/d/file.txt</tt>
      * </p>
      *
-     * <p>In the second example, the supplied URI is returned given that it is absolute
-     * and there is no common prefix between it and the request URI.</p>
+     * <p>
+     * In the second example, the supplied URI is returned given that it is absolute and there is no common prefix between
+     * it and the request URI.
+     * </p>
      *
      * @param uri URI to relativize against the request URI.
      * @return newly relativized URI.

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Variant.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Variant.java
@@ -41,11 +41,9 @@ public class Variant {
      * Create a new instance of Variant.
      *
      * @param mediaType the media type of the variant - may be {@code null}.
-     * @param language  the language of the variant (two-letter ISO-639 code);
-     *                  may be {@code null}.
-     * @param encoding  the content encoding of the variant - may be {@code null}.
-     * @throws java.lang.IllegalArgumentException
-     *          if all the parameters are {@code null}.
+     * @param language the language of the variant (two-letter ISO-639 code); may be {@code null}.
+     * @param encoding the content encoding of the variant - may be {@code null}.
+     * @throws java.lang.IllegalArgumentException if all the parameters are {@code null}.
      * @since 2.0
      */
     public Variant(final MediaType mediaType, final String language, final String encoding) {
@@ -61,13 +59,11 @@ public class Variant {
      * Create a new instance of Variant.
      *
      * @param mediaType the media type of the variant - may be {@code null}.
-     * @param language  the language of the variant (two-letter ISO-639 code);
-     *                  may be {@code null}.
-     * @param country   uppercase two-letter ISO-3166 language code of the variant;
-     *                  may be {@code null} provided {@code language} is {@code null} too.
-     * @param encoding  the content encoding of the variant - may be {@code null}.
-     * @throws java.lang.IllegalArgumentException
-     *          if all the parameters are {@code null}.
+     * @param language the language of the variant (two-letter ISO-639 code); may be {@code null}.
+     * @param country uppercase two-letter ISO-3166 language code of the variant; may be {@code null} provided
+     * {@code language} is {@code null} too.
+     * @param encoding the content encoding of the variant - may be {@code null}.
+     * @throws java.lang.IllegalArgumentException if all the parameters are {@code null}.
      * @since 2.0
      */
     public Variant(final MediaType mediaType, final String language, final String country, final String encoding) {
@@ -82,18 +78,14 @@ public class Variant {
     /**
      * Create a new instance of Variant.
      *
-     * @param mediaType       the media type of the variant - may be {@code null}.
-     * @param language        the language of the variant (two-letter ISO-639 code);
-     *                        may be {@code null}.
-     * @param country         uppercase two-letter ISO-3166 language code of the variant;
-     *                        may be {@code null} provided {@code language} is {@code null} too.
-     * @param languageVariant vendor and browser specific language code of the variant
-     *                        (see also {@link Locale} class description);
-     *                        may be {@code null} provided {@code language} and
-     *                        {@code country} are {@code null} too.
-     * @param encoding        the content encoding of the variant - may be {@code null}.
-     * @throws java.lang.IllegalArgumentException
-     *          if all the parameters are {@code null}.
+     * @param mediaType the media type of the variant - may be {@code null}.
+     * @param language the language of the variant (two-letter ISO-639 code); may be {@code null}.
+     * @param country uppercase two-letter ISO-3166 language code of the variant; may be {@code null} provided
+     * {@code language} is {@code null} too.
+     * @param languageVariant vendor and browser specific language code of the variant (see also {@link Locale} class
+     * description); may be {@code null} provided {@code language} and {@code country} are {@code null} too.
+     * @param encoding the content encoding of the variant - may be {@code null}.
+     * @throws java.lang.IllegalArgumentException if all the parameters are {@code null}.
      * @since 2.0
      */
     public Variant(final MediaType mediaType, final String language, final String country, final String languageVariant, final String encoding) {
@@ -109,10 +101,9 @@ public class Variant {
      * Create a new instance of Variant.
      *
      * @param mediaType the media type of the variant - may be {@code null}.
-     * @param language  the language of the variant - may be {@code null}.
-     * @param encoding  the content encoding of the variant - may be {@code null}.
-     * @throws java.lang.IllegalArgumentException
-     *          if all the parameters are {@code null}.
+     * @param language the language of the variant - may be {@code null}.
+     * @param encoding the content encoding of the variant - may be {@code null}.
+     * @throws java.lang.IllegalArgumentException if all the parameters are {@code null}.
      */
     public Variant(final MediaType mediaType, final Locale language, final String encoding) {
         if (mediaType == null && language == null && encoding == null) {
@@ -126,18 +117,16 @@ public class Variant {
     /**
      * Get the language of the variant.
      *
-     * @return the language or  {@code null} if none set.
+     * @return the language or {@code null} if none set.
      */
     public Locale getLanguage() {
         return language;
     }
 
     /**
-     * Get the string representation of the variant language,
-     * or {@code null} if no language has been set.
+     * Get the string representation of the variant language, or {@code null} if no language has been set.
      *
-     * @return the string representing variant language or {@code null}
-     *         if none set.
+     * @return the string representing variant language or {@code null} if none set.
      * @since 2.0
      */
     public String getLanguageString() {
@@ -163,16 +152,12 @@ public class Variant {
     }
 
     /**
-     * Create a {@link VariantListBuilder} initialized with a set of supported
-     * media types.
+     * Create a {@link VariantListBuilder} initialized with a set of supported media types.
      *
-     * @param mediaTypes the available mediaTypes. If specific char-sets
-     *                   are supported they should be included as parameters of the respective
-     *                   media type.
+     * @param mediaTypes the available mediaTypes. If specific char-sets are supported they should be included as parameters
+     * of the respective media type.
      * @return the initialized builder.
-     * @throws java.lang.IllegalArgumentException
-     *          if mediaTypes is null or
-     *          contains no elements.
+     * @throws java.lang.IllegalArgumentException if mediaTypes is null or contains no elements.
      */
     public static VariantListBuilder mediaTypes(final MediaType... mediaTypes) {
         VariantListBuilder b = VariantListBuilder.newInstance();
@@ -181,14 +166,11 @@ public class Variant {
     }
 
     /**
-     * Create a {@link VariantListBuilder} initialized with a set of supported
-     * languages.
+     * Create a {@link VariantListBuilder} initialized with a set of supported languages.
      *
      * @param languages the available languages.
      * @return the initialized builder.
-     * @throws java.lang.IllegalArgumentException
-     *          if languages is null or
-     *          contains no elements.
+     * @throws java.lang.IllegalArgumentException if languages is null or contains no elements.
      */
     public static VariantListBuilder languages(final Locale... languages) {
         VariantListBuilder b = VariantListBuilder.newInstance();
@@ -197,14 +179,11 @@ public class Variant {
     }
 
     /**
-     * Create a {@link VariantListBuilder} initialized with a set of supported
-     * encodings.
+     * Create a {@link VariantListBuilder} initialized with a set of supported encodings.
      *
      * @param encodings the available encodings.
      * @return the initialized builder.
-     * @throws java.lang.IllegalArgumentException
-     *          if encodings is null or
-     *          contains no elements.
+     * @throws java.lang.IllegalArgumentException if encodings is null or contains no elements.
      */
     public static VariantListBuilder encodings(final String... encodings) {
         VariantListBuilder b = VariantListBuilder.newInstance();
@@ -227,8 +206,7 @@ public class Variant {
     }
 
     /**
-     * Compares obj to this variant to see if they are the same
-     * considering all property values.
+     * Compares obj to this variant to see if they are the same considering all property values.
      *
      * @param obj the object to compare to.
      * @return true if the two variants are the same, false otherwise.
@@ -248,7 +226,7 @@ public class Variant {
         if (this.mediaType != other.mediaType && (this.mediaType == null || !this.mediaType.equals(other.mediaType))) {
             return false;
         }
-        //noinspection StringEquality
+        // noinspection StringEquality
         return this.encoding == other.encoding || (this.encoding != null && this.encoding.equals(other.encoding));
     }
 
@@ -271,8 +249,7 @@ public class Variant {
     public static abstract class VariantListBuilder {
 
         /**
-         * Protected constructor, use the static {@code newInstance}
-         * method to obtain an instance.
+         * Protected constructor, use the static {@code newInstance} method to obtain an instance.
          */
         protected VariantListBuilder() {
         }
@@ -287,41 +264,43 @@ public class Variant {
         }
 
         /**
-         * Add the current combination of metadata to the list of supported variants
-         * (provided the current combination of metadata is not empty) and
-         * build a list of representation variants from the current state of
-         * the builder. After this method is called the builder is reset to
-         * an empty state.
+         * Add the current combination of metadata to the list of supported variants (provided the current combination of
+         * metadata is not empty) and build a list of representation variants from the current state of the builder. After this
+         * method is called the builder is reset to an empty state.
          *
          * @return a list of representation variants.
          */
         public abstract List<Variant> build();
 
         /**
-         * Add the current combination of metadata to the list of supported variants,
-         * after this method is called the current combination of metadata is emptied.
+         * Add the current combination of metadata to the list of supported variants, after this method is called the current
+         * combination of metadata is emptied.
          * <p>
-         * If more than one value is supplied for one or more of the variant properties
-         * then a variant will be generated for each possible combination. E.g.
-         * in the following {@code list} would have five (4 + 1) members:
+         * If more than one value is supplied for one or more of the variant properties then a variant will be generated for
+         * each possible combination. E.g. in the following {@code list} would have five (4 + 1) members:
          * </p>
-         * <pre>List&lt;Variant&gt; list = VariantListBuilder.newInstance()
+         *
+         * <pre>
+         * List&lt;Variant&gt; list = VariantListBuilder.newInstance()
          *         .languages(Locale.ENGLISH, Locale.FRENCH).encodings("zip", "identity").add()
          *         .languages(Locale.GERMAN).mediaTypes(MediaType.TEXT_PLAIN_TYPE).add()
-         *         .build()</pre>
+         *         .build()
+         * </pre>
          * <p>
-         * Note that it is not necessary to call the {@code add()} method immediately before
-         * the build method is called. E.g. the resulting list produced in the example above
-         * would be identical to the list produced by the following code:
+         * Note that it is not necessary to call the {@code add()} method immediately before the build method is called. E.g.
+         * the resulting list produced in the example above would be identical to the list produced by the following code:
          * </p>
-         * <pre>List&lt;Variant&gt; list = VariantListBuilder.newInstance()
+         *
+         * <pre>
+         * List&lt;Variant&gt; list = VariantListBuilder.newInstance()
          *         .languages(Locale.ENGLISH, Locale.FRENCH).encodings("zip", "identity").add()
          *         .languages(Locale.GERMAN).mediaTypes(MediaType.TEXT_PLAIN_TYPE)
-         *         .build()</pre>
+         *         .build()
+         * </pre>
          *
          * @return the updated builder.
-         * @throws IllegalStateException if there is not at least one
-         *                               mediaType, language or encoding set for the current variant.
+         * @throws IllegalStateException if there is not at least one mediaType, language or encoding set for the current
+         * variant.
          */
         public abstract VariantListBuilder add();
 
@@ -344,9 +323,8 @@ public class Variant {
         /**
          * Set the media type(s) for this variant.
          *
-         * @param mediaTypes the available mediaTypes. If specific charsets
-         *                   are supported they should be included as parameters of the respective
-         *                   media type.
+         * @param mediaTypes the available mediaTypes. If specific charsets are supported they should be included as parameters
+         * of the respective media type.
          * @return the updated builder.
          */
         public abstract VariantListBuilder mediaTypes(MediaType... mediaTypes);

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/package-info.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/package-info.java
@@ -15,7 +15,6 @@
  */
 
 /**
- * Low-level interfaces and annotations used to create RESTful service
- * resources.
+ * Low-level interfaces and annotations used to create RESTful service resources.
  */
 package javax.ws.rs.core;

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/ContextResolver.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/ContextResolver.java
@@ -17,17 +17,14 @@
 package javax.ws.rs.ext;
 
 /**
- * Contract for a provider that supplies context information to resource
- * classes and other providers.
+ * Contract for a provider that supplies context information to resource classes and other providers.
  *
- * A {@code ContextResolver} implementation may be annotated
- * with {@link javax.ws.rs.Produces} to restrict the media types for
- * which it will be considered suitable.
+ * A {@code ContextResolver} implementation may be annotated with {@link javax.ws.rs.Produces} to restrict the media
+ * types for which it will be considered suitable.
  * <p>
- * Providers implementing {@code ContextResolver} contract must be either programmatically
- * registered in a JAX-RS runtime or must be annotated with
- * {@link javax.ws.rs.ext.Provider &#64;Provider} annotation to be automatically discovered
- * by the JAX-RS runtime during a provider scanning phase.
+ * Providers implementing {@code ContextResolver} contract must be either programmatically registered in a JAX-RS
+ * runtime or must be annotated with {@link javax.ws.rs.ext.Provider &#64;Provider} annotation to be automatically
+ * discovered by the JAX-RS runtime during a provider scanning phase.
  * </p>
  *
  * @param <T> type of the context
@@ -42,12 +39,11 @@ package javax.ws.rs.ext;
 public interface ContextResolver<T> {
 
     /**
-     * Get a context of type {@code T} that is applicable to the supplied
-     * type.
+     * Get a context of type {@code T} that is applicable to the supplied type.
      *
      * @param type the class of object for which a context is desired
-     * @return a context for the supplied type or {@code null} if a
-     *         context for the supplied type is not available from this provider.
+     * @return a context for the supplied type or {@code null} if a context for the supplied type is not available from this
+     * provider.
      */
     T getContext(Class<?> type);
 }

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/ExceptionMapper.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/ExceptionMapper.java
@@ -21,10 +21,9 @@ import javax.ws.rs.core.Response;
 /**
  * Contract for a provider that maps Java exceptions to {@link javax.ws.rs.core.Response}.
  * <p>
- * Providers implementing {@code ExceptionMapper} contract must be either programmatically
- * registered in a JAX-RS runtime or must be annotated with
- * {@link javax.ws.rs.ext.Provider &#64;Provider} annotation to be automatically discovered
- * by the JAX-RS runtime during a provider scanning phase.
+ * Providers implementing {@code ExceptionMapper} contract must be either programmatically registered in a JAX-RS
+ * runtime or must be annotated with {@link javax.ws.rs.ext.Provider &#64;Provider} annotation to be automatically
+ * discovered by the JAX-RS runtime during a provider scanning phase.
  *
  * @param <E> exception type supported by the provider.
  * @author Paul Sandoz
@@ -36,9 +35,8 @@ import javax.ws.rs.core.Response;
 public interface ExceptionMapper<E extends Throwable> {
 
     /**
-     * Map an exception to a {@link javax.ws.rs.core.Response}. Returning
-     * {@code null} results in a {@link javax.ws.rs.core.Response.Status#NO_CONTENT}
-     * response. Throwing a runtime exception results in a
+     * Map an exception to a {@link javax.ws.rs.core.Response}. Returning {@code null} results in a
+     * {@link javax.ws.rs.core.Response.Status#NO_CONTENT} response. Throwing a runtime exception results in a
      * {@link javax.ws.rs.core.Response.Status#INTERNAL_SERVER_ERROR} response.
      *
      * @param exception the exception to map to a response.

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/FactoryFinder.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/FactoryFinder.java
@@ -60,14 +60,12 @@ final class FactoryFinder {
     }
 
     /**
-     * Creates an instance of the specified class using the specified
-     * {@code ClassLoader} object.
+     * Creates an instance of the specified class using the specified {@code ClassLoader} object.
      *
-     * @param className   name of the class to be instantiated.
+     * @param className name of the class to be instantiated.
      * @param classLoader class loader to be used.
      * @return instance of the specified class.
-     * @throws ClassNotFoundException if the given class could not be found
-     *                                or could not be instantiated.
+     * @throws ClassNotFoundException if the given class could not be found or could not be instantiated.
      */
     private static Object newInstance(final String className, final ClassLoader classLoader) throws ClassNotFoundException {
         try {
@@ -81,8 +79,8 @@ final class FactoryFinder {
                     LOGGER.log(
                             Level.FINE,
                             "Unable to load provider class " + className
-                            + " using custom classloader " + classLoader.getClass().getName()
-                            + " trying again with current classloader.",
+                                    + " using custom classloader " + classLoader.getClass().getName()
+                                    + " trying again with current classloader.",
                             ex);
                     spiClass = Class.forName(className);
                 }
@@ -96,25 +94,19 @@ final class FactoryFinder {
     }
 
     /**
-     * Finds the implementation {@code Class} for the given factory name,
-     * or if that fails, finds the {@code Class} for the given fallback
-     * class name and create its instance. The arguments supplied MUST be
-     * used in order. If using the first argument is successful, the second
-     * one will not be used.
+     * Finds the implementation {@code Class} for the given factory name, or if that fails, finds the {@code Class} for the
+     * given fallback class name and create its instance. The arguments supplied MUST be used in order. If using the first
+     * argument is successful, the second one will not be used.
      * <p>
      * This method is package private so that this code can be shared.
      *
-     * @param factoryId         the name of the factory to find, which is
-     *                          a system property.
-     * @param fallbackClassName the implementation class name, which is
-     *                          to be used only if nothing else.
-     *                          is found; {@code null} to indicate that
-     *                          there is no fallback class name.
-     * @param service           service to be found.
-     * @param <T>               type of the service to be found.
+     * @param factoryId the name of the factory to find, which is a system property.
+     * @param fallbackClassName the implementation class name, which is to be used only if nothing else. is found;
+     * {@code null} to indicate that there is no fallback class name.
+     * @param service service to be found.
+     * @param <T> type of the service to be found.
      * @return the instance of the specified service; may not be {@code null}.
-     * @throws ClassNotFoundException if the given class could not be found
-     *                                or could not be instantiated.
+     * @throws ClassNotFoundException if the given class could not be found or could not be instantiated.
      */
     static <T> Object find(final String factoryId, final String fallbackClassName, final Class<T> service) throws ClassNotFoundException {
         ClassLoader classLoader = getContextClassLoader();
@@ -122,7 +114,7 @@ final class FactoryFinder {
         try {
             Iterator<T> iterator = ServiceLoader.load(service, FactoryFinder.getContextClassLoader()).iterator();
 
-            if(iterator.hasNext()) {
+            if (iterator.hasNext()) {
                 return iterator.next();
             }
         } catch (Exception | ServiceConfigurationError ex) {
@@ -132,7 +124,7 @@ final class FactoryFinder {
         try {
             Iterator<T> iterator = ServiceLoader.load(service, FactoryFinder.class.getClassLoader()).iterator();
 
-            if(iterator.hasNext()) {
+            if (iterator.hasNext()) {
                 return iterator.next();
             }
         } catch (Exception | ServiceConfigurationError ex) {

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/InterceptorContext.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/InterceptorContext.java
@@ -23,11 +23,9 @@ import java.util.Collection;
 import javax.ws.rs.core.MediaType;
 
 /**
- * Context shared by message body interceptors that can be used to wrap
- * calls to {@link javax.ws.rs.ext.MessageBodyReader#readFrom} and
- * {@link javax.ws.rs.ext.MessageBodyWriter#writeTo}. The getters and
- * setters in this context class correspond to the parameters in
- * the aforementioned methods.
+ * Context shared by message body interceptors that can be used to wrap calls to
+ * {@link javax.ws.rs.ext.MessageBodyReader#readFrom} and {@link javax.ws.rs.ext.MessageBodyWriter#writeTo}. The getters
+ * and setters in this context class correspond to the parameters in the aforementioned methods.
  *
  * @author Santiago Pericas-Geertsen
  * @author Bill Burke
@@ -40,40 +38,38 @@ import javax.ws.rs.core.MediaType;
 public interface InterceptorContext {
 
     /**
-     * Returns the property with the given name registered in the current request/response
-     * exchange context, or {@code null} if there is no property by that name.
+     * Returns the property with the given name registered in the current request/response exchange context, or {@code null}
+     * if there is no property by that name.
      * <p>
-     * A property allows a JAX-RS filters and interceptors to exchange
-     * additional custom information not already provided by this interface.
+     * A property allows a JAX-RS filters and interceptors to exchange additional custom information not already provided by
+     * this interface.
      * </p>
      * <p>
-     * A list of supported properties can be retrieved using {@link #getPropertyNames()}.
-     * Custom property names should follow the same convention as package names.
+     * A list of supported properties can be retrieved using {@link #getPropertyNames()}. Custom property names should
+     * follow the same convention as package names.
      * </p>
      * <p>
-     * In a Servlet container, on the server side, the properties are backed by the
-     * {@code ServletRequest} and contain all the attributes available in the {@code ServletRequest}.
+     * In a Servlet container, on the server side, the properties are backed by the {@code ServletRequest} and contain all
+     * the attributes available in the {@code ServletRequest}.
      * </p>
      *
      * @param name a {@code String} specifying the name of the property.
-     * @return an {@code Object} containing the value of the property, or
-     *         {@code null} if no property exists matching the given name.
+     * @return an {@code Object} containing the value of the property, or {@code null} if no property exists matching the
+     * given name.
      * @see #getPropertyNames()
      */
     public Object getProperty(String name);
 
     /**
-     * Returns an immutable {@link java.util.Collection collection} containing the property
-     * names available within the context of the current request/response exchange context.
+     * Returns an immutable {@link java.util.Collection collection} containing the property names available within the
+     * context of the current request/response exchange context.
      * <p>
-     * Use the {@link #getProperty} method with a property name to get the value of
-     * a property.
+     * Use the {@link #getProperty} method with a property name to get the value of a property.
      * </p>
      * <p>
-     * In a Servlet container, the properties are synchronized with the {@code ServletRequest}
-     * and expose all the attributes available in the {@code ServletRequest}. Any modifications
-     * of the properties are also reflected in the set of properties of the associated
-     * {@code ServletRequest}.
+     * In a Servlet container, the properties are synchronized with the {@code ServletRequest} and expose all the attributes
+     * available in the {@code ServletRequest}. Any modifications of the properties are also reflected in the set of
+     * properties of the associated {@code ServletRequest}.
      * </p>
      *
      * @return an immutable {@link java.util.Collection collection} of property names.
@@ -82,38 +78,35 @@ public interface InterceptorContext {
     public Collection<String> getPropertyNames();
 
     /**
-     * Binds an object to a given property name in the current request/response
-     * exchange context. If the name specified is already used for a property,
-     * this method will replace the value of the property with the new value.
+     * Binds an object to a given property name in the current request/response exchange context. If the name specified is
+     * already used for a property, this method will replace the value of the property with the new value.
      * <p>
-     * A property allows a JAX-RS filters and interceptors to exchange
-     * additional custom information not already provided by this interface.
+     * A property allows a JAX-RS filters and interceptors to exchange additional custom information not already provided by
+     * this interface.
      * </p>
      * <p>
-     * A list of supported properties can be retrieved using {@link #getPropertyNames()}.
-     * Custom property names should follow the same convention as package names.
+     * A list of supported properties can be retrieved using {@link #getPropertyNames()}. Custom property names should
+     * follow the same convention as package names.
      * </p>
      * <p>
-     * If a {@code null} value is passed, the effect is the same as calling the
-     * {@link #removeProperty(String)} method.
+     * If a {@code null} value is passed, the effect is the same as calling the {@link #removeProperty(String)} method.
      * </p>
      * <p>
-     * In a Servlet container, on the server side, the properties are backed by the
-     * {@code ServletRequest} and contain all the attributes available in the {@code ServletRequest}.
+     * In a Servlet container, on the server side, the properties are backed by the {@code ServletRequest} and contain all
+     * the attributes available in the {@code ServletRequest}.
      * </p>
      *
-     * @param name   a {@code String} specifying the name of the property.
+     * @param name a {@code String} specifying the name of the property.
      * @param object an {@code Object} representing the property to be bound.
      */
     public void setProperty(String name, Object object);
 
     /**
-     * Removes a property with the given name from the current request/response
-     * exchange context. After removal, subsequent calls to {@link #getProperty}
-     * to retrieve the property value will return {@code null}.
+     * Removes a property with the given name from the current request/response exchange context. After removal, subsequent
+     * calls to {@link #getProperty} to retrieve the property value will return {@code null}.
      * <p>
-     * In a Servlet container, on the server side, the properties are backed by the
-     * {@code ServletRequest} and contain all the attributes available in the {@code ServletRequest}.
+     * In a Servlet container, on the server side, the properties are backed by the {@code ServletRequest} and contain all
+     * the attributes available in the {@code ServletRequest}.
      * </p>
      *
      * @param name a {@code String} specifying the name of the property to be removed.
@@ -121,34 +114,29 @@ public interface InterceptorContext {
     public void removeProperty(String name);
 
     /**
-     * Get an array of the annotations formally declared on the artifact that
-     * initiated the intercepted entity provider invocation.
+     * Get an array of the annotations formally declared on the artifact that initiated the intercepted entity provider
+     * invocation.
      *
-     * E.g. if the message body is to be converted into a method parameter, this
-     * will be the annotations on that parameter returned by
-     * {@link java.lang.reflect.Method#getParameterAnnotations Method.getParameterAnnotations()};
-     * if the server-side response entity instance is to be converted into an
-     * output stream, this will be the annotations on the matched resource method
-     * returned by {@link java.lang.reflect.Method#getAnnotations() Method.getAnnotations()}.
+     * E.g. if the message body is to be converted into a method parameter, this will be the annotations on that parameter
+     * returned by {@link java.lang.reflect.Method#getParameterAnnotations Method.getParameterAnnotations()}; if the
+     * server-side response entity instance is to be converted into an output stream, this will be the annotations on the
+     * matched resource method returned by {@link java.lang.reflect.Method#getAnnotations() Method.getAnnotations()}.
      *
-     * This method may return an empty array in case the interceptor is
-     * not invoked in a context of any particular resource method
-     * (e.g. as part of the client API), but will never return {@code null}.
+     * This method may return an empty array in case the interceptor is not invoked in a context of any particular resource
+     * method (e.g. as part of the client API), but will never return {@code null}.
      *
-     * @return annotations declared on the artifact that initiated the intercepted
-     *         entity provider invocation.
+     * @return annotations declared on the artifact that initiated the intercepted entity provider invocation.
      */
     public Annotation[] getAnnotations();
 
     /**
-     * Update annotations on the formal declaration of the artifact that
-     * initiated the intercepted entity provider invocation.
+     * Update annotations on the formal declaration of the artifact that initiated the intercepted entity provider
+     * invocation.
      *
      * Calling this method has no effect in the client API.
      *
-     * @param annotations updated annotations declarataion of the artifact that
-     *                    initiated the intercepted entity provider invocation.
-     *                    Must not be {@code null}.
+     * @param annotations updated annotations declarataion of the artifact that initiated the intercepted entity provider
+     * invocation. Must not be {@code null}.
      * @throws NullPointerException in case the input parameter is {@code null}.
      */
     public void setAnnotations(Annotation[] annotations);

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/MessageBodyReader.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/MessageBodyReader.java
@@ -24,17 +24,14 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 
 /**
- * Contract for a provider that supports the conversion of a stream to a
- * Java type.
+ * Contract for a provider that supports the conversion of a stream to a Java type.
  *
- * A {@code MessageBodyReader} implementation may be annotated
- * with {@link javax.ws.rs.Consumes} to restrict the media types for which it will
- * be considered suitable.
+ * A {@code MessageBodyReader} implementation may be annotated with {@link javax.ws.rs.Consumes} to restrict the media
+ * types for which it will be considered suitable.
  * <p>
- * Providers implementing {@code MessageBodyReader} contract must be either programmatically
- * registered in a JAX-RS runtime or must be annotated with
- * {@link javax.ws.rs.ext.Provider &#64;Provider} annotation to be automatically discovered
- * by the JAX-RS runtime during a provider scanning phase.
+ * Providers implementing {@code MessageBodyReader} contract must be either programmatically registered in a JAX-RS
+ * runtime or must be annotated with {@link javax.ws.rs.ext.Provider &#64;Provider} annotation to be automatically
+ * discovered by the JAX-RS runtime during a provider scanning phase.
  * </p>
  *
  * @param <T> Java type supported by the provider
@@ -47,75 +44,59 @@ import javax.ws.rs.core.MultivaluedMap;
 public interface MessageBodyReader<T> {
 
     /**
-     * Ascertain if the MessageBodyReader can produce an instance of a
-     * particular type. The {@code type} parameter gives the
-     * class of the instance that should be produced, the {@code genericType} parameter
-     * gives the {@link java.lang.reflect.Type java.lang.reflect.Type} of the instance
-     * that should be produced.
-     * E.g. if the instance to be produced is {@code List<String>}, the {@code type} parameter
-     * will be {@code java.util.List} and the {@code genericType} parameter will be
-     * {@link java.lang.reflect.ParameterizedType java.lang.reflect.ParameterizedType}.
+     * Ascertain if the MessageBodyReader can produce an instance of a particular type. The {@code type} parameter gives the
+     * class of the instance that should be produced, the {@code genericType} parameter gives the
+     * {@link java.lang.reflect.Type java.lang.reflect.Type} of the instance that should be produced. E.g. if the instance
+     * to be produced is {@code List<String>}, the {@code type} parameter will be {@code java.util.List} and the
+     * {@code genericType} parameter will be {@link java.lang.reflect.ParameterizedType
+     * java.lang.reflect.ParameterizedType}.
      *
-     * @param type        the class of instance to be produced.
-     * @param genericType the type of instance to be produced. E.g. if the
-     *                    message body is to be converted into a method parameter, this will be
-     *                    the formal type of the method parameter as returned by
-     *                    {@code Method.getGenericParameterTypes}.
-     * @param annotations an array of the annotations on the declaration of the
-     *                    artifact that will be initialized with the produced instance. E.g. if the
-     *                    message body is to be converted into a method parameter, this will be
-     *                    the annotations on that parameter returned by
-     *                    {@code Method.getParameterAnnotations}.
-     * @param mediaType   the media type of the HTTP entity, if one is not
-     *                    specified in the request then {@code application/octet-stream} is
-     *                    used.
+     * @param type the class of instance to be produced.
+     * @param genericType the type of instance to be produced. E.g. if the message body is to be converted into a method
+     * parameter, this will be the formal type of the method parameter as returned by
+     * {@code Method.getGenericParameterTypes}.
+     * @param annotations an array of the annotations on the declaration of the artifact that will be initialized with the
+     * produced instance. E.g. if the message body is to be converted into a method parameter, this will be the annotations
+     * on that parameter returned by {@code Method.getParameterAnnotations}.
+     * @param mediaType the media type of the HTTP entity, if one is not specified in the request then
+     * {@code application/octet-stream} is used.
      * @return {@code true} if the type is supported, otherwise {@code false}.
      */
     public boolean isReadable(Class<?> type, Type genericType,
-                              Annotation[] annotations, MediaType mediaType);
+            Annotation[] annotations, MediaType mediaType);
 
     /**
      * Read a type from the {@link InputStream}.
      * <p>
-     * In case the entity input stream is empty, the reader is expected to either return a
-     * Java representation of a zero-length entity or throw a {@link javax.ws.rs.core.NoContentException}
-     * in case no zero-length entity representation is defined for the supported Java type.
-     * A {@code NoContentException}, if thrown by a message body reader while reading a server
-     * request entity, is automatically translated by JAX-RS server runtime into a {@link javax.ws.rs.BadRequestException}
-     * wrapping the original {@code NoContentException} and rethrown for a standard processing by
-     * the registered {@link javax.ws.rs.ext.ExceptionMapper exception mappers}.
+     * In case the entity input stream is empty, the reader is expected to either return a Java representation of a
+     * zero-length entity or throw a {@link javax.ws.rs.core.NoContentException} in case no zero-length entity
+     * representation is defined for the supported Java type. A {@code NoContentException}, if thrown by a message body
+     * reader while reading a server request entity, is automatically translated by JAX-RS server runtime into a
+     * {@link javax.ws.rs.BadRequestException} wrapping the original {@code NoContentException} and rethrown for a standard
+     * processing by the registered {@link javax.ws.rs.ext.ExceptionMapper exception mappers}.
      * </p>
      *
-     * @param type         the type that is to be read from the entity stream.
-     * @param genericType  the type of instance to be produced. E.g. if the
-     *                     message body is to be converted into a method parameter, this will be
-     *                     the formal type of the method parameter as returned by
-     *                     {@code Method.getGenericParameterTypes}.
-     * @param annotations  an array of the annotations on the declaration of the
-     *                     artifact that will be initialized with the produced instance. E.g.
-     *                     if the message body is to be converted into a method parameter, this
-     *                     will be the annotations on that parameter returned by
-     *                     {@code Method.getParameterAnnotations}.
-     * @param mediaType    the media type of the HTTP entity.
-     * @param httpHeaders  the read-only HTTP headers associated with HTTP entity.
-     * @param entityStream the {@link InputStream} of the HTTP entity. The
-     *                     caller is responsible for ensuring that the input stream ends when the
-     *                     entity has been consumed. The implementation should not close the input
-     *                     stream.
-     * @return the type that was read from the stream. In case the entity input stream is empty, the reader
-     *         is expected to either return an instance representing a zero-length entity or throw
-     *         a {@link javax.ws.rs.core.NoContentException} in case no zero-length entity representation is
-     *         defined for the supported Java type.
-     * @throws java.io.IOException if an IO error arises. In case the entity input stream is empty
-     *                             and the reader is not able to produce a Java representation for
-     *                             a zero-length entity, {@code NoContentException} is expected to
-     *                             be thrown.
-     * @throws javax.ws.rs.WebApplicationException
-     *                             if a specific HTTP error response needs to be produced.
-     *                             Only effective if thrown prior to the response being committed.
+     * @param type the type that is to be read from the entity stream.
+     * @param genericType the type of instance to be produced. E.g. if the message body is to be converted into a method
+     * parameter, this will be the formal type of the method parameter as returned by
+     * {@code Method.getGenericParameterTypes}.
+     * @param annotations an array of the annotations on the declaration of the artifact that will be initialized with the
+     * produced instance. E.g. if the message body is to be converted into a method parameter, this will be the annotations
+     * on that parameter returned by {@code Method.getParameterAnnotations}.
+     * @param mediaType the media type of the HTTP entity.
+     * @param httpHeaders the read-only HTTP headers associated with HTTP entity.
+     * @param entityStream the {@link InputStream} of the HTTP entity. The caller is responsible for ensuring that the input
+     * stream ends when the entity has been consumed. The implementation should not close the input stream.
+     * @return the type that was read from the stream. In case the entity input stream is empty, the reader is expected to
+     * either return an instance representing a zero-length entity or throw a {@link javax.ws.rs.core.NoContentException} in
+     * case no zero-length entity representation is defined for the supported Java type.
+     * @throws java.io.IOException if an IO error arises. In case the entity input stream is empty and the reader is not
+     * able to produce a Java representation for a zero-length entity, {@code NoContentException} is expected to be thrown.
+     * @throws javax.ws.rs.WebApplicationException if a specific HTTP error response needs to be produced. Only effective if
+     * thrown prior to the response being committed.
      */
     public T readFrom(Class<T> type, Type genericType,
-                      Annotation[] annotations, MediaType mediaType,
-                      MultivaluedMap<String, String> httpHeaders,
-                      InputStream entityStream) throws java.io.IOException, javax.ws.rs.WebApplicationException;
+            Annotation[] annotations, MediaType mediaType,
+            MultivaluedMap<String, String> httpHeaders,
+            InputStream entityStream) throws java.io.IOException, javax.ws.rs.WebApplicationException;
 }

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/MessageBodyWriter.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/MessageBodyWriter.java
@@ -24,17 +24,14 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 
 /**
- * Contract for a provider that supports the conversion of a Java type to a
- * stream.
+ * Contract for a provider that supports the conversion of a Java type to a stream.
  *
- * A {@code MessageBodyWriter} implementation may be annotated
- * with {@link javax.ws.rs.Produces} to restrict the media types for which it will
- * be considered suitable.
+ * A {@code MessageBodyWriter} implementation may be annotated with {@link javax.ws.rs.Produces} to restrict the media
+ * types for which it will be considered suitable.
  * <p>
- * Providers implementing {@code MessageBodyWriter} contract must be either programmatically
- * registered in a JAX-RS runtime or must be annotated with
- * {@link javax.ws.rs.ext.Provider &#64;Provider} annotation to be automatically discovered
- * by the JAX-RS runtime during a provider scanning phase.
+ * Providers implementing {@code MessageBodyWriter} contract must be either programmatically registered in a JAX-RS
+ * runtime or must be annotated with {@link javax.ws.rs.ext.Provider &#64;Provider} annotation to be automatically
+ * discovered by the JAX-RS runtime during a provider scanning phase.
  * </p>
  *
  * @param <T> the type that can be written.
@@ -49,64 +46,59 @@ public interface MessageBodyWriter<T> {
     /**
      * Ascertain if the MessageBodyWriter supports a particular type.
      *
-     * @param type        the class of instance that is to be written.
-     * @param genericType the type of instance to be written, obtained either
-     *                    by reflection of a resource method return type or via inspection
-     *                    of the returned instance. {@link javax.ws.rs.core.GenericEntity}
-     *                    provides a way to specify this information at runtime.
+     * @param type the class of instance that is to be written.
+     * @param genericType the type of instance to be written, obtained either by reflection of a resource method return type
+     * or via inspection of the returned instance. {@link javax.ws.rs.core.GenericEntity} provides a way to specify this
+     * information at runtime.
      * @param annotations an array of the annotations attached to the message entity instance.
-     * @param mediaType   the media type of the HTTP entity.
+     * @param mediaType the media type of the HTTP entity.
      * @return {@code true} if the type is supported, otherwise {@code false}.
      */
     public boolean isWriteable(Class<?> type, Type genericType,
-                               Annotation[] annotations, MediaType mediaType);
+            Annotation[] annotations, MediaType mediaType);
 
     /**
-     * Originally, the method has been called before {@code writeTo} to ascertain the length in bytes of
-     * the serialized form of {@code t}. A non-negative return value has been used in a HTTP
-     * {@code Content-Length} header.
+     * Originally, the method has been called before {@code writeTo} to ascertain the length in bytes of the serialized form
+     * of {@code t}. A non-negative return value has been used in a HTTP {@code Content-Length} header.
      * <p>
-     * As of JAX-RS 2.0, the method has been deprecated and the value returned by the method is ignored
-     * by a JAX-RS runtime. All {@code MessageBodyWriter} implementations are advised to return {@code -1}
-     * from the method. Responsibility to compute the actual {@code Content-Length} header value has been
-     * delegated to JAX-RS runtime.
+     * As of JAX-RS 2.0, the method has been deprecated and the value returned by the method is ignored by a JAX-RS runtime.
+     * All {@code MessageBodyWriter} implementations are advised to return {@code -1} from the method. Responsibility to
+     * compute the actual {@code Content-Length} header value has been delegated to JAX-RS runtime.
      * </p>
      *
-     * @param t           the instance to write
-     * @param type        the class of instance that is to be written.
-     * @param genericType the type of instance to be written. {@link javax.ws.rs.core.GenericEntity}
-     *                    provides a way to specify this information at runtime.
+     * @param t the instance to write
+     * @param type the class of instance that is to be written.
+     * @param genericType the type of instance to be written. {@link javax.ws.rs.core.GenericEntity} provides a way to
+     * specify this information at runtime.
      * @param annotations an array of the annotations attached to the message entity instance.
-     * @param mediaType   the media type of the HTTP entity.
+     * @param mediaType the media type of the HTTP entity.
      * @return length in bytes or -1 if the length cannot be determined in advance.
      */
     public default long getSize(final T t, final Class<?> type, final Type genericType, final Annotation[] annotations,
-                        final MediaType mediaType) {
+            final MediaType mediaType) {
         return -1L;
     }
 
     /**
-     * Write a type to an HTTP message. The message header map is mutable
-     * but any changes must be made before writing to the output stream since
-     * the headers will be flushed prior to writing the message body.
+     * Write a type to an HTTP message. The message header map is mutable but any changes must be made before writing to the
+     * output stream since the headers will be flushed prior to writing the message body.
      *
-     * @param t            the instance to write.
-     * @param type         the class of instance that is to be written.
-     * @param genericType  the type of instance to be written. {@link javax.ws.rs.core.GenericEntity}
-     *                     provides a way to specify this information at runtime.
-     * @param annotations  an array of the annotations attached to the message entity instance.
-     * @param mediaType    the media type of the HTTP entity.
-     * @param httpHeaders  a mutable map of the HTTP message headers.
-     * @param entityStream the {@link OutputStream} for the HTTP entity. The
-     *                     implementation should not close the output stream.
+     * @param t the instance to write.
+     * @param type the class of instance that is to be written.
+     * @param genericType the type of instance to be written. {@link javax.ws.rs.core.GenericEntity} provides a way to
+     * specify this information at runtime.
+     * @param annotations an array of the annotations attached to the message entity instance.
+     * @param mediaType the media type of the HTTP entity.
+     * @param httpHeaders a mutable map of the HTTP message headers.
+     * @param entityStream the {@link OutputStream} for the HTTP entity. The implementation should not close the output
+     * stream.
      * @throws java.io.IOException if an IO error arises.
-     * @throws javax.ws.rs.WebApplicationException
-     *                             if a specific HTTP error response needs to be produced.
-     *                             Only effective if thrown prior to the message being committed.
+     * @throws javax.ws.rs.WebApplicationException if a specific HTTP error response needs to be produced. Only effective if
+     * thrown prior to the message being committed.
      */
     public void writeTo(T t, Class<?> type, Type genericType, Annotation[] annotations,
-                        MediaType mediaType,
-                        MultivaluedMap<String, Object> httpHeaders,
-                        OutputStream entityStream)
+            MediaType mediaType,
+            MultivaluedMap<String, Object> httpHeaders,
+            OutputStream entityStream)
             throws java.io.IOException, javax.ws.rs.WebApplicationException;
 }

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/ParamConverter.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/ParamConverter.java
@@ -25,32 +25,26 @@ import java.lang.annotation.Target;
 import javax.ws.rs.DefaultValue;
 
 /**
- * Defines a contract for a delegate responsible for converting between a
- * {@code String} form of a message parameter value and the corresponding custom
- * Java type {@code T}.
+ * Defines a contract for a delegate responsible for converting between a {@code String} form of a message parameter
+ * value and the corresponding custom Java type {@code T}.
  *
- * Conversion of message parameter values injected via
- * {@link javax.ws.rs.PathParam &#64;PathParam}, {@link javax.ws.rs.QueryParam &#64;QueryParam},
- * {@link javax.ws.rs.MatrixParam &#64;MatrixParam}, {@link javax.ws.rs.FormParam &#64;FormParam},
- * {@link javax.ws.rs.CookieParam &#64;CookieParam} and {@link javax.ws.rs.HeaderParam &#64;HeaderParam}
- * is supported.
+ * Conversion of message parameter values injected via {@link javax.ws.rs.PathParam &#64;PathParam},
+ * {@link javax.ws.rs.QueryParam &#64;QueryParam}, {@link javax.ws.rs.MatrixParam &#64;MatrixParam},
+ * {@link javax.ws.rs.FormParam &#64;FormParam}, {@link javax.ws.rs.CookieParam &#64;CookieParam} and
+ * {@link javax.ws.rs.HeaderParam &#64;HeaderParam} is supported.
  * <p>
- * By default, when used for injection of parameter values, a selected {@code ParamConverter}
- * instance MUST be used eagerly by a JAX-RS runtime to convert any {@link DefaultValue
- * default value} in the resource or provider model, that is during the application deployment,
- * before any value &ndash; default or otherwise &ndash; is actually required.
- * This conversion strategy ensures that any errors in the default values are reported
- * as early as possible.
- * This default behavior may be overridden by annotating the {@code ParamConverter}
- * implementation class with a {@link Lazy &#64;Lazy} annotation. In such case any default
- * value conversion delegated to the {@code @Lazy}-annotated converter will be deferred
- * to a latest possible moment (i.e. until the injection of such default value is required).
+ * By default, when used for injection of parameter values, a selected {@code ParamConverter} instance MUST be used
+ * eagerly by a JAX-RS runtime to convert any {@link DefaultValue default value} in the resource or provider model, that
+ * is during the application deployment, before any value &ndash; default or otherwise &ndash; is actually required.
+ * This conversion strategy ensures that any errors in the default values are reported as early as possible. This
+ * default behavior may be overridden by annotating the {@code ParamConverter} implementation class with a {@link Lazy
+ * &#64;Lazy} annotation. In such case any default value conversion delegated to the {@code @Lazy}-annotated converter
+ * will be deferred to a latest possible moment (i.e. until the injection of such default value is required).
  * </p>
  * <p>
- * NOTE: A service implementing this contract is not recognized as a registrable
- * JAX-RS extension provider. Instead, a {@link ParamConverterProvider} instance
- * responsible for providing {@code ParamConverter} instances has to be registered
- * as one of the JAX-RS extension providers.
+ * NOTE: A service implementing this contract is not recognized as a registrable JAX-RS extension provider. Instead, a
+ * {@link ParamConverterProvider} instance responsible for providing {@code ParamConverter} instances has to be
+ * registered as one of the JAX-RS extension providers.
  * </p>
  *
  * @param <T> the supported Java type convertible to/from a {@code String} format.
@@ -60,14 +54,13 @@ import javax.ws.rs.DefaultValue;
 public interface ParamConverter<T> {
 
     /**
-     * Mandates that a conversion of any {@link DefaultValue default value} delegated
-     * to a {@link ParamConverter parameter converter} annotated with {@code @Lazy}
-     * annotation SHOULD occur only once the value is actually required (e.g. to be
+     * Mandates that a conversion of any {@link DefaultValue default value} delegated to a {@link ParamConverter parameter
+     * converter} annotated with {@code @Lazy} annotation SHOULD occur only once the value is actually required (e.g. to be
      * injected for the first time).
      *
      * @since 2.0
      */
-    @Target({ElementType.TYPE})
+    @Target({ ElementType.TYPE })
     @Retention(RetentionPolicy.RUNTIME)
     @Documented
     public static @interface Lazy {
@@ -79,24 +72,21 @@ public interface ParamConverter<T> {
      * @param value the string value.
      * @return the newly created instance of {@code T}.
      *
-     * @throws IllegalArgumentException if the supplied string cannot be
-     *                                  parsed or is {@code null}.
+     * @throws IllegalArgumentException if the supplied string cannot be parsed or is {@code null}.
      */
     public T fromString(String value);
 
     /**
      * Convert the supplied value to a String.
      * <p>
-     * This method is reserved for future use. Proprietary JAX-RS extensions may leverage the method.
-     * Users should be aware that any such support for the method comes at the expense of producing
-     * non-portable code.
+     * This method is reserved for future use. Proprietary JAX-RS extensions may leverage the method. Users should be aware
+     * that any such support for the method comes at the expense of producing non-portable code.
      * </p>
      *
      * @param value the value of type {@code T}.
      * @return a String representation of the value.
      *
-     * @throws IllegalArgumentException if the supplied object cannot be
-     *                                  serialized or is {@code null}.
+     * @throws IllegalArgumentException if the supplied object cannot be serialized or is {@code null}.
      */
     public String toString(T value);
 }

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/ParamConverterProvider.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/ParamConverterProvider.java
@@ -22,10 +22,9 @@ import java.lang.reflect.Type;
 /**
  * Contract for a provider of {@link ParamConverter} instances.
  * <p>
- * Providers implementing {@code ParamConverterProvider} contract must be either programmatically
- * registered in a JAX-RS runtime or must be annotated with
- * {@link javax.ws.rs.ext.Provider &#64;Provider} annotation to be automatically discovered
- * by the JAX-RS runtime during a provider scanning phase.
+ * Providers implementing {@code ParamConverterProvider} contract must be either programmatically registered in a JAX-RS
+ * runtime or must be annotated with {@link javax.ws.rs.ext.Provider &#64;Provider} annotation to be automatically
+ * discovered by the JAX-RS runtime during a provider scanning phase.
  * </p>
  *
  * @author Marek Potociar
@@ -34,19 +33,16 @@ import java.lang.reflect.Type;
 public interface ParamConverterProvider {
 
     /**
-     * Obtain a {@link ParamConverter} that can provide from/to string conversion
-     * for an instance of a particular Java type.
+     * Obtain a {@link ParamConverter} that can provide from/to string conversion for an instance of a particular Java type.
      *
-     * @param <T>         the supported Java type convertible to/from a {@code String} format.
-     * @param rawType     the raw type of the object to be converted.
-     * @param genericType the type of object to be converted. E.g. if an String value
-     *                    representing the injected request parameter
-     *                    is to be converted into a method parameter, this will be the
-     *                    formal type of the method parameter as returned by {@code Class.getGenericParameterTypes}.
-     * @param annotations an array of the annotations associated with the convertible
-     *                    parameter instance. E.g. if a string value is to be converted into a method parameter,
-     *                    this would be the annotations on that parameter as returned by
-     *                    {@link java.lang.reflect.Method#getParameterAnnotations}.
+     * @param <T> the supported Java type convertible to/from a {@code String} format.
+     * @param rawType the raw type of the object to be converted.
+     * @param genericType the type of object to be converted. E.g. if an String value representing the injected request
+     * parameter is to be converted into a method parameter, this will be the formal type of the method parameter as
+     * returned by {@code Class.getGenericParameterTypes}.
+     * @param annotations an array of the annotations associated with the convertible parameter instance. E.g. if a string
+     * value is to be converted into a method parameter, this would be the annotations on that parameter as returned by
+     * {@link java.lang.reflect.Method#getParameterAnnotations}.
      * @return the string converter, otherwise {@code null}.
      */
     public <T> ParamConverter<T> getConverter(Class<T> rawType, Type genericType, Annotation annotations[]);

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/Provider.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/Provider.java
@@ -23,14 +23,14 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks an implementation of an extension interface that should be discoverable
- * by JAX-RS runtime during a provider scanning phase.
+ * Marks an implementation of an extension interface that should be discoverable by JAX-RS runtime during a provider
+ * scanning phase.
  *
  * @author Paul Sandoz
  * @author Marc Hadley
  * @since 1.0
  */
-@Target({ElementType.TYPE})
+@Target({ ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface Provider {

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/Providers.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/Providers.java
@@ -36,101 +36,75 @@ import javax.ws.rs.core.MediaType;
 public interface Providers {
 
     /**
-     * Get a message body reader that matches a set of criteria. The set of
-     * readers is first filtered by comparing the supplied value of
-     * {@code mediaType} with the value of each reader's
-     * {@link javax.ws.rs.Consumes}, ensuring the supplied value of
-     * {@code type} is assignable to the generic type of the reader, and
-     * eliminating those that do not match.
-     * The list of matching readers is then ordered with those with the best
-     * matching values of {@link javax.ws.rs.Consumes} (x/y &gt; x&#47;* &gt; *&#47;*)
-     * sorted first. Finally, the
-     * {@link MessageBodyReader#isReadable(Class, Type, Annotation[], MediaType)}
-     * method is called on each reader in order using the supplied criteria and
-     * the first reader that returns {@code true} is selected and returned.
+     * Get a message body reader that matches a set of criteria. The set of readers is first filtered by comparing the
+     * supplied value of {@code mediaType} with the value of each reader's {@link javax.ws.rs.Consumes}, ensuring the
+     * supplied value of {@code type} is assignable to the generic type of the reader, and eliminating those that do not
+     * match. The list of matching readers is then ordered with those with the best matching values of
+     * {@link javax.ws.rs.Consumes} (x/y &gt; x&#47;* &gt; *&#47;*) sorted first. Finally, the
+     * {@link MessageBodyReader#isReadable(Class, Type, Annotation[], MediaType)} method is called on each reader in order
+     * using the supplied criteria and the first reader that returns {@code true} is selected and returned.
      *
-     * @param <T>         type of the the object that is to be read.
-     * @param type        the class of the object that is to be read.
-     * @param genericType the type of object to be produced. E.g. if the
-     *                    message body is to be converted into a method parameter, this will be
-     *                    the formal type of the method parameter as returned by
-     *                    {@code Class.getGenericParameterTypes}.
-     * @param annotations an array of the annotations on the declaration of the
-     *                    artifact that will be initialized with the produced instance. E.g. if
-     *                    the message body is to be converted into a method parameter, this will
-     *                    be the annotations on that parameter returned by
-     *                    {@code Class.getParameterAnnotations}.
-     * @param mediaType   the media type of the data that will be read.
-     * @return a MessageBodyReader that matches the supplied criteria or {@code null}
-     *         if none is found.
+     * @param <T> type of the the object that is to be read.
+     * @param type the class of the object that is to be read.
+     * @param genericType the type of object to be produced. E.g. if the message body is to be converted into a method
+     * parameter, this will be the formal type of the method parameter as returned by
+     * {@code Class.getGenericParameterTypes}.
+     * @param annotations an array of the annotations on the declaration of the artifact that will be initialized with the
+     * produced instance. E.g. if the message body is to be converted into a method parameter, this will be the annotations
+     * on that parameter returned by {@code Class.getParameterAnnotations}.
+     * @param mediaType the media type of the data that will be read.
+     * @return a MessageBodyReader that matches the supplied criteria or {@code null} if none is found.
      */
     <T> MessageBodyReader<T> getMessageBodyReader(Class<T> type,
-                                                  Type genericType, Annotation[] annotations, MediaType mediaType);
+            Type genericType, Annotation[] annotations, MediaType mediaType);
 
     /**
-     * Get a message body writer that matches a set of criteria. The set of
-     * writers is first filtered by comparing the supplied value of
-     * {@code mediaType} with the value of each writer's
-     * {@link javax.ws.rs.Produces}, ensuring the supplied value of
-     * {@code type} is assignable to the generic type of the reader, and
-     * eliminating those that do not match.
-     * The list of matching writers is then ordered with those with the best
-     * matching values of {@link javax.ws.rs.Produces} (x/y &gt; x&#47;* &gt; *&#47;*)
-     * sorted first. Finally, the
-     * {@link MessageBodyWriter#isWriteable(Class, Type, Annotation[], MediaType)}
-     * method is called on each writer in order using the supplied criteria and
-     * the first writer that returns {@code true} is selected and returned.
+     * Get a message body writer that matches a set of criteria. The set of writers is first filtered by comparing the
+     * supplied value of {@code mediaType} with the value of each writer's {@link javax.ws.rs.Produces}, ensuring the
+     * supplied value of {@code type} is assignable to the generic type of the reader, and eliminating those that do not
+     * match. The list of matching writers is then ordered with those with the best matching values of
+     * {@link javax.ws.rs.Produces} (x/y &gt; x&#47;* &gt; *&#47;*) sorted first. Finally, the
+     * {@link MessageBodyWriter#isWriteable(Class, Type, Annotation[], MediaType)} method is called on each writer in order
+     * using the supplied criteria and the first writer that returns {@code true} is selected and returned.
      *
-     * @param <T>         type of the object that is to be written.
-     * @param type        the class of the object that is to be written.
-     * @param genericType the type of object to be written. E.g. if the
-     *                    message body is to be produced from a field, this will be
-     *                    the declared type of the field as returned by {@code Field.getGenericType}.
-     * @param annotations an array of the annotations on the declaration of the
-     *                    artifact that will be written. E.g. if the
-     *                    message body is to be produced from a field, this will be
-     *                    the annotations on that field returned by
-     *                    {@code Field.getDeclaredAnnotations}.
-     * @param mediaType   the media type of the data that will be written.
-     * @return a MessageBodyReader that matches the supplied criteria or {@code null}
-     *         if none is found.
+     * @param <T> type of the object that is to be written.
+     * @param type the class of the object that is to be written.
+     * @param genericType the type of object to be written. E.g. if the message body is to be produced from a field, this
+     * will be the declared type of the field as returned by {@code Field.getGenericType}.
+     * @param annotations an array of the annotations on the declaration of the artifact that will be written. E.g. if the
+     * message body is to be produced from a field, this will be the annotations on that field returned by
+     * {@code Field.getDeclaredAnnotations}.
+     * @param mediaType the media type of the data that will be written.
+     * @return a MessageBodyReader that matches the supplied criteria or {@code null} if none is found.
      */
     <T> MessageBodyWriter<T> getMessageBodyWriter(Class<T> type,
-                                                  Type genericType, Annotation[] annotations, MediaType mediaType);
+            Type genericType, Annotation[] annotations, MediaType mediaType);
 
     /**
-     * Get an exception mapping provider for a particular class of exception.
-     * Returns the provider whose generic type is the nearest superclass of
-     * {@code type}.
+     * Get an exception mapping provider for a particular class of exception. Returns the provider whose generic type is the
+     * nearest superclass of {@code type}.
      *
-     * @param <T>  type of the exception handled by the exception mapping provider.
+     * @param <T> type of the exception handled by the exception mapping provider.
      * @param type the class of exception.
-     * @return an {@link ExceptionMapper} for the supplied type or {@code null}
-     *         if none is found.
+     * @return an {@link ExceptionMapper} for the supplied type or {@code null} if none is found.
      */
     <T extends Throwable> ExceptionMapper<T> getExceptionMapper(Class<T> type);
 
     /**
-     * Get a context resolver for a particular type of context and media type.
-     * The set of resolvers is first filtered by comparing the supplied value of
-     * {@code mediaType} with the value of each resolver's
-     * {@link javax.ws.rs.Produces}, ensuring the generic type of the context
-     * resolver is assignable to the supplied value of {@code contextType}, and
-     * eliminating those that do not match. If only one resolver matches the
-     * criteria then it is returned. If more than one resolver matches then the
-     * list of matching resolvers is ordered with those with the best
-     * matching values of {@link javax.ws.rs.Produces} (x/y &gt; x&#47;* &gt; *&#47;*)
-     * sorted first. A proxy is returned that delegates calls to
-     * {@link ContextResolver#getContext(java.lang.Class)} to each matching context
-     * resolver in order and returns the first non-null value it obtains or null
-     * if all matching context resolvers return null.
+     * Get a context resolver for a particular type of context and media type. The set of resolvers is first filtered by
+     * comparing the supplied value of {@code mediaType} with the value of each resolver's {@link javax.ws.rs.Produces},
+     * ensuring the generic type of the context resolver is assignable to the supplied value of {@code contextType}, and
+     * eliminating those that do not match. If only one resolver matches the criteria then it is returned. If more than one
+     * resolver matches then the list of matching resolvers is ordered with those with the best matching values of
+     * {@link javax.ws.rs.Produces} (x/y &gt; x&#47;* &gt; *&#47;*) sorted first. A proxy is returned that delegates calls
+     * to {@link ContextResolver#getContext(java.lang.Class)} to each matching context resolver in order and returns the
+     * first non-null value it obtains or null if all matching context resolvers return null.
      *
-     * @param <T>         type of the context.
+     * @param <T> type of the context.
      * @param contextType the class of context desired.
-     * @param mediaType   the media type of data for which a context is required.
-     * @return a matching context resolver instance or {@code null} if no matching
-     *         context providers are found.
+     * @param mediaType the media type of data for which a context is required.
+     * @return a matching context resolver instance or {@code null} if no matching context providers are found.
      */
     <T> ContextResolver<T> getContextResolver(Class<T> contextType,
-                                              MediaType mediaType);
+            MediaType mediaType);
 }

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/ReaderInterceptor.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/ReaderInterceptor.java
@@ -17,15 +17,13 @@
 package javax.ws.rs.ext;
 
 /**
- * Interface for message body reader interceptors that wrap around calls
- * to {@link javax.ws.rs.ext.MessageBodyReader#readFrom}.
+ * Interface for message body reader interceptors that wrap around calls to
+ * {@link javax.ws.rs.ext.MessageBodyReader#readFrom}.
  * <p>
- * Providers implementing {@code ReaderInterceptor} contract must be either programmatically
- * registered in a JAX-RS runtime or must be annotated with
- * {@link javax.ws.rs.ext.Provider &#64;Provider} annotation to be automatically discovered
- * by the JAX-RS runtime during a provider scanning phase.
- * Message body interceptor instances may also be discovered and
- * bound {@link javax.ws.rs.container.DynamicFeature dynamically} to particular resource methods.
+ * Providers implementing {@code ReaderInterceptor} contract must be either programmatically registered in a JAX-RS
+ * runtime or must be annotated with {@link javax.ws.rs.ext.Provider &#64;Provider} annotation to be automatically
+ * discovered by the JAX-RS runtime during a provider scanning phase. Message body interceptor instances may also be
+ * discovered and bound {@link javax.ws.rs.container.DynamicFeature dynamically} to particular resource methods.
  * </p>
  *
  * @author Santiago Pericas-Geertsen
@@ -39,17 +37,15 @@ public interface ReaderInterceptor {
     /**
      * Interceptor method wrapping calls to {@link MessageBodyReader#readFrom} method.
      *
-     * The parameters of the wrapped method called are available from {@code context}.
-     * Implementations of this method SHOULD explicitly call {@link ReaderInterceptorContext#proceed}
-     * to invoke the next interceptor in the chain, and ultimately the wrapped
-     * {@link MessageBodyReader#readFrom} method.
+     * The parameters of the wrapped method called are available from {@code context}. Implementations of this method SHOULD
+     * explicitly call {@link ReaderInterceptorContext#proceed} to invoke the next interceptor in the chain, and ultimately
+     * the wrapped {@link MessageBodyReader#readFrom} method.
      *
      * @param context invocation context.
      * @return result of next interceptor invoked or the wrapped method if last interceptor in chain.
-     * @throws java.io.IOException if an IO error arises or is thrown by the wrapped
-     *                             {@code MessageBodyReader.readFrom} method.
-     * @throws javax.ws.rs.WebApplicationException
-     *                             thrown by the wrapped {@code MessageBodyReader.readFrom} method.
+     * @throws java.io.IOException if an IO error arises or is thrown by the wrapped {@code MessageBodyReader.readFrom}
+     * method.
+     * @throws javax.ws.rs.WebApplicationException thrown by the wrapped {@code MessageBodyReader.readFrom} method.
      */
     public Object aroundReadFrom(ReaderInterceptorContext context)
             throws java.io.IOException, javax.ws.rs.WebApplicationException;

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/ReaderInterceptorContext.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/ReaderInterceptorContext.java
@@ -23,9 +23,8 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MultivaluedMap;
 
 /**
- * Context class used by {@link javax.ws.rs.ext.ReaderInterceptor}
- * to intercept calls to (@link javax.ws.rs.ext.MessageBodyReader#readFrom}.
- * The getters and setters in this context class correspond to the
+ * Context class used by {@link javax.ws.rs.ext.ReaderInterceptor} to intercept calls to (@link
+ * javax.ws.rs.ext.MessageBodyReader#readFrom}. The getters and setters in this context class correspond to the
  * parameters of the intercepted method.
  *
  * @author Santiago Pericas-Geertsen
@@ -37,32 +36,26 @@ import javax.ws.rs.core.MultivaluedMap;
 public interface ReaderInterceptorContext extends InterceptorContext {
 
     /**
-     * Proceed to the next interceptor in the chain. Return the result of the
-     * next interceptor invoked. Interceptors MUST explicitly call this method
-     * to continue the execution chain; the call to this method in the
-     * last interceptor of the chain will invoke the wrapped
-     * {@link javax.ws.rs.ext.MessageBodyReader#readFrom}.
+     * Proceed to the next interceptor in the chain. Return the result of the next interceptor invoked. Interceptors MUST
+     * explicitly call this method to continue the execution chain; the call to this method in the last interceptor of the
+     * chain will invoke the wrapped {@link javax.ws.rs.ext.MessageBodyReader#readFrom}.
      *
      * @return result of next interceptor invoked.
-     * @throws IOException if an IO error arises or is
-     *                     thrown by the wrapped {@code MessageBodyReader.readFrom} method.
-     * @throws javax.ws.rs.WebApplicationException
-     *                     thrown by the wrapped {@code MessageBodyReader.readFrom} method.
+     * @throws IOException if an IO error arises or is thrown by the wrapped {@code MessageBodyReader.readFrom} method.
+     * @throws javax.ws.rs.WebApplicationException thrown by the wrapped {@code MessageBodyReader.readFrom} method.
      */
     public Object proceed() throws IOException, WebApplicationException;
 
     /**
-     * Get the input stream of the object to be read. The JAX-RS runtime is responsible
-     * for closing the input stream.
+     * Get the input stream of the object to be read. The JAX-RS runtime is responsible for closing the input stream.
      *
      * @return input stream of the object to be read.
      */
     public InputStream getInputStream();
 
     /**
-     * Set the input stream of the object to be read. For example, by wrapping
-     * it with another input stream. The JAX-RS runtime is responsible for closing
-     * the input stream that is set.
+     * Set the input stream of the object to be read. For example, by wrapping it with another input stream. The JAX-RS
+     * runtime is responsible for closing the input stream that is set.
      *
      * @param is new input stream.
      */
@@ -71,10 +64,9 @@ public interface ReaderInterceptorContext extends InterceptorContext {
     /**
      * Get mutable map of HTTP headers.
      * <p>
-     * Note that while the headers are mutable, a {@link ReaderInterceptor reader interceptor}
-     * should typically roll-back any header modifications once the call to {@link #proceed()
-     * context.proceed()} returns, to avoid externally visible side-effects of the interceptor
-     * invocation.
+     * Note that while the headers are mutable, a {@link ReaderInterceptor reader interceptor} should typically roll-back
+     * any header modifications once the call to {@link #proceed() context.proceed()} returns, to avoid externally visible
+     * side-effects of the interceptor invocation.
      * </p>
      *
      * @return map of HTTP headers.

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/RuntimeDelegate.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/RuntimeDelegate.java
@@ -29,11 +29,9 @@ import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.Variant.VariantListBuilder;
 
 /**
- * Implementations of JAX-RS provide a concrete subclass of RuntimeDelegate and
- * various JAX-RS API methods defer to methods of RuntimeDelegate for their
- * functionality. Regular users of JAX-RS are not expected to use this class
- * directly and overriding an implementation of this class with a user supplied
- * subclass may cause unexpected behavior.
+ * Implementations of JAX-RS provide a concrete subclass of RuntimeDelegate and various JAX-RS API methods defer to
+ * methods of RuntimeDelegate for their functionality. Regular users of JAX-RS are not expected to use this class
+ * directly and overriding an implementation of this class with a user supplied subclass may cause unexpected behavior.
  *
  * @author Paul Sandoz
  * @author Marc Hadley
@@ -42,8 +40,8 @@ import javax.ws.rs.core.Variant.VariantListBuilder;
 public abstract class RuntimeDelegate {
 
     /**
-     * Name of the property identifying the {@link RuntimeDelegate} implementation
-     * to be returned from {@link RuntimeDelegate#getInstance()}.
+     * Name of the property identifying the {@link RuntimeDelegate} implementation to be returned from
+     * {@link RuntimeDelegate#getInstance()}.
      */
     public static final String JAXRS_RUNTIME_DELEGATE_PROPERTY = "javax.ws.rs.ext.RuntimeDelegate";
     private static final Object RD_LOCK = new Object();
@@ -57,33 +55,23 @@ public abstract class RuntimeDelegate {
     }
 
     /**
-     * Obtain a {@code RuntimeDelegate} instance. If an instance had not already been
-     * created and set via {@link #setInstance(RuntimeDelegate)}, the first
-     * invocation will create an instance which will then be cached for future use.
+     * Obtain a {@code RuntimeDelegate} instance. If an instance had not already been created and set via
+     * {@link #setInstance(RuntimeDelegate)}, the first invocation will create an instance which will then be cached for
+     * future use.
      *
      * <p>
-     * The algorithm used to locate the RuntimeDelegate subclass to use consists
-     * of the following steps:
+     * The algorithm used to locate the RuntimeDelegate subclass to use consists of the following steps:
      * </p>
      * <ul>
-     * <li>
-     * If a resource with the name of {@code META-INF/services/javax.ws.rs.ext.RuntimeDelegate}
-     * exists, then its first line, if present, is used as the UTF-8 encoded
-     * name of the implementation class.
-     * </li>
-     * <li>
-     * If the $java.home/lib/jaxrs.properties file exists and it is readable by
-     * the {@code java.util.Properties.load(InputStream)} method and it contains
-     * an entry whose key is {@code javax.ws.rs.ext.RuntimeDelegate}, then the value of
-     * that entry is used as the name of the implementation class.
-     * </li>
-     * <li>
-     * If a system property with the name {@code javax.ws.rs.ext.RuntimeDelegate}
-     * is defined, then its value is used as the name of the implementation class.
-     * </li>
-     * <li>
-     * Finally, a default implementation class name is used.
-     * </li>
+     * <li>If a resource with the name of {@code META-INF/services/javax.ws.rs.ext.RuntimeDelegate} exists, then its first
+     * line, if present, is used as the UTF-8 encoded name of the implementation class.</li>
+     * <li>If the $java.home/lib/jaxrs.properties file exists and it is readable by the
+     * {@code java.util.Properties.load(InputStream)} method and it contains an entry whose key is
+     * {@code javax.ws.rs.ext.RuntimeDelegate}, then the value of that entry is used as the name of the implementation
+     * class.</li>
+     * <li>If a system property with the name {@code javax.ws.rs.ext.RuntimeDelegate} is defined, then its value is used as
+     * the name of the implementation class.</li>
+     * <li>Finally, a default implementation class name is used.</li>
      * </ul>
      *
      * @return an instance of {@code RuntimeDelegate}.
@@ -104,8 +92,7 @@ public abstract class RuntimeDelegate {
     }
 
     /**
-     * Obtain a {@code RuntimeDelegate} instance using the method described in
-     * {@link #getInstance}.
+     * Obtain a {@code RuntimeDelegate} instance using the method described in {@link #getInstance}.
      *
      * @return an instance of {@code RuntimeDelegate}.
      */
@@ -134,13 +121,12 @@ public abstract class RuntimeDelegate {
     }
 
     /**
-     * Set the runtime delegate that will be used by JAX-RS classes. If this method
-     * is not called prior to {@link #getInstance} then an implementation will
-     * be sought as described in {@link #getInstance}.
+     * Set the runtime delegate that will be used by JAX-RS classes. If this method is not called prior to
+     * {@link #getInstance} then an implementation will be sought as described in {@link #getInstance}.
      *
      * @param rd the runtime delegate instance
-     * @throws SecurityException if there is a security manager and the permission
-     *                           ReflectPermission("suppressAccessChecks") has not been granted.
+     * @throws SecurityException if there is a security manager and the permission ReflectPermission("suppressAccessChecks")
+     * has not been granted.
      */
     public static void setInstance(final RuntimeDelegate rd) {
         SecurityManager security = System.getSecurityManager();
@@ -177,44 +163,36 @@ public abstract class RuntimeDelegate {
     public abstract VariantListBuilder createVariantListBuilder();
 
     /**
-     * Create a configured instance of the supplied endpoint type. How the
-     * returned endpoint instance is published is dependent on the type of
-     * endpoint.
+     * Create a configured instance of the supplied endpoint type. How the returned endpoint instance is published is
+     * dependent on the type of endpoint.
      *
-     * @param <T>          endpoint type.
-     * @param application  the application configuration.
+     * @param <T> endpoint type.
+     * @param application the application configuration.
      * @param endpointType the type of endpoint instance to be created.
      * @return a configured instance of the requested type.
-     * @throws java.lang.IllegalArgumentException
-     *          if application is null or the requested endpoint type is
-     *          not supported.
-     * @throws java.lang.UnsupportedOperationException
-     *          if the implementation supports no endpoint types.
+     * @throws java.lang.IllegalArgumentException if application is null or the requested endpoint type is not supported.
+     * @throws java.lang.UnsupportedOperationException if the implementation supports no endpoint types.
      */
     public abstract <T> T createEndpoint(Application application, Class<T> endpointType)
             throws IllegalArgumentException, UnsupportedOperationException;
 
     /**
-     * Obtain an instance of a {@link HeaderDelegate} for the supplied class. An
-     * implementation is required to support the following values for type:
-     * {@link javax.ws.rs.core.CacheControl}, {@link javax.ws.rs.core.Cookie},
-     * {@link javax.ws.rs.core.EntityTag}, {@link javax.ws.rs.core.Link},
-     * {@link javax.ws.rs.core.NewCookie}, {@link javax.ws.rs.core.MediaType}
-     * and {@code java.util.Date}.
+     * Obtain an instance of a {@link HeaderDelegate} for the supplied class. An implementation is required to support the
+     * following values for type: {@link javax.ws.rs.core.CacheControl}, {@link javax.ws.rs.core.Cookie},
+     * {@link javax.ws.rs.core.EntityTag}, {@link javax.ws.rs.core.Link}, {@link javax.ws.rs.core.NewCookie},
+     * {@link javax.ws.rs.core.MediaType} and {@code java.util.Date}.
      *
-     * @param <T>  header type.
+     * @param <T> header type.
      * @param type the class of the header.
      * @return an instance of {@code HeaderDelegate} for the supplied type.
-     * @throws java.lang.IllegalArgumentException
-     *          if type is {@code null}.
+     * @throws java.lang.IllegalArgumentException if type is {@code null}.
      * @see javax.ws.rs.ext.RuntimeDelegate.HeaderDelegate
      */
     public abstract <T> HeaderDelegate<T> createHeaderDelegate(Class<T> type)
             throws IllegalArgumentException;
 
     /**
-     * Defines the contract for a delegate that is responsible for
-     * converting between the String form of a HTTP header and
+     * Defines the contract for a delegate that is responsible for converting between the String form of a HTTP header and
      * the corresponding JAX-RS type {@code T}.
      *
      * @param <T> a JAX-RS type that corresponds to the value of a HTTP header.
@@ -226,8 +204,7 @@ public abstract class RuntimeDelegate {
          *
          * @param value the string value.
          * @return the newly created instance of {@code T}.
-         * @throws IllegalArgumentException if the supplied string cannot be
-         *                                  parsed or is {@code null}.
+         * @throws IllegalArgumentException if the supplied string cannot be parsed or is {@code null}.
          */
         public T fromString(String value);
 
@@ -236,8 +213,7 @@ public abstract class RuntimeDelegate {
          *
          * @param value the value of type {@code T}.
          * @return a String representation of the value.
-         * @throws IllegalArgumentException if the supplied object cannot be
-         *                                  serialized or is {@code null}.
+         * @throws IllegalArgumentException if the supplied object cannot be serialized or is {@code null}.
          */
         public String toString(T value);
     }
@@ -253,8 +229,8 @@ public abstract class RuntimeDelegate {
     /**
      * Create a new instance of a {@link javax.ws.rs.JAXRS.Configuration.Builder}.
      * <p>
-     * <em>This method is not intended to be invoked by applications. Call
-     * {@link JAXRS.Configuration#builder()} instead.</em>
+     * <em>This method is not intended to be invoked by applications. Call {@link JAXRS.Configuration#builder()}
+     * instead.</em>
      * </p>
      *
      * @return new {@code JAXRS.Configuration.Builder} instance.
@@ -265,16 +241,14 @@ public abstract class RuntimeDelegate {
     /**
      * Perform startup of the application in Java SE environments.
      * <p>
-     * <em>This method is not intended to be invoked by applications. Call
-     * {@link JAXRS#start(Application, Configuration)} instead.</em>
+     * <em>This method is not intended to be invoked by applications. Call {@link JAXRS#start(Application, Configuration)}
+     * instead.</em>
      * </p>
      *
-     * @param application
-     *            The application to start up.
-     * @param configuration
-     *            The bootstrap configuration.
-     * @return {@code CompletionStage} asynchronously producing handle of the
-     *         running application {@link JAXRS.Instance instance}.
+     * @param application The application to start up.
+     * @param configuration The bootstrap configuration.
+     * @return {@code CompletionStage} asynchronously producing handle of the running application {@link JAXRS.Instance
+     * instance}.
      */
     public abstract CompletionStage<Instance> bootstrap(Application application, JAXRS.Configuration configuration);
 }

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/WriterInterceptor.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/WriterInterceptor.java
@@ -17,16 +17,14 @@
 package javax.ws.rs.ext;
 
 /**
- * Interface for message body writer interceptors that wrap around calls
- * to {@link javax.ws.rs.ext.MessageBodyWriter#writeTo}.
+ * Interface for message body writer interceptors that wrap around calls to
+ * {@link javax.ws.rs.ext.MessageBodyWriter#writeTo}.
  *
  * <p>
- * Providers implementing {@code WriterInterceptor} contract must be either programmatically
- * registered in a JAX-RS runtime or must be annotated with
- * {@link javax.ws.rs.ext.Provider &#64;Provider} annotation to be automatically discovered
- * by the JAX-RS runtime during a provider scanning phase.
- * Message body interceptor instances may also be discovered and
- * bound {@link javax.ws.rs.container.DynamicFeature dynamically} to particular resource methods.
+ * Providers implementing {@code WriterInterceptor} contract must be either programmatically registered in a JAX-RS
+ * runtime or must be annotated with {@link javax.ws.rs.ext.Provider &#64;Provider} annotation to be automatically
+ * discovered by the JAX-RS runtime during a provider scanning phase. Message body interceptor instances may also be
+ * discovered and bound {@link javax.ws.rs.container.DynamicFeature dynamically} to particular resource methods.
  * </p>
  *
  * @author Santiago Pericas-Geertsen
@@ -38,17 +36,15 @@ package javax.ws.rs.ext;
 public interface WriterInterceptor {
 
     /**
-     * Interceptor method wrapping calls to {@link MessageBodyWriter#writeTo} method.
-     * The parameters of the wrapped method called are available from {@code context}.
-     * Implementations of this method SHOULD explicitly call
-     * {@link WriterInterceptorContext#proceed} to invoke the next interceptor in the chain,
-     * and ultimately the wrapped {@code MessageBodyWriter.writeTo} method.
+     * Interceptor method wrapping calls to {@link MessageBodyWriter#writeTo} method. The parameters of the wrapped method
+     * called are available from {@code context}. Implementations of this method SHOULD explicitly call
+     * {@link WriterInterceptorContext#proceed} to invoke the next interceptor in the chain, and ultimately the wrapped
+     * {@code MessageBodyWriter.writeTo} method.
      *
      * @param context invocation context.
-     * @throws java.io.IOException if an IO error arises or is thrown by the wrapped
-     *                             {@code MessageBodyWriter.writeTo} method.
-     * @throws javax.ws.rs.WebApplicationException
-     *                             thrown by the wrapped {@code MessageBodyWriter.writeTo} method.
+     * @throws java.io.IOException if an IO error arises or is thrown by the wrapped {@code MessageBodyWriter.writeTo}
+     * method.
+     * @throws javax.ws.rs.WebApplicationException thrown by the wrapped {@code MessageBodyWriter.writeTo} method.
      */
     void aroundWriteTo(WriterInterceptorContext context)
             throws java.io.IOException, javax.ws.rs.WebApplicationException;

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/WriterInterceptorContext.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/WriterInterceptorContext.java
@@ -23,9 +23,8 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MultivaluedMap;
 
 /**
- * Context class used by {@link javax.ws.rs.ext.WriterInterceptor}
- * to intercept calls to {@link javax.ws.rs.ext.MessageBodyWriter#writeTo}.
- * The getters and setters in this context class correspond to the
+ * Context class used by {@link javax.ws.rs.ext.WriterInterceptor} to intercept calls to
+ * {@link javax.ws.rs.ext.MessageBodyWriter#writeTo}. The getters and setters in this context class correspond to the
  * parameters of the intercepted method.
  *
  * @author Santiago Pericas-Geertsen
@@ -39,14 +38,12 @@ public interface WriterInterceptorContext extends InterceptorContext {
     /**
      * Proceed to the next interceptor in the chain.
      *
-     * Interceptors MUST explicitly call this method to continue the execution chain;
-     * the call to this method in the last interceptor of the chain will invoke
-     * the wrapped {@link javax.ws.rs.ext.MessageBodyWriter#writeTo} method.
+     * Interceptors MUST explicitly call this method to continue the execution chain; the call to this method in the last
+     * interceptor of the chain will invoke the wrapped {@link javax.ws.rs.ext.MessageBodyWriter#writeTo} method.
      *
-     * @throws java.io.IOException if an IO error arises or is thrown by the wrapped
-     *                             {@code MessageBodyWriter.writeTo} method.
-     * @throws javax.ws.rs.WebApplicationException
-     *                             thrown by the wrapped {@code MessageBodyWriter.writeTo} method.
+     * @throws java.io.IOException if an IO error arises or is thrown by the wrapped {@code MessageBodyWriter.writeTo}
+     * method.
+     * @throws javax.ws.rs.WebApplicationException thrown by the wrapped {@code MessageBodyWriter.writeTo} method.
      */
     void proceed() throws IOException, WebApplicationException;
 
@@ -65,17 +62,15 @@ public interface WriterInterceptorContext extends InterceptorContext {
     void setEntity(Object entity);
 
     /**
-     * Get the output stream for the object to be written. The JAX-RS runtime
-     * is responsible for closing the output stream.
+     * Get the output stream for the object to be written. The JAX-RS runtime is responsible for closing the output stream.
      *
      * @return output stream for the object to be written.
      */
     OutputStream getOutputStream();
 
     /**
-     * Set a new output stream for the object to be written. For example, by wrapping
-     * it with another output stream. The JAX-RS runtime is responsible for closing
-     * the output stream that is set.
+     * Set a new output stream for the object to be written. For example, by wrapping it with another output stream. The
+     * JAX-RS runtime is responsible for closing the output stream that is set.
      *
      * @param os new output stream for the object to be written.
      */

--- a/jaxrs-api/src/main/java/javax/ws/rs/package-info.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/package-info.java
@@ -15,8 +15,8 @@
  */
 
 /**
- * High-level interfaces and annotations used to create RESTful service
- * resources. For example:
+ * High-level interfaces and annotations used to create RESTful service resources. For example:
+ *
  * <pre>
  * &#064;Path("widgets/{widgetid}")
  * &#064;Consumes("application/widgets+xml")

--- a/jaxrs-api/src/main/java/javax/ws/rs/sse/FactoryFinder.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/sse/FactoryFinder.java
@@ -60,14 +60,12 @@ final class FactoryFinder {
     }
 
     /**
-     * Creates an instance of the specified class using the specified
-     * {@code ClassLoader} object.
+     * Creates an instance of the specified class using the specified {@code ClassLoader} object.
      *
-     * @param className   name of the class to be instantiated.
+     * @param className name of the class to be instantiated.
      * @param classLoader class loader to be used.
      * @return instance of the specified class.
-     * @throws ClassNotFoundException if the given class could not be found
-     *                                or could not be instantiated.
+     * @throws ClassNotFoundException if the given class could not be found or could not be instantiated.
      */
     private static Object newInstance(final String className, final ClassLoader classLoader) throws ClassNotFoundException {
         try {
@@ -96,25 +94,19 @@ final class FactoryFinder {
     }
 
     /**
-     * Finds the implementation {@code Class} for the given factory name,
-     * or if that fails, finds the {@code Class} for the given fallback
-     * class name and create its instance. The arguments supplied MUST be
-     * used in order. If using the first argument is successful, the second
-     * one will not be used.
+     * Finds the implementation {@code Class} for the given factory name, or if that fails, finds the {@code Class} for the
+     * given fallback class name and create its instance. The arguments supplied MUST be used in order. If using the first
+     * argument is successful, the second one will not be used.
      * <p>
      * This method is package private so that this code can be shared.
      *
-     * @param factoryId         the name of the factory to find, which is
-     *                          a system property.
-     * @param fallbackClassName the implementation class name, which is
-     *                          to be used only if nothing else.
-     *                          is found; {@code null} to indicate that
-     *                          there is no fallback class name.
-     * @param service           service to be found.
-     * @param <T>               type of the service to be found.
+     * @param factoryId the name of the factory to find, which is a system property.
+     * @param fallbackClassName the implementation class name, which is to be used only if nothing else. is found;
+     * {@code null} to indicate that there is no fallback class name.
+     * @param service service to be found.
+     * @param <T> type of the service to be found.
      * @return the instance of the specified service; may not be {@code null}.
-     * @throws ClassNotFoundException if the given class could not be found
-     *                                or could not be instantiated.
+     * @throws ClassNotFoundException if the given class could not be found or could not be instantiated.
      */
     static <T> Object find(final String factoryId, final String fallbackClassName, final Class<T> service) throws ClassNotFoundException {
         ClassLoader classLoader = getContextClassLoader();
@@ -122,7 +114,7 @@ final class FactoryFinder {
         try {
             Iterator<T> iterator = ServiceLoader.load(service, FactoryFinder.getContextClassLoader()).iterator();
 
-            if(iterator.hasNext()) {
+            if (iterator.hasNext()) {
                 return iterator.next();
             }
         } catch (Exception | ServiceConfigurationError ex) {
@@ -132,7 +124,7 @@ final class FactoryFinder {
         try {
             Iterator<T> iterator = ServiceLoader.load(service, FactoryFinder.class.getClassLoader()).iterator();
 
-            if(iterator.hasNext()) {
+            if (iterator.hasNext()) {
                 return iterator.next();
             }
         } catch (Exception | ServiceConfigurationError ex) {

--- a/jaxrs-api/src/main/java/javax/ws/rs/sse/InboundSseEvent.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/sse/InboundSseEvent.java
@@ -40,7 +40,8 @@ public interface InboundSseEvent extends SseEvent {
      * Get the original event data as {@link String}.
      *
      * @return event data de-serialized into a string.
-     * @throws javax.ws.rs.ProcessingException when provided type can't be read. The thrown exception wraps the original cause.
+     * @throws javax.ws.rs.ProcessingException when provided type can't be read. The thrown exception wraps the original
+     * cause.
      */
     String readData();
 
@@ -50,7 +51,8 @@ public interface InboundSseEvent extends SseEvent {
      * @param <T> generic event data type
      * @param type Java type to be used for event data de-serialization.
      * @return event data de-serialized as an instance of a given type.
-     * @throws javax.ws.rs.ProcessingException when provided type can't be read. The thrown exception wraps the original cause.
+     * @throws javax.ws.rs.ProcessingException when provided type can't be read. The thrown exception wraps the original
+     * cause.
      */
     <T> T readData(Class<T> type);
 
@@ -60,7 +62,8 @@ public interface InboundSseEvent extends SseEvent {
      * @param <T> generic event data type
      * @param type generic type to be used for event data de-serialization.
      * @return event data de-serialized as an instance of a given type.
-     * @throws javax.ws.rs.ProcessingException when provided type can't be read. The thrown exception wraps the original cause.
+     * @throws javax.ws.rs.ProcessingException when provided type can't be read. The thrown exception wraps the original
+     * cause.
      */
     <T> T readData(GenericType<T> type);
 
@@ -69,9 +72,10 @@ public interface InboundSseEvent extends SseEvent {
      *
      * @param <T> generic event data type
      * @param messageType Java type to be used for event data de-serialization.
-     * @param mediaType   {@link MediaType media type} to be used for event data de-serialization.
+     * @param mediaType {@link MediaType media type} to be used for event data de-serialization.
      * @return event data de-serialized as an instance of a given type.
-     * @throws javax.ws.rs.ProcessingException when provided type can't be read. The thrown exception wraps the original cause.
+     * @throws javax.ws.rs.ProcessingException when provided type can't be read. The thrown exception wraps the original
+     * cause.
      */
     <T> T readData(Class<T> messageType, MediaType mediaType);
 
@@ -79,10 +83,11 @@ public interface InboundSseEvent extends SseEvent {
      * Read event data as a given generic type.
      *
      * @param <T> generic event data type
-     * @param type      generic type to be used for event data de-serialization.
+     * @param type generic type to be used for event data de-serialization.
      * @param mediaType {@link MediaType media type} to be used for event data de-serialization.
      * @return event data de-serialized as an instance of a given type.
-     * @throws javax.ws.rs.ProcessingException when provided type can't be read. The thrown exception wraps the original cause.
+     * @throws javax.ws.rs.ProcessingException when provided type can't be read. The thrown exception wraps the original
+     * cause.
      */
     <T> T readData(GenericType<T> type, MediaType mediaType);
 

--- a/jaxrs-api/src/main/java/javax/ws/rs/sse/OutboundSseEvent.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/sse/OutboundSseEvent.java
@@ -57,14 +57,13 @@ public interface OutboundSseEvent extends SseEvent {
         public Builder name(String name);
 
         /**
-         * Set reconnection delay (in milliseconds) that indicates how long the event receiver should wait
-         * before attempting to reconnect in case a connection to SSE event source is lost.
+         * Set reconnection delay (in milliseconds) that indicates how long the event receiver should wait before attempting to
+         * reconnect in case a connection to SSE event source is lost.
          * <p>
          * Will be send as a value of the SSE {@code "retry"} field. This field is optional.
          * <p>
-         * Absence of a value of this field in an {@link OutboundSseEvent} instance
-         * is indicated by {@link SseEvent#RECONNECT_NOT_SET} value returned from
-         * {@link #getReconnectDelay()}.
+         * Absence of a value of this field in an {@link OutboundSseEvent} instance is indicated by
+         * {@link SseEvent#RECONNECT_NOT_SET} value returned from {@link #getReconnectDelay()}.
          *
          * @param milliseconds reconnection delay in milliseconds. Negative values un-set the reconnection delay.
          * @return updated builder instance.
@@ -85,12 +84,12 @@ public interface OutboundSseEvent extends SseEvent {
         /**
          * Set comment string associated with the event.
          * <p>
-         * The comment will be serialized with the event, before event data are serialized. If the event
-         * does not contain any data, a separate "event" that contains only the comment will be sent.
-         * This information is optional, provided the event data are set.
+         * The comment will be serialized with the event, before event data are serialized. If the event does not contain any
+         * data, a separate "event" that contains only the comment will be sent. This information is optional, provided the
+         * event data are set.
          * <p>
-         * Note that multiple invocations of this method result in a previous comment being replaced with a new one.
-         * To achieve multi-line comments, a multi-line comment string has to be used.
+         * Note that multiple invocations of this method result in a previous comment being replaced with a new one. To achieve
+         * multi-line comments, a multi-line comment string has to be used.
          *
          * @param comment comment string.
          * @return updated builder instance.
@@ -128,8 +127,8 @@ public interface OutboundSseEvent extends SseEvent {
         /**
          * Set event data and java type of event data.
          * <p>
-         * This is a convenience method that derives the event data type information from the runtime type of
-         * the event data. The supplied event data may be represented as {@link javax.ws.rs.core.GenericEntity}.
+         * This is a convenience method that derives the event data type information from the runtime type of the event data.
+         * The supplied event data may be represented as {@link javax.ws.rs.core.GenericEntity}.
          * <p>
          * Note that multiple invocations of this method result in previous even data being replaced with new one.
          *
@@ -144,11 +143,11 @@ public interface OutboundSseEvent extends SseEvent {
          * <p>
          * There are two valid configurations:
          * <ul>
-         * <li>if a {@link Builder#comment(String) comment} is set, all other parameters are optional.
-         * If event {@link Builder#data(Class, Object) data} and {@link Builder#mediaType(MediaType) media type} is set,
-         * event data will be serialized after the comment.</li>
-         * <li>if a {@link Builder#comment(String) comment} is not set, at least the event
-         * {@link Builder#data(Class, Object) data} must be set. All other parameters are optional.</li>
+         * <li>if a {@link Builder#comment(String) comment} is set, all other parameters are optional. If event
+         * {@link Builder#data(Class, Object) data} and {@link Builder#mediaType(MediaType) media type} is set, event data will
+         * be serialized after the comment.</li>
+         * <li>if a {@link Builder#comment(String) comment} is not set, at least the event {@link Builder#data(Class, Object)
+         * data} must be set. All other parameters are optional.</li>
          * </ul>
          *
          * @return new {@link OutboundSseEvent} instance.
@@ -160,8 +159,8 @@ public interface OutboundSseEvent extends SseEvent {
     /**
      * Get data type.
      * <p>
-     * This information is used to select a proper {@link javax.ws.rs.ext.MessageBodyWriter} to be used for
-     * serializing the {@link #getData() event data}.
+     * This information is used to select a proper {@link javax.ws.rs.ext.MessageBodyWriter} to be used for serializing the
+     * {@link #getData() event data}.
      *
      * @return data type. May return {@code null}, if the event does not contain any data.
      */
@@ -170,8 +169,8 @@ public interface OutboundSseEvent extends SseEvent {
     /**
      * Get generic data type.
      * <p>
-     * This information is used to select a proper {@link javax.ws.rs.ext.MessageBodyWriter} to be used for
-     * serializing the {@link #getData() event data}.
+     * This information is used to select a proper {@link javax.ws.rs.ext.MessageBodyWriter} to be used for serializing the
+     * {@link #getData() event data}.
      *
      * @return generic data type. May return {@code null}, if the event does not contain any data.
      */
@@ -180,8 +179,8 @@ public interface OutboundSseEvent extends SseEvent {
     /**
      * Get {@link MediaType media type} of the event data.
      * <p>
-     * This information is used to a select proper {@link javax.ws.rs.ext.MessageBodyWriter} to be used for
-     * serializing the {@link #getData() event data}.
+     * This information is used to a select proper {@link javax.ws.rs.ext.MessageBodyWriter} to be used for serializing the
+     * {@link #getData() event data}.
      *
      * @return data {@link MediaType}.
      */
@@ -190,10 +189,10 @@ public interface OutboundSseEvent extends SseEvent {
     /**
      * Get event data.
      * <p>
-     * The event data, if specified, are serialized and sent as one or more SSE event {@code "data"} fields
-     * (depending on the line breaks in the actual serialized data content). The data are serialized
-     * using an available {@link javax.ws.rs.ext.MessageBodyWriter} that is selected based on the event
-     * {@link #getType() type}, {@link #getGenericType()} generic type} and {@link #getMediaType()} media type}.
+     * The event data, if specified, are serialized and sent as one or more SSE event {@code "data"} fields (depending on
+     * the line breaks in the actual serialized data content). The data are serialized using an available
+     * {@link javax.ws.rs.ext.MessageBodyWriter} that is selected based on the event {@link #getType() type},
+     * {@link #getGenericType()} generic type} and {@link #getMediaType()} media type}.
      *
      * @return event data. May return {@code null}, if the event does not contain any data.
      */

--- a/jaxrs-api/src/main/java/javax/ws/rs/sse/Sse.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/sse/Sse.java
@@ -19,9 +19,9 @@ package javax.ws.rs.sse;
 /**
  * Server-side entry point for creating {@link OutboundSseEvent} and {@link SseBroadcaster}.
  * <p>
- * Instance of this interface can be injected into a field or as a parameter of a method or
- * a constructor. Also, the instance is thread safe, meaning that it can be shared and its
- * method invoked from different threads without causing inconsistent internal state.
+ * Instance of this interface can be injected into a field or as a parameter of a method or a constructor. Also, the
+ * instance is thread safe, meaning that it can be shared and its method invoked from different threads without causing
+ * inconsistent internal state.
  *
  * @author Marek Potociar (marek.potociar at oracle.com)
  * @since 2.1

--- a/jaxrs-api/src/main/java/javax/ws/rs/sse/SseBroadcaster.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/sse/SseBroadcaster.java
@@ -23,12 +23,12 @@ import java.util.function.Consumer;
 /**
  * Server-Sent events broadcasting facility.
  * <p>
- * Server broadcaster can be used to manage multiple {@link SseEventSink server sinks}. It enables
- * sending events to all registered event outputs and provides facility to effectively handle
- * exceptions and closures of individual registered event outputs.
+ * Server broadcaster can be used to manage multiple {@link SseEventSink server sinks}. It enables sending events to all
+ * registered event outputs and provides facility to effectively handle exceptions and closures of individual registered
+ * event outputs.
  * <p>
- * Instance of this interface is thread safe, meaning that it can be shared and its method invoked
- * from different threads without causing inconsistent internal state.
+ * Instance of this interface is thread safe, meaning that it can be shared and its method invoked from different
+ * threads without causing inconsistent internal state.
  *
  * @author Marek Potociar
  * @since 2.1
@@ -36,25 +36,25 @@ import java.util.function.Consumer;
 public interface SseBroadcaster extends AutoCloseable {
 
     /**
-     * Register a listener, which will be called when an exception was thrown by a given SSE event output when trying
-     * to write to it or close it.
+     * Register a listener, which will be called when an exception was thrown by a given SSE event output when trying to
+     * write to it or close it.
      * <p>
-     * This operation is potentially slow, especially if large number of listeners get registered in the broadcaster.
-     * The {@code SseBroadcaster} implementation is optimized to efficiently handle small amounts of
-     * concurrent listener registrations and removals and large amounts of registered listener notifications.
+     * This operation is potentially slow, especially if large number of listeners get registered in the broadcaster. The
+     * {@code SseBroadcaster} implementation is optimized to efficiently handle small amounts of concurrent listener
+     * registrations and removals and large amounts of registered listener notifications.
      *
-     * @param onError bi-consumer, taking two parameters: {@link SseEventSink}, which is the source of the
-     *                error and the actual {@link Throwable} instance.
+     * @param onError bi-consumer, taking two parameters: {@link SseEventSink}, which is the source of the error and the
+     * actual {@link Throwable} instance.
      */
     void onError(BiConsumer<SseEventSink, Throwable> onError);
 
     /**
-     * Register a listener, which will be called when the SSE event output has been closed (either by client closing
-     * the connection or by calling {@link SseEventSink#close()} on the server side.
+     * Register a listener, which will be called when the SSE event output has been closed (either by client closing the
+     * connection or by calling {@link SseEventSink#close()} on the server side.
      * <p>
-     * This operation is potentially slow, especially if large number of listeners get registered in the broadcaster.
-     * The {@code SseBroadcaster} implementation is optimized to efficiently handle small amounts of
-     * concurrent listener registrations and removals and large amounts of registered listener notifications.
+     * This operation is potentially slow, especially if large number of listeners get registered in the broadcaster. The
+     * {@code SseBroadcaster} implementation is optimized to efficiently handle small amounts of concurrent listener
+     * registrations and removals and large amounts of registered listener notifications.
      *
      * @param onClose consumer taking single parameter, a {@link SseEventSink}, which was closed.
      */
@@ -76,27 +76,23 @@ public interface SseBroadcaster extends AutoCloseable {
     CompletionStage<?> broadcast(final OutboundSseEvent event);
 
     /**
-     * Close the broadcaster and all registered {@link SseEventSink} instances. Any other resources
-     * associated with the {@link SseBroadcaster} should be released. This method is equivalent to
-     * calling {@code close(true)}.
+     * Close the broadcaster and all registered {@link SseEventSink} instances. Any other resources associated with the
+     * {@link SseBroadcaster} should be released. This method is equivalent to calling {@code close(true)}.
      * <p>
-     * Subsequent calls have no effect and are ignored. Once the {@link SseBroadcaster} is closed,
-     * invoking any other method on the broadcaster instance would result in an
-     * {@link IllegalStateException} being thrown.
+     * Subsequent calls have no effect and are ignored. Once the {@link SseBroadcaster} is closed, invoking any other method
+     * on the broadcaster instance would result in an {@link IllegalStateException} being thrown.
      */
     @Override
     void close();
 
     /**
-     * Close the broadcaster and release any resources associated with it. The closing of
-     * registered {@link SseEventSink} is controlled by the {@code cascading} parameter.
+     * Close the broadcaster and release any resources associated with it. The closing of registered {@link SseEventSink} is
+     * controlled by the {@code cascading} parameter.
      * <p>
-     * Subsequent calls have no effect and are ignored. Once the {@link SseBroadcaster} is closed,
-     * invoking any other method on the broadcaster instance would result in an
-     * {@link IllegalStateException} being thrown.
+     * Subsequent calls have no effect and are ignored. Once the {@link SseBroadcaster} is closed, invoking any other method
+     * on the broadcaster instance would result in an {@link IllegalStateException} being thrown.
      *
-     * @param cascading Boolean value that controls closing of registered {@link SseEventSink}
-     *                  instances.
+     * @param cascading Boolean value that controls closing of registered {@link SseEventSink} instances.
      */
     void close(boolean cascading);
 }

--- a/jaxrs-api/src/main/java/javax/ws/rs/sse/SseEvent.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/sse/SseEvent.java
@@ -19,12 +19,11 @@ package javax.ws.rs.sse;
 /**
  * Base Server Sent Event definition.
  * <p>
- * This interface provides basic properties of the Server Sent Event, namely ID, Name, and Comment.
- * It also provides access to the Reconnect delay property.
+ * This interface provides basic properties of the Server Sent Event, namely ID, Name, and Comment. It also provides
+ * access to the Reconnect delay property.
  * <p>
- * {@code SseEvent} is extended by another two interfaces, {@link InboundSseEvent} and
- * {@link OutboundSseEvent}. The main difference is in how are instances created and how the stored
- * data can be accessed (or provided).
+ * {@code SseEvent} is extended by another two interfaces, {@link InboundSseEvent} and {@link OutboundSseEvent}. The
+ * main difference is in how are instances created and how the stored data can be accessed (or provided).
  *
  * @author Marek Potociar
  * @since 2.1
@@ -59,19 +58,19 @@ public interface SseEvent {
     /**
      * Get a comment string that accompanies the event.
      * <p>
-     * Contains value of the comment associated with SSE event. This field is optional. Method may return {@code null},
-     * if the event comment is not specified.
+     * Contains value of the comment associated with SSE event. This field is optional. Method may return {@code null}, if
+     * the event comment is not specified.
      *
      * @return comment associated with the event.
      */
     String getComment();
 
     /**
-     * Get new connection retry time in milliseconds the event receiver should wait before attempting to
-     * reconnect after a connection to the SSE event source is lost.
+     * Get new connection retry time in milliseconds the event receiver should wait before attempting to reconnect after a
+     * connection to the SSE event source is lost.
      * <p>
-     * Contains value of SSE {@code "retry"} field. This field is optional. Method returns {@link #RECONNECT_NOT_SET}
-     * if no value has been set.
+     * Contains value of SSE {@code "retry"} field. This field is optional. Method returns {@link #RECONNECT_NOT_SET} if no
+     * value has been set.
      *
      * @return reconnection delay in milliseconds or {@link #RECONNECT_NOT_SET} if no value has been set.
      */

--- a/jaxrs-api/src/main/java/javax/ws/rs/sse/SseEventSink.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/sse/SseEventSink.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CompletionStage;
  * Outbound Server-Sent Events stream.
  * <p>
  * The instance of {@link SseEventSink} can be only acquired by injection of a resource method parameter:
+ *
  * <pre>
  * &#64;GET
  * &#64;Path("eventStream")
@@ -30,12 +31,12 @@ import java.util.concurrent.CompletionStage;
  *     // ...
  * }
  * </pre>
- * The injected instance is then considered as a return type, so the resource method doesn't return anything,
- * similarly as in server-side async processing.
+ *
+ * The injected instance is then considered as a return type, so the resource method doesn't return anything, similarly
+ * as in server-side async processing.
  * <p>
- * The underlying client connection is kept open and the application code
- * is able to send events. A server-side instance implementing the interface
- * corresponds exactly to a single client HTTP connection.
+ * The underlying client connection is kept open and the application code is able to send events. A server-side instance
+ * implementing the interface corresponds exactly to a single client HTTP connection.
  * <p>
  * The injected instance is thread safe.
  *
@@ -47,8 +48,8 @@ public interface SseEventSink extends AutoCloseable {
     /**
      * Check if the stream has been closed already.
      * <p>
-     * Please note that the client connection represented by this {@code SseServerSink} can be closed by the
-     * client side when a client decides to close connection and disconnect from the server.
+     * Please note that the client connection represented by this {@code SseServerSink} can be closed by the client side
+     * when a client decides to close connection and disconnect from the server.
      *
      * @return {@code true} when closed, {@code false} otherwise.
      */
@@ -60,17 +61,16 @@ public interface SseEventSink extends AutoCloseable {
      * Event will be serialized and sent to the client.
      *
      * @param event event to be written.
-     * @return completion stage that completes when the event has been sent. If there is a problem during sending of
-     * an event, completion stage will be completed exceptionally.
+     * @return completion stage that completes when the event has been sent. If there is a problem during sending of an
+     * event, completion stage will be completed exceptionally.
      */
     public CompletionStage<?> send(OutboundSseEvent event);
 
     /**
      * Close the {@link SseEventSink} instance and release all associated resources.
      * <p>
-     * Subsequent calls have no effect and are ignored. Once the {@link SseEventSink} is closed,
-     * invoking any method other than this one and {@link #isClosed()} would result in
-     * an {@link IllegalStateException} being thrown.
+     * Subsequent calls have no effect and are ignored. Once the {@link SseEventSink} is closed, invoking any method other
+     * than this one and {@link #isClosed()} would result in an {@link IllegalStateException} being thrown.
      */
     @Override
     void close();

--- a/jaxrs-api/src/main/java/javax/ws/rs/sse/SseEventSource.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/sse/SseEventSource.java
@@ -27,40 +27,40 @@ import javax.ws.rs.client.WebTarget;
  * Client for reading and processing {@link InboundSseEvent incoming Server-Sent Events}.
  * <p>
  * SSE event source instances of this class are thread safe. To build a new instance, you can use the
- * {@link #target(javax.ws.rs.client.WebTarget) SseEventSource.target(endpoint)} factory method to get
- * a new event source builder that can be further customised and eventually used to create a new SSE
- * event source.
+ * {@link #target(javax.ws.rs.client.WebTarget) SseEventSource.target(endpoint)} factory method to get a new event
+ * source builder that can be further customised and eventually used to create a new SSE event source.
  * <p>
- * Once a {@link SseEventSource} is created, it can be used to {@link #open open a connection}
- * to the associated {@link WebTarget web target}. After establishing the connection, the event source starts
- * processing any incoming inbound events. Whenever a new event is received, an
- * {@link Consumer#accept(Object) Consumer&lt;InboundSseEvent&gt;#accept(InboundSseEvent)} method is invoked on any registered event consumers.
+ * Once a {@link SseEventSource} is created, it can be used to {@link #open open a connection} to the associated
+ * {@link WebTarget web target}. After establishing the connection, the event source starts processing any incoming
+ * inbound events. Whenever a new event is received, an {@link Consumer#accept(Object)
+ * Consumer&lt;InboundSseEvent&gt;#accept(InboundSseEvent)} method is invoked on any registered event consumers.
  * <h3>Reconnect support</h3>
  * <p>
- * The {@code SseEventSource} supports automated recuperation from a connection loss, including
- * negotiation of delivery of any missed events based on the last received  SSE event {@code id} field value, provided
- * this field is set by the server and the negotiation facility is supported by the server. In case of a connection loss,
- * the last received SSE event {@code id} field value is send in the
- * <tt>{@value javax.ws.rs.core.HttpHeaders#LAST_EVENT_ID_HEADER}</tt> HTTP
- * request header as part of a new connection request sent to the SSE endpoint. Upon a receipt of such reconnect request, the SSE
- * endpoint that supports this negotiation facility is expected to replay all missed events. Note however, that this is a
- * best-effort mechanism which does not provide any guaranty that all events would be delivered without a loss. You should
- * therefore not rely on receiving every single event and design your client application code accordingly.
+ * The {@code SseEventSource} supports automated recuperation from a connection loss, including negotiation of delivery
+ * of any missed events based on the last received SSE event {@code id} field value, provided this field is set by the
+ * server and the negotiation facility is supported by the server. In case of a connection loss, the last received SSE
+ * event {@code id} field value is send in the <tt>{@value javax.ws.rs.core.HttpHeaders#LAST_EVENT_ID_HEADER}</tt> HTTP
+ * request header as part of a new connection request sent to the SSE endpoint. Upon a receipt of such reconnect
+ * request, the SSE endpoint that supports this negotiation facility is expected to replay all missed events. Note
+ * however, that this is a best-effort mechanism which does not provide any guaranty that all events would be delivered
+ * without a loss. You should therefore not rely on receiving every single event and design your client application code
+ * accordingly.
  * <p>
- * By default, when a connection the the SSE endpoint is lost, the event source will wait 500&nbsp;ms
- * before attempting to reconnect to the SSE endpoint. The SSE endpoint can however control the client-side retry delay
- * by including a special {@code retry} field value in the any send event. JAX-RS {@code SseEventSource} tracks any
- * received SSE event {@code retry} field values set by the endpoint and adjusts the reconnect delay accordingly,
- * using the last received {@code retry} field value as the reconnect delay.
+ * By default, when a connection the the SSE endpoint is lost, the event source will wait 500&nbsp;ms before attempting
+ * to reconnect to the SSE endpoint. The SSE endpoint can however control the client-side retry delay by including a
+ * special {@code retry} field value in the any send event. JAX-RS {@code SseEventSource} tracks any received SSE event
+ * {@code retry} field values set by the endpoint and adjusts the reconnect delay accordingly, using the last received
+ * {@code retry} field value as the reconnect delay.
  * <p>
- * In addition to handling the standard connection loss failures, JAX-RS {@code SseEventSource} automatically deals with any
- * {@code HTTP 503 Service Unavailable} responses from an SSE endpoint, that contain a
+ * In addition to handling the standard connection loss failures, JAX-RS {@code SseEventSource} automatically deals with
+ * any {@code HTTP 503 Service Unavailable} responses from an SSE endpoint, that contain a
  * <tt>{@value javax.ws.rs.core.HttpHeaders#RETRY_AFTER}</tt> HTTP header with a valid value. The
- * <tt>HTTP 503 + {@value javax.ws.rs.core.HttpHeaders#RETRY_AFTER}</tt> technique is often used by HTTP endpoints
- * as a means of connection and traffic throttling.
- * In case a <tt>HTTP 503 + {@value javax.ws.rs.core.HttpHeaders#RETRY_AFTER}</tt> response is received in return to a connection
+ * <tt>HTTP 503 + {@value javax.ws.rs.core.HttpHeaders#RETRY_AFTER}</tt> technique is often used by HTTP endpoints as a
+ * means of connection and traffic throttling. In case a
+ * <tt>HTTP 503 + {@value javax.ws.rs.core.HttpHeaders#RETRY_AFTER}</tt> response is received in return to a connection
  * request, JAX-RS SSE event source will automatically schedule a new reconnect attempt and use the received
- * <tt>{@value javax.ws.rs.core.HttpHeaders#RETRY_AFTER}</tt> HTTP header value as a one-time override of the reconnect delay.
+ * <tt>{@value javax.ws.rs.core.HttpHeaders#RETRY_AFTER}</tt> HTTP header value as a one-time override of the reconnect
+ * delay.
  *
  * @author Marek Potociar
  * @since 2.1
@@ -70,15 +70,16 @@ public interface SseEventSource extends AutoCloseable {
     /**
      * JAX-RS {@link SseEventSource} builder class.
      * <p>
-     * Event source builder provides methods that let you conveniently configure and subsequently build
-     * a new {@code SseEventSource} instance. You can obtain a new event source builder instance using
-     * a static {@link SseEventSource#target(javax.ws.rs.client.WebTarget) SseEventSource.target(endpoint)} factory method.
+     * Event source builder provides methods that let you conveniently configure and subsequently build a new
+     * {@code SseEventSource} instance. You can obtain a new event source builder instance using a static
+     * {@link SseEventSource#target(javax.ws.rs.client.WebTarget) SseEventSource.target(endpoint)} factory method.
      * <p>
      * For example:
+     *
      * <pre>
      * SseEventSource es = SseEventSource.target(endpoint)
-     *                             .reconnectingEvery(5, SECONDS)
-     *                             .build();
+     *         .reconnectingEvery(5, SECONDS)
+     *         .build();
      * es.register(System.out::println);
      * es.open();
      * </pre>
@@ -86,16 +87,14 @@ public interface SseEventSource extends AutoCloseable {
     abstract class Builder {
 
         /**
-         * Name of the property identifying the {@link SseEventSource.Builder} implementation
-         * to be returned from {@link SseEventSource.Builder#newBuilder()}.
+         * Name of the property identifying the {@link SseEventSource.Builder} implementation to be returned from
+         * {@link SseEventSource.Builder#newBuilder()}.
          */
-        public static final String JAXRS_DEFAULT_SSE_BUILDER_PROPERTY =
-                "javax.ws.rs.sse.SseEventSource.Builder";
+        public static final String JAXRS_DEFAULT_SSE_BUILDER_PROPERTY = "javax.ws.rs.sse.SseEventSource.Builder";
         /**
          * Default SSE event source builder implementation class name.
          */
-        private static final String JAXRS_DEFAULT_SSE_BUILDER =
-                "org.glassfish.jersey.media.sse.internal.JerseySseEventSource$Builder";
+        private static final String JAXRS_DEFAULT_SSE_BUILDER = "org.glassfish.jersey.media.sse.internal.JerseySseEventSource$Builder";
 
         /**
          * Allows custom implementations to extend the SSE event source builder class.
@@ -104,8 +103,8 @@ public interface SseEventSource extends AutoCloseable {
         }
 
         /**
-         * Create a new SSE event source instance using the default implementation class provided by the JAX-RS
-         * implementation provider.
+         * Create a new SSE event source instance using the default implementation class provided by the JAX-RS implementation
+         * provider.
          *
          * @return new SSE event source builder instance.
          */
@@ -122,8 +121,8 @@ public interface SseEventSource extends AutoCloseable {
                     }
                     URL targetTypeURL = loader.getResource(classnameAsResource);
                     throw new LinkageError("ClassCastException: attempting to cast"
-                                           + delegate.getClass().getClassLoader().getResource(classnameAsResource)
-                                           + " to " + targetTypeURL);
+                            + delegate.getClass().getClassLoader().getResource(classnameAsResource)
+                            + " to " + targetTypeURL);
                 }
                 return (Builder) delegate;
             } catch (Exception ex) {
@@ -136,12 +135,12 @@ public interface SseEventSource extends AutoCloseable {
         /**
          * Set the initial reconnect delay to be used by the event source.
          * <p>
-         * Note that this value may be later overridden by the SSE endpoint using either a {@code retry} SSE event field
-         * or <tt>HTTP 503 + {@value javax.ws.rs.core.HttpHeaders#RETRY_AFTER}</tt> mechanism as described
-         * in the {@link SseEventSource} javadoc.
+         * Note that this value may be later overridden by the SSE endpoint using either a {@code retry} SSE event field or
+         * <tt>HTTP 503 + {@value javax.ws.rs.core.HttpHeaders#RETRY_AFTER}</tt> mechanism as described in the
+         * {@link SseEventSource} javadoc.
          *
          * @param delay the default time to wait before attempting to recover from a connection loss.
-         * @param unit  time unit of the reconnect delay parameter.
+         * @param unit time unit of the reconnect delay parameter.
          * @return updated event source builder instance.
          */
         public abstract Builder reconnectingEvery(long delay, TimeUnit unit);
@@ -149,14 +148,13 @@ public interface SseEventSource extends AutoCloseable {
         /**
          * Build new SSE event source pointing at a SSE streaming {@link WebTarget web target}.
          * <p>
-         * The returned event source is ready, but not {@link SseEventSource#open() connected} to the SSE endpoint.
-         * It is expected that you will manually invoke its {@link #open()} method once you are ready to start
-         * receiving SSE events. In case you want to build an event source instance that is already connected
-         * to the SSE endpoint, use the event source builder {@link #open()} method instead.
+         * The returned event source is ready, but not {@link SseEventSource#open() connected} to the SSE endpoint. It is
+         * expected that you will manually invoke its {@link #open()} method once you are ready to start receiving SSE events.
+         * In case you want to build an event source instance that is already connected to the SSE endpoint, use the event
+         * source builder {@link #open()} method instead.
          * <p>
-         * Once the event source is open, the incoming events are processed by the event source in an
-         * asynchronous task that runs in an internal single-threaded {@link ScheduledExecutorService
-         * scheduled executor service}.
+         * Once the event source is open, the incoming events are processed by the event source in an asynchronous task that
+         * runs in an internal single-threaded {@link ScheduledExecutorService scheduled executor service}.
          *
          * @return new event source instance, ready to be connected to the SSE endpoint.
          * @see #open()
@@ -185,27 +183,27 @@ public interface SseEventSource extends AutoCloseable {
      * @throws IllegalArgumentException when the any of the provided parameters is {@code null}.
      */
     void register(Consumer<InboundSseEvent> onEvent,
-                  Consumer<Throwable> onError);
+            Consumer<Throwable> onError);
 
     /**
      * Register {@link InboundSseEvent} and {@link Throwable} consumers and onComplete callback.
      * <p>
      * Event consumer is invoked once per each received event, {@code Throwable} consumer is invoked invoked upon a
-     * unrecoverable error encountered by a {@link SseEventSource}, onComplete callback is invoked when there are no
-     * further events to be received.
+     * unrecoverable error encountered by a {@link SseEventSource}, onComplete callback is invoked when there are no further
+     * events to be received.
      *
-     * @param onEvent    event consumer.
-     * @param onError    error consumer.
+     * @param onEvent event consumer.
+     * @param onError error consumer.
      * @param onComplete onComplete handler.
      * @throws IllegalArgumentException when the any of the provided parameters is {@code null}.
      */
     void register(Consumer<InboundSseEvent> onEvent,
-                  Consumer<Throwable> onError,
-                  Runnable onComplete);
+            Consumer<Throwable> onError,
+            Runnable onComplete);
 
     /**
-     * Create a new {@link SseEventSource.Builder event source builder} that provides convenient way how to
-     * configure and fine-tune various aspects of a newly prepared event source instance.
+     * Create a new {@link SseEventSource.Builder event source builder} that provides convenient way how to configure and
+     * fine-tune various aspects of a newly prepared event source instance.
      *
      * @param endpoint SSE streaming endpoint. Must not be {@code null}.
      * @return a builder of a new event source instance pointing at the specified SSE streaming endpoint.
@@ -241,20 +239,19 @@ public interface SseEventSource extends AutoCloseable {
     }
 
     /**
-     * Close this event source and wait for the internal event processing task to complete
-     * for up to the specified amount of wait time.
+     * Close this event source and wait for the internal event processing task to complete for up to the specified amount of
+     * wait time.
      * <p>
-     * The method blocks until the event processing task has completed execution after a shutdown
-     * request, or until the timeout occurs, or the current thread is interrupted, whichever happens
-     * first.
+     * The method blocks until the event processing task has completed execution after a shutdown request, or until the
+     * timeout occurs, or the current thread is interrupted, whichever happens first.
      * <p>
-     * In case the waiting for the event processing task has been interrupted, this method restores
-     * the {@link Thread#interrupted() interrupt} flag on the thread before returning {@code false}.
+     * In case the waiting for the event processing task has been interrupted, this method restores the
+     * {@link Thread#interrupted() interrupt} flag on the thread before returning {@code false}.
      *
      * @param timeout the maximum time to wait.
-     * @param unit    the time unit of the timeout argument.
-     * @return {@code true} if this executor terminated and {@code false} if the timeout elapsed
-     * before termination or the termination was interrupted.
+     * @param unit the time unit of the timeout argument.
+     * @return {@code true} if this executor terminated and {@code false} if the timeout elapsed before termination or the
+     * termination was interrupted.
      */
     boolean close(final long timeout, final TimeUnit unit);
 }

--- a/jaxrs-api/src/main/java/javax/ws/rs/sse/package-info.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/sse/package-info.java
@@ -17,7 +17,7 @@
 /**
  * Server-Sent Events related API.
  *
- * This package provides support for providing event streams from the server
- * and also for processing then on the client side.
+ * This package provides support for providing event streams from the server and also for processing then on the client
+ * side.
  */
 package javax.ws.rs.sse;

--- a/jaxrs-api/src/test/java/javax/ws/rs/JAXRSTest.java
+++ b/jaxrs-api/src/test/java/javax/ws/rs/JAXRSTest.java
@@ -30,8 +30,8 @@ import org.junit.Test;
 public final class JAXRSTest {
 
     /**
-     * Installs a new {@code RuntimeDelegate} mock before each test case, as some
-     * test cases need to find a pristine <em>installed</em> RuntimeDelegate.
+     * Installs a new {@code RuntimeDelegate} mock before each test case, as some test cases need to find a pristine
+     * <em>installed</em> RuntimeDelegate.
      */
     @Before
     public final void setUp() {
@@ -39,8 +39,8 @@ public final class JAXRSTest {
     }
 
     /**
-     * Uninstalls the {@code RuntimeDelegate} mock after each test case to be sure
-     * that the <em>next</em> test case does not use a possibly cluttered instance.
+     * Uninstalls the {@code RuntimeDelegate} mock after each test case to be sure that the <em>next</em> test case does not
+     * use a possibly cluttered instance.
      */
     @After
     public final void tearDown() {
@@ -89,8 +89,7 @@ public final class JAXRSTest {
     }
 
     /**
-     * Assert that {@code Configuration.Builder}'s
-     * {@code from(external configuration)} bulk-loading method simply returns
+     * Assert that {@code Configuration.Builder}'s {@code from(external configuration)} bulk-loading method simply returns
      * {@code this}, but does nothing else, as it is a no-op implementation.
      *
      * @since 2.2
@@ -112,9 +111,8 @@ public final class JAXRSTest {
     }
 
     /**
-     * Assert that {@code Configuration.Builder}'s convenience methods delegate to
-     * its generic {@code property(name, value)} method using the <em>right</em>
-     * property name.
+     * Assert that {@code Configuration.Builder}'s convenience methods delegate to its generic {@code property(name, value)}
+     * method using the <em>right</em> property name.
      *
      * @since 2.2
      */
@@ -148,8 +146,8 @@ public final class JAXRSTest {
     }
 
     /**
-     * Assert that {@code Configuration}'s convenience methods delegate to its
-     * generic {@code property(name)} method using the <em>right</em> property name.
+     * Assert that {@code Configuration}'s convenience methods delegate to its generic {@code property(name)} method using
+     * the <em>right</em> property name.
      *
      * @since 2.2
      */

--- a/jaxrs-api/src/test/java/javax/ws/rs/core/EntityTagTest.java
+++ b/jaxrs-api/src/test/java/javax/ws/rs/core/EntityTagTest.java
@@ -29,7 +29,6 @@ import javax.ws.rs.ext.RuntimeDelegate;
 
 public class EntityTagTest {
 
-
     @Before
     public void setUp() {
         RuntimeDelegate.setInstance(mock(RuntimeDelegate.class));

--- a/jaxrs-api/src/test/java/javax/ws/rs/core/GenericEntityTest.java
+++ b/jaxrs-api/src/test/java/javax/ws/rs/core/GenericEntityTest.java
@@ -127,11 +127,11 @@ public class GenericEntityTest {
             // check GenericEntity(Integer[], Number[]) works
             Method getNumbers = this.getClass().getDeclaredMethod("getNumbers");
             rt = getNumbers.getGenericReturnType();
-            Integer ints[] = {1, 2};
+            Integer ints[] = { 1, 2 };
             ge = new GenericEntity(ints, rt);
             // check GenericEntity(String[], Number[]) fails
             try {
-                String strings[] = {"foo", "bar"};
+                String strings[] = { "foo", "bar" };
                 ge = new GenericEntity(strings, rt);
                 fail("Expected IllegalArgumentException");
             } catch (IllegalArgumentException e) {

--- a/jaxrs-api/src/test/java/javax/ws/rs/core/GenericTypeTest.java
+++ b/jaxrs-api/src/test/java/javax/ws/rs/core/GenericTypeTest.java
@@ -59,9 +59,8 @@ public class GenericTypeTest {
 
     @Test
     public void testParameterizedSubclass2() {
-        ParameterizedSubclass2<String, ArrayList<String>> ps =
-                new ParameterizedSubclass2<String, ArrayList<String>>() {
-                };
+        ParameterizedSubclass2<String, ArrayList<String>> ps = new ParameterizedSubclass2<String, ArrayList<String>>() {
+        };
 
         assertEquals(arrayListOfStringsType, ps.getType());
         assertEquals(ArrayList.class, ps.getRawType());
@@ -73,7 +72,7 @@ public class GenericTypeTest {
         GenericType type = new GenericType(new ParameterizedType() {
             @Override
             public Type[] getActualTypeArguments() {
-                return new Type[]{String.class};
+                return new Type[] { String.class };
             }
 
             @Override
@@ -128,6 +127,7 @@ public class GenericTypeTest {
     // Regression test for JAX_RS_SPEC-274
     @Test
     public void testGenericTypeOfNonGenericArray() {
-        assertEquals(String[].class, new GenericType<String[]>(){}.getRawType());
+        assertEquals(String[].class, new GenericType<String[]>() {
+        }.getRawType());
     }
 }

--- a/jaxrs-api/src/test/java/javax/ws/rs/core/JaxbLinkTest.java
+++ b/jaxrs-api/src/test/java/javax/ws/rs/core/JaxbLinkTest.java
@@ -56,8 +56,7 @@ public class JaxbLinkTest {
 
         final StringWriter writer = new StringWriter();
 
-        JAXBElement<Link.JaxbLink> jaxbLinkJAXBElement =
-                new JAXBElement<Link.JaxbLink>(new QName("", "link"), Link.JaxbLink.class, expected);
+        JAXBElement<Link.JaxbLink> jaxbLinkJAXBElement = new JAXBElement<Link.JaxbLink>(new QName("", "link"), Link.JaxbLink.class, expected);
         marshaller.marshal(jaxbLinkJAXBElement, writer);
 
         final Link.JaxbLink actual = unmarshaller.unmarshal(new StreamSource(

--- a/jaxrs-api/src/test/java/javax/ws/rs/core/MediaTypeTest.java
+++ b/jaxrs-api/src/test/java/javax/ws/rs/core/MediaTypeTest.java
@@ -45,8 +45,8 @@ public class MediaTypeTest {
     }
 
     /**
-     * Test that passing {@code null} values to {@link MediaType} constructor does
-     * not throw a {@link NullPointerException} and produces expected result.
+     * Test that passing {@code null} values to {@link MediaType} constructor does not throw a {@link NullPointerException}
+     * and produces expected result.
      */
     @Test
     public void testNullConstructorValues() {

--- a/jaxrs-api/src/test/java/javax/ws/rs/core/MultivaluedHashMapTest.java
+++ b/jaxrs-api/src/test/java/javax/ws/rs/core/MultivaluedHashMapTest.java
@@ -110,12 +110,12 @@ public class MultivaluedHashMapTest {
         mvm.addAll("foo1", "bar1", "bar2", "bar1");
 
         try (ByteArrayOutputStream out = new ByteArrayOutputStream();
-             ObjectOutputStream objOut = new ObjectOutputStream(out)) {
+                ObjectOutputStream objOut = new ObjectOutputStream(out)) {
 
             objOut.writeObject(mvm);
 
             try (ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
-                 ObjectInputStream objIn = new ObjectInputStream(in)) {
+                    ObjectInputStream objIn = new ObjectInputStream(in)) {
 
                 assertEquals(mvm, objIn.readObject());
             }

--- a/jaxrs-api/src/test/java/javax/ws/rs/core/RuntimeDelegateStub.java
+++ b/jaxrs-api/src/test/java/javax/ws/rs/core/RuntimeDelegateStub.java
@@ -60,11 +60,11 @@ public class RuntimeDelegateStub extends RuntimeDelegate {
 
     @Override
     public Configuration.Builder createConfigurationBuilder() {
-	return null;
+        return null;
     }
 
     @Override
     public CompletionStage<Instance> bootstrap(final Application application, final JAXRS.Configuration configuration) {
-	return null;
+        return null;
     }
 }

--- a/jaxrs-api/src/test/java/javax/ws/rs/core/RxClientTest.java
+++ b/jaxrs-api/src/test/java/javax/ws/rs/core/RxClientTest.java
@@ -35,64 +35,61 @@ import org.junit.Test;
  */
 public class RxClientTest {
 
-    private Client client = null;       // does not run
+    private Client client = null; // does not run
 
     /**
-     * Shows how to use the default reactive invoker by calling method {@link
-     * javax.ws.rs.client.Invocation.Builder#rx()} without any arguments.
+     * Shows how to use the default reactive invoker by calling method {@link javax.ws.rs.client.Invocation.Builder#rx()}
+     * without any arguments.
      */
     @Test
     @Ignore
     public void testRxClient() {
-        CompletionStage<List<String>> cs =
-                client.target("remote/forecast/{destination}")
-                      .resolveTemplate("destination", "mars")
-                      .request()
-                      .header("Rx-User", "Java8")
-                      .rx()                               // gets CompletionStageRxInvoker
-                      .get(new GenericType<List<String>>() {
-                      });
+        CompletionStage<List<String>> cs = client.target("remote/forecast/{destination}")
+                .resolveTemplate("destination", "mars")
+                .request()
+                .header("Rx-User", "Java8")
+                .rx() // gets CompletionStageRxInvoker
+                .get(new GenericType<List<String>>() {
+                });
 
         cs.thenAccept(System.out::println);
     }
 
     /**
-     * Shows how other reactive invokers could be plugged in using the class
-     * as an argument in {@link javax.ws.rs.client.Invocation.Builder#rx(Class)}.
+     * Shows how other reactive invokers could be plugged in using the class as an argument in
+     * {@link javax.ws.rs.client.Invocation.Builder#rx(Class)}.
      */
     @Test
     @Ignore
     public void testRxClient2() {
         Client rxClient = client.register(CompletionStageRxInvokerProvider.class, RxInvokerProvider.class);
 
-        CompletionStage<List<String>> cs =
-                rxClient.target("remote/forecast/{destination}")
-                        .resolveTemplate("destination", "mars")
-                        .request()
-                        .header("Rx-User", "Java8")
-                        .rx(CompletionStageRxInvoker.class)
-                        .get(new GenericType<List<String>>() {
-                        });
+        CompletionStage<List<String>> cs = rxClient.target("remote/forecast/{destination}")
+                .resolveTemplate("destination", "mars")
+                .request()
+                .header("Rx-User", "Java8")
+                .rx(CompletionStageRxInvoker.class)
+                .get(new GenericType<List<String>>() {
+                });
 
         cs.thenAccept(System.out::println);
     }
 
     /**
-     * Shows how other reactive invokers could be plugged in using the class instance
-     * as an argument in {@link javax.ws.rs.client.Invocation.Builder#rx(Class)}.
+     * Shows how other reactive invokers could be plugged in using the class instance as an argument in
+     * {@link javax.ws.rs.client.Invocation.Builder#rx(Class)}.
      */
     @Test
     @Ignore
     public void testRxClient3() {
         Client rxClient = client.register(CompletionStageRxInvokerProvider.class, RxInvokerProvider.class);
 
-        CompletionStage<String> cs =
-                rxClient.target("remote/forecast/{destination}")
-                        .resolveTemplate("destination", "mars")
-                        .request()
-                        .header("Rx-User", "Java8")
-                        .rx(CompletionStageRxInvoker.class)
-                        .get(String.class);
+        CompletionStage<String> cs = rxClient.target("remote/forecast/{destination}")
+                .resolveTemplate("destination", "mars")
+                .request()
+                .header("Rx-User", "Java8")
+                .rx(CompletionStageRxInvoker.class)
+                .get(String.class);
 
         cs.thenAccept(System.out::println);
     }


### PR DESCRIPTION
Formatting of the entire code base according to [recommended EE4J rules](https://github.com/eclipse-ee4j/ee4j/wiki/Code-Conventions).

*Mostly affected the Javadoc.*