### PR TITLE
New method #hasProperty

### DIFF
--- a/jaxrs-api/src/main/java/javax/ws/rs/JAXRS.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/JAXRS.java
@@ -298,7 +298,7 @@ public interface JAXRS {
          * Returns whether the property with the given name is configured, either explicitly or by default.
          *
          * @param name a {@code String} specifying the name of the property.
-         * @return {@code true} if the property has a value other than {@code null}, or {@code false} otherwise.
+         * @return {@code false} if no property exists matching the given name, {@code true} otherwise.
          * @since 2.2
          */
         default boolean hasProperty(String name) {

--- a/jaxrs-api/src/main/java/javax/ws/rs/JAXRS.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/JAXRS.java
@@ -295,6 +295,17 @@ public interface JAXRS {
         Object property(String name);
 
         /**
+         * Returns whether the property with the given name exists.
+         *
+         * @param name a {@code String} specifying the name of the property.
+         * @return {@code true} if the property exists, or {@code false} otherwise.
+         * @since 2.2
+         */
+        default boolean hasProperty(String name) {
+            return property(name) != null;
+        }
+
+        /**
          * Convenience method to get the {@code protocol} to be used.
          * <p>
          * Same as if calling {@link #property(String) (String) property(PROTOCOL)}.

--- a/jaxrs-api/src/main/java/javax/ws/rs/JAXRS.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/JAXRS.java
@@ -295,10 +295,10 @@ public interface JAXRS {
         Object property(String name);
 
         /**
-         * Returns whether the property with the given name exists.
+         * Returns whether the property with the given name is configured, either explicitly or by default.
          *
          * @param name a {@code String} specifying the name of the property.
-         * @return {@code true} if the property exists, or {@code false} otherwise.
+         * @return {@code true} if the property has a value other than {@code null}, or {@code false} otherwise.
          * @since 2.2
          */
         default boolean hasProperty(String name) {

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/ClientRequestContext.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/ClientRequestContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -75,6 +75,22 @@ public interface ClientRequestContext {
      * @see #getProperty
      */
     public Collection<String> getPropertyNames();
+
+    /**
+     * Returns {@code true} if the property with the given name is registered in the current request/response exchange
+     * context, or {@code false} if there is no property by that name.
+     * <p>
+     * Use the {@link #getProperty} method with a property name to get the value of a property.
+     * </p>
+     *
+     * @param name a {@code String} specifying the name of the property.
+     * @return {@code true} if this property is registered in the context, or {@code false} if no property exists matching
+     * the given name.
+     * @see #getPropertyNames()
+     */
+    default public boolean hasProperty(String name) {
+        return getProperty(name) != null;
+    }
 
     /**
      * Binds an object to a given property name in the current request/response exchange context. If the name specified is

--- a/jaxrs-api/src/main/java/javax/ws/rs/container/ContainerRequestContext.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/container/ContainerRequestContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -67,6 +67,22 @@ public interface ContainerRequestContext {
      * @see #getPropertyNames()
      */
     public Object getProperty(String name);
+
+    /**
+     * Returns {@code true} if the property with the given name is registered in the current request/response exchange
+     * context, or {@code false} if there is no property by that name.
+     * <p>
+     * Use the {@link #getProperty} method with a property name to get the value of a property.
+     * </p>
+     *
+     * @param name a {@code String} specifying the name of the property.
+     * @return {@code true} if this property is registered in the context, or {@code false} if no property exists matching
+     * the given name.
+     * @see #getPropertyNames()
+     */
+    default public boolean hasProperty(String name) {
+        return getProperty(name) != null;
+    }
 
     /**
      * Returns an immutable {@link java.util.Collection collection} containing the property names available within the

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Configuration.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Configuration.java
@@ -64,11 +64,11 @@ public interface Configuration {
     public Object getProperty(String name);
 
     /**
-     * Check whether the property with a given name exists.
+     * Check whether the property with a given name is configured.
      *
      * @param name property name.
-     * @return {@code true} if the property with the specified property name exists, or {@code false} if the property with
-     * such name is not configured.
+     * @return {@code true} if the property with the specified property name has a value other than {@code null}, or
+     * {@code false} if the property with such name is not configured.
      */
     default public boolean hasProperty(String name) {
         return getProperty(name) != null;

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Configuration.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Configuration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -62,6 +62,17 @@ public interface Configuration {
      * configured.
      */
     public Object getProperty(String name);
+
+    /**
+     * Check whether the property with a given name exists.
+     *
+     * @param name property name.
+     * @return {@code true} if the property with the specified property name exists, or {@code false} if the property with
+     * such name is not configured.
+     */
+    default public boolean hasProperty(String name) {
+        return getProperty(name) != null;
+    }
 
     /**
      * Returns an immutable {@link java.util.Collection collection} containing the property names available within the

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Configuration.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Configuration.java
@@ -67,8 +67,7 @@ public interface Configuration {
      * Check whether the property with a given name is configured.
      *
      * @param name property name.
-     * @return {@code true} if the property with the specified property name has a value other than {@code null}, or
-     * {@code false} if the property with such name is not configured.
+     * @return {@code false} if the property with such name is not configured, {@code true} otherwise.
      */
     default public boolean hasProperty(String name) {
         return getProperty(name) != null;

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/InterceptorContext.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/InterceptorContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -59,6 +59,22 @@ public interface InterceptorContext {
      * @see #getPropertyNames()
      */
     public Object getProperty(String name);
+
+    /**
+     * Returns {@code true} if the property with the given name is registered in the current request/response exchange context,
+     * or {@code false} if there is no property by that name.
+     * <p>
+     * Use the {@link #getProperty} method with a property name to get the value of a property.
+     * </p>
+     *
+     * @param name a {@code String} specifying the name of the property.
+     * @return {@code true} if this property is registered in the context, or {@code false} if no property exists matching the
+     * given name.
+     * @see #getPropertyNames()
+     */
+    default public boolean hasProperty(String name) {
+        return getProperty(name) != null;
+    }
 
     /**
      * Returns an immutable {@link java.util.Collection collection} containing the property names available within the

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/InterceptorContext.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/InterceptorContext.java
@@ -61,15 +61,15 @@ public interface InterceptorContext {
     public Object getProperty(String name);
 
     /**
-     * Returns {@code true} if the property with the given name is registered in the current request/response exchange context,
-     * or {@code false} if there is no property by that name.
+     * Returns {@code true} if the property with the given name is registered in the current request/response exchange
+     * context, or {@code false} if there is no property by that name.
      * <p>
      * Use the {@link #getProperty} method with a property name to get the value of a property.
      * </p>
      *
      * @param name a {@code String} specifying the name of the property.
-     * @return {@code true} if this property is registered in the context, or {@code false} if no property exists matching the
-     * given name.
+     * @return {@code true} if this property is registered in the context, or {@code false} if no property exists matching
+     * the given name.
      * @see #getPropertyNames()
      */
     default public boolean hasProperty(String name) {


### PR DESCRIPTION
In some circumstances it might be beneficial to have a new method `InterceptorContext#hasProperty(String name)` which simply returns `true` if a property name is known to the context. As of JAX-RS 2.1 it is possible to workaround this by `InterceptorContext#getProperty(String name) != null`, but this might imply a performance penalty in case the implementation needs *additionional time* to actually retrieve the value of the property. Some implementations might benefit from having this method, and some application programmers might like the brevity of this new method.

This PR implements this as a `default` interface method, so implementations can decide to either implement a performance improved variant, or simply stay with the default solution without breaking backwards compatibility.