### PR TITLE
Fix for #734 (Javadoc fails on JDK 11 and later)

### DIFF
--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -479,6 +479,7 @@
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>${maven.javadoc.plugin.version}</version>
                     <configuration>
+                        <source>8</source>
                         <doctitle>${apidocs.title}</doctitle>
                         <bottom>
                             <![CDATA[Copyright &#169; 1996-2017,
@@ -718,7 +719,7 @@
 
         <maven.bundle.plugin.version>3.5.0</maven.bundle.plugin.version>
         <maven.compiler.plugin.version>3.7.0</maven.compiler.plugin.version>
-        <maven.javadoc.plugin.version>3.0.0</maven.javadoc.plugin.version>
+        <maven.javadoc.plugin.version>3.1.0</maven.javadoc.plugin.version>
 
         <api.package>javax.ws.rs</api.package>
         <last.final.spec.version>2.1</last.final.spec.version>


### PR DESCRIPTION
Fixes #734 by using Maven Javadoc Plugin 3.1.0

**As these are no API changes, I propose a fast-track review period of just one day as per our [current committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**