### PR TITLE
Dependencies migrated from javax to jakarta

### DIFF
--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -693,7 +693,7 @@
         <spec.version>${last.final.spec.version}</spec.version>
         <spec.version.revision /> <!-- e.g. (Rev a) -->
 
-        <jaxb.api.version>2.3.0</jaxb.api.version>
+        <jaxb.api.version>2.3.2</jaxb.api.version>
         <jaxb.impl.version>2.3.2</jaxb.impl.version>
         <activation.api.version>1.2.1</activation.api.version>
     </properties>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -192,14 +192,14 @@
             </activation>
             <dependencies>
                 <dependency>
-                    <groupId>javax.xml.bind</groupId>
-                    <artifactId>jaxb-api</artifactId>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
                     <version>${jaxb.api.version}</version>
                     <scope>provided</scope>
                 </dependency>
                 <dependency>
-                    <groupId>javax.activation</groupId>
-                    <artifactId>javax.activation-api</artifactId>
+                    <groupId>jakarta.activation</groupId>
+                    <artifactId>jakarta.activation-api</artifactId>
                     <version>${activation.api.version}</version>
                     <scope>provided</scope>
                 </dependency>
@@ -694,8 +694,8 @@
         <spec.version.revision /> <!-- e.g. (Rev a) -->
 
         <jaxb.api.version>2.3.0</jaxb.api.version>
-        <jaxb.impl.version>2.3.0.1</jaxb.impl.version>
-        <activation.api.version>1.2.0</activation.api.version>
+        <jaxb.impl.version>2.3.2</jaxb.impl.version>
+        <activation.api.version>1.2.1</activation.api.version>
     </properties>
 
     <distributionManagement>


### PR DESCRIPTION
Changing dependencies from javax to jakarta as requested by @m0mus in https://github.com/eclipse-ee4j/jaxrs-api/issues/690.

**No API is changed. To help minimize the delay of GlassFish release, I hereby request a shortened review period of only five days.**

*This PR will not build until JAF and JAXB have released to Maven Central, which is intended, to ensure that JAX-RS does not depend on pre-releases but always only depends upon publicly released components. To prevent the need of refreshing votes, it is advisory to wait with the voting until Travis CI approves the build.*