### PR TITLE
Excluding JRE's implied JAXB implementation with JDK11+

### DIFF
--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -206,7 +206,8 @@
                                     <id>default-compile</id>
                                     <configuration>
                                         <!-- compile everything to ensure module-info contains right entries -->
-                                        <release>9</release>
+                                        <source>9</source>
+                                        <target>9</target>
                                     </configuration>
                                 </execution>
                                 <execution>


### PR DESCRIPTION
As JDK11+ explicitly requests a particular version of JAXB, it is more safe to exclude the version of JAXB implicitly contained by the JRE itself.

*Replaces https://github.com/eclipse-ee4j/jaxrs-api/pull/699*

**The review period ends after seven days already, as this is a replacement of #699, which already started seven days ago.**