### PR TITLE
CI on JDK-ea

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ jdk:
   - openjdk9
   - openjdk10
   - openjdk11
+  - openjdk-ea
 
 install:
   - cd $TRAVIS_BUILD_DIR/jaxrs-api


### PR DESCRIPTION
This PR sets up CI for building on early access builds of OpenJDK.

It intentionally only adds OpenJDK but not OracleJDK anymore, due to several reasons:
* Oracle claims there is no difference between OracleJDK and OpenJDK anymore other than branding and support.
* Prepare a level playing field for all vendors. Otherwise we would have to add support of Azul and others who also provide repackaged OpenJDKs.