### PR TITLE
Clarify that ParamConverters must be preferred and work with all types

### DIFF
--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/ParamConverter.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/ParamConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -32,6 +32,10 @@ import javax.ws.rs.DefaultValue;
  * {@link javax.ws.rs.QueryParam &#64;QueryParam}, {@link javax.ws.rs.MatrixParam &#64;MatrixParam},
  * {@link javax.ws.rs.FormParam &#64;FormParam}, {@link javax.ws.rs.CookieParam &#64;CookieParam} and
  * {@link javax.ws.rs.HeaderParam &#64;HeaderParam} is supported.
+ * JAX-RS implementations MUST support the {@code ParamConverter} mechanism for all Java types. If a
+ * {@code ParamConverter} is available for a type, it MUST be preferred over all other conversion strategies mentioned 
+ * in section 3.2 (i.e. single {@code String} argument constructor, static {@code valueOf} or {@code fromString} 
+ * methods, etc.).
  * <p>
  * By default, when used for injection of parameter values, a selected {@code ParamConverter} instance MUST be used
  * eagerly by a JAX-RS runtime to convert any {@link DefaultValue default value} in the resource or provider model, that


### PR DESCRIPTION
This pull request contains the clarification for the handling of ParamConverters which was just merged into the `EE4J_8` branch as part of #762.

As the vote for this clarification already succeeded, we can fast track this PR to get the `master` branch up to date.