### PR TITLE
Improve MediaType compatibility check

### DIFF
--- a/jaxrs-api/src/main/java/javax/ws/rs/core/MediaType.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/MediaType.java
@@ -310,8 +310,11 @@ public class MediaType {
     }
 
     /**
-     * Check if this media type is compatible with another media type. E.g. image/* is compatible with image/jpeg,
-     * image/png, etc. Media type parameters are ignored. The function is commutative.
+     * Check if this media type is compatible with another media type.
+     * Two media types are considered to be compatible if and only if their types are equal,
+     * or one of them has a wildcard type, and their subtypes are equal or one of them has a wildcard subtype.
+     *
+     * Media type parameters are ignored. The function is commutative.
      *
      * @param other the media type to compare with.
      * @return true if the types are compatible, false otherwise.
@@ -321,16 +324,11 @@ public class MediaType {
             return false;
         }
 
-        // Two media types are compatible if and only if both of the following conditions are met:
-        // 1) one of their types is a wildcard, or their types are equal
-        // 2) one of their subtypes is a wildcard, or their two subtypes are equal.
-        if (type.equalsIgnoreCase(other.type) || type.equals(MEDIA_TYPE_WILDCARD)
-            || other.type.equals(MEDIA_TYPE_WILDCARD)) {
-            return subtype.equals(MEDIA_TYPE_WILDCARD) || other.subtype.equals(MEDIA_TYPE_WILDCARD)
-                   || subtype.equalsIgnoreCase(other.subtype);
-        }
-
-        return false;
+        return
+            (type.equalsIgnoreCase(other.type) || this.isWildcardType() || other.isWildcardType())
+            &&
+            (subtype.equalsIgnoreCase(other.subtype) || this.isWildcardSubtype()
+             || other.isWildcardSubtype());
     }
 
     /**

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/MediaType.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/MediaType.java
@@ -317,12 +317,20 @@ public class MediaType {
      * @return true if the types are compatible, false otherwise.
      */
     public boolean isCompatible(final MediaType other) {
-        return other != null && // return false if other is null, else
-                (type.equals(MEDIA_TYPE_WILDCARD) || other.type.equals(MEDIA_TYPE_WILDCARD) || // both are wildcard types, or
-                        (type.equalsIgnoreCase(other.type) && (subtype.equals(MEDIA_TYPE_WILDCARD)
-                                || other.subtype.equals(MEDIA_TYPE_WILDCARD)))
-                        || // same types, wildcard sub-types, or
-                        (type.equalsIgnoreCase(other.type) && this.subtype.equalsIgnoreCase(other.subtype))); // same types & sub-types
+        if (other == null) {
+            return false;
+        }
+
+        // Two media types are compatible if and only if both of the following conditions are met:
+        // 1) one of their types is a wildcard, or their types are equal
+        // 2) one of their subtypes is a wildcard, or their two subtypes are equal.
+        if (type.equalsIgnoreCase(other.type) || type.equals(MEDIA_TYPE_WILDCARD)
+            || other.type.equals(MEDIA_TYPE_WILDCARD)) {
+            return subtype.equals(MEDIA_TYPE_WILDCARD) || other.subtype.equals(MEDIA_TYPE_WILDCARD)
+                   || subtype.equalsIgnoreCase(other.subtype);
+        }
+
+        return false;
     }
 
     /**

--- a/jaxrs-api/src/test/java/javax/ws/rs/core/MediaTypeTest.java
+++ b/jaxrs-api/src/test/java/javax/ws/rs/core/MediaTypeTest.java
@@ -16,13 +16,16 @@
 
 package javax.ws.rs.core;
 
+import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThat;
+
+import org.hamcrest.Description;
+import org.hamcrest.DiagnosingMatcher;
+import org.hamcrest.Matcher;
+import org.junit.Test;
 
 import java.util.Map;
-
-import org.junit.Test;
 
 /**
  * {@link MediaType} unit test.
@@ -61,109 +64,97 @@ public class MediaTypeTest {
         assertEquals(MediaType.WILDCARD_TYPE, actual);
     }
 
-    /**
-     * Test that a wildcard type {@link MediaType} value with explicit subtype is not compatible with
-     * a non-wildcard type {@link MediaType} value with a different subtype.
-     */
     @Test
     public void testMediaTypeWithWildcardTypeNotCompatibleWhenSubtypeDifferent() {
-        MediaType wildcard = new MediaType(MediaType.MEDIA_TYPE_WILDCARD, "json");
+        MediaType anyJson = new MediaType(MediaType.MEDIA_TYPE_WILDCARD, "json");
 
-        assertFalse(wildcard.isCompatible(MediaType.APPLICATION_OCTET_STREAM_TYPE));
-        assertFalse(MediaType.APPLICATION_OCTET_STREAM_TYPE.isCompatible(wildcard));
+        assertThat(anyJson, not(isCompatibleWith(MediaType.APPLICATION_OCTET_STREAM_TYPE)));
+        assertThat(MediaType.APPLICATION_OCTET_STREAM_TYPE, not(isCompatibleWith(anyJson)));
     }
 
