### PR TITLE
Preparing JAX-RS 2.1.6-SNAPSHOT

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>jakarta.ws.rs</groupId>
     <artifactId>jakarta.ws.rs-examples</artifactId>
-    <version>2.1.5</version>
+    <version>2.1.6-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>jakarta.ws.rs-examples</name>
 
@@ -260,7 +260,7 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>2.1.5</version>
+            <version>2.1.6-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>jakarta.ws.rs</groupId>
     <artifactId>jakarta.ws.rs-api</artifactId>
-    <version>2.1.5</version>
+    <version>2.1.6-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>javax.ws.rs-api</name>
     <description>Java API for RESTful Web Services</description>


### PR DESCRIPTION
This PR prepares branch `EE4J_8` for a future bug fix release JAX-RS 2.1.6 (if needed before JAX-RS 2.2 is released).

**As these are no API changes, I propose a fast-track review period of just one day as per our [recently update committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**