### PR TITLE
Replaced spec-version-maven-plugin with explicit configuration

### DIFF
--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -76,19 +76,6 @@
 
     <profiles>
         <profile>
-            <id>final</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <properties>
-                <!-- Final API bundle version properties -->
-                <spec.version>${next.final.spec.version}</spec.version>
-                <new.spec.version />
-                <milestone.number />
-                <non.final>false</non.final>
-            </properties>
-        </profile>
-        <profile>
             <!-- Use it with release-perform goal to skip another test run. -->
             <id>skip-tests</id>
             <activation>
@@ -401,32 +388,6 @@
                     </executions>
                 </plugin>
                 <plugin>
-                    <!-- This plugin generates the spec.* properties used in maven-bundle-plugin -->
-                    <groupId>org.glassfish.build</groupId>
-                    <artifactId>spec-version-maven-plugin</artifactId>
-                    <version>1.5</version>
-                    <configuration>
-                        <specMode>jakarta</specMode>
-                        <spec>
-                            <nonFinal>${non.final}</nonFinal>
-                            <jarType>api</jarType>
-                            <specVersion>${spec.version}</specVersion>
-                            <newSpecVersion>${new.spec.version}</newSpecVersion>
-                            <specBuild>${milestone.number}</specBuild>
-                            <specImplVersion>${project.version}</specImplVersion>
-                            <apiPackage>${api.package}</apiPackage>
-                        </spec>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>set-spec-properties</goal>
-                                <goal>check-module</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
                     <version>${maven.bundle.plugin.version}</version>
@@ -436,14 +397,14 @@
                             <_failok>true</_failok>
                             <Build-Id>${buildNumber}</Build-Id>
                             <Bundle-Description>Java API for RESTful Web Services (JAX-RS)</Bundle-Description>
-                            <Bundle-Version>${spec.bundle.version}</Bundle-Version>
-                            <Bundle-SymbolicName>${spec.bundle.symbolic-name}</Bundle-SymbolicName>
+                            <Bundle-Version>${project.version}</Bundle-Version>
+                            <Bundle-SymbolicName>${api.package}-api</Bundle-SymbolicName>
                             <DynamicImport-Package>*</DynamicImport-Package>
-                            <Extension-Name>${spec.extension.name}</Extension-Name>
-                            <Implementation-Version>${spec.implementation.version}</Implementation-Version>
-                            <Specification-Version>${spec.specification.version}</Specification-Version>
+                            <Extension-Name>${api.package}</Extension-Name>
+                            <Implementation-Version>${project.version}</Implementation-Version>
+                            <Specification-Version>${spec.version}</Specification-Version>
                             <Specification-Vendor>Oracle Corporation</Specification-Vendor>
-                            <specversion>${spec.specification.version}</specversion>
+                            <specversion>${spec.version}</specversion>
                             <_versionpolicy>[$(version;==;$(@)),$(version;+;$(@)))</_versionpolicy>
                             <_nodefaultversion>false</_nodefaultversion>
                         </instructions>
@@ -606,10 +567,6 @@
                 <artifactId>maven-bundle-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.glassfish.build</groupId>
-                <artifactId>spec-version-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
             <plugin>
@@ -662,14 +619,9 @@
         <maven.javadoc.plugin.version>3.0.0</maven.javadoc.plugin.version>
 
         <api.package>javax.ws.rs</api.package>
-        <last.final.spec.version>2.1</last.final.spec.version>
-        <milestone.number>01</milestone.number>
-        <next.final.spec.version>2.2</next.final.spec.version>
-        <new.spec.version>${next.final.spec.version}</new.spec.version>
-        <non.final>true</non.final>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <skip.release.tests>false</skip.release.tests>
-        <spec.version>${last.final.spec.version}</spec.version>
+        <spec.version>2.2</spec.version>
         <spec.version.revision /> <!-- e.g. (Rev a) -->
 
         <jaxb.api.version>2.3.0</jaxb.api.version>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -403,7 +403,7 @@
                             <Extension-Name>${api.package}</Extension-Name>
                             <Implementation-Version>${project.version}</Implementation-Version>
                             <Specification-Version>${spec.version}</Specification-Version>
-                            <Specification-Vendor>Oracle Corporation</Specification-Vendor>
+                            <Specification-Vendor>Eclipse Foundation</Specification-Vendor>
                             <specversion>${spec.version}</specversion>
                             <_versionpolicy>[$(version;==;$(@)),$(version;+;$(@)))</_versionpolicy>
                             <_nodefaultversion>false</_nodefaultversion>


### PR DESCRIPTION
This pull request is basically a proof of concept that shows how the build could look like if we replace the `spec-version-maven-plugin` with explicit configuration of the relevant manifest entries.

Please note that the PR removes some Maven properties which aren't required anymore. It also removes the concept of the `nonFinal` flag which was the root cause of the weird version numbers created.

Most of the manifest attributes are generated exactly the same way as before. The only noteworthy difference is the handling of the version related attributes:

  * `Bundle-Version`
    * This is the OSGi bundle version
    * The previous value was `2.1` or `2.1.2` with the `final` profile and `2.1.99.b01` without it.
    * The value is now the same as the Maven project version normalized to the OSGi format. For the current master branch it would be `2.2.0.SNAPSHOT`
  * `Specification-Version`
    * This is basically the version of the specification. Something like `2.2` or `3.0`.
    * The previous value was something like `2.2` with the `final` profile and `2.1.99.01` without it.
    * This value is now defined via a Maven property.
  * `Implementation-Version`
    * This is the version number of the API classes.
    * For some reason this was set to `2.2` with and without the `final` profile before.
    * The value is now the same as the Maven project version which IMO makes most sense.

I know that there is no official decision yet if we want to get rid of the `spec-version-maven-plugin` or not. But please take the chance to review the PR to see if it could work in theory and if it improves the maintainability of the build.

And please also note that this PR is targeting the `master` branch. IMO we should keep the spec-version plugin for the `EE4J_8` branch and just explore different ways to do it in the future.