### PR TITLE
2.1.2 Rollup

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -259,8 +259,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <version>2.2-SNAPSHOT</version>
         </dependency>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -21,11 +21,11 @@
         <version>1</version>
     </parent>
 
-    <groupId>javax.ws.rs</groupId>
-    <artifactId>javax.ws.rs-examples</artifactId>
+    <groupId>jakarta.ws.rs</groupId>
+    <artifactId>jakarta.ws.rs-examples</artifactId>
     <version>2.2-SNAPSHOT</version>
     <packaging>jar</packaging>
-    <name>javax.ws.rs-examples</name>
+    <name>jakarta.ws.rs-examples</name>
 
     <url>https://github.com/jax-rs/api</url>
 

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -404,17 +404,17 @@
                     <!-- This plugin generates the spec.* properties used in maven-bundle-plugin -->
                     <groupId>org.glassfish.build</groupId>
                     <artifactId>spec-version-maven-plugin</artifactId>
-                    <version>1.4</version>
+                    <version>1.5</version>
                     <configuration>
+                        <specMode>jakarta</specMode>
                         <spec>
-                            <groupIdPrefix>jakarta.</groupIdPrefix>
                             <nonFinal>${non.final}</nonFinal>
                             <jarType>api</jarType>
                             <specVersion>${spec.version}</specVersion>
                             <newSpecVersion>${new.spec.version}</newSpecVersion>
                             <specBuild>${milestone.number}</specBuild>
                             <specImplVersion>${project.version}</specImplVersion>
-                            <apiPackage>${project.groupId}</apiPackage>
+                            <apiPackage>${api.package}</apiPackage>
                         </spec>
                     </configuration>
                     <executions>
@@ -662,6 +662,7 @@
         <maven.compiler.plugin.version>3.7.0</maven.compiler.plugin.version>
         <maven.javadoc.plugin.version>3.0.0</maven.javadoc.plugin.version>
 
+        <api.package>javax.ws.rs</api.package>
         <last.final.spec.version>2.1</last.final.spec.version>
         <milestone.number>01</milestone.number>
         <next.final.spec.version>2.2</next.final.spec.version>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -20,8 +20,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>javax.ws.rs</groupId>
-    <artifactId>javax.ws.rs-api</artifactId>
+    <groupId>jakarta.ws.rs</groupId>
+    <artifactId>jakarta.ws.rs-api</artifactId>
     <version>2.2-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>javax.ws.rs-api</name>
@@ -404,9 +404,10 @@
                     <!-- This plugin generates the spec.* properties used in maven-bundle-plugin -->
                     <groupId>org.glassfish.build</groupId>
                     <artifactId>spec-version-maven-plugin</artifactId>
-                    <version>1.2</version>
+                    <version>1.4</version>
                     <configuration>
                         <spec>
+                            <groupIdPrefix>jakarta.</groupIdPrefix>
                             <nonFinal>${non.final}</nonFinal>
                             <jarType>api</jarType>
                             <specVersion>${spec.version}</specVersion>


### PR DESCRIPTION
This PR is a *rollup* of all commits between 2.1.1 and 2.1.2 (`EE4J_8`) into 2.2-SNAPSHOT (`master`).
* Changes Maven Coordinates from `javax` to `jakarta` as requested by PMC.
* *(All other commits of `EE4J-8` existed in `master` already.)*