### PR TITLE
2.1.5-Rollup

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2011, 2017 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2011, 2017 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -667,7 +667,7 @@
         <jaxb.api.version>2.3.2</jaxb.api.version>
         <jaxb.impl.version>2.3.2</jaxb.impl.version>
         <activation.api.version>1.2.1</activation.api.version>
-        <legal.doc.folder>${maven.multiModuleProjectDirectory}/..</legal.doc.folder>
+        <legal.doc.folder>${project.basedir}/..</legal.doc.folder>
     </properties>
 
     <distributionManagement>

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/ClientBuilder.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/ClientBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -237,7 +237,7 @@ public abstract class ClientBuilder implements Configurable<ClientBuilder> {
      *
      * @param scheduledExecutorService executor service to be used for scheduled async invocations.
      * @return an updated client builder instance.
-     * @see SseEventSource.Builder#reconnectingEvery(long, TimeUnit)
+     * @see javax.ws.rs.sse.SseEventSource.Builder#reconnectingEvery(long, TimeUnit)
      * @since 2.1
      */
     public abstract ClientBuilder scheduledExecutorService(final ScheduledExecutorService scheduledExecutorService);


### PR DESCRIPTION
This PR is a *rollup* of all commits between 2.1.4 and 2.1.5 (`EE4J_8`) into 2.2-SNAPSHOT (`master`).
* Adding missing files in JAR demanded by EF.
* Minor fixes.

**As these are no API changes, and as all these changes are already contained in `EE4J_8` I propose a fast-track review period of just one day as per our [recently update committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**

**This PR is to be merged *after* the 2.1.4-rollup (#717)!**

**Ths PR is to be merged *after* fixing the current build probles (#724)!**