### PR TITLE
2.1.4 Rollup

### DIFF
--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -406,7 +406,7 @@
                             <Build-Id>${buildNumber}</Build-Id>
                             <Bundle-Description>Java API for RESTful Web Services (JAX-RS)</Bundle-Description>
                             <Bundle-Version>${project.version}</Bundle-Version>
-                            <Bundle-SymbolicName>${api.package}-api</Bundle-SymbolicName>
+                            <Bundle-SymbolicName>jakarta.ws.rs-api</Bundle-SymbolicName>
                             <DynamicImport-Package>*</DynamicImport-Package>
                             <Extension-Name>${api.package}</Extension-Name>
                             <Implementation-Version>${project.version}</Implementation-Version>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -483,6 +483,33 @@
                     </executions>
                 </plugin>
                 <plugin>
+                    <!-- Adding files to jar-->
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>3.0.0</version>
+                    <executions>
+                        <execution>
+                            <id>add-legal-resource</id>
+                            <phase>generate-resources</phase>
+                            <goals>
+                                <goal>add-resource</goal>
+                            </goals>
+                            <configuration>
+                                <resources>
+                                    <resource>
+                                        <directory>${legal.doc.folder}</directory>
+                                        <includes>
+                                            <include>NOTICE.md</include>
+                                            <include>LICENSE.md</include>
+                                        </includes>
+                                        <targetPath>META-INF</targetPath>
+                                    </resource>
+                                </resources>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
                     <version>2.8.2</version>
                     <configuration>
@@ -601,6 +628,10 @@
                 <groupId>org.glassfish.copyright</groupId>
                 <artifactId>glassfish-copyright-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 
@@ -636,6 +667,7 @@
         <jaxb.api.version>2.3.2</jaxb.api.version>
         <jaxb.impl.version>2.3.2</jaxb.impl.version>
         <activation.api.version>1.2.1</activation.api.version>
+        <legal.doc.folder>${maven.multiModuleProjectDirectory}/..</legal.doc.folder>
     </properties>
 
     <distributionManagement>


### PR DESCRIPTION
This PR is a *rollup* of all commits between 2.1.3 and 2.1.4 (`EE4J_8`) into 2.2-SNAPSHOT (`master`).
* Adding missing files in JAR demanded by EF.
* Fixes OSGi manifest as requested by downstream teams.

**As these are no API changes, and as all these changes are already contained in `EE4J_8` I propose a fast-track review period of just one day as per our [recently update committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**

**This PR is to be merged *before* the 2.1.5-rollup (#723)!**