### PR TITLE
Fixed JavaDocs: <tt> must either be <code> or {@code}

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>jakarta.ws.rs</groupId>
     <artifactId>jakarta.ws.rs-examples</artifactId>
-    <version>2.1.5</version>
+    <version>2.1.6-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>jakarta.ws.rs-examples</name>
 
@@ -260,7 +260,7 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>2.1.5</version>
+            <version>2.1.6-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/examples/src/main/java/jaxrs/examples/sse/ItemStoreResource.java
+++ b/examples/src/main/java/jaxrs/examples/sse/ItemStoreResource.java
@@ -128,7 +128,7 @@ public class ItemStoreResource {
     /**
      * Connect or re-connect to SSE event stream.
      *
-     * @param lastEventId Value of custom SSE HTTP <tt>{@value javax.ws.rs.core.HttpHeaders#LAST_EVENT_ID_HEADER}</tt> header.
+     * @param lastEventId Value of custom SSE HTTP <code>{@value javax.ws.rs.core.HttpHeaders#LAST_EVENT_ID_HEADER}</code> header.
      *                    Defaults to {@code -1} if not set.
      * @param serverSink new SSE server sink stream representing the (re-)established SSE client connection.
      * @throws InternalServerErrorException in case replaying missed events to the reconnected output stream fails.

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>jakarta.ws.rs</groupId>
     <artifactId>jakarta.ws.rs-api</artifactId>
-    <version>2.1.5</version>
+    <version>2.1.6-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>javax.ws.rs-api</name>
     <description>Java API for RESTful Web Services</description>

--- a/jaxrs-api/src/main/java/javax/ws/rs/container/ContainerResponseContext.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/container/ContainerResponseContext.java
@@ -327,7 +327,7 @@ public interface ContainerResponseContext {
      * </pre>
      * <p>
      * The container response context for a response returned from the {@code getMe()} method above would contain all
-     * the annotations declared on the {@code getAnnotatedMe()} method (<tt>&#64;GET, &#64;Custom</tt>) as well as all
+     * the annotations declared on the {@code getAnnotatedMe()} method ({@code @GET}, {@code @Custom}) as well as all
      * the annotations from the {@code extras} field, provided this value has not been replaced by any container response filter
      * invoked earlier.
      * </p>
@@ -352,7 +352,7 @@ public interface ContainerResponseContext {
      * <p>
      * Provided that the value has not been replaced by any container response filter invoked earlier,
      * the container response context for a response returned from the {@code getMe()} method above would contain all
-     * the annotations on the {@code getMe()} method (<tt>&#64;GET</tt>) as well as all the annotations from the
+     * the annotations on the {@code getMe()} method ({@code @GET}) as well as all the annotations from the
      * {@code extras} field. It would however not contain any annotations declared on the {@code AnnotatedMe} class.
      * </p>
      *

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Link.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Link.java
@@ -216,7 +216,7 @@ public abstract class Link {
 
     /**
      * Convenience method to build a link from a resource. Equivalent to
-     * <tt>Link.fromUriBuilder({@link UriBuilder#fromResource UriBuilder.fromResource(resource)})</tt>.
+     * {@code Link.fromUriBuilder({@link UriBuilder#fromResource UriBuilder.fromResource(resource)})}.
      * Note that the link URI passed to the {@code Link.Builder} instance returned by this
      * method is relative. Should the link be built as absolute, a {@link Link.Builder#baseUri(URI)
      * base URI} has to be specified in the builder prior to building the new link instance.
@@ -236,7 +236,7 @@ public abstract class Link {
 
     /**
      * Convenience method to build a link from a resource. Equivalent to
-     * <tt>Link.fromUriBuilder({@link UriBuilder#fromMethod(Class, String) UriBuilder.fromMethod(resource, method)})</tt>.
+     * {@code Link.fromUriBuilder({@link UriBuilder#fromMethod(Class, String) UriBuilder.fromMethod(resource, method)})}.
      * Note that the link URI passed to the {@code Link.Builder} instance returned by this
      * method is relative. Should the link be built as absolute, a {@link Link.Builder#baseUri(URI)
      * base URI} has to be specified in the builder prior to building the new link instance.

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/MultivaluedHashMap.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/MultivaluedHashMap.java
@@ -35,7 +35,7 @@ import java.util.Map;
  * {@link #addFirstNull(List) addFirstNull(...)} methods.
  * <p />
  * This implementation provides constant-time performance for the basic
- * operations (<tt>get</tt> and <tt>put</tt>), assuming the hash function
+ * operations ({@code get} and {@code put}), assuming the hash function
  * disperses the elements properly among the buckets. Iteration over
  * collection views requires time proportional to the "capacity" of the
  * map instance (the number of buckets) plus its size (the number
@@ -43,7 +43,7 @@ import java.util.Map;
  * capacity too high (or the load factor too low) if iteration performance is
  * important.
  * <p />
- * An instance of <tt>MultivaluedHashMap</tt> has two parameters that affect its
+ * An instance of {@code MultivaluedHashMap} has two parameters that affect its
  * performance: <i>initial capacity</i> and <i>load factor</i>. The <i>capacity</i>
  * is the number of buckets in the hash table, and the initial capacity is simply
  * the capacity at the time the hash table is created. The <i>load factor</i> is
@@ -56,14 +56,14 @@ import java.util.Map;
  * As a general rule, the default load factor (.75) offers a good tradeoff
  * between time and space costs. Higher values decrease the space overhead
  * but increase the lookup cost (reflected in most of the operations of the
- * <tt>HashMap</tt> class, including <tt>get</tt> and <tt>put</tt>). The
+ * {@code HashMap} class, including {@code get} and {@code put}). The
  * expected number of entries in the map and its load factor should be taken
  * into account when setting its initial capacity, so as to minimize the
  * number of rehash operations. If the initial capacity is greater
  * than the maximum number of entries divided by the load factor, no
  * rehash operations will ever occur.
  * <p />
- * If many mappings are to be stored in a <tt>MultivaluedHashMap</tt> instance,
+ * If many mappings are to be stored in a {@code MultivaluedHashMap} instance,
  * creating it with a sufficiently large capacity will allow the mappings to
  * be stored more efficiently than letting it perform automatic rehashing as
  * needed to grow the table.
@@ -80,7 +80,7 @@ import java.util.Map;
  * The iterators returned by all of this class's "collection view methods"
  * are <i>fail-fast</i>: if the map is structurally modified at any time after
  * the iterator is created, in any way except through the iterator's own
- * <tt>remove</tt> method, the iterator will throw a {@link ConcurrentModificationException}.
+ * {@code remove} method, the iterator will throw a {@link ConcurrentModificationException}.
  * Thus, in the face of concurrent modification, the iterator fails quickly and
  * cleanly, rather than risking arbitrary, non-deterministic behavior at an
  * undetermined time in the future.
@@ -88,7 +88,7 @@ import java.util.Map;
  * Note that the fail-fast behavior of an iterator cannot be guaranteed
  * as it is, generally speaking, impossible to make any hard guarantees in the
  * presence of unsynchronized concurrent modification. Fail-fast iterators
- * throw <tt>ConcurrentModificationException</tt> on a best-effort basis.
+ * throw {@code ConcurrentModificationException} on a best-effort basis.
  * Therefore, it would be wrong to write a program that depended on this
  * exception for its correctness: <i>the fail-fast behavior of iterators
  * should be used only to detect bugs.</i>

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Response.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Response.java
@@ -249,8 +249,8 @@ public abstract class Response implements AutoCloseable {
      * {@code true} if the entity is present, returns {@code false} otherwise.
      * <p>
      * Note that the method may return {@code true} also for response messages with
-     * a zero-length content, in case the <tt>{@value javax.ws.rs.core.HttpHeaders#CONTENT_LENGTH}</tt> and
-     * <tt>{@value javax.ws.rs.core.HttpHeaders#CONTENT_TYPE}</tt> headers are specified in the message.
+     * a zero-length content, in case the <code>{@value javax.ws.rs.core.HttpHeaders#CONTENT_LENGTH}</code> and
+     * <code>{@value javax.ws.rs.core.HttpHeaders#CONTENT_TYPE}</code> headers are specified in the message.
      * In such case, an attempt to read the entity using one of the {@code readEntity(...)}
      * methods will return a corresponding instance representing a zero-length entity for a
      * given Java type or produce a {@link ProcessingException} in case no such instance

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/UriInfo.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/UriInfo.java
@@ -362,13 +362,13 @@ public interface UriInfo {
      *
      * <p>Examples (for base URI {@code http://example.com:8080/app/root/}):
      * <br/>
-     * <br/><b>Request URI:</b> <tt>http://example.com:8080/app/root/a/b/c/resource.html</tt>
-     * <br/><b>Supplied URI:</b> <tt>a/b/c/d/file.txt</tt>
-     * <br/><b>Returned URI:</b> <tt>d/file.txt</tt>
+     * <br/><b>Request URI:</b> {@code http://example.com:8080/app/root/a/b/c/resource.html}
+     * <br/><b>Supplied URI:</b> {@code a/b/c/d/file.txt}
+     * <br/><b>Returned URI:</b> {@code d/file.txt}
      * <br/>
-     * <br/><b>Request URI:</b> <tt>http://example.com:8080/app/root/a/b/c/resource.html</tt>
-     * <br/><b>Supplied URI:</b> <tt>http://example2.com:9090/app2/root2/a/d/file.txt</tt>
-     * <br/><b>Returned URI:</b> <tt>http://example2.com:9090/app2/root2/a/d/file.txt</tt>
+     * <br/><b>Request URI:</b> {@code http://example.com:8080/app/root/a/b/c/resource.html}
+     * <br/><b>Supplied URI:</b> {@code http://example2.com:9090/app2/root2/a/d/file.txt}
+     * <br/><b>Returned URI:</b> {@code http://example2.com:9090/app2/root2/a/d/file.txt}
      * </p>
      *
      * <p>In the second example, the supplied URI is returned given that it is absolute

--- a/jaxrs-api/src/main/java/javax/ws/rs/sse/SseEventSource.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/sse/SseEventSource.java
@@ -41,7 +41,7 @@ import javax.ws.rs.client.WebTarget;
  * negotiation of delivery of any missed events based on the last received  SSE event {@code id} field value, provided
  * this field is set by the server and the negotiation facility is supported by the server. In case of a connection loss,
  * the last received SSE event {@code id} field value is send in the
- * <tt>{@value javax.ws.rs.core.HttpHeaders#LAST_EVENT_ID_HEADER}</tt> HTTP
+ * <code>{@value javax.ws.rs.core.HttpHeaders#LAST_EVENT_ID_HEADER}</code> HTTP
  * request header as part of a new connection request sent to the SSE endpoint. Upon a receipt of such reconnect request, the SSE
  * endpoint that supports this negotiation facility is expected to replay all missed events. Note however, that this is a
  * best-effort mechanism which does not provide any guaranty that all events would be delivered without a loss. You should
@@ -55,12 +55,12 @@ import javax.ws.rs.client.WebTarget;
  * <p>
  * In addition to handling the standard connection loss failures, JAX-RS {@code SseEventSource} automatically deals with any
  * {@code HTTP 503 Service Unavailable} responses from an SSE endpoint, that contain a
- * <tt>{@value javax.ws.rs.core.HttpHeaders#RETRY_AFTER}</tt> HTTP header with a valid value. The
- * <tt>HTTP 503 + {@value javax.ws.rs.core.HttpHeaders#RETRY_AFTER}</tt> technique is often used by HTTP endpoints
+ * <code>{@value javax.ws.rs.core.HttpHeaders#RETRY_AFTER}</code> HTTP header with a valid value. The
+ * <code>HTTP 503 + {@value javax.ws.rs.core.HttpHeaders#RETRY_AFTER}</code> technique is often used by HTTP endpoints
  * as a means of connection and traffic throttling.
- * In case a <tt>HTTP 503 + {@value javax.ws.rs.core.HttpHeaders#RETRY_AFTER}</tt> response is received in return to a connection
+ * In case a <code>HTTP 503 + {@value javax.ws.rs.core.HttpHeaders#RETRY_AFTER}</code> response is received in return to a connection
  * request, JAX-RS SSE event source will automatically schedule a new reconnect attempt and use the received
- * <tt>{@value javax.ws.rs.core.HttpHeaders#RETRY_AFTER}</tt> HTTP header value as a one-time override of the reconnect delay.
+ * <code>{@value javax.ws.rs.core.HttpHeaders#RETRY_AFTER}</code> HTTP header value as a one-time override of the reconnect delay.
  *
  * @author Marek Potociar
  * @since 2.1
@@ -137,7 +137,7 @@ public interface SseEventSource extends AutoCloseable {
          * Set the initial reconnect delay to be used by the event source.
          * <p>
          * Note that this value may be later overridden by the SSE endpoint using either a {@code retry} SSE event field
-         * or <tt>HTTP 503 + {@value javax.ws.rs.core.HttpHeaders#RETRY_AFTER}</tt> mechanism as described
+         * or <code>HTTP 503 + {@value javax.ws.rs.core.HttpHeaders#RETRY_AFTER}</code> mechanism as described
          * in the {@link SseEventSource} javadoc.
          *
          * @param delay the default time to wait before attempting to recover from a connection loss.


### PR DESCRIPTION
Latest JavaDoc does not allow `<tt>` anymore as it was deprecated with HTML 5, hence replacing it by `<code>` or `{@code}`.