### PR TITLE
JAX-RS Extensions

### DIFF
--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/Extension.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/Extension.java
@@ -16,6 +16,8 @@
 
 package javax.ws.rs.ext;
 
+import java.util.ServiceLoader;
+
 /**
  * <p>
  * An extension to the JAX-RS runtime.
@@ -26,9 +28,9 @@ package javax.ws.rs.ext;
  * runtimes.
  * </p>
  * <p>
- * JAX-RS implementations MUST automatically register classes implementing this interface in
- * {@link javax.ws.rs.core.Configuration runtime configurations} if the fully qualified name of the implementing class
- * is found in the file {@code javax.ws.rs.ext.Extension} in the {@code META-INF/services} directory.
+ * JAX-RS implementations MUST automatically register a class in {@link javax.ws.rs.core.Configuration runtime
+ * configurations} if the class is a <em>provider class</em> for the {@link Extension} <em>service type</em> according
+ * to the rules set out in the description of {@link ServiceLoader}.
  * </p>
  *
  * @author Markus KARG (markus@headcrashing.eu)

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/Extension.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/Extension.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018 Markus KARG. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package javax.ws.rs.ext;
+
+/**
+ * <p>
+ * An extension to the JAX-RS runtime.
+ * </p>
+ * <p>
+ * All kinds of JAX-RS components (i. e. filters and interceptors, features, providers, etc.) can be marked as an
+ * extension to the JAX-RS runtime, hence will become available to <em>all</em> applications running on thusly extended
+ * runtimes.
+ * </p>
+ * <p>
+ * JAX-RS implementations MUST automatically register classes implementing this interface in
+ * {@link javax.ws.rs.core.Configuration runtime configurations} if the fully qualified name of the implementing class
+ * is found in the file {@code javax.ws.rs.ext.Extension} in the {@code META-INF/services} directory.
+ * </p>
+ *
+ * @author Markus KARG (markus@headcrashing.eu)
+ */
+public interface Extension {
+}


### PR DESCRIPTION
This proposed feature standardizes an API for **JAX-RS Extensions**.

While JAX-RS components since ever could be *explicitly declared* to be loaded by `Application` classes, only *some* environments could auto-detect them *without* such explicit declaration of the application. In environments *not* supporting auto-detection this is not nice, because JAX-RS components might be provided on the classpath to be used with *any* application, i. e. *without* both, neither the application provider's knowledge or explicit grant, nor the runtime vendor's. Examples could be tracing and monitoring functionality, possibly from third parties (like cloud providers) *combining* JAX-RS *applications* with JAX-RS *runtimes*.

So JAX-RS Extensions provide a third origin of components on the classpath, besides runtime vendors and application providers: Deployers and Administrators.

JAX-RS Extensions are *not* a new kind of component, but simply are a declarative way to turn *any* kind of JAX-RS component into a forcefully **auto-loaded** component, just by declaring a marker interface in the way Java's ServiceLoader API works. In fact, the proposed mechanism does not actually instantiate components, but just detects the declared classes, and registers these into the JAX-RS configuration, so the already existing JAX-RS component lifecycle and scope will be in applied. That way this new extension is not only most flexible, but also least complex to add to existing runtimes: [A sample implementation](https://github.com/mkarg/jersey/commit/af3ea47681bac6f51d7d0fc5c81c969bd50e37e6) proofs that the new mechanism can be supported by e. g. Jersey without even touching Jersey's source code, just by adding a new external incubator module! Please also find the [demo application](https://github.com/mkarg/jaxrs-extensions-example) showing how Java SE bootstrapping works with this new feature.

**As CDI adoption is a long way to go, and as Jersey apparently can so easily support this, I'd like to propose that we adopt this rather small but really useful mechanism to JAX-RS 2.2.**