### PR TITLE
Jenkinsfile explicitly refers to external config files [New Infrastructure] [master]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,11 +19,16 @@ pipeline {
 				}
 			}
 			steps {
-				dir ('jaxrs-api') {
-					sh "$MVN deploy"
-				}
-				dir ('examples') {
-					sh "$MVN deploy"
+				configFileProvider([
+					configFile(fileId: 'a79c37a7-bfd9-4699-8077-f992027b2c1b', targetLocation: '/home/jenkins/.m2/settings.xml'),
+					configFile(fileId: 'b78b4e15-215f-42bc-81ac-53cd3e2ef708', targetLocation: '/home/jenkins/.m2/')
+				]) {
+					dir ('jaxrs-api') {
+						sh "$MVN deploy"
+					}
+					dir ('examples') {
+						sh "$MVN deploy"
+					}
 				}
 			}
 		}

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -124,6 +124,12 @@
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
+                                <configuration>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
The EF's new Jenkins infrastructure needs a change in the Jenkinsfiles: The external Maven configuration files have to be explicitly declared now.

**This fix is for the `master` branch. A similar fix exists for the `EE4J_8` branch (#737).**

**As these are no API changes, I propose a fast-track review period of just one day as per our [recently update committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**