### PR TITLE
[581] Remove Jersey as default implementation

### DIFF
--- a/jaxrs-api/src/main/java/javax/ws/rs/client/ClientBuilder.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/ClientBuilder.java
@@ -43,10 +43,6 @@ public abstract class ClientBuilder implements Configurable<ClientBuilder> {
      * {@link ClientBuilder#newBuilder()}.
      */
     public static final String JAXRS_DEFAULT_CLIENT_BUILDER_PROPERTY = "javax.ws.rs.client.ClientBuilder";
-    /**
-     * Default client builder implementation class name.
-     */
-    private static final String JAXRS_DEFAULT_CLIENT_BUILDER = "org.glassfish.jersey.client.JerseyClientBuilder";
 
     /**
      * Allows custom implementations to extend the {@code ClientBuilder} class.
@@ -62,8 +58,7 @@ public abstract class ClientBuilder implements Configurable<ClientBuilder> {
      */
     public static ClientBuilder newBuilder() {
         try {
-            Object delegate = FactoryFinder.find(JAXRS_DEFAULT_CLIENT_BUILDER_PROPERTY,
-                    JAXRS_DEFAULT_CLIENT_BUILDER, ClientBuilder.class);
+            Object delegate = FactoryFinder.find(JAXRS_DEFAULT_CLIENT_BUILDER_PROPERTY, ClientBuilder.class);
             if (!(delegate instanceof ClientBuilder)) {
                 Class pClass = ClientBuilder.class;
                 String classnameAsResource = pClass.getName().replace('.', '/') + ".class";

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/FactoryFinder.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/FactoryFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/FactoryFinder.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/FactoryFinder.java
@@ -94,21 +94,17 @@ final class FactoryFinder {
     }
 
     /**
-     * Finds the implementation {@code Class} for the given factory name, or if that fails, finds the {@code Class} for the
-     * given fallback class name and create its instance. The arguments supplied MUST be used in order. If using the first
-     * argument is successful, the second one will not be used.
+     * Finds the implementation {@code Class} for the given factory name and create its instance.
      * <p>
      * This method is package private so that this code can be shared.
      *
      * @param factoryId the name of the factory to find, which is a system property.
-     * @param fallbackClassName the implementation class name, which is to be used only if nothing else. is found;
-     * {@code null} to indicate that there is no fallback class name.
      * @param service service to be found.
      * @param <T> type of the service to be found.
      * @return the instance of the specified service; may not be {@code null}.
      * @throws ClassNotFoundException if the given class could not be found or could not be instantiated.
      */
-    static <T> Object find(final String factoryId, final String fallbackClassName, final Class<T> service) throws ClassNotFoundException {
+    static <T> Object find(final String factoryId, final Class<T> service) throws ClassNotFoundException {
         ClassLoader classLoader = getContextClassLoader();
 
         try {
@@ -169,11 +165,7 @@ final class FactoryFinder {
                     + " from a system property", se);
         }
 
-        if (fallbackClassName == null) {
-            throw new ClassNotFoundException(
-                    "Provider for " + factoryId + " cannot be found", null);
-        }
-
-        return newInstance(fallbackClassName, classLoader);
+        throw new ClassNotFoundException(
+                "Provider for " + factoryId + " cannot be found", null);
     }
 }

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/FactoryFinder.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/FactoryFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/FactoryFinder.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/FactoryFinder.java
@@ -94,21 +94,17 @@ final class FactoryFinder {
     }
 
     /**
-     * Finds the implementation {@code Class} for the given factory name, or if that fails, finds the {@code Class} for the
-     * given fallback class name and create its instance. The arguments supplied MUST be used in order. If using the first
-     * argument is successful, the second one will not be used.
+     * Finds the implementation {@code Class} for the given factory name and create its instance.
      * <p>
      * This method is package private so that this code can be shared.
      *
      * @param factoryId the name of the factory to find, which is a system property.
-     * @param fallbackClassName the implementation class name, which is to be used only if nothing else. is found;
-     * {@code null} to indicate that there is no fallback class name.
      * @param service service to be found.
      * @param <T> type of the service to be found.
      * @return the instance of the specified service; may not be {@code null}.
      * @throws ClassNotFoundException if the given class could not be found or could not be instantiated.
      */
-    static <T> Object find(final String factoryId, final String fallbackClassName, final Class<T> service) throws ClassNotFoundException {
+    static <T> Object find(final String factoryId, final Class<T> service) throws ClassNotFoundException {
         ClassLoader classLoader = getContextClassLoader();
 
         try {
@@ -169,11 +165,7 @@ final class FactoryFinder {
                     + " from a system property", se);
         }
 
-        if (fallbackClassName == null) {
-            throw new ClassNotFoundException(
-                    "Provider for " + factoryId + " cannot be found", null);
-        }
-
-        return newInstance(fallbackClassName, classLoader);
+        throw new ClassNotFoundException(
+                "Provider for " + factoryId + " cannot be found", null);
     }
 }

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/RuntimeDelegate.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/RuntimeDelegate.java
@@ -98,10 +98,7 @@ public abstract class RuntimeDelegate {
      */
     private static RuntimeDelegate findDelegate() {
         try {
-            Object delegate = FactoryFinder.find(
-                    JAXRS_RUNTIME_DELEGATE_PROPERTY,
-                    null,
-                    RuntimeDelegate.class);
+            Object delegate = FactoryFinder.find(JAXRS_RUNTIME_DELEGATE_PROPERTY, RuntimeDelegate.class);
             if (!(delegate instanceof RuntimeDelegate)) {
                 Class pClass = RuntimeDelegate.class;
                 String classnameAsResource = pClass.getName().replace('.', '/') + ".class";

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/RuntimeDelegate.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/RuntimeDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/jaxrs-api/src/main/java/javax/ws/rs/sse/FactoryFinder.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/sse/FactoryFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/jaxrs-api/src/main/java/javax/ws/rs/sse/FactoryFinder.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/sse/FactoryFinder.java
@@ -94,21 +94,17 @@ final class FactoryFinder {
     }
 
     /**
-     * Finds the implementation {@code Class} for the given factory name, or if that fails, finds the {@code Class} for the
-     * given fallback class name and create its instance. The arguments supplied MUST be used in order. If using the first
-     * argument is successful, the second one will not be used.
+     * Finds the implementation {@code Class} for the given factory name and create its instance.
      * <p>
      * This method is package private so that this code can be shared.
      *
      * @param factoryId the name of the factory to find, which is a system property.
-     * @param fallbackClassName the implementation class name, which is to be used only if nothing else. is found;
-     * {@code null} to indicate that there is no fallback class name.
      * @param service service to be found.
      * @param <T> type of the service to be found.
      * @return the instance of the specified service; may not be {@code null}.
      * @throws ClassNotFoundException if the given class could not be found or could not be instantiated.
      */
-    static <T> Object find(final String factoryId, final String fallbackClassName, final Class<T> service) throws ClassNotFoundException {
+    static <T> Object find(final String factoryId, final Class<T> service) throws ClassNotFoundException {
         ClassLoader classLoader = getContextClassLoader();
 
         try {
@@ -169,11 +165,7 @@ final class FactoryFinder {
                     + " from a system property", se);
         }
 
-        if (fallbackClassName == null) {
-            throw new ClassNotFoundException(
-                    "Provider for " + factoryId + " cannot be found", null);
-        }
-
-        return newInstance(fallbackClassName, classLoader);
+        throw new ClassNotFoundException(
+                "Provider for " + factoryId + " cannot be found", null);
     }
 }

--- a/jaxrs-api/src/main/java/javax/ws/rs/sse/SseEventSource.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/sse/SseEventSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/jaxrs-api/src/main/java/javax/ws/rs/sse/SseEventSource.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/sse/SseEventSource.java
@@ -91,10 +91,6 @@ public interface SseEventSource extends AutoCloseable {
          * {@link SseEventSource.Builder#newBuilder()}.
          */
         public static final String JAXRS_DEFAULT_SSE_BUILDER_PROPERTY = "javax.ws.rs.sse.SseEventSource.Builder";
-        /**
-         * Default SSE event source builder implementation class name.
-         */
-        private static final String JAXRS_DEFAULT_SSE_BUILDER = "org.glassfish.jersey.media.sse.internal.JerseySseEventSource$Builder";
 
         /**
          * Allows custom implementations to extend the SSE event source builder class.
@@ -111,7 +107,7 @@ public interface SseEventSource extends AutoCloseable {
         static Builder newBuilder() {
             try {
                 Object delegate = FactoryFinder.find(JAXRS_DEFAULT_SSE_BUILDER_PROPERTY,
-                        JAXRS_DEFAULT_SSE_BUILDER, SseEventSource.Builder.class);
+                        null, SseEventSource.Builder.class);
                 if (!(delegate instanceof Builder)) {
                     Class pClass = Builder.class;
                     String classnameAsResource = pClass.getName().replace('.', '/') + ".class";

--- a/jaxrs-api/src/main/java/javax/ws/rs/sse/SseEventSource.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/sse/SseEventSource.java
@@ -106,8 +106,7 @@ public interface SseEventSource extends AutoCloseable {
          */
         static Builder newBuilder() {
             try {
-                Object delegate = FactoryFinder.find(JAXRS_DEFAULT_SSE_BUILDER_PROPERTY,
-                        null, SseEventSource.Builder.class);
+                Object delegate = FactoryFinder.find(JAXRS_DEFAULT_SSE_BUILDER_PROPERTY, SseEventSource.Builder.class);
                 if (!(delegate instanceof Builder)) {
                     Class pClass = Builder.class;
                     String classnameAsResource = pClass.getName().replace('.', '/') + ".class";


### PR DESCRIPTION
This PR finishes the work started by PR #592: While #592 solved issue #581 in one location, this new PR solves the same issue on all remaining locations - it removes the dependency to Jersey.

Also this PR removes the fallback class name parameter completely, as it is unused now, as suggested by @andymc12.