-    /**
-     * Test that a wildcard type {@link MediaType} value with explicit subtype is compatible with
-     * a non-wildcard type {@link MediaType} value with the same explicit subtype.
-     */
     @Test
     public void testMediaTypeWithWildcardTypeCompatibleWhenSubtypeMatches() {
-        MediaType wildcard = new MediaType(MediaType.MEDIA_TYPE_WILDCARD, "json");
+        MediaType anyJson = new MediaType(MediaType.MEDIA_TYPE_WILDCARD, "json");
 
-        assertTrue(wildcard.isCompatible(MediaType.APPLICATION_JSON_TYPE));
-        assertTrue(MediaType.APPLICATION_JSON_TYPE.isCompatible(wildcard));
+        assertThat(anyJson, isCompatibleWith(MediaType.APPLICATION_JSON_TYPE));
+        assertThat(MediaType.APPLICATION_JSON_TYPE, isCompatibleWith(anyJson));
     }
 
-    /**
-     * Test that a wildcard type {@link MediaType} value with explicit subtype is not compatible with
-     * a non-wildcard type {@link MediaType} value with a different subtype.
-     */
     @Test
     public void testMediaTypeWithWildcardTypeCompatibleWithExplicitTypeAndWildcardSubtype() {
-        MediaType wildcardType = new MediaType(MediaType.MEDIA_TYPE_WILDCARD, "json");
-        MediaType wildcardSubtype = new MediaType("application", MediaType.MEDIA_TYPE_WILDCARD);
+        MediaType anyJson = new MediaType(MediaType.MEDIA_TYPE_WILDCARD, "json");
+        MediaType applicationAny = new MediaType("application", MediaType.MEDIA_TYPE_WILDCARD);
 
-        assertTrue(wildcardType.isCompatible(wildcardSubtype));
-        assertTrue(wildcardSubtype.isCompatible(wildcardType));
+        assertThat(anyJson, isCompatibleWith(applicationAny));
+        assertThat(applicationAny, isCompatibleWith(anyJson));
     }
 
-    /**
-     * Test that a {@link MediaType} value with explicit type and wildcard subtype
-     * is compatible with a {@link MediaType} value with the same type and an explicit subtype.
-     */
     @Test
     public void testMediaTypeWithWildcardSubtypeCompatibleWhenTypeMatches() {
-        MediaType wildcard = new MediaType("application", MediaType.MEDIA_TYPE_WILDCARD);
+        MediaType applicationAny = new MediaType("application", MediaType.MEDIA_TYPE_WILDCARD);
 
-        assertTrue(wildcard.isCompatible(MediaType.APPLICATION_JSON_TYPE));
-        assertTrue(MediaType.APPLICATION_JSON_TYPE.isCompatible(wildcard));
+        assertThat(applicationAny, isCompatibleWith(MediaType.APPLICATION_JSON_TYPE));
+        assertThat(MediaType.APPLICATION_JSON_TYPE, isCompatibleWith(applicationAny));
     }
 
-    /**
-     * Test that a {@link MediaType} value with explicit type and wildcard subtype
-     * is not compatible with a {@link MediaType} value with a different type and an explicit subtype.
-     */
     @Test
     public void testMediaTypeWithWildcardSubtypeNotCompatibleWhenTypeDoesNotMatch() {
-        MediaType wildcard = new MediaType("application", MediaType.MEDIA_TYPE_WILDCARD);
+        MediaType applicationAny = new MediaType("application", MediaType.MEDIA_TYPE_WILDCARD);
 
-        assertFalse(wildcard.isCompatible(MediaType.TEXT_HTML_TYPE));
-        assertFalse(MediaType.TEXT_HTML_TYPE.isCompatible(wildcard));
+        assertThat(applicationAny, not(isCompatibleWith(MediaType.TEXT_HTML_TYPE)));
+        assertThat(MediaType.TEXT_HTML_TYPE, not(isCompatibleWith(applicationAny)));
     }
 
-    /**
-     * Test that a {@link MediaType} value with explicit type and subtype
-     * is compatible with a {@link MediaType} value with the same type and subtype (i.e. itself).
-     */
     @Test
     public void testMediaTypeWithExplicitTypeAndSubTypeCompatibleWithSelf() {
-        assertTrue(MediaType.APPLICATION_JSON_TYPE.isCompatible(MediaType.APPLICATION_JSON_TYPE));
+        assertThat(MediaType.APPLICATION_JSON_TYPE, isCompatibleWith(MediaType.APPLICATION_JSON_TYPE));
     }
 
