### PR TITLE
Releasing using OpenJDK (latest) instead of 8uX.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
 		pollSCM('H H * * *')
 	}
 	tools {
-		jdk 'jdk1.8.0-latest'
+		jdk 'openjdk-latest'
 		maven 'apache-maven-latest'
 	}
 	environment {


### PR DESCRIPTION
This is the same as #724 but this time we need it for `EE4J_8`.

**As these are no API changes, I propose a fast-track review period of just one day as per our [recently update committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**