### PR TITLE
Fixed spec-version properties and Travis config for 2.1 releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ sudo: false
 jdk:
   - oraclejdk8
   - oraclejdk9
-  - oraclejdk10
   - oraclejdk11
   - openjdk8
   - openjdk9

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -78,7 +78,9 @@
         <profile>
             <id>final</id>
             <activation>
-                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>!nonFinal</name>
+                </property>
             </activation>
             <properties>
                 <!-- Final API bundle version properties -->

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>jakarta.ws.rs</groupId>
     <artifactId>jakarta.ws.rs-api</artifactId>
-    <version>2.1.2</version>
+    <version>2.1.3-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>javax.ws.rs-api</name>
     <description>Java API for RESTful Web Services</description>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -681,7 +681,7 @@
         <maven.javadoc.plugin.version>3.0.0</maven.javadoc.plugin.version>
 
         <api.package>javax.ws.rs</api.package>
-        <last.final.spec.version>2.0</last.final.spec.version>
+        <last.final.spec.version>2.1</last.final.spec.version>
         <milestone.number>01</milestone.number>
         <next.final.spec.version>2.1</next.final.spec.version>
         <new.spec.version>${next.final.spec.version}</new.spec.version>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -680,9 +680,9 @@
         <maven.javadoc.plugin.version>3.0.0</maven.javadoc.plugin.version>
 
         <api.package>javax.ws.rs</api.package>
-        <last.final.spec.version>2.1</last.final.spec.version>
+        <last.final.spec.version>2.0</last.final.spec.version>
         <milestone.number>01</milestone.number>
-        <next.final.spec.version>2.2</next.final.spec.version>
+        <next.final.spec.version>2.1</next.final.spec.version>
         <new.spec.version>${next.final.spec.version}</new.spec.version>
         <non.final>true</non.final>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -452,6 +452,7 @@
                             <Automatic-Module-Name>java.ws.rs</Automatic-Module-Name>
                             <_versionpolicy>[$(version;==;$(@)),$(version;+;$(@)))</_versionpolicy>
                             <_nodefaultversion>false</_nodefaultversion>
+                            <Require-Capability>osgi.ee;filter:="(&amp;(osgi.ee=JavaSE)(version=1.8))"</Require-Capability>
                         </instructions>
                     </configuration>
                     <executions>


### PR DESCRIPTION
I had a deeper look at the OSGi manifest issues described in #681. It looks like the wrong version numbers were created because the `final` profile wasn't active during the release. Unfortunately activating this profile currently fails the build with:

```
[INFO] --- spec-version-maven-plugin:1.5:check-module (default) @ jakarta.ws.rs-api ---

[ jakarta.ws.rs:jakarta.ws.rs-api:2.1.2 ]
{ groupIdPrefix=jakarta. spec-version=2.2 apiPackage=javax.ws.rs API final spec-impl-version=2.1.2 }
- WARNING: spec-impl-version (2.1.2) must start with JCP spec-version number (2.2)
```

The root cause for this seems to be that the Maven properties `last.final.spec.version` and `next.final.spec.version` aren't set correctly. As the `EE4J_8` branch is a maintenance branch for JAX-RS 2.1, the properties need to point to different versions.

After applying this change, running the Maven build with `-Pfinal` seems to create the correct version numbers in the OSGi manifest:

```
Bundle-Version: 2.1.2
Implementation-Version: 2.1.2
Specification-Version: 2.1
```

As this PR doesn't change the JAX-RS API in any way and just affects the build, I would like to apply the rule for a shorter review period of only one week. 