### PR TITLE
CI on JDK12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ jdk:
   - openjdk9
   - openjdk10
   - openjdk11
+  - openjdk12
 
 cache:
   directories:


### PR DESCRIPTION
This PR prepares CI for building on JDK12.

It intentionally only adds OpenJDK but not OracleJDK anymore, due to several reasons:
* Oracle claims there is no difference between OracleJDK and OpenJDK anymore other than branding and support.
* Prevent frequent CI add-and-remove actions due to Oracle's recent support changes.
* Prepare a level playing field for all vendors. Otherwise we would have to add support of Azul and others who also provide repackaged OpenJDKs.

**As of today, this build will break as Travis CI does not support JDK12 already. This PR solely is solely *preparing* support, so we could merge it as soon as Travis CI is ready. Nevertheless, feel free to discuss and review already!**