### PR TITLE
Use ${project.basedir} to define legal.doc.folder

### DIFF
--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -728,7 +728,7 @@
         <jaxb.api.version>2.3.2</jaxb.api.version>
         <jaxb.impl.version>2.3.2</jaxb.impl.version>
         <activation.api.version>1.2.1</activation.api.version>
-        <legal.doc.folder>${maven.multiModuleProjectDirectory}/..</legal.doc.folder>
+        <legal.doc.folder>${project.basedir}/..</legal.doc.folder>
     </properties>
 
     <distributionManagement>


### PR DESCRIPTION
As discussed in #712, the Maven property `${maven.multiModuleProjectDirectory}` doesn't seem to work very well in all scenarios. As `jakarta.ws.rs-api` isn't a multi-module project, we could simply use `${project.basedir}` instead. In my tests this seems to work fine in all cases.

This is a very minor fix, so I propose a fast-track review period of one day.