### PR TITLE
Updated project name in README, NOTICE and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Eclipse Project for JAX-RS
+# Contributing to Jakarta RESTful Web Services
 
 Thanks for your interest in this project.
 

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,13 +1,13 @@
 # Notices for Eclipse Project for JAX-RS
 
-This content is produced and maintained by the Eclipse Project for JAX-RS
+This content is produced and maintained by the **Jakarta RESTful Web Services**
 project.
 
 * Project home: https://projects.eclipse.org/projects/ee4j.jaxrs
 
 ## Trademarks
 
-Eclipse Project for JAX-RS is a trademark of the Eclipse Foundation.
+**Jakarta RESTful Web Services** is a trademark of the Eclipse Foundation.
 
 ## Copyright
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@
 
 ---
 
-# JAX-RS API [![Build Status](https://travis-ci.org/eclipse-ee4j/jaxrs-api.svg?branch=master)](https://travis-ci.org/eclipse-ee4j/jaxrs-api)
+# Jakarta RESTful Web Services [![Build Status](https://travis-ci.org/eclipse-ee4j/jaxrs-api.svg?branch=master)](https://travis-ci.org/eclipse-ee4j/jaxrs-api)
 
 This repository contains JAX-RS API source code.

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -24,8 +24,8 @@
     <artifactId>jakarta.ws.rs-api</artifactId>
     <version>2.1.6-SNAPSHOT</version>
     <packaging>bundle</packaging>
-    <name>javax.ws.rs-api</name>
-    <description>Java API for RESTful Web Services</description>
+    <name>jakarta.ws.rs-api</name>
+    <description>Jakarta RESTful Web Services</description>
 
     <url>https://github.com/eclipse-ee4j/jaxrs-api</url>
 
@@ -449,7 +449,7 @@
                         <instructions>
                             <_failok>true</_failok>
                             <Build-Id>${buildNumber}</Build-Id>
-                            <Bundle-Description>Java API for RESTful Web Services (JAX-RS)</Bundle-Description>
+                            <Bundle-Description>Jakarta RESTful Web Services API (JAX-RS)</Bundle-Description>
                             <Bundle-Version>${spec.bundle.version}</Bundle-Version>
                             <Bundle-SymbolicName>jakarta.ws.rs-api</Bundle-SymbolicName>
                             <DynamicImport-Package>*</DynamicImport-Package>

--- a/jaxrs-api/src/main/javadoc/overview.html
+++ b/jaxrs-api/src/main/javadoc/overview.html
@@ -18,8 +18,8 @@
 
 <html xmlns="http://www.w3.org/1999/html" xmlns="http://www.w3.org/1999/html" xmlns="http://www.w3.org/1999/html">
 <body>
-<p>The Java API for RESTful Web Services provides portable APIs for developing, exposing and accessing
-    Web applications designed and implemented in compliance with principles of REST architectural style.</p>
+<p>Jakarta RESTful Web Services provides a specification document, TCK and foundational API to develop web services
+    following the Representational State Transfer (REST) architectural pattern.</p>
 
 <h2>Web resources</h2>
 


### PR DESCRIPTION
This is a first step for addressing the first TODO item mentioned in #776.

It replaces the old project name "Eclipse Project for JAX-RS" with "Jakarta RESTful Web Services" and updates the scope statement.