### PR TITLE
Travis CI does not support oraclejdk10 anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ sudo: false
 jdk:
   - oraclejdk8
   - oraclejdk9
-  - oraclejdk10
   - oraclejdk11
   - openjdk8
   - openjdk9


### PR DESCRIPTION
Due to Oracle's recent changes in their support policy, Travis CI does not suppot oraclejdk10 anymore.

It fails the build with the following message:
```
oraclejdk10 is deprecated. See https://www.oracle.com/technetwork/java/javase/eol-135779.html for more details. Consider using openjdk10 instead.
```

This PR follows that given advice and simply removes oraclejdk10, as openjdk10 is already supported.