### PR TITLE
Clarify that ParamConverters must be preferred and work with all types

### DIFF
--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/ParamConverter.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/ParamConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -34,6 +34,10 @@ import javax.ws.rs.DefaultValue;
  * {@link javax.ws.rs.MatrixParam &#64;MatrixParam}, {@link javax.ws.rs.FormParam &#64;FormParam},
  * {@link javax.ws.rs.CookieParam &#64;CookieParam} and {@link javax.ws.rs.HeaderParam &#64;HeaderParam}
  * is supported.
+ * JAX-RS implementations MUST support the {@code ParamConverter} mechanism for all Java types.
+ * If a {@code ParamConverter} is available for a type, it MUST be preferred over all other 
+ * conversion strategies mentioned in section 3.2 (i.e. single {@code String} argument constructor, 
+ * static {@code valueOf} or {@code fromString} methods, etc.).
  * <p>
  * By default, when used for injection of parameter values, a selected {@code ParamConverter}
  * instance MUST be used eagerly by a JAX-RS runtime to convert any {@link DefaultValue


### PR DESCRIPTION
The `ParamConverter` API is mentioned only briefly in section 3.2 of the specification document like this:

> Valid parameter types for each of the above annotations are listed in the corresponding Javadoc, however in general (excluding `@Context` ) the following types are supported:
> 1. Types for which a `ParamConverter` is available via a registered `ParamConverterProvider`. See
Javadoc for these classes for more information.
> 2. [...]

Unfortunately JAX-RS implementations aren't handling all aspects of this API in the same way. RESTEasy for example completely ignores `ParamConverters` for all primitive types (see [RESTEASY-2222](https://issues.jboss.org/browse/RESTEASY-2222) for details). Although the spec isn't very explicit about which types are supported, I don't see any reason why primitive types should be handled differently. Jersey seems to support the `ParamConverter` API for all types, which is exactly what I would expect from an JAX-RS implementation.

This PR adds the following clarifications to the `ParamConverter` API docs:

  * You can register converters for all Java types (including primitives)
  * If there is a converter, it must be preferred over all other conversion strategies mentioned in the spec.

Let me know what you think.

Please note that I created this pull request for the `EE4J_8` as I consider it to be a clarification. Feel free to mention it if you disagree with this.