### PR TITLE
Travis CI is caching local Maven Repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ jdk:
   - openjdk10
   - openjdk11
 
+cache:
+  directories:
+    - $HOME/.m2
+
 install:
   - cd $TRAVIS_BUILD_DIR/jaxrs-api
   - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V


### PR DESCRIPTION
Improves Travis CI performance by loading one big folder instead of running a lot of single dependency downloads (in my tests, performance was about doubled). :-)

Unfortunately EF has no similar solution at hand for Jenkins (at least right now off-the-box). :-(