### PR TITLE
2.1.3 Rollup

### DIFF
--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -177,14 +177,14 @@
             </activation>
             <dependencies>
                 <dependency>
-                    <groupId>javax.xml.bind</groupId>
-                    <artifactId>jaxb-api</artifactId>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
                     <version>${jaxb.api.version}</version>
                     <scope>provided</scope>
                 </dependency>
                 <dependency>
-                    <groupId>javax.activation</groupId>
-                    <artifactId>javax.activation-api</artifactId>
+                    <groupId>jakarta.activation</groupId>
+                    <artifactId>jakarta.activation-api</artifactId>
                     <version>${activation.api.version}</version>
                     <scope>provided</scope>
                 </dependency>
@@ -626,8 +626,8 @@
         <spec.version.revision /> <!-- e.g. (Rev a) -->
 
         <jaxb.api.version>2.3.0</jaxb.api.version>
-        <jaxb.impl.version>2.3.0.1</jaxb.impl.version>
-        <activation.api.version>1.2.0</activation.api.version>
+        <jaxb.impl.version>2.3.2</jaxb.impl.version>
+        <activation.api.version>1.2.1</activation.api.version>
     </properties>
 
     <distributionManagement>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -238,6 +238,13 @@
                     </plugins>
                 </pluginManagement>
             </build>
+            <repositories>
+                <!-- JAXB and JAF are not found in Maven Central yet, so we pull it from OSSRH staging instead. -->
+                <repository>
+                    <id>ossrh-staging</id>
+                    <url>https://oss.sonatype.org/content/repositories/staging</url>
+                </repository>
+            </repositories>
         </profile>
         <profile>
             <id>jdk9-jdk10</id>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -625,7 +625,7 @@
         <spec.version>2.2</spec.version>
         <spec.version.revision /> <!-- e.g. (Rev a) -->
 
-        <jaxb.api.version>2.3.0</jaxb.api.version>
+        <jaxb.api.version>2.3.2</jaxb.api.version>
         <jaxb.impl.version>2.3.2</jaxb.impl.version>
         <activation.api.version>1.2.1</activation.api.version>
     </properties>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -407,6 +407,7 @@
                             <specversion>${spec.version}</specversion>
                             <_versionpolicy>[$(version;==;$(@)),$(version;+;$(@)))</_versionpolicy>
                             <_nodefaultversion>false</_nodefaultversion>
+                            <Require-Capability>osgi.ee;filter:="(&amp;(osgi.ee=JavaSE)(version=1.8))"</Require-Capability>
                         </instructions>
                     </configuration>
                     <executions>


### PR DESCRIPTION
This PR is a *rollup* of all commits between 2.1.2 and 2.1.3 (`EE4J_8`) into 2.2-SNAPSHOT (`master`).
* Changes Maven Coordinates of dependencies from `javax` to `jakarta` as requested by PMC.
* Fixes OSGi manifest as requested by team Jersey.
* *(All other commits of `EE4J-8` existed in `master` already.)*

**As these are no API changes, and as all these changes are already contained in `EE4J_8` I propose a reduced review period of just five days.**