### PR TITLE
Release 2.1.4

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>jakarta.ws.rs</groupId>
     <artifactId>jakarta.ws.rs-examples</artifactId>
-    <version>2.1.3</version>
+    <version>2.1.4-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>jakarta.ws.rs-examples</name>
 
@@ -260,7 +260,7 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>2.1.2</version>
+            <version>2.1.4-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>jakarta.ws.rs</groupId>
     <artifactId>jakarta.ws.rs-examples</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>2.1.4</version>
     <packaging>jar</packaging>
     <name>jakarta.ws.rs-examples</name>
 
@@ -260,7 +260,7 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>2.1.4-SNAPSHOT</version>
+            <version>2.1.4</version>
         </dependency>
 
         <dependency>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>jakarta.ws.rs</groupId>
     <artifactId>jakarta.ws.rs-api</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>2.1.4</version>
     <packaging>bundle</packaging>
     <name>javax.ws.rs-api</name>
     <description>Java API for RESTful Web Services</description>


### PR DESCRIPTION
# Releasing JAX-RS 2.1.4

See https://github.com/eclipse-ee4j/jaxrs-api/issues/714.

**This PR will be fast-tracked as it does not change any source code at all but solely fixes the technical form of the bundle. The minimum review period is one day according to the [new fast-track rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#voting-rules) we agreed upon recently.**

*All committers pleace check today's nightly build whether the release should be done (+1) or should be withhold (-1). In particular please double-check the OSGi manifest and all legal issues. I noticed that the snapshot contains the version number "2.1.3" in the OSGi declarations, so please OSGi experts do confirm that this will be correctly turn to "2.1.4" as soon as this is not a snapshot anymore. Thanks.*