-    /**
-     * Test that a {@link MediaType} value with explicit type and subtype
-     * is not compatible with a {@link MediaType} value with a different type and same subtype
-     */
     @Test
     public void testMediaTypeNotCompatibleWithOtherExplicitMediaTypeWhenTypeDifferent() {
-        assertFalse(MediaType.TEXT_XML_TYPE.isCompatible(MediaType.APPLICATION_XML_TYPE));
+        assertThat(MediaType.TEXT_XML_TYPE, not(isCompatibleWith(MediaType.APPLICATION_XML_TYPE)));
     }
 
-    /**
-     * Test that a {@link MediaType} value with explicit type and subtype
-     * is not compatible with a {@link MediaType} value with the same type and different subtype
-     */
     @Test
     public void testMediaTypeNotCompatibleWithOtherExplicitMediaTypeWhenSubtypeDifferent() {
-        assertFalse(MediaType.TEXT_XML_TYPE.isCompatible(MediaType.TEXT_HTML_TYPE));
+        assertThat(MediaType.TEXT_XML_TYPE, not(isCompatibleWith(MediaType.TEXT_HTML_TYPE)));
     }
 
-
-    /**
-     * Test that a {@link MediaType} value with explicit type and subtype
-     * is not compatible with a {@link MediaType} value with a different type and different subtype.
-     */
     @Test
     public void testMediaTypeNotCompatibleWithOtherMediaTypeWhenTypeAndSubtypeDifferent() {
-        assertFalse(MediaType.TEXT_XML_TYPE.isCompatible(MediaType.APPLICATION_JSON_TYPE));
+        assertThat(MediaType.TEXT_XML_TYPE, not(isCompatibleWith(MediaType.APPLICATION_JSON_TYPE)));
     }
 
-    /**
-     * Test that a {@link MediaType} value is not compatible with a {@code null} value.
-     */
     @Test
     public void testMediaTypeNotCompatibleWithNull() {
-        assertFalse(MediaType.APPLICATION_JSON_TYPE.isCompatible(null));
+        assertThat(MediaType.APPLICATION_JSON_TYPE, not(isCompatibleWith(null)));
+    }
+
+    private static Matcher<MediaType> isCompatibleWith(MediaType other) {
+        return new DiagnosingMatcher<MediaType>() {
+
+            @Override
+            protected boolean matches(Object o, Description description) {
+                if (o instanceof MediaType) {
+                    MediaType mediaType = (MediaType) o;
+
+                    if (!mediaType.isCompatible(other)) {
+                        description.appendText("incompatible");
+                        return false;
+                    }
+
+                    return true;
+                }
+
+                description.appendText("not a media type");
+
+                return false;
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("a compatible media type");
+            }
+        };
     }
 }

--- a/jaxrs-api/src/test/java/javax/ws/rs/core/MediaTypeTest.java
+++ b/jaxrs-api/src/test/java/javax/ws/rs/core/MediaTypeTest.java
@@ -17,6 +17,8 @@
 package javax.ws.rs.core;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Map;
 
