### PR TITLE
New Eclipse Foundation CI Infrastructure (Jenkins)

### DIFF
--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -139,6 +139,12 @@
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
+                                <configuration>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
This PR modifies the branch `EE4J_8` so it can be built using the new Eclipse Foundation CI Infrastructure (Jenkins).

See #721 and https://wiki.eclipse.org/EE4J_Build.

**As these are no API changes, I propose a fast-track review period of just one day as per our [recently update committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**