### PR TITLE
2.1.x-Backport

### DIFF
--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/MessageBodyReader.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/MessageBodyReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -28,7 +28,8 @@ import java.lang.reflect.Type;
  *
  * A {@code MessageBodyReader} implementation may be annotated
  * with {@link javax.ws.rs.Consumes} to restrict the media types for which it will
- * be considered suitable.
+ * be considered suitable. The {@code MessageBodyReader} pipeline is executed if the matching 
+ * resource method declares an entity parameter or uses at least one {@link javax.ws.rs.FormParam}.
  * <p>
  * Providers implementing {@code MessageBodyReader} contract must be either programmatically
  * registered in an API runtime or must be annotated with

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/MessageBodyWriter.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/MessageBodyWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -28,7 +28,8 @@ import java.lang.reflect.Type;
  *
  * A {@code MessageBodyWriter} implementation may be annotated
  * with {@link javax.ws.rs.Produces} to restrict the media types for which it will
- * be considered suitable.
+ * be considered suitable. The {@code MessageBodyWriter} pipeline is only invoked if there is 
+ * a non-null response entity.
  * <p>
  * Providers implementing {@code MessageBodyWriter} contract must be either programmatically
  * registered in an API runtime or must be annotated with


### PR DESCRIPTION
This PR is a *backport* of select **bug fixes** between `2.1.5` and `master:HEAD` into 2.1.6-SNAPSHOT (`EE4J_8`).

**As these are no API changes, and as all these changes are already contained in `master` I propose a fast-track review period of just one day as per our [recently update committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**