@@ -57,5 +59,111 @@ public class MediaTypeTest {
 
         actual = new MediaType(null, null, (String) null);
         assertEquals(MediaType.WILDCARD_TYPE, actual);
+    }
+
+    /**
+     * Test that a wildcard type {@link MediaType} value with explicit subtype is not compatible with
+     * a non-wildcard type {@link MediaType} value with a different subtype.
+     */
+    @Test
+    public void testMediaTypeWithWildcardTypeNotCompatibleWhenSubtypeDifferent() {
+        MediaType wildcard = new MediaType(MediaType.MEDIA_TYPE_WILDCARD, "json");
+
+        assertFalse(wildcard.isCompatible(MediaType.APPLICATION_OCTET_STREAM_TYPE));
+        assertFalse(MediaType.APPLICATION_OCTET_STREAM_TYPE.isCompatible(wildcard));
+    }
+
+    /**
+     * Test that a wildcard type {@link MediaType} value with explicit subtype is compatible with
+     * a non-wildcard type {@link MediaType} value with the same explicit subtype.
+     */
+    @Test
+    public void testMediaTypeWithWildcardTypeCompatibleWhenSubtypeMatches() {
+        MediaType wildcard = new MediaType(MediaType.MEDIA_TYPE_WILDCARD, "json");
+
+        assertTrue(wildcard.isCompatible(MediaType.APPLICATION_JSON_TYPE));
+        assertTrue(MediaType.APPLICATION_JSON_TYPE.isCompatible(wildcard));
+    }
+
+    /**
+     * Test that a wildcard type {@link MediaType} value with explicit subtype is not compatible with
+     * a non-wildcard type {@link MediaType} value with a different subtype.
+     */
+    @Test
+    public void testMediaTypeWithWildcardTypeCompatibleWithExplicitTypeAndWildcardSubtype() {
+        MediaType wildcardType = new MediaType(MediaType.MEDIA_TYPE_WILDCARD, "json");
+        MediaType wildcardSubtype = new MediaType("application", MediaType.MEDIA_TYPE_WILDCARD);
+
+        assertTrue(wildcardType.isCompatible(wildcardSubtype));
+        assertTrue(wildcardSubtype.isCompatible(wildcardType));
+    }
+
+    /**
+     * Test that a {@link MediaType} value with explicit type and wildcard subtype
+     * is compatible with a {@link MediaType} value with the same type and an explicit subtype.
+     */
+    @Test
+    public void testMediaTypeWithWildcardSubtypeCompatibleWhenTypeMatches() {
+        MediaType wildcard = new MediaType("application", MediaType.MEDIA_TYPE_WILDCARD);
+
+        assertTrue(wildcard.isCompatible(MediaType.APPLICATION_JSON_TYPE));
+        assertTrue(MediaType.APPLICATION_JSON_TYPE.isCompatible(wildcard));
+    }
+
+    /**
+     * Test that a {@link MediaType} value with explicit type and wildcard subtype
+     * is not compatible with a {@link MediaType} value with a different type and an explicit subtype.
+     */
+    @Test
+    public void testMediaTypeWithWildcardSubtypeNotCompatibleWhenTypeDoesNotMatch() {
+        MediaType wildcard = new MediaType("application", MediaType.MEDIA_TYPE_WILDCARD);
+
+        assertFalse(wildcard.isCompatible(MediaType.TEXT_HTML_TYPE));
+        assertFalse(MediaType.TEXT_HTML_TYPE.isCompatible(wildcard));
+    }
+
+    /**
+     * Test that a {@link MediaType} value with explicit type and subtype
+     * is compatible with a {@link MediaType} value with the same type and subtype (i.e. itself).
+     */
+    @Test
+    public void testMediaTypeWithExplicitTypeAndSubTypeCompatibleWithSelf() {
+        assertTrue(MediaType.APPLICATION_JSON_TYPE.isCompatible(MediaType.APPLICATION_JSON_TYPE));
+    }
+
+    /**
+     * Test that a {@link MediaType} value with explicit type and subtype
+     * is not compatible with a {@link MediaType} value with a different type and same subtype
+     */
+    @Test
+    public void testMediaTypeNotCompatibleWithOtherExplicitMediaTypeWhenTypeDifferent() {
+        assertFalse(MediaType.TEXT_XML_TYPE.isCompatible(MediaType.APPLICATION_XML_TYPE));
+    }
+
+    /**
+     * Test that a {@link MediaType} value with explicit type and subtype
+     * is not compatible with a {@link MediaType} value with the same type and different subtype
+     */
+    @Test
+    public void testMediaTypeNotCompatibleWithOtherExplicitMediaTypeWhenSubtypeDifferent() {
+        assertFalse(MediaType.TEXT_XML_TYPE.isCompatible(MediaType.TEXT_HTML_TYPE));
+    }
+
+
+    /**
+     * Test that a {@link MediaType} value with explicit type and subtype
+     * is not compatible with a {@link MediaType} value with a different type and different subtype.
+     */
+    @Test
+    public void testMediaTypeNotCompatibleWithOtherMediaTypeWhenTypeAndSubtypeDifferent() {
+        assertFalse(MediaType.TEXT_XML_TYPE.isCompatible(MediaType.APPLICATION_JSON_TYPE));
+    }
+
+    /**
+     * Test that a {@link MediaType} value is not compatible with a {@code null} value.
+     */
+    @Test
+    public void testMediaTypeNotCompatibleWithNull() {
+        assertFalse(MediaType.APPLICATION_JSON_TYPE.isCompatible(null));
     }
 }


### PR DESCRIPTION
As described in https://github.com/eclipse-ee4j/jaxrs-api/issues/543, the `javax.ws.rs.core.MediaType#isCompatible` method is not behaving as expected when one of the media types to be compared has a wildcard type and explicit subtype, e.g. `*/json`. The referred media type is considered to be compatible with any type, even if the subtypes do not match (e.g. `*/json` will be considered compatible with `application/octet-stream`). As such, if an implementation of JAX-RS relies on `javax.ws.rs.core.MediaType#isCompatible` to determine if the media type of an incoming request is compatible with the accepted media types of a resource method, as per Section 3.5 of the specification (via Step 3a in Section 3.7.2), it might result in a surprising behaviour for the end-user.

This change aims to improve and clarify the logic of `javax.ws.rs.core.MediaType#isCompatible` so that it handles wildcard types better, and adds unit tests for the referred method.

Resolves #543 

Signed-off-by: mszabo-wikia <mszabo@wikia-inc.com>