### PR TITLE
MediaType improvements

### DIFF
--- a/jaxrs-api/src/main/java/javax/ws/rs/core/MediaType.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/MediaType.java
@@ -35,9 +35,9 @@ import javax.ws.rs.ext.RuntimeDelegate;
 @SuppressWarnings("JavaDoc")
 public class MediaType {
 
-    private String type;
-    private String subtype;
-    private Map<String, String> parameters;
+    private final String type;
+    private final String subtype;
+    private final Map<String, String> parameters;
     private final int hash;
 
     /**

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/MediaType.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/MediaType.java
@@ -38,7 +38,7 @@ public class MediaType {
     private String type;
     private String subtype;
     private Map<String, String> parameters;
-    private int hash;
+    private final int hash;
 
     /**
      * The media type {@code charset} parameter name.
@@ -250,6 +250,7 @@ public class MediaType {
             parameterMap.put(CHARSET_PARAMETER, charset);
         }
         this.parameters = Collections.unmodifiableMap(parameterMap);
+        this.hash = Objects.hash(this.type.toLowerCase(), this.subtype.toLowerCase(), this.parameters);
     }
 
     /**
@@ -372,12 +373,7 @@ public class MediaType {
     @SuppressWarnings("UnnecessaryJavaDocLink")
     @Override
     public int hashCode() {
-        int h = this.hash;
-        if (h == 0) {
-            h = Objects.hash(this.type.toLowerCase(), this.subtype.toLowerCase(), this.parameters);
-            this.hash = h;
-        }
-        return h;
+        return this.hash;
     }
 
     /**

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/MediaType.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/MediaType.java
@@ -374,7 +374,7 @@ public class MediaType {
     public int hashCode() {
         int h = this.hash;
         if (h == 0) {
-            h = Objects.hash(this.parameters, this.subtype.toLowerCase(), this.type.toLowerCase());
+            h = Objects.hash(this.type.toLowerCase(), this.subtype.toLowerCase(), this.parameters);
             this.hash = h;
         }
         return h;

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/MediaType.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/MediaType.java
@@ -19,6 +19,7 @@ package javax.ws.rs.core;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 
 import javax.ws.rs.ext.RuntimeDelegate;
@@ -37,6 +38,7 @@ public class MediaType {
     private String type;
     private String subtype;
     private Map<String, String> parameters;
+    private int hash;
 
     /**
      * The media type {@code charset} parameter name.
@@ -343,6 +345,9 @@ public class MediaType {
     @SuppressWarnings("UnnecessaryJavaDocLink")
     @Override
     public boolean equals(final Object obj) {
+        if (obj == this) {
+            return true;
+        }
         if (!(obj instanceof MediaType)) {
             return false;
         }
@@ -367,7 +372,12 @@ public class MediaType {
     @SuppressWarnings("UnnecessaryJavaDocLink")
     @Override
     public int hashCode() {
-        return (this.type.toLowerCase() + this.subtype.toLowerCase()).hashCode() + this.parameters.hashCode();
+        int h = this.hash;
+        if (h == 0) {
+            h = Objects.hash(this.parameters, this.subtype.toLowerCase(), this.type.toLowerCase());
+            this.hash = h;
+        }
+        return h;
     }
 
     /**

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/MediaType.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/MediaType.java
@@ -17,7 +17,6 @@
 package javax.ws.rs.core;
 
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.TreeMap;
@@ -174,13 +173,7 @@ public class MediaType {
     }
 
     private static TreeMap<String, String> createParametersMap(final Map<String, String> initialValues) {
-        final TreeMap<String, String> map = new TreeMap<String, String>(new Comparator<String>() {
-
-            @Override
-            public int compare(final String o1, final String o2) {
-                return o1.compareToIgnoreCase(o2);
-            }
-        });
+        final TreeMap<String, String> map = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         if (initialValues != null) {
             for (Map.Entry<String, String> e : initialValues.entrySet()) {
                 map.put(e.getKey().toLowerCase(), e.getValue());
@@ -237,13 +230,7 @@ public class MediaType {
         this.subtype = subtype == null ? MEDIA_TYPE_WILDCARD : subtype;
 
         if (parameterMap == null) {
-            parameterMap = new TreeMap<String, String>(new Comparator<String>() {
-
-                @Override
-                public int compare(final String o1, final String o2) {
-                    return o1.compareToIgnoreCase(o2);
-                }
-            });
+            parameterMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         }
 
         if (charset != null && !charset.isEmpty()) {


### PR DESCRIPTION
The struct is immutable, reuse the result of hash code

This makes it more efficient to use MediaType as keys in hash maps, caches and other hash-based strucutres.

* single computation of hash code
* final fields