### PR TITLE
Travis generates JavaDoc and runs integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,6 @@ install:
 
 script:
   - cd $TRAVIS_BUILD_DIR/jaxrs-api
-  - mvn test -B
+  - mvn verify -B
   - cd $TRAVIS_BUILD_DIR/examples
-  - mvn test -B
+  - mvn verify -B

--- a/examples/src/main/java/jaxrs/examples/sse/ItemStoreResource.java
+++ b/examples/src/main/java/jaxrs/examples/sse/ItemStoreResource.java
@@ -125,7 +125,7 @@ public class ItemStoreResource {
     /**
      * Connect or re-connect to SSE event stream.
      *
-     * @param lastEventId Value of custom SSE HTTP <tt>{@value javax.ws.rs.core.HttpHeaders#LAST_EVENT_ID_HEADER}</tt>
+     * @param lastEventId Value of custom SSE HTTP <code>{@value javax.ws.rs.core.HttpHeaders#LAST_EVENT_ID_HEADER}</code>
      * header. Defaults to {@code -1} if not set.
      * @param serverSink new SSE server sink stream representing the (re-)established SSE client connection.
      * @throws InternalServerErrorException in case replaying missed events to the reconnected output stream fails.

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -438,6 +438,7 @@
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>${maven.javadoc.plugin.version}</version>
                     <configuration>
+                        <source>8</source>
                         <doctitle>${apidocs.title}</doctitle>
                         <bottom>
                             <![CDATA[Copyright &#169; 1996-2017,
@@ -662,7 +663,7 @@
 
         <maven.bundle.plugin.version>3.5.0</maven.bundle.plugin.version>
         <maven.compiler.plugin.version>3.7.0</maven.compiler.plugin.version>
-        <maven.javadoc.plugin.version>3.0.0</maven.javadoc.plugin.version>
+        <maven.javadoc.plugin.version>3.1.0</maven.javadoc.plugin.version>
 
         <api.package>javax.ws.rs</api.package>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/jaxrs-api/src/main/java/javax/ws/rs/container/ContainerResponseContext.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/container/ContainerResponseContext.java
@@ -305,7 +305,7 @@ public interface ContainerResponseContext {
      * </pre>
      * <p>
      * The container response context for a response returned from the {@code getMe()} method above would contain all the
-     * annotations declared on the {@code getAnnotatedMe()} method (<tt>&#64;GET, &#64;Custom</tt>) as well as all the
+     * annotations declared on the {@code getAnnotatedMe()} method ({@code @GET}, {@code @Custom}) as well as all the
      * annotations from the {@code extras} field, provided this value has not been replaced by any container response filter
      * invoked earlier.
      * </p>
@@ -331,7 +331,7 @@ public interface ContainerResponseContext {
      * <p>
      * Provided that the value has not been replaced by any container response filter invoked earlier, the container
      * response context for a response returned from the {@code getMe()} method above would contain all the annotations on
-     * the {@code getMe()} method (<tt>&#64;GET</tt>) as well as all the annotations from the {@code extras} field. It would
+     * the {@code getMe()} method ({@code @GET}) as well as all the annotations from the {@code extras} field. It would
      * however not contain any annotations declared on the {@code AnnotatedMe} class.
      * </p>
      *

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Link.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Link.java
@@ -211,7 +211,7 @@ public abstract class Link {
 
     /**
      * Convenience method to build a link from a resource. Equivalent to
-     * <tt>Link.fromUriBuilder({@link UriBuilder#fromResource UriBuilder.fromResource(resource)})</tt>. Note that the link
+     * {@code Link.fromUriBuilder({@link UriBuilder#fromResource UriBuilder.fromResource(resource)})}. Note that the link
      * URI passed to the {@code Link.Builder} instance returned by this method is relative. Should the link be built as
      * absolute, a {@link Link.Builder#baseUri(URI) base URI} has to be specified in the builder prior to building the new
      * link instance. For example, on a server side a {@link UriInfo#getBaseUri()} may be typically used to define the base
@@ -229,7 +229,7 @@ public abstract class Link {
 
     /**
      * Convenience method to build a link from a resource. Equivalent to
-     * <tt>Link.fromUriBuilder({@link UriBuilder#fromMethod(Class, String) UriBuilder.fromMethod(resource, method)})</tt>.
+     * {@code Link.fromUriBuilder({@link UriBuilder#fromMethod(Class, String) UriBuilder.fromMethod(resource, method)})}.
      * Note that the link URI passed to the {@code Link.Builder} instance returned by this method is relative. Should the
      * link be built as absolute, a {@link Link.Builder#baseUri(URI) base URI} has to be specified in the builder prior to
      * building the new link instance. For example, on a server side a {@link UriInfo#getBaseUri()} may be typically used to

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/MultivaluedHashMap.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/MultivaluedHashMap.java
@@ -34,14 +34,14 @@ import java.util.Map;
  * {@link #addFirstNull(List) addFirstNull(...)} methods.
  * </p>
  * <p>
- * This implementation provides constant-time performance for the basic operations (<tt>get</tt> and <tt>put</tt>),
+ * This implementation provides constant-time performance for the basic operations ({@code get} and {@code put}),
  * assuming the hash function disperses the elements properly among the buckets. Iteration over collection views
  * requires time proportional to the "capacity" of the map instance (the number of buckets) plus its size (the number of
  * key-value mappings). Thus, it's very important not to set the initial capacity too high (or the load factor too low)
  * if iteration performance is important.
  * </p>
  * <p>
- * An instance of <tt>MultivaluedHashMap</tt> has two parameters that affect its performance: <i>initial capacity</i>
+ * An instance of {@code MultivaluedHashMap} has two parameters that affect its performance: <i>initial capacity</i>
  * and <i>load factor</i>. The <i>capacity</i> is the number of buckets in the hash table, and the initial capacity is
  * simply the capacity at the time the hash table is created. The <i>load factor</i> is a measure of how full the hash
  * table is allowed to get before its capacity is automatically increased. When the number of entries in the hash table
@@ -50,14 +50,14 @@ import java.util.Map;
  * </p>
  * <p>
  * As a general rule, the default load factor (.75) offers a good tradeoff between time and space costs. Higher values
- * decrease the space overhead but increase the lookup cost (reflected in most of the operations of the <tt>HashMap</tt>
- * class, including <tt>get</tt> and <tt>put</tt>). The expected number of entries in the map and its load factor should
+ * decrease the space overhead but increase the lookup cost (reflected in most of the operations of the {@code HashMap}
+ * class, including {@code get} and {@code put}). The expected number of entries in the map and its load factor should
  * be taken into account when setting its initial capacity, so as to minimize the number of rehash operations. If the
  * initial capacity is greater than the maximum number of entries divided by the load factor, no rehash operations will
  * ever occur.
  * </p>
  * <p>
- * If many mappings are to be stored in a <tt>MultivaluedHashMap</tt> instance, creating it with a sufficiently large
+ * If many mappings are to be stored in a {@code MultivaluedHashMap} instance, creating it with a sufficiently large
  * capacity will allow the mappings to be stored more efficiently than letting it perform automatic rehashing as needed
  * to grow the table.
  * </p>
@@ -71,13 +71,13 @@ import java.util.Map;
  * <p>
  * The iterators returned by all of this class's "collection view methods" are <i>fail-fast</i>: if the map is
  * structurally modified at any time after the iterator is created, in any way except through the iterator's own
- * <tt>remove</tt> method, the iterator will throw a {@link ConcurrentModificationException}. Thus, in the face of
+ * {@code remove} method, the iterator will throw a {@link ConcurrentModificationException}. Thus, in the face of
  * concurrent modification, the iterator fails quickly and cleanly, rather than risking arbitrary, non-deterministic
  * behavior at an undetermined time in the future.
  * </p>
  * Note that the fail-fast behavior of an iterator cannot be guaranteed as it is, generally speaking, impossible to make
  * any hard guarantees in the presence of unsynchronized concurrent modification. Fail-fast iterators throw
- * <tt>ConcurrentModificationException</tt> on a best-effort basis. Therefore, it would be wrong to write a program that
+ * {@code ConcurrentModificationException} on a best-effort basis. Therefore, it would be wrong to write a program that
  * depended on this exception for its correctness: <i>the fail-fast behavior of iterators should be used only to detect
  * bugs.</i>
  *

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Response.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Response.java
@@ -218,8 +218,8 @@ public abstract class Response implements AutoCloseable {
      * returns {@code false} otherwise.
      * <p>
      * Note that the method may return {@code true} also for response messages with a zero-length content, in case the
-     * <tt>{@value javax.ws.rs.core.HttpHeaders#CONTENT_LENGTH}</tt> and
-     * <tt>{@value javax.ws.rs.core.HttpHeaders#CONTENT_TYPE}</tt> headers are specified in the message. In such case, an
+     * <code>{@value javax.ws.rs.core.HttpHeaders#CONTENT_LENGTH}</code> and
+     * <code>{@value javax.ws.rs.core.HttpHeaders#CONTENT_TYPE}</code> headers are specified in the message. In such case, an
      * attempt to read the entity using one of the {@code readEntity(...)} methods will return a corresponding instance
      * representing a zero-length entity for a given Java type or produce a {@link ProcessingException} in case no such
      * instance is available for the Java type.

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/UriInfo.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/UriInfo.java
@@ -325,13 +325,13 @@ public interface UriInfo {
      * <p>
      * Examples (for base URI {@code http://example.com:8080/app/root/}): <br>
      * <br>
-     * <b>Request URI:</b> <tt>http://example.com:8080/app/root/a/b/c/resource.html</tt> <br>
-     * <b>Supplied URI:</b> <tt>a/b/c/d/file.txt</tt> <br>
-     * <b>Returned URI:</b> <tt>d/file.txt</tt> <br>
+     * <b>Request URI:</b> {@code http://example.com:8080/app/root/a/b/c/resource.html} <br>
+     * <b>Supplied URI:</b> {@code a/b/c/d/file.txt} <br>
+     * <b>Returned URI:</b> {@code d/file.txt} <br>
      * <br>
-     * <b>Request URI:</b> <tt>http://example.com:8080/app/root/a/b/c/resource.html</tt> <br>
-     * <b>Supplied URI:</b> <tt>http://example2.com:9090/app2/root2/a/d/file.txt</tt> <br>
-     * <b>Returned URI:</b> <tt>http://example2.com:9090/app2/root2/a/d/file.txt</tt>
+     * <b>Request URI:</b> {@code http://example.com:8080/app/root/a/b/c/resource.html} <br>
+     * <b>Supplied URI:</b> {@code http://example2.com:9090/app2/root2/a/d/file.txt} <br>
+     * <b>Returned URI:</b> {@code http://example2.com:9090/app2/root2/a/d/file.txt}
      * </p>
      *
      * <p>

--- a/jaxrs-api/src/main/java/javax/ws/rs/sse/SseEventSource.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/sse/SseEventSource.java
@@ -39,7 +39,7 @@ import javax.ws.rs.client.WebTarget;
  * The {@code SseEventSource} supports automated recuperation from a connection loss, including negotiation of delivery
  * of any missed events based on the last received SSE event {@code id} field value, provided this field is set by the
  * server and the negotiation facility is supported by the server. In case of a connection loss, the last received SSE
- * event {@code id} field value is send in the <tt>{@value javax.ws.rs.core.HttpHeaders#LAST_EVENT_ID_HEADER}</tt> HTTP
+ * event {@code id} field value is send in the <code>{@value javax.ws.rs.core.HttpHeaders#LAST_EVENT_ID_HEADER}</code> HTTP
  * request header as part of a new connection request sent to the SSE endpoint. Upon a receipt of such reconnect
  * request, the SSE endpoint that supports this negotiation facility is expected to replay all missed events. Note
  * however, that this is a best-effort mechanism which does not provide any guaranty that all events would be delivered
@@ -54,12 +54,12 @@ import javax.ws.rs.client.WebTarget;
  * <p>
  * In addition to handling the standard connection loss failures, JAX-RS {@code SseEventSource} automatically deals with
  * any {@code HTTP 503 Service Unavailable} responses from an SSE endpoint, that contain a
- * <tt>{@value javax.ws.rs.core.HttpHeaders#RETRY_AFTER}</tt> HTTP header with a valid value. The
- * <tt>HTTP 503 + {@value javax.ws.rs.core.HttpHeaders#RETRY_AFTER}</tt> technique is often used by HTTP endpoints as a
+ * <code>{@value javax.ws.rs.core.HttpHeaders#RETRY_AFTER}</code> HTTP header with a valid value. The
+ * <code>HTTP 503 + {@value javax.ws.rs.core.HttpHeaders#RETRY_AFTER}</code> technique is often used by HTTP endpoints as a
  * means of connection and traffic throttling. In case a
- * <tt>HTTP 503 + {@value javax.ws.rs.core.HttpHeaders#RETRY_AFTER}</tt> response is received in return to a connection
+ * <code>HTTP 503 + {@value javax.ws.rs.core.HttpHeaders#RETRY_AFTER}</code> response is received in return to a connection
  * request, JAX-RS SSE event source will automatically schedule a new reconnect attempt and use the received
- * <tt>{@value javax.ws.rs.core.HttpHeaders#RETRY_AFTER}</tt> HTTP header value as a one-time override of the reconnect
+ * <code>{@value javax.ws.rs.core.HttpHeaders#RETRY_AFTER}</code> HTTP header value as a one-time override of the reconnect
  * delay.
  *
  * @author Marek Potociar
@@ -136,7 +136,7 @@ public interface SseEventSource extends AutoCloseable {
          * Set the initial reconnect delay to be used by the event source.
          * <p>
          * Note that this value may be later overridden by the SSE endpoint using either a {@code retry} SSE event field or
-         * <tt>HTTP 503 + {@value javax.ws.rs.core.HttpHeaders#RETRY_AFTER}</tt> mechanism as described in the
+         * <code>HTTP 503 + {@value javax.ws.rs.core.HttpHeaders#RETRY_AFTER}</code> mechanism as described in the
          * {@link SseEventSource} javadoc.
          *
          * @param delay the default time to wait before attempting to recover from a connection loss.


### PR DESCRIPTION
To detect problems as soon as possible, Travis now generates JavaDocs and runs integration tests.

**As these are no API changes, I propose a fast-track review period of just one day as per our [recently update committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**