### PR TITLE
Removed Automatic-Module-Name from manifest

### DIFF
--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -444,7 +444,6 @@
                             <Specification-Version>${spec.specification.version}</Specification-Version>
                             <Specification-Vendor>Oracle Corporation</Specification-Vendor>
                             <specversion>${spec.specification.version}</specversion>
-                            <Automatic-Module-Name>java.ws.rs</Automatic-Module-Name>
                             <_versionpolicy>[$(version;==;$(@)),$(version;+;$(@)))</_versionpolicy>
                             <_nodefaultversion>false</_nodefaultversion>
                         </instructions>


### PR DESCRIPTION
As @jansupol pointed out in #681, we don't need `Automatic-Module-Name` anymore, because we now have a real `module-info.java`. Therefore, it should be safe to remove the manifest entry.

As this PR only doesn't change the JAX-RS API, I would like to apply the rule for the reduced review period of one week.

Please note that we should also backport this PR to the `EE4J_8` branch.