### PR TITLE
Removed Travis JDK 11 support in EE4J_8 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,9 @@ sudo: false
 jdk:
   - oraclejdk8
   - oraclejdk9
-  - oraclejdk11
   - openjdk8
   - openjdk9
   - openjdk10
-  - openjdk11
 
 install:
   - cd $TRAVIS_BUILD_DIR/jaxrs-api


### PR DESCRIPTION
See discussion in:

https://github.com/eclipse-ee4j/jaxrs-api/pull/692

JDK 11 support is not a requirement for this branch. We shall continue to test with JDK 11 in our master branch. 

I propose to fast track this PR.

Signed-off-by: Santiago Pericas-Geertsen <Santiago.PericasGeertsen@oracle.com>