### PR TITLE
Jenkinsfile explicitly refers to external config files [New Infrastructure] [EE4J_8]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,11 +19,16 @@ pipeline {
 				}
 			}
 			steps {
-				dir ('jaxrs-api') {
-					sh "$MVN deploy"
-				}
-				dir ('examples') {
-					sh "$MVN deploy"
+				configFileProvider([
+					configFile(fileId: 'a79c37a7-bfd9-4699-8077-f992027b2c1b', targetLocation: '/home/jenkins/.m2/settings.xml'),
+					configFile(fileId: 'b78b4e15-215f-42bc-81ac-53cd3e2ef708', targetLocation: '/home/jenkins/.m2/')
+				]) {
+					dir ('jaxrs-api') {
+						sh "$MVN deploy"
+					}
+					dir ('examples') {
+						sh "$MVN deploy"
+					}
 				}
 			}
 		}


### PR DESCRIPTION
The EF's new Jenkins infrastructure needs a change in the Jenkinsfiles:
The external Maven configuration files have to be explicitly declared
now.

**This fix is for the `EE4J_8` branch. A similar for exists for the `master` branch (#738).**

**As these are no API changes, I propose a fast-track review period of just one day as per our [recently update committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**