### PR TITLE
Changes for Jakarta EE 8 Release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
-# Contributing to Jakarta RESTful Web Services
+# Contributing to the Jakarta RESTful Web Services Project
 
 Thanks for your interest in this project.
 
 ## Project description
 
-JAX-RS: Java API for RESTful Web Services (JAX-RS) is a Java programming
-language API spec that provides support in creating web services according to
-the Representational State Transfer (REST) architectural pattern.
+Jakarta RESTful Web Services provides a specification document, TCK and foundational 
+API to develop web services following the Representational State Transfer (REST) 
+architectural pattern.
 
 * https://projects.eclipse.org/projects/ee4j.jaxrs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Eclipse Project for JAX-RS
+# Contributing to Jakarta RESTful Web Services
 
 Thanks for your interest in this project.
 

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,4 +1,4 @@
-# Notices for Eclipse Project for JAX-RS
+# Notices for the Jakarta RESTful Web Services Project
 
 This content is produced and maintained by the **Jakarta RESTful Web Services**
 project.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,13 +1,13 @@
 # Notices for Eclipse Project for JAX-RS
 
-This content is produced and maintained by the Eclipse Project for JAX-RS
+This content is produced and maintained by the **Jakarta RESTful Web Services**
 project.
 
 * Project home: https://projects.eclipse.org/projects/ee4j.jaxrs
 
 ## Trademarks
 
-Eclipse Project for JAX-RS is a trademark of the Eclipse Foundation.
+**Jakarta RESTful Web Services** is a trademark of the Eclipse Foundation.
 
 ## Copyright
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@
 
 ---
 
-# JAX-RS API [![Build Status](https://travis-ci.org/eclipse-ee4j/jaxrs-api.svg?branch=master)](https://travis-ci.org/eclipse-ee4j/jaxrs-api)
+# Jakarta RESTful Web Services [![Build Status](https://travis-ci.org/eclipse-ee4j/jaxrs-api.svg?branch=master)](https://travis-ci.org/eclipse-ee4j/jaxrs-api)
 
-This repository contains JAX-RS API source code.
+**Jakarta RESTful Web Services** provides a specification document, TCK and foundational API to develop web services following the Representational State Transfer (REST) architectural pattern.
+
+Contributions are welcome, please sign the Eclipse Contributor Agreement before submitting PRs: https://www.eclipse.org/contribute/cla
+
+Project page: https://projects.eclipse.org/projects/ee4j.jaxrs
+
+Mailinglist: https://accounts.eclipse.org/mailing-list/jaxrs-dev

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -15,12 +15,6 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>net.java</groupId>
-        <artifactId>jvnet-parent</artifactId>
-        <version>1</version>
-    </parent>
-
     <groupId>jakarta.ws.rs</groupId>
     <artifactId>jakarta.ws.rs-examples</artifactId>
     <version>2.1.6-SNAPSHOT</version>
@@ -34,8 +28,8 @@
     </properties>
 
     <organization>
-        <name>Oracle Corporation</name>
-        <url>http://www.oracle.com/</url>
+        <name>Eclipse Foundation</name>
+        <url>https://www.eclipse.org/org/foundation/</url>
     </organization>
 
     <issueManagement>
@@ -45,8 +39,8 @@
 
     <mailingLists>
         <mailingList>
-            <name>JAX-RS Discussion Group </name>
-            <archive>jaxrs-spec@javaee.groups.io</archive>
+            <name>Developer Discussions</name>
+            <archive>jaxrs-dev@eclipse.org</archive>
         </mailingList>
     </mailingLists>
 
@@ -66,14 +60,10 @@
 
     <developers>
         <developer>
-            <email>santiago.pericasgeertsen@oracle.com</email>
-            <id>Santiago</id>
-            <name>Santiago Pericas-Geertsen</name>
-            <organization>Oracle</organization>
-            <roles>
-                <role>JAX-RS Spec Lead</role>
-            </roles>
-            <timezone>EST</timezone>
+            <id>developers</id>
+            <name>API Developers</name>
+            <email>jaxrs-dev@eclipse.org</email>
+            <url>https://github.com/eclipse-ee4j/jaxrs-api/graphs/contributors</url>
         </developer>
     </developers>
 
@@ -119,7 +109,7 @@
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>2.10.3</version>
                     <configuration>
-                        <doctitle>JAX-RS ${project.version} API Specification</doctitle>
+                        <doctitle>${project.version} API Specification</doctitle>
                         <bottom>
                             <![CDATA[Copyright &#169; 1996-2014,
                                 <a href="http://www.oracle.com">Oracle</a>
@@ -273,13 +263,13 @@
     <distributionManagement>
         <repository>
             <id>repo.eclipse.org</id>
-            <name>JAX-RS API Repository - Releases</name>
+            <name>API Repository - Releases</name>
             <url>https://repo.eclipse.org/content/repositories/jax-rs-api-releases/</url>
         </repository>
 
         <snapshotRepository>
             <id>repo.eclipse.org</id>
-            <name>JAX-RS API Repository - Snapshots</name>
+            <name>API Repository - Snapshots</name>
             <url>https://repo.eclipse.org/content/repositories/jax-rs-api-snapshots/</url>
         </snapshotRepository>
     </distributionManagement>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -24,8 +24,8 @@
     <artifactId>jakarta.ws.rs-api</artifactId>
     <version>2.1.6-SNAPSHOT</version>
     <packaging>bundle</packaging>
-    <name>javax.ws.rs-api</name>
-    <description>Java API for RESTful Web Services</description>
+    <name>jakarta.ws.rs-api</name>
+    <description>Jakarta RESTful Web Services</description>
 
     <url>https://github.com/eclipse-ee4j/jaxrs-api</url>
 
@@ -449,8 +449,8 @@
                         <instructions>
                             <_failok>true</_failok>
                             <Build-Id>${buildNumber}</Build-Id>
-                            <Bundle-Description>Java API for RESTful Web Services (JAX-RS)</Bundle-Description>
-                            <Bundle-Version>${spec.bundle.version}</Bundle-Version>
+                            <Bundle-Description>Jakarta RESTful Web Services API (JAX-RS)</Bundle-Description>
+                            <Bundle-Version>${project.version}</Bundle-Version>
                             <Bundle-SymbolicName>jakarta.ws.rs-api</Bundle-SymbolicName>
                             <DynamicImport-Package>*</DynamicImport-Package>
                             <Extension-Name>${spec.extension.name}</Extension-Name>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -24,8 +24,8 @@
     <artifactId>jakarta.ws.rs-api</artifactId>
     <version>2.1.6-SNAPSHOT</version>
     <packaging>bundle</packaging>
-    <name>jakarta.ws.rs-api</name>
-    <description>Jakarta RESTful Web Services</description>
+    <name>javax.ws.rs-api</name>
+    <description>Jakarta RESTful Web Services API</description>
 
     <url>https://github.com/eclipse-ee4j/jaxrs-api</url>
 
@@ -37,7 +37,7 @@
     <developers>
         <developer>
             <id>developers</id>
-            <name>JAX-RS API Developers</name>
+            <name>API Developers</name>
             <email>jaxrs-dev@eclipse.org</email>
             <url>https://github.com/eclipse-ee4j/jaxrs-api/graphs/contributors</url>
         </developer>
@@ -50,7 +50,7 @@
 
     <mailingLists>
         <mailingList>
-            <name>JAX-RS Developer Discussions</name>
+            <name>Developer Discussions</name>
             <archive>jaxrs-dev@eclipse.org</archive>
         </mailingList>
     </mailingLists>
@@ -449,8 +449,8 @@
                         <instructions>
                             <_failok>true</_failok>
                             <Build-Id>${buildNumber}</Build-Id>
-                            <Bundle-Description>Jakarta RESTful Web Services API (JAX-RS)</Bundle-Description>
-                            <Bundle-Version>${project.version}</Bundle-Version>
+                            <Bundle-Description>Jakarta RESTful Web Services API</Bundle-Description>
+                            <Bundle-Version>${spec.bundle.version}</Bundle-Version>
                             <Bundle-SymbolicName>jakarta.ws.rs-api</Bundle-SymbolicName>
                             <DynamicImport-Package>*</DynamicImport-Package>
                             <Extension-Name>${spec.extension.name}</Extension-Name>
@@ -714,7 +714,7 @@
     </dependencies>
 
     <properties>
-        <apidocs.title>JAX-RS ${spec.version} API Specification ${spec.version.revision}</apidocs.title>
+        <apidocs.title>Jakarta RESTful Web Services ${spec.version} API Specification ${spec.version.revision}</apidocs.title>
         <java.version>1.8</java.version>
 
         <maven.bundle.plugin.version>3.5.0</maven.bundle.plugin.version>
@@ -741,13 +741,13 @@
     <distributionManagement>
         <repository>
             <id>repo.eclipse.org</id>
-            <name>JAX-RS API Repository - Releases</name>
+            <name>API Repository - Releases</name>
             <url>https://repo.eclipse.org/content/repositories/jax-rs-api-releases/</url>
         </repository>
 
         <snapshotRepository>
             <id>repo.eclipse.org</id>
-            <name>JAX-RS API Repository - Snapshots</name>
+            <name>API Repository - Snapshots</name>
 	    <url>https://repo.eclipse.org/content/repositories/jax-rs-api-snapshots/</url>
         </snapshotRepository>
     </distributionManagement>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -24,7 +24,7 @@
     <artifactId>jakarta.ws.rs-api</artifactId>
     <version>2.1.6-SNAPSHOT</version>
     <packaging>bundle</packaging>
-    <name>javax.ws.rs-api</name>
+    <name>jakarta.ws.rs-api</name>
     <description>Jakarta RESTful Web Services API</description>
 
     <url>https://github.com/eclipse-ee4j/jaxrs-api</url>

--- a/jaxrs-api/src/main/java/javax/ws/rs/BeanParam.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/BeanParam.java
@@ -23,10 +23,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * The annotation that may be used to inject custom JAX-RS "parameter aggregator" value object
+ * The annotation that may be used to inject a custom "parameter aggregator" value object
  * into a resource class field, property or resource method parameter.
  * <p>
- * The JAX-RS runtime will instantiate the object and inject all it's fields and properties annotated
+ * The runtime will instantiate the object and inject all it's fields and properties annotated
  * with either one of the {@code @XxxParam} annotation ({@link PathParam &#64;PathParam},
  * {@link FormParam &#64;FormParam} ...) or the {@link javax.ws.rs.core.Context &#64;Context}
  * annotation. For the POJO classes same instantiation and injection rules apply as in case of instantiation

--- a/jaxrs-api/src/main/java/javax/ws/rs/ConstrainedTo.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ConstrainedTo.java
@@ -23,14 +23,14 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Indicates the run-time context in which an annotated JAX-RS provider
+ * Indicates the run-time context in which an annotated provider
  * is applicable. If a {@code @ConstrainedTo} annotation is not
- * present on a JAX-RS provider type declaration, the declared provider
+ * present on a provider type declaration, the declared provider
  * may be used in any run-time context. If such a annotation is present,
- * the JAX-RS runtime will enforce the specified usage restriction.
+ * the runtime will enforce the specified usage restriction.
  * <p>
  * The following example illustrates restricting a {@link javax.ws.rs.ext.MessageBodyReader}
- * provider implementation to run only as part of a {@link RuntimeType#CLIENT JAX-RS client run-time}:
+ * provider implementation to run only as part of a {@link RuntimeType#CLIENT Client run-time}:
  * </p>
  * <pre>
  *  &#064;ConstrainedTo(RuntimeType.CLIENT)
@@ -40,7 +40,7 @@ import java.lang.annotation.Target;
  * </pre>
  * <p>
  * The following example illustrates restricting a {@link javax.ws.rs.ext.WriterInterceptor}
- * provider implementation to run only as part of a {@link RuntimeType#SERVER JAX-RS server run-time}:
+ * provider implementation to run only as part of a {@link RuntimeType#SERVER Server run-time}:
  * </p>
  * <pre>
  *  &#064;ConstrainedTo(RuntimeType.SERVER)
@@ -49,17 +49,17 @@ import java.lang.annotation.Target;
  *  }
  * </pre>
  * <p>
- * It is a configuration error to constraint a JAX-RS provider implementation to
- * a run-time context in which the provider cannot be applied. In such case a JAX-RS
+ * It is a configuration error to constraint a provider implementation to
+ * a run-time context in which the provider cannot be applied. In such case, the
  * runtime SHOULD inform a user about the issue and ignore the provider implementation in further
  * processing.
  * </p>
  * <p>
  * For example, the following restriction of a {@link javax.ws.rs.client.ClientRequestFilter}
- * to run only as part of a JAX-RS server run-time would be considered invalid:
+ * to run only as part of the server run-time would be considered invalid:
  * </p>
  * <pre>
- *  // reported as invalid and ignored by JAX-RS runtime
+ *  // reported as invalid and ignored by the runtime
  *  &#064;ConstrainedTo(RuntimeType.SERVER)
  *  public class MyFilter implements ClientRequestFilter {
  *      ...
@@ -75,7 +75,7 @@ import java.lang.annotation.Target;
 public @interface ConstrainedTo {
 
     /**
-     * Define the {@link RuntimeType constraint type} to be placed on a JAX-RS provider.
+     * Define the {@link RuntimeType constraint type} to be placed on a provider.
      */
     RuntimeType value();
 }

--- a/jaxrs-api/src/main/java/javax/ws/rs/CookieParam.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/CookieParam.java
@@ -37,7 +37,7 @@ import java.lang.annotation.Target;
  * <li>Have a static method named {@code valueOf} or {@code fromString}
  * that accepts a single String argument (see, for example, {@link Integer#valueOf(String)})</li>
  * <li>Have a registered implementation of {@link javax.ws.rs.ext.ParamConverterProvider}
- * JAX-RS extension SPI that returns a {@link javax.ws.rs.ext.ParamConverter}
+ * that returns a {@link javax.ws.rs.ext.ParamConverter}
  * instance capable of a "from string" conversion for the type.</li>
  * <li>Be {@code List<T>}, {@code Set<T>} or
  * {@code SortedSet<T>}, where {@code T} satisfies 2, 3, 4 or 5 above.

--- a/jaxrs-api/src/main/java/javax/ws/rs/FormParam.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/FormParam.java
@@ -38,7 +38,7 @@ import java.lang.annotation.Target;
  * that accepts a single {@code String} argument (see, for example,
  * {@link Integer#valueOf(String)})</li>
  * <li>Have a registered implementation of {@link javax.ws.rs.ext.ParamConverterProvider}
- * JAX-RS extension SPI that returns a {@link javax.ws.rs.ext.ParamConverter}
+ * that returns a {@link javax.ws.rs.ext.ParamConverter}
  * instance capable of a "from string" conversion for the type.</li>
  * <li>Be {@code List<T>}, {@code Set<T>} or
  * {@code SortedSet<T>}, where {@code T} satisfies 2, 3 or 4 above.

--- a/jaxrs-api/src/main/java/javax/ws/rs/HeaderParam.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/HeaderParam.java
@@ -36,7 +36,7 @@ import java.lang.annotation.Target;
  * that accepts a single
  * {@code String} argument (see, for example, {@link Integer#valueOf(String)})</li>
  * <li>Have a registered implementation of {@link javax.ws.rs.ext.ParamConverterProvider}
- * JAX-RS extension SPI that returns a {@link javax.ws.rs.ext.ParamConverter}
+ * that returns a {@link javax.ws.rs.ext.ParamConverter}
  * instance capable of a "from string" conversion for the type.</li>
  * <li>Be {@code List<T>}, {@code Set<T>} or
  * {@code SortedSet<T>}, where {@code T} satisfies 2, 3 or 4 above.

--- a/jaxrs-api/src/main/java/javax/ws/rs/MatrixParam.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/MatrixParam.java
@@ -45,7 +45,7 @@ import java.lang.annotation.Target;
  * that accepts a single
  * {@code String} argument (see, for example, {@link Integer#valueOf(String)})</li>
  * <li>Have a registered implementation of {@link javax.ws.rs.ext.ParamConverterProvider}
- * JAX-RS extension SPI that returns a {@link javax.ws.rs.ext.ParamConverter}
+ * that returns a {@link javax.ws.rs.ext.ParamConverter}
  * instance capable of a "from string" conversion for the type.</li>
  * <li>Be {@code List<T>}, {@code Set<T>} or
  * {@code SortedSet<T>}, where {@code T} satisfies 2, 3 or 4 above.

--- a/jaxrs-api/src/main/java/javax/ws/rs/NameBinding.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/NameBinding.java
@@ -50,7 +50,7 @@ import java.lang.annotation.Target;
  * </pre>
  *
  * At last, the name-binding annotation is applied to the resource method(s) to which the
- * name-bound JAX-RS provider(s) should be bound to:
+ * name-bound provider(s) should be bound to:
  *
  * <pre>
  *  &#64;Path("/")
@@ -65,10 +65,10 @@ import java.lang.annotation.Target;
  *  }
  * </pre>
  *
- * A name-binding annotation may also be attached to a custom JAX-RS
- * {@link javax.ws.rs.core.Application} subclass. In such case a name-bound JAX-RS provider
+ * A name-binding annotation may also be attached to a custom
+ * {@link javax.ws.rs.core.Application} subclass. In such case a name-bound provider
  * bound by the annotation will be applied to all {@link HttpMethod resource and sub-resource
- * methods} in the JAX-RS application:
+ * methods} in the application:
  *
  * <pre>
  *  <b>&#64;Logged</b>

--- a/jaxrs-api/src/main/java/javax/ws/rs/PathParam.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/PathParam.java
@@ -48,7 +48,7 @@ import java.lang.annotation.Target;
  * that accepts a single
  * String argument (see, for example, {@link Integer#valueOf(String)}).</li>
  * <li>Have a registered implementation of {@link javax.ws.rs.ext.ParamConverterProvider}
- * JAX-RS extension SPI that returns a {@link javax.ws.rs.ext.ParamConverter}
+ * that returns a {@link javax.ws.rs.ext.ParamConverter}
  * instance capable of a "from string" conversion for the type.</li>
  * </ul>
  *

--- a/jaxrs-api/src/main/java/javax/ws/rs/Priorities.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/Priorities.java
@@ -17,11 +17,11 @@
 package javax.ws.rs;
 
 /**
- * A collection of built-in priority constants for the JAX-RS components that are supposed to be
+ * A collection of built-in priority constants for the components that are supposed to be
  * ordered based on their {@code javax.annotation.Priority} class-level annotation value when used
- * or applied by JAX-RS runtime.
+ * or applied by the runtime.
  * <p>
- * For example, JAX-RS filters and interceptors are grouped in chains for each of the message
+ * For example, filters and interceptors are grouped in chains for each of the message
  * processing extension points: Pre, PreMatch, Post as well as ReadFrom and WriteTo.
  * Each of these chains is sorted based on priorities which are represented as integer numbers.
  * All chains, except Post, are sorted in ascending order; the lower the number the higher the priority.
@@ -29,7 +29,7 @@ package javax.ws.rs;
  * <em>reverse order</em>.
  * </p>
  * <p>
- * JAX-RS components that belong to the same priority class (same integer value) are executed in an
+ * Components that belong to the same priority class (same integer value) are executed in an
  * implementation-defined manner. By default, when the {@code @Priority} annotation is absent on a component,
  * for which a priority should be applied, the {@link Priorities#USER} priority value is used.
  * </p>

--- a/jaxrs-api/src/main/java/javax/ws/rs/ProcessingException.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ProcessingException.java
@@ -17,7 +17,7 @@
 package javax.ws.rs;
 
 /**
- * A base JAX-RS runtime processing exception.
+ * A base runtime processing exception.
  *
  * The exception of this type is thrown during HTTP request or response processing,
  * to signal a runtime processing failure. Typical classes of failures covered by
@@ -30,12 +30,12 @@ package javax.ws.rs;
  * entity {@link javax.ws.rs.ext.MessageBodyReader readers} and {@link javax.ws.rs.ext.MessageBodyWriter writers}
  * during entity serialization and de-serialization.</li>
  * </ul>
- * as well as any other JAX-RS runtime processing errors.
+ * as well as any other runtime processing errors.
  * The exception message or nested {@link Throwable}
  * cause SHOULD contain additional information about the reason of the processing
  * failure.
  * <p>
- * Note that the exception is used to indicate (internal) JAX-RS processing errors.
+ * Note that the exception is used to indicate (internal) processing errors.
  * It is not used to indicate HTTP error response states. A HTTP error response is
  * represented by a {@link javax.ws.rs.WebApplicationException} class or one of it's
  * sub-classes.
@@ -49,7 +49,7 @@ public class ProcessingException extends RuntimeException {
     private static final long serialVersionUID = -4232431597816056514L;
 
     /**
-     * Constructs a new JAX-RS runtime processing exception with the specified cause
+     * Constructs a new runtime processing exception with the specified cause
      * and a detail message of {@code (cause==null ? null : cause.toString())}
      * (which typically contains the class and detail message of {@code cause}).
      * This constructor is useful for runtime exceptions that are little more
@@ -64,7 +64,7 @@ public class ProcessingException extends RuntimeException {
     }
 
     /**
-     * Constructs a new JAX-RS runtime processing exception with the specified detail
+     * Constructs a new runtime processing exception with the specified detail
      * message and cause.
      * <p/>
      * Note that the detail message associated with {@code cause} is <i>not</i>
@@ -81,7 +81,7 @@ public class ProcessingException extends RuntimeException {
     }
 
     /**
-     * Constructs a new JAX-RS runtime processing exception with the specified detail
+     * Constructs a new runtime processing exception with the specified detail
      * message. The cause is not initialized, and may subsequently be initialized
      * by a call to {@link #initCause}.
      *

--- a/jaxrs-api/src/main/java/javax/ws/rs/QueryParam.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/QueryParam.java
@@ -38,7 +38,7 @@ import java.lang.annotation.Target;
  * that accepts a single
  * {@code String} argument (see, for example, {@link Integer#valueOf(String)})</li>
  * <li>Have a registered implementation of {@link javax.ws.rs.ext.ParamConverterProvider}
- * JAX-RS extension SPI that returns a {@link javax.ws.rs.ext.ParamConverter}
+ * that returns a {@link javax.ws.rs.ext.ParamConverter}
  * instance capable of a "from string" conversion for the type.</li>
  * <li>Be {@code List<T>}, {@code Set<T>} or
  * {@code SortedSet<T>}, where {@code T} satisfies 2, 3 or 4 above.

--- a/jaxrs-api/src/main/java/javax/ws/rs/RuntimeType.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/RuntimeType.java
@@ -17,18 +17,18 @@
 package javax.ws.rs;
 
 /**
- * Enumeration of JAX-RS runtime types.
+ * Enumeration of runtime types.
  *
  * @author Marek Potociar
  * @since 2.0
  */
 public enum RuntimeType {
     /**
-     * JAX-RS client run-time.
+     * The client run-time.
      */
     CLIENT,
     /**
-     * JAX-RS server run-time.
+     * The server run-time.
      */
     SERVER
 }

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/ClientBuilder.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/ClientBuilder.java
@@ -16,20 +16,17 @@
 
 package javax.ws.rs.client;
 
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.core.Configurable;
+import javax.ws.rs.core.Configuration;
 import java.net.URL;
 import java.security.KeyStore;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
-import javax.ws.rs.ProcessingException;
-import javax.ws.rs.core.Configurable;
-import javax.ws.rs.core.Configuration;
-import javax.ws.rs.sse.SseEventSource;
-
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLContext;
 
 /**
  * Main entry point to the client API used to bootstrap {@link javax.ws.rs.client.Client}
@@ -60,7 +57,7 @@ public abstract class ClientBuilder implements Configurable<ClientBuilder> {
 
     /**
      * Create a new {@code ClientBuilder} instance using the default client builder
-     * implementation class provided by the JAX-RS implementation provider.
+     * implementation class provided by the implementation provider.
      *
      * @return new client builder instance.
      */
@@ -89,7 +86,7 @@ public abstract class ClientBuilder implements Configurable<ClientBuilder> {
 
     /**
      * Create a new {@link Client} instance using the default client builder implementation
-     * class provided by the JAX-RS implementation provider.
+     * class provided by the implementation provider.
      *
      * @return new client instance.
      */
@@ -99,7 +96,7 @@ public abstract class ClientBuilder implements Configurable<ClientBuilder> {
 
     /**
      * Create a new custom-configured {@link Client} instance using the default client builder
-     * implementation class provided by the JAX-RS implementation provider.
+     * implementation class provided by the implementation provider.
      *
      * @param configuration data used to provide initial configuration for the new
      *                      client instance.

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/ClientRequestContext.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/ClientRequestContext.java
@@ -16,6 +16,12 @@
 
 package javax.ws.rs.client;
 
+import javax.ws.rs.core.Configuration;
+import javax.ws.rs.core.Cookie;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.MessageBodyWriter;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
@@ -25,13 +31,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-
-import javax.ws.rs.core.Configuration;
-import javax.ws.rs.core.Cookie;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.MessageBodyWriter;
 
 /**
  * Client request filter context.
@@ -50,7 +49,7 @@ public interface ClientRequestContext {
      * Returns the property with the given name registered in the current request/response
      * exchange context, or {@code null} if there is no property by that name.
      * <p>
-     * A property allows a JAX-RS filters and interceptors to exchange
+     * A property allows filters and interceptors to exchange
      * additional custom information not already provided by this interface.
      * </p>
      * <p>
@@ -85,7 +84,7 @@ public interface ClientRequestContext {
      * exchange context. If the name specified is already used for a property,
      * this method will replace the value of the property with the new value.
      * <p>
-     * A property allows a JAX-RS filters and interceptors to exchange
+     * A property allows a filters and interceptors to exchange
      * additional custom information not already provided by this interface.
      * </p>
      * <p>
@@ -319,7 +318,7 @@ public interface ClientRequestContext {
 
 
     /**
-     * Get the entity output stream. The JAX-RS runtime is responsible for
+     * Get the entity output stream. The runtime is responsible for
      * closing the output stream.
      *
      * @return entity output stream.
@@ -327,7 +326,7 @@ public interface ClientRequestContext {
     public OutputStream getEntityStream();
 
     /**
-     * Set a new entity output stream. The JAX-RS runtime is responsible for
+     * Set a new entity output stream. The runtime is responsible for
      * closing the output stream.
      *
      * @param outputStream new entity output stream.

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/ClientRequestFilter.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/ClientRequestFilter.java
@@ -22,7 +22,7 @@ import java.io.IOException;
  * An extension interface implemented by client request filters.
  *
  * Filters implementing this interface MUST be annotated with
- * {@link javax.ws.rs.ext.Provider &#64;Provider} to be discovered by the JAX-RS
+ * {@link javax.ws.rs.ext.Provider &#64;Provider} to be discovered by the
  * runtime. This type of filters is supported only as part of the Client API.
  *
  * @author Marek Potociar

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/ClientResponseContext.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/ClientResponseContext.java
@@ -16,19 +16,18 @@
 
 package javax.ws.rs.client;
 
-import java.io.InputStream;
-import java.net.URI;
-import java.util.Date;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-
 import javax.ws.rs.core.EntityTag;
 import javax.ws.rs.core.Link;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.Response;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Client response filter context.
@@ -208,7 +207,7 @@ public interface ClientResponseContext {
     public boolean hasEntity();
 
     /**
-     * Get the entity input stream. The JAX-RS runtime is responsible for
+     * Get the entity input stream. The runtime is responsible for
      * closing the input stream.
      *
      * @return entity input stream.
@@ -216,7 +215,7 @@ public interface ClientResponseContext {
     public InputStream getEntityStream();
 
     /**
-     * Set a new entity input stream. The JAX-RS runtime is responsible for
+     * Set a new entity input stream. The runtime is responsible for
      * closing the input stream.
      *
      * @param input new entity input stream.

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/ClientResponseFilter.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/ClientResponseFilter.java
@@ -22,7 +22,7 @@ import java.io.IOException;
  * An extension interface implemented by client response filters.
  *
  * Filters implementing this interface MUST be annotated with
- * {@link javax.ws.rs.ext.Provider &#64;Provider} to be discovered by the JAX-RS
+ * {@link javax.ws.rs.ext.Provider &#64;Provider} to be discovered by the
  * runtime. This type of filters is supported only as part of the Client API.
  *
  * @author Marek Potociar

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/Invocation.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/Invocation.java
@@ -16,9 +16,6 @@
 
 package javax.ws.rs.client;
 
-import java.util.Locale;
-import java.util.concurrent.Future;
-
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.CacheControl;
@@ -27,6 +24,8 @@ import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
+import java.util.Locale;
+import java.util.concurrent.Future;
 
 /**
  * A client request invocation.
@@ -276,7 +275,7 @@ public interface Invocation {
          * Access a reactive invoker based on a {@link RxInvoker} subclass provider. Note
          * that corresponding {@link RxInvokerProvider} must be registered in the client runtime.
          * <p>
-         * This method is an extension point for JAX-RS implementations to support other types
+         * This method is an extension point for implementations to support other types
          * representing asynchronous computations.
          *
          * @param clazz {@link RxInvoker} subclass.

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/ResponseProcessingException.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/ResponseProcessingException.java
@@ -20,7 +20,7 @@ import javax.ws.rs.ProcessingException;
 import javax.ws.rs.core.Response;
 
 /**
- * JAX-RS client-side runtime processing exception thrown to indicate that
+ * Client-side runtime processing exception thrown to indicate that
  * response processing has failed (e.g. in a filter chain or during message
  * entity de-serialization). The exception contains the nested {@link Response}
  * instance for which the runtime response processing failed.
@@ -35,7 +35,7 @@ public class ResponseProcessingException extends ProcessingException {
     private final Response response;
 
     /**
-     * Constructs a new JAX-RS runtime response processing exception
+     * Constructs a new runtime response processing exception
      * for a specific {@link Response response} with the specified cause
      * and a detail message of {@code (cause==null ? null : cause.toString())}
      * (which typically contains the class and detail message of {@code cause}).
@@ -53,7 +53,7 @@ public class ResponseProcessingException extends ProcessingException {
     }
 
     /**
-     * Constructs a new JAX-RS runtime response processing exception with the specified detail
+     * Constructs a new runtime response processing exception with the specified detail
      * message and cause.
      * <p/>
      * Note that the detail message associated with {@code cause} is <i>not</i>
@@ -72,7 +72,7 @@ public class ResponseProcessingException extends ProcessingException {
     }
 
     /**
-     * Constructs a new JAX-RS runtime processing exception with the specified detail
+     * Constructs a new runtime processing exception with the specified detail
      * message. The cause is not initialized, and may subsequently be initialized
      * by a call to {@link #initCause}.
      *

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/RxInvoker.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/RxInvoker.java
@@ -19,9 +19,9 @@ package javax.ws.rs.client;
 import javax.ws.rs.core.GenericType;
 
 /**
- * Uniform interface for reactive invocation of HTTP methods. All reactive invokers in JAX-RS must
+ * Uniform interface for reactive invocation of HTTP methods. All reactive invokers must
  * implement this interface. The type parameter {@code T} represents the Java type of an asynchronous
- * computation. All JAX-RS implementations MUST support the default reactive invoker based on
+ * computation. All API implementations MUST support the default reactive invoker based on
  * {@link java.util.concurrent.CompletionStage}.
  *
  * @param <T> a type representing the asynchronous computation.

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/package-info.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/package-info.java
@@ -15,17 +15,17 @@
  */
 
 /**
- * <h1>The JAX-RS client API</h1>
+ * <h1>The Client API</h1>
  *
- * The JAX-RS client API is a Java based API used to access Web resources.
- * It is not restricted to resources implemented using JAX-RS.
+ * The Client API is a Java based API used to access Web resources.
+ * It is not restricted to resources implemented using this API.
  * It provides a higher-level abstraction compared to a {@link java.net.HttpURLConnection
- * plain HTTP communication API} as well as integration with the JAX-RS extension
+ * plain HTTP communication API} as well as integration with extension
  * providers, in order to enable concise and efficient implementation of
  * reusable client-side solutions that leverage existing and well
  * established client-side implementations of HTTP-based communication.
  * <p />
- * The JAX-RS Client API encapsulates the Uniform Interface Constraint &ndash;
+ * The Client API encapsulates the Uniform Interface Constraint &ndash;
  * a key constraint of the REST architectural style &ndash; and associated data
  * elements as client-side Java artifacts and supports a pluggable architecture
  * by defining multiple extension points.
@@ -63,7 +63,7 @@
  *       {@link javax.ws.rs.client.Invocation} for later submission</li>
  * </ol>
  *
- * As illustrated above, individual Web resources are in the JAX-RS Client API
+ * As illustrated above, individual Web resources are in the Client API
  * represented as resource targets. Each {@code WebTarget} instance is bound to a
  * concrete URI, e.g. {@code "http://example.org/messages/123"},
  * or a URI template, e.g. {@code "http://example.org/messages/{id}"}.

--- a/jaxrs-api/src/main/java/javax/ws/rs/container/AsyncResponse.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/container/AsyncResponse.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 /**
- * An injectable JAX-RS asynchronous response that provides means for asynchronous server side
+ * An injectable and asynchronous response that provides means for asynchronous server side
  * response processing.
  * <p>
  * A new instance of {@code AsyncResponse} may be injected into a
@@ -86,16 +86,16 @@ public interface AsyncResponse {
      * Resume the suspended request processing using the provided response data.
      *
      * The provided response data can be of any Java type that can be
-     * returned from a {@link javax.ws.rs.HttpMethod JAX-RS resource method}.
+     * returned from a {@link javax.ws.rs.HttpMethod Resource method}.
      * <p>
      * The asynchronous response must be still in a {@link #isSuspended() suspended} state
      * for this method to succeed.
      * </p>
      * <p>
      * By executing this method, the request is guaranteed to complete either successfully or
-     * with an error. The data processing by the JAX-RS runtime follows the same path
-     * as it would for the response data returned synchronously by a JAX-RS resource,
-     * except that unmapped exceptions are not re-thrown by JAX-RS runtime to be handled by
+     * with an error. The data processing by the runtime follows the same path
+     * as it would for the response data returned synchronously by a resource,
+     * except that unmapped exceptions are not re-thrown by the runtime to be handled by
      * a hosting I/O container. Instead, any unmapped exceptions are propagated to the hosting
      * I/O container via a container-specific callback mechanism. Depending on the container
      * implementation, propagated unmapped exceptions typically result in an error status
@@ -113,12 +113,12 @@ public interface AsyncResponse {
      * Resume the suspended request processing using the provided throwable.
      *
      * For the provided throwable same rules apply as for an exception thrown
-     * by a {@link javax.ws.rs.HttpMethod JAX-RS resource method}.
+     * by a {@link javax.ws.rs.HttpMethod Resource method}.
      * <p>
      * By executing this method, the request is guaranteed to complete either successfully or
-     * with an error. The throwable processing by the JAX-RS runtime follows the same path
-     * as it would for the response data returned synchronously by a JAX-RS resource,
-     * except that unmapped exceptions are not re-thrown by JAX-RS runtime to be handled by
+     * with an error. The throwable processing by the runtime follows the same path
+     * as it would for the response data returned synchronously by a resource,
+     * except that unmapped exceptions are not re-thrown by the runtime to be handled by
      * a hosting I/O container. Instead, any unmapped exceptions are propagated to the hosting
      * I/O container via a container-specific callback mechanism. Depending on the container
      * implementation, propagated unmapped exceptions typically result in an error status
@@ -136,7 +136,7 @@ public interface AsyncResponse {
     /**
      * Cancel the suspended request processing.
      * <p>
-     * When a request processing is cancelled using this method, the JAX-RS implementation
+     * When a request processing is cancelled using this method, the API implementation
      * MUST indicate to the client that the request processing has been cancelled by sending
      * back a {@link javax.ws.rs.core.Response.Status#SERVICE_UNAVAILABLE HTTP 503 (Service unavailable)}
      * error response.
@@ -161,7 +161,7 @@ public interface AsyncResponse {
     /**
      * Cancel the suspended request processing.
      * <p>
-     * When a request processing is cancelled using this method, the JAX-RS implementation
+     * When a request processing is cancelled using this method, the API implementation
      * MUST indicate to the client that the request processing has been cancelled by sending
      * back a {@link javax.ws.rs.core.Response.Status#SERVICE_UNAVAILABLE HTTP 503 (Service unavailable)}
      * error response with a {@code Retry-After} header set to the value provided by the method
@@ -190,7 +190,7 @@ public interface AsyncResponse {
     /**
      * Cancel the suspended request processing.
      * <p>
-     * When a request processing is cancelled using this method, the JAX-RS implementation
+     * When a request processing is cancelled using this method, the API implementation
      * MUST indicate to the client that the request processing has been cancelled by sending
      * back a {@link javax.ws.rs.core.Response.Status#SERVICE_UNAVAILABLE HTTP 503 (Service unavailable)}
      * error response with a {@code Retry-After} header set to the value provided by the method

--- a/jaxrs-api/src/main/java/javax/ws/rs/container/ConnectionCallback.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/container/ConnectionCallback.java
@@ -20,7 +20,7 @@ package javax.ws.rs.container;
  * Asynchronous request processing lifecycle callback that receives connection
  * related {@link AsyncResponse asynchronous response} lifecycle events.
  * <p>
- * Support for this type of callback by JAX-RS runtime is OPTIONAL.
+ * Support for this type of callback by the runtime is OPTIONAL.
  * </p>
  *
  * @author Marek Potociar

--- a/jaxrs-api/src/main/java/javax/ws/rs/container/ContainerRequestContext.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/container/ContainerRequestContext.java
@@ -16,14 +16,6 @@
 
 package javax.ws.rs.container;
 
-import java.io.InputStream;
-import java.net.URI;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-
 import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
@@ -31,6 +23,13 @@ import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 /**
  * Container request filter context.
@@ -49,7 +48,7 @@ public interface ContainerRequestContext {
      * Returns the property with the given name registered in the current request/response
      * exchange context, or {@code null} if there is no property by that name.
      * <p>
-     * A property allows a JAX-RS filters and interceptors to exchange
+     * A property allows filters and interceptors to exchange
      * additional custom information not already provided by this interface.
      * </p>
      * <p>
@@ -94,7 +93,7 @@ public interface ContainerRequestContext {
      * exchange context. If the name specified is already used for a property,
      * this method will replace the value of the property with the new value.
      * <p>
-     * A property allows a JAX-RS filters and interceptors to exchange
+     * A property allows filters and interceptors to exchange
      * additional custom information not already provided by this interface.
      * </p>
      * <p>
@@ -295,7 +294,7 @@ public interface ContainerRequestContext {
     public boolean hasEntity();
 
     /**
-     * Get the entity input stream. The JAX-RS runtime is responsible for
+     * Get the entity input stream. The runtime is responsible for
      * closing the input stream.
      *
      * @return entity input stream.
@@ -303,7 +302,7 @@ public interface ContainerRequestContext {
     public InputStream getEntityStream();
 
     /**
-     * Set a new entity input stream. The JAX-RS runtime is responsible for
+     * Set a new entity input stream. The runtime is responsible for
      * closing the input stream.
      *
      * @param input new entity input stream.

--- a/jaxrs-api/src/main/java/javax/ws/rs/container/ContainerRequestFilter.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/container/ContainerRequestFilter.java
@@ -24,7 +24,7 @@ import java.io.IOException;
  * By default, i.e. if no {@link javax.ws.rs.NameBinding name binding} is applied
  * to the filter implementation class, the filter instance is applied globally,
  * however only after the incoming request has been matched to a particular resource
- * by JAX-RS runtime.
+ * by the runtime.
  * If there is a {@link javax.ws.rs.NameBinding &#64;NameBinding} annotation
  * applied to the filter, the filter will also be executed at the <i>post-match</i>
  * request extension point, but only in case the matched {@link javax.ws.rs.HttpMethod
@@ -32,18 +32,18 @@ import java.io.IOException;
  * </p>
  * <p>
  * In case the filter should be applied at the <i>pre-match</i> extension point,
- * i.e. before any request matching has been performed by JAX-RS runtime, the
+ * i.e. before any request matching has been performed by the runtime, the
  * filter MUST be annotated with a {@link PreMatching &#64;PreMatching} annotation.
  * </p>
  * <p>
- * Use a pre-match request filter to update the input to the JAX-RS matching algorithm,
+ * Use a pre-match request filter to update the input to the matching algorithm,
  * e.g., the HTTP method, Accept header, return cached responses etc. Otherwise,
  * the use of a request filter invoked at the <i>post-match</i> request extension point
  * (after a successful resource method matching) is recommended.
  * </p>
  * <p>
  * Filters implementing this interface must be annotated with
- * {@link javax.ws.rs.ext.Provider &#64;Provider} to be discovered by the JAX-RS
+ * {@link javax.ws.rs.ext.Provider &#64;Provider} to be discovered by the
  * runtime. Container request filter instances may also be discovered and
  * bound {@link DynamicFeature dynamically} to particular resource methods.
  * </p>

--- a/jaxrs-api/src/main/java/javax/ws/rs/container/ContainerResponseContext.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/container/ContainerResponseContext.java
@@ -16,6 +16,13 @@
 
 package javax.ws.rs.container;
 
+import javax.ws.rs.core.EntityTag;
+import javax.ws.rs.core.Link;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.NewCookie;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.MessageBodyWriter;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
@@ -24,14 +31,6 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-
-import javax.ws.rs.core.EntityTag;
-import javax.ws.rs.core.Link;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.NewCookie;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.MessageBodyWriter;
 
 /**
  * Container response filter context.
@@ -361,7 +360,7 @@ public interface ContainerResponseContext {
     public Annotation[] getEntityAnnotations();
 
     /**
-     * Get the entity output stream. The JAX-RS runtime is responsible for
+     * Get the entity output stream. The runtime is responsible for
      * closing the output stream.
      *
      * @return entity output stream.
@@ -369,7 +368,7 @@ public interface ContainerResponseContext {
     public OutputStream getEntityStream();
 
     /**
-     * Set a new entity output stream. The JAX-RS runtime is responsible for
+     * Set a new entity output stream. The runtime is responsible for
      * closing the output stream.
      *
      * @param outputStream new entity output stream.

--- a/jaxrs-api/src/main/java/javax/ws/rs/container/ContainerResponseFilter.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/container/ContainerResponseFilter.java
@@ -27,7 +27,7 @@ import java.io.IOException;
  * If there is a {@code @NameBinding} annotation applied to the filter, the filter
  * will only be executed for a response for which the request has been matched to
  * a {@link javax.ws.rs.HttpMethod resource or sub-resource method} AND the method
- * or the whole custom {@link javax.ws.rs.core.Application JAX-RS Application} class
+ * or the whole custom {@link javax.ws.rs.core.Application Application} class
  * is bound to the same name-binding annotation.
  * </p>
  * <p>
@@ -38,7 +38,7 @@ import java.io.IOException;
  * </p>
  * <p>
  * Filters implementing this interface must be annotated with
- * {@link javax.ws.rs.ext.Provider &#64;Provider} to be discovered by the JAX-RS
+ * {@link javax.ws.rs.ext.Provider &#64;Provider} to be discovered by the
  * runtime. Container response filter instances may also be discovered and
  * bound {@link DynamicFeature dynamically} to particular resource methods.
  * </p>

--- a/jaxrs-api/src/main/java/javax/ws/rs/container/DynamicFeature.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/container/DynamicFeature.java
@@ -21,16 +21,16 @@ import javax.ws.rs.ext.ReaderInterceptor;
 import javax.ws.rs.ext.WriterInterceptor;
 
 /**
- * A JAX-RS meta-provider for dynamic registration of <i>post-matching</i> providers
- * during a JAX-RS application setup at deployment time.
+ * A meta-provider for dynamic registration of <i>post-matching</i> providers
+ * during an application setup at deployment time.
  *
- * Dynamic feature is used by JAX-RS runtime to register providers that shall be applied
+ * Dynamic feature is used by the runtime to register providers that shall be applied
  * to a particular resource class and method and overrides any annotation-based binding
  * definitions defined on any registered resource filter or interceptor instance.
  * <p>
  * Providers implementing this interface MAY be annotated with
  * {@link javax.ws.rs.ext.Provider &#64;Provider} annotation in order to be
- * discovered by JAX-RS runtime when scanning for resources and providers.
+ * discovered by the runtime when scanning for resources and providers.
  * This provider types is supported only as part of the Server API.
  * </p>
  *
@@ -43,7 +43,7 @@ import javax.ws.rs.ext.WriterInterceptor;
 public interface DynamicFeature {
 
     /**
-     * A callback method called by the JAX-RS runtime during the application
+     * A callback method called by the runtime during the application
      * deployment to register provider instances or classes in a
      * {@link javax.ws.rs.core.Configuration runtime configuration} scope of a particular {@link javax.ws.rs.HttpMethod
      * resource or sub-resource method}; i.e. the providers that should be dynamically bound
@@ -61,9 +61,9 @@ public interface DynamicFeature {
      * </ul>
      * <p>
      * A provider instance or class that does not implement any of the interfaces
-     * above may be ignored by the JAX-RS implementation. In such case a
+     * above may be ignored by the API implementation. In such case a
      * {@link java.util.logging.Level#WARNING warning} message must be logged.
-     * JAX-RS implementations may support additional provider contracts that
+     * API implementations may support additional provider contracts that
      * can be registered using a dynamic feature concept.
      * </p>
      * <p>

--- a/jaxrs-api/src/main/java/javax/ws/rs/container/PreMatching.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/container/PreMatching.java
@@ -27,7 +27,7 @@ import java.lang.annotation.Target;
  * container request filter} to indicate that such filter should be applied globally
  * on all resources in the application before the actual resource matching occurs.
  * <p>
- * The JAX-RS runtime will apply the filters marked with the {@code @PreMatching}
+ * The runtime will apply the filters marked with the {@code @PreMatching}
  * annotation globally to all resources, before the incoming request has been matched
  * to a particular resource method.
  * Any {@link javax.ws.rs.NameBinding named binding annotations} will be ignored on

--- a/jaxrs-api/src/main/java/javax/ws/rs/container/ResourceContext.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/container/ResourceContext.java
@@ -39,7 +39,7 @@ public interface ResourceContext {
      * <p>
      * The resolved resource instance is properly initialized in the context of the
      * current request processing scope. The scope of the resolved resource instance
-     * depends on the managing container. For resources managed by JAX-RS container
+     * depends on the managing container. For resources managed by the runtime container
      * the default scope is per-request.
      * </p>
      *
@@ -52,7 +52,7 @@ public interface ResourceContext {
     /**
      * Initialize the resource or sub-resource instance.
      *
-     * All JAX-RS injectable fields in the resource instance will be properly initialized in
+     * All injectable fields in the resource instance will be properly initialized in
      * the context of the current request processing scope.
      *
      * @param <T>      resource instance type.

--- a/jaxrs-api/src/main/java/javax/ws/rs/container/Suspended.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/container/Suspended.java
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Inject a suspended {@link AsyncResponse} into a parameter of an invoked
- * JAX-RS {@link javax.ws.rs.HttpMethod resource or sub-resource method}.
+ * {@link javax.ws.rs.HttpMethod resource or sub-resource method}.
  *
  * The injected {@code AsyncResponse} instance is bound to the processing
  * of the active request and can be used to resume the request processing when
@@ -59,7 +59,7 @@ import java.util.concurrent.TimeUnit;
  * {@code AsyncResponse} using the {@code @Suspended} annotation is expected
  * be declared to return {@code void} type. Methods that inject asynchronous
  * response instance using the {@code @Suspended} annotation and declare a
- * return type other than {@code void} MUST be detected by the JAX-RS runtime and
+ * return type other than {@code void} MUST be detected by the the runtime and
  * a warning message MUST be logged. Any response value returned from such resource
  * or sub-resource method MUST be ignored by the framework:
  * </p>

--- a/jaxrs-api/src/main/java/javax/ws/rs/container/TimeoutHandler.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/container/TimeoutHandler.java
@@ -19,10 +19,10 @@ package javax.ws.rs.container;
 /**
  * Asynchronous response suspend time-out handler.
  *
- * JAX-RS users may utilize this callback interface to provide
+ * Users may utilize this callback interface to provide
  * custom resolution of time-out events.
  * <p>
- * By default, JAX-RS runtime generates a {@link javax.ws.rs.WebApplicationException}
+ * By default, the runtime generates a {@link javax.ws.rs.WebApplicationException}
  * with a {@link javax.ws.rs.core.Response.Status#SERVICE_UNAVAILABLE HTTP 503
  * (Service unavailable)} error response status code. A custom time-out handler
  * may be {@link AsyncResponse#setTimeoutHandler(TimeoutHandler) set} on an
@@ -83,7 +83,7 @@ public interface TimeoutHandler {
      * Invoked when the suspended asynchronous response is about to time out.
      *
      * Implementing time-out handlers may use the callback method to change the
-     * default time-out strategy defined by JAX-RS specification (see
+     * default time-out strategy defined by this specification (see
      * {@link javax.ws.rs.container.AsyncResponse} API documentation).
      * <p>
      * A custom time-out handler may decide to either
@@ -95,7 +95,7 @@ public interface TimeoutHandler {
      * </ul>
      * </p>
      * In case the time-out handler does not take any of the actions mentioned above,
-     * a default time-out strategy is executed by the JAX-RS runtime.
+     * a default time-out strategy is executed by the runtime.
      *
      * @param asyncResponse suspended asynchronous response that is timing out.
      */

--- a/jaxrs-api/src/main/java/javax/ws/rs/container/package-info.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/container/package-info.java
@@ -15,6 +15,6 @@
  */
 
 /**
- * Container-specific JAX-RS API.
+ * Container-specific API.
  */
 package javax.ws.rs.container;

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Application.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Application.java
@@ -21,8 +21,8 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Defines the components of a JAX-RS application and supplies additional
- * meta-data. A JAX-RS application or implementation supplies a concrete
+ * Defines the components of an application and supplies additional
+ * meta-data. An application or implementation supplies a concrete
  * subclass of this abstract class.
  * <p>
  * The implementation-created instance of an Application subclass may be
@@ -92,7 +92,7 @@ public class Application {
      * Get a map of custom application-wide properties.
      * <p>
      * The returned properties are reflected in the application {@link Configuration configuration}
-     * passed to the server-side features or injected into server-side JAX-RS components.
+     * passed to the server-side features or injected into server-side components.
      * </p>
      * <p>
      * The set of returned properties may be further extended or customized at deployment time

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Configurable.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Configurable.java
@@ -19,19 +19,19 @@ package javax.ws.rs.core;
 import java.util.Map;
 
 /**
- * Represents a client or server-side configurable context in JAX-RS.
+ * Represents a client or server-side configurable context.
  *
- * A configurable context can be used to define the JAX-RS components as well as
+ * A configurable context can be used to define the components as well as
  * additional meta-data that should be used in the scope of the configured context.
  * The modification of the context typically involves setting properties or registering
- * custom JAX-RS components, such as providers and/or features.
+ * custom components, such as providers and/or features.
  * All modifications of a {@code Configurable} context are reflected in the associated
  * {@link Configuration} state which is exposed via {@link #getConfiguration()} method.
  * <p>
- * A configurable context can be either indirectly associated with a particular JAX-RS component
+ * A configurable context can be either indirectly associated with a particular component
  * (such as application or resource method configurable context passed to a {@link Feature}
  * or {@link javax.ws.rs.container.DynamicFeature} meta-providers) or can be directly represented
- * by a concrete JAX-RS component implementing the {@code Configurable} interface
+ * by a concrete component implementing the {@code Configurable} interface
  * (such as {@link javax.ws.rs.client.Client} or {@link javax.ws.rs.client.WebTarget}).
  * As such, the exact scope of a configuration context is typically determined by a use case
  * scenario in which the context is accessed.
@@ -43,16 +43,16 @@ import java.util.Map;
  * properties is available via the underlying {@code Configuration} object. An existing property
  * can be removed by assigning a {@code null} value to the property.
  * </p>
- * <h3>Registering JAX-RS components.</h3>
+ * <h3>Registering components.</h3>
  * <p>
- * Registered custom JAX-RS component classes and instances are important part of the contextual
+ * Registered custom component classes and instances are important part of the contextual
  * configuration information as these are the main factors that determine the capabilities of
  * a configured runtime.
  * Implementations SHOULD warn about and ignore registrations that do not conform to the requirements
- * of supported JAX-RS components in a given configurable context.
+ * of supported components in a given configurable context.
  * </p>
  * <p>
- * In most cases, when registering a JAX-RS component, the simplest form of methods
+ * In most cases, when registering a component, the simplest form of methods
  * ({@link #register(Class)} or {@link #register(Object)}) of the available registration API
  * is sufficient.
  * </p>
@@ -64,9 +64,9 @@ import java.util.Map;
  * </pre>
  * </p>
  * <p>
- * In some situations a JAX-RS component class or instance may implement multiple
- * provider contracts recognized by a JAX-RS implementation (e.g. filter, interceptor or entity provider).
- * By default, the JAX-RS implementation MUST register the new component class or instance as
+ * In some situations a component class or instance may implement multiple
+ * provider contracts recognized by an implementation (e.g. filter, interceptor or entity provider).
+ * By default, the implementation MUST register the new component class or instance as
  * a provider for all the recognized provider contracts implemented by the component class.
  * </p>
  * <p>
@@ -84,10 +84,10 @@ import java.util.Map;
  * </pre>
  * </p>
  * <p>
- * There are however situations when the default registration of a JAX-RS component to all the
+ * There are however situations when the default registration of a component to all the
  * recognized provider contracts is not desirable. In such cases users may use other versions of the
  * {@code register(...)} method to explicitly specify the collection of the provider contracts
- * for which the JAX-RS component should be registered and/or the priority of each registered
+ * for which the component should be registered and/or the priority of each registered
  * provider contract.
  * </p>
  * <p>
@@ -112,7 +112,7 @@ import java.util.Map;
  * </pre>
  * </p>
  * <p>
- * As a general rule, for each JAX-RS component class there can be at most one registration
+ * As a general rule, for each component class there can be at most one registration
  * &mdash; class-based or instance-based &mdash; configured at any given moment. Implementations
  * MUST reject any attempts to configure a new registration for a provider class that has been
  * already registered in the given configurable context earlier. Implementations SHOULD also raise
@@ -165,40 +165,40 @@ public interface Configurable<C extends Configurable> {
     public C property(String name, Object value);
 
     /**
-     * Register a class of a custom JAX-RS component (such as an extension provider or
+     * Register a class of a custom component (such as an extension provider or
      * a {@link javax.ws.rs.core.Feature feature} meta-provider) to be instantiated
      * and used in the scope of this configurable context.
      *
      * Implementations SHOULD warn about and ignore registrations that do not
-     * conform to the requirements of supported JAX-RS component types in the
+     * conform to the requirements of supported component types in the
      * given configurable context. Any subsequent registration attempts for a component
      * type, for which a class or instance-based registration already exists in the system
-     * MUST be rejected by the JAX-RS implementation and a warning SHOULD be raised to
+     * MUST be rejected by the API implementation and a warning SHOULD be raised to
      * inform the user about the rejected registration.
      *
-     * The registered JAX-RS component class is registered as a contract provider of
-     * all the recognized JAX-RS or implementation-specific extension contracts including
+     * The registered component class is registered as a contract provider of
+     * all the recognized API or implementation-specific extension contracts including
      * meta-provider contracts, such as {@code Feature} or {@link javax.ws.rs.container.DynamicFeature}.
      * <p>
      * As opposed to component instances registered via {@link #register(Object)} method,
      * the lifecycle of components registered using this class-based {@code register(...)}
-     * method is fully managed by the JAX-RS implementation or any underlying IoC
+     * method is fully managed by the implementation or any underlying IoC
      * container supported by the implementation.
      * </p>
      *
-     * @param componentClass JAX-RS component class to be configured in the scope of this
+     * @param componentClass component class to be configured in the scope of this
      *                       configurable context.
      * @return the updated configurable context.
      */
     public C register(Class<?> componentClass);
 
     /**
-     * Register a class of a custom JAX-RS component (such as an extension provider or
+     * Register a class of a custom component (such as an extension provider or
      * a {@link javax.ws.rs.core.Feature feature} meta-provider) to be instantiated
      * and used in the scope of this configurable context.
      * <p>
      * This registration method provides the same functionality as {@link #register(Class)}
-     * except that any priority specified on the registered JAX-RS component class via
+     * except that any priority specified on the registered component class via
      * {@code javax.annotation.Priority} annotation is overridden with the supplied
      * {@code priority} value.
      * </p>
@@ -208,7 +208,7 @@ public interface Configurable<C extends Configurable> {
      * {@code priority} value will be ignored for that contract.
      * </p>
      *
-     * @param componentClass JAX-RS component class to be configured in the scope of this
+     * @param componentClass component class to be configured in the scope of this
      *                       configurable context.
      * @param priority       the overriding priority for the registered component
      *                       and all the provider contracts the component implements.
@@ -217,12 +217,12 @@ public interface Configurable<C extends Configurable> {
     public C register(Class<?> componentClass, int priority);
 
     /**
-     * Register a class of a custom JAX-RS component (such as an extension provider or
+     * Register a class of a custom component (such as an extension provider or
      * a {@link javax.ws.rs.core.Feature feature} meta-provider) to be instantiated
      * and used in the scope of this configurable context.
      * <p>
      * This registration method provides the same functionality as {@link #register(Class)}
-     * except the JAX-RS component class is only registered as a provider of the listed
+     * except the component class is only registered as a provider of the listed
      * extension provider or meta-provider {@code contracts}.
      * All explicitly enumerated contract types must represent a class or an interface
      * implemented or extended by the registered component. Contracts that are not
@@ -231,7 +231,7 @@ public interface Configurable<C extends Configurable> {
      * ignored contract(s).
      * </p>
      *
-     * @param componentClass JAX-RS component class to be configured in the scope of this
+     * @param componentClass component class to be configured in the scope of this
      *                       configurable context.
      * @param contracts      the specific extension provider or meta-provider contracts
      *                       implemented by the component for which the component should
@@ -244,29 +244,29 @@ public interface Configurable<C extends Configurable> {
     public C register(Class<?> componentClass, Class<?>... contracts);
 
     /**
-     * Register a class of a custom JAX-RS component (such as an extension provider or
+     * Register a class of a custom component (such as an extension provider or
      * a {@link javax.ws.rs.core.Feature feature} meta-provider) to be instantiated
      * and used in the scope of this configurable context.
      * <p>
      * This registration method provides same functionality as {@link #register(Class, Class[])}
-     * except that any priority specified on the registered JAX-RS component class via
+     * except that any priority specified on the registered component class via
      * {@code javax.annotation.Priority} annotation is overridden
      * for each extension provider contract type separately with an integer priority value
      * specified as a value in the supplied map of [contract type, priority] pairs.
      * </p>
      * <p>
      * Note that in case a priority is not applicable to a provider contract registered
-     * for the JAX-RS component, the supplied priority value is ignored for such
+     * for the component, the supplied priority value is ignored for such
      * contract.
      * </p>
      *
-     * @param componentClass JAX-RS component class to be configured in the scope of this
+     * @param componentClass component class to be configured in the scope of this
      *                       configurable context.
      * @param contracts      map of the specific extension provider and meta-provider contracts
-     *                       and their associated priorities for which the JAX-RS component
+     *                       and their associated priorities for which the component
      *                       is registered.
      *                       All contracts in the map must represent a class or an interface
-     *                       implemented or extended by the JAX-RS component. Contracts that are
+     *                       implemented or extended by the component. Contracts that are
      *                       not {@link Class#isAssignableFrom(Class) assignable from} the registered
      *                       component class MUST be ignored and implementations SHOULD raise a warning
      *                       to inform users about the ignored contract(s).
@@ -275,42 +275,42 @@ public interface Configurable<C extends Configurable> {
     public C register(Class<?> componentClass, Map<Class<?>, Integer> contracts);
 
     /**
-     * Register an instance of a custom JAX-RS component (such as an extension provider or
+     * Register an instance of a custom component (such as an extension provider or
      * a {@link javax.ws.rs.core.Feature feature} meta-provider) to be instantiated
      * and used in the scope of this configurable context.
      *
      * Implementations SHOULD warn about and ignore registrations that do not
-     * conform to the requirements of supported JAX-RS component types in the
+     * conform to the requirements of supported component types in the
      * given configurable context. Any subsequent registration attempts for a component
      * type, for which a class or instance-based registration already exists in the system
-     * MUST be rejected by the JAX-RS implementation and a warning SHOULD be raised to
+     * MUST be rejected by the API implementation and a warning SHOULD be raised to
      * inform the user about the rejected registration.
      *
-     * The registered JAX-RS component is registered as a contract provider of
-     * all the recognized JAX-RS or implementation-specific extension contracts including
+     * The registered component is registered as a contract provider of
+     * all the recognized API or implementation-specific extension contracts including
      * meta-provider contracts, such as {@code Feature} or {@link javax.ws.rs.container.DynamicFeature}.
      * <p>
      * As opposed to components registered via {@link #register(Class)} method,
      * the lifecycle of providers registered using this instance-based {@code register(...)}
-     * is not managed by JAX-RS runtime. The same registered component instance is used during
+     * is not managed by the runtime. The same registered component instance is used during
      * the whole lifespan of the configurable context.
-     * Fields and properties of all registered JAX-RS component instances are injected with their
-     * declared dependencies (see {@link Context}) by the JAX-RS runtime prior to use.
+     * Fields and properties of all registered component instances are injected with their
+     * declared dependencies (see {@link Context}) by the runtime prior to use.
      * </p>
      *
-     * @param component JAX-RS component instance to be configured in the scope of this
+     * @param component component instance to be configured in the scope of this
      *                  configurable context.
      * @return the updated configurable context.
      */
     public C register(Object component);
 
     /**
-     * Register an instance of a custom JAX-RS component (such as an extension provider or
+     * Register an instance of a custom component (such as an extension provider or
      * a {@link javax.ws.rs.core.Feature feature} meta-provider) to be instantiated
      * and used in the scope of this configurable context.
      * <p>
      * This registration method provides the same functionality as {@link #register(Object)}
-     * except that any priority specified on the registered JAX-RS component class via
+     * except that any priority specified on the registered component class via
      * {@code javax.annotation.Priority} annotation is overridden with the supplied
      * {@code priority} value.
      * </p>
@@ -320,7 +320,7 @@ public interface Configurable<C extends Configurable> {
      * {@code priority} value will be ignored for that contract.
      * </p>
      *
-     * @param component JAX-RS component instance to be configured in the scope of this
+     * @param component component instance to be configured in the scope of this
      *                  configurable context.
      * @param priority  the overriding priority for the registered component
      *                  and all the provider contracts the component implements.
@@ -329,12 +329,12 @@ public interface Configurable<C extends Configurable> {
     public C register(Object component, int priority);
 
     /**
-     * Register an instance of a custom JAX-RS component (such as an extension provider or
+     * Register an instance of a custom component (such as an extension provider or
      * a {@link javax.ws.rs.core.Feature feature} meta-provider) to be instantiated
      * and used in the scope of this configurable context.
      * <p>
      * This registration method provides the same functionality as {@link #register(Object)}
-     * except the JAX-RS component class is only registered as a provider of the listed
+     * except the component class is only registered as a provider of the listed
      * extension provider or meta-provider {@code contracts}.
      * All explicitly enumerated contract types must represent a class or an interface
      * implemented or extended by the registered component. Contracts that are not
@@ -343,7 +343,7 @@ public interface Configurable<C extends Configurable> {
      * ignored contract(s).
      * </p>
      *
-     * @param component JAX-RS component instance to be configured in the scope of this
+     * @param component component instance to be configured in the scope of this
      *                  configurable context.
      * @param contracts the specific extension provider or meta-provider contracts
      *                  implemented by the component for which the component should
@@ -356,29 +356,29 @@ public interface Configurable<C extends Configurable> {
     public C register(Object component, Class<?>... contracts);
 
     /**
-     * Register an instance of a custom JAX-RS component (such as an extension provider or
+     * Register an instance of a custom component (such as an extension provider or
      * a {@link javax.ws.rs.core.Feature feature} meta-provider) to be instantiated
      * and used in the scope of this configurable context.
      * <p>
      * This registration method provides same functionality as {@link #register(Object, Class[])}
-     * except that any priority specified on the registered JAX-RS component class via
+     * except that any priority specified on the registered component class via
      * {@code javax.annotation.Priority} annotation is overridden
      * for each extension provider contract type separately with an integer priority value
      * specified as a value in the supplied map of [contract type, priority] pairs.
      * </p>
      * <p>
      * Note that in case a priority is not applicable to a provider contract registered
-     * for the JAX-RS component, the supplied priority value is ignored for such
+     * for the component, the supplied priority value is ignored for such
      * contract.
      * </p>
      *
-     * @param component JAX-RS component instance to be configured in the scope of this
+     * @param component component instance to be configured in the scope of this
      *                  configurable context.
      * @param contracts map of the specific extension provider and meta-provider contracts
-     *                  and their associated priorities for which the JAX-RS component
+     *                  and their associated priorities for which the component
      *                  is registered.
      *                  All contracts in the map must represent a class or an interface
-     *                  implemented or extended by the JAX-RS component. Contracts that are
+     *                  implemented or extended by the component. Contracts that are
      *                  not {@link Class#isAssignableFrom(Class) assignable from} the registered
      *                  component class MUST be ignored and implementations SHOULD raise a warning
      *                  to inform users about the ignored contract(s).

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Configuration.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Configuration.java
@@ -16,20 +16,19 @@
 
 package javax.ws.rs.core;
 
+import javax.ws.rs.RuntimeType;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
-import javax.ws.rs.RuntimeType;
-
 /**
- * A configuration state associated with a {@link Configurable configurable} JAX-RS context.
+ * A configuration state associated with a {@link Configurable configurable} context.
  * Defines the components as well as additional meta-data for the configured context.
  * <p>
  * A configuration state may be used to retrieve configuration information about
- * of the associated JAX-RS context (e.g. application, resource method, etc.) or component
+ * of the associated context (e.g. application, resource method, etc.) or component
  * (e.g. {@link javax.ws.rs.client.Client}, {@link javax.ws.rs.client.WebTarget}, etc.).
- * Configuration information consists of properties, registered JAX-RS component classes
+ * Configuration information consists of properties, registered component classes
  * and/or instances.
  * </p>
  * <p>
@@ -108,7 +107,7 @@ public interface Configuration {
     public boolean isEnabled(Class<? extends Feature> featureClass);
 
     /**
-     * Check if a particular JAX-RS {@code component} instance (such as providers or
+     * Check if a particular API {@code component} instance (such as providers or
      * {@link Feature features}) has been previously registered in the runtime configuration context.
      * <p>
      * Method returns {@code true} only in case an instance equal to the {@code component}
@@ -124,7 +123,7 @@ public interface Configuration {
     public boolean isRegistered(Object component);
 
     /**
-     * Check if a JAX-RS component of the supplied {@code componentClass} class has been previously
+     * Check if a component of the supplied {@code componentClass} class has been previously
      * registered in the runtime configuration context.
      * <p>
      * Method returns {@code true} in case a component of the supplied {@code componentClass} class
@@ -153,7 +152,7 @@ public interface Configuration {
     public Map<Class<?>, Integer> getContracts(Class<?> componentClass);
 
     /**
-     * Get the immutable set of registered JAX-RS component (such as provider or
+     * Get the immutable set of registered component (such as provider or
      * {@link Feature feature}) classes to be instantiated, injected and utilized in the scope
      * of the configurable instance.
      * <p>
@@ -161,14 +160,14 @@ public interface Configuration {
      * present in the configuration context at any given time.
      * </p>
      *
-     * @return the immutable set of registered JAX-RS component classes. The returned
+     * @return the immutable set of registered component classes. The returned
      *         value may be empty but will never be {@code null}.
      * @see #getInstances
      */
     public Set<Class<?>> getClasses();
 
     /**
-     * Get the immutable set of registered JAX-RS component (such as provider or
+     * Get the immutable set of registered component (such as provider or
      * {@link Feature feature}) instances to be utilized by the configurable instance.
      * Fields and properties of returned instances are injected with their declared dependencies
      * (see {@link Context}) by the runtime prior to use.
@@ -177,7 +176,7 @@ public interface Configuration {
      * present in the configuration context at any given time.
      * </p>
      *
-     * @return the immutable set of registered JAX-RS component instances. The returned
+     * @return the immutable set of registered component instances. The returned
      *         value may be empty but will never be {@code null}.
      * @see #getClasses
      */

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Feature.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Feature.java
@@ -22,8 +22,8 @@ package javax.ws.rs.core;
  * Typically encapsulates a concept or facility that involves configuration of multiple providers
  * (e.g. filters or interceptors) and/or properties.
  * <p>
- * A {@code Feature} is a special type of JAX-RS configuration meta-provider. Once a feature is registered,
- * its {@link #configure(FeatureContext)} method is invoked during JAX-RS runtime configuration and bootstrapping
+ * A {@code Feature} is a special type of configuration meta-provider. Once a feature is registered,
+ * its {@link #configure(FeatureContext)} method is invoked during runtime configuration and bootstrapping
  * phase allowing the feature to further configure the runtime context in which it has been registered.
  * From within the invoked {@code configure(...)} method a feature may provide additional runtime configuration
  * for the facility or conceptual domain it represents, such as registering additional contract providers,
@@ -31,8 +31,8 @@ package javax.ws.rs.core;
  * </p>
  * <p>
  * Features implementing this interface MAY be annotated with the {@link javax.ws.rs.ext.Provider &#64;Provider}
- * annotation in order to be discovered by the JAX-RS runtime when scanning for resources and providers.
- * Please note that this will only work for server side features. Features for the JAX-RS client must
+ * annotation in order to be discovered by the runtime when scanning for resources and providers.
+ * Please note that this will only work for server side features. Features in the Client API must
  * be registered programmatically.
  * </p>
  *

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/FeatureContext.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/FeatureContext.java
@@ -18,7 +18,7 @@ package javax.ws.rs.core;
 
 /**
  * A configurable context passed to {@link Feature} and {@link javax.ws.rs.container.DynamicFeature}
- * instances by JAX-RS runtime during the phase of their configuration.
+ * instances by the runtime during the phase of their configuration.
  *
  * @author Marek Potociar (marek.potociar at oracle.com)
  */

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Link.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Link.java
@@ -536,7 +536,7 @@ public abstract class Link {
 
     /**
      * An implementation of JAXB {@link javax.xml.bind.annotation.adapters.XmlAdapter}
-     * that maps the JAX-RS {@link javax.ws.rs.core.Link} type to a value that can be
+     * that maps the {@link javax.ws.rs.core.Link} type to a value that can be
      * marshalled and unmarshalled by JAXB. The following example shows how to use
      * this adapter on a JAXB bean class:
      *

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/NoContentException.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/NoContentException.java
@@ -24,7 +24,7 @@ import java.io.IOException;
  * is not able to produce an instance representing an zero-length message content.
  * <p>
  * This exception, when thrown while reading a server request entity, is automatically
- * translated by JAX-RS server runtime into a {@link javax.ws.rs.BadRequestException}
+ * translated by the server runtime into a {@link javax.ws.rs.BadRequestException}
  * wrapping the original {@code NoContentException} and rethrown for a standard processing by
  * the registered {@link javax.ws.rs.ext.ExceptionMapper exception mappers}.
  * </p>

--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Response.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Response.java
@@ -16,6 +16,10 @@
 
 package javax.ws.rs.core;
 
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.RuntimeDelegate;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.net.URI;
@@ -25,17 +29,12 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
-import javax.ws.rs.ProcessingException;
-import javax.ws.rs.ext.MessageBodyReader;
-import javax.ws.rs.ext.MessageBodyWriter;
-import javax.ws.rs.ext.RuntimeDelegate;
-
 /**
  * Defines the contract between a returned instance and the runtime when
  * an application needs to provide meta-data to the runtime.
  * <p>
  * An application class should not extend this class directly. {@code Response} class is
- * reserved for an extension by a JAX-RS implementation providers. An application should use one
+ * reserved for an extension by API implementation providers. An application should use one
  * of the static methods to create a {@code Response} instance using a ResponseBuilder.
  * </p>
  * <p>
@@ -456,7 +455,7 @@ public abstract class Response implements AutoCloseable {
      *
      * This method is considered deprecated. Users are encouraged to switch their
      * code to use the {@code getHeaders()} method instead. The method may be annotated
-     * as {@link Deprecated &#64;Deprecated} in a future release of JAX-RS API.
+     * as {@link Deprecated &#64;Deprecated} in a future release of the API.
      *
      * @return response headers as a multivalued map.
      */
@@ -465,7 +464,7 @@ public abstract class Response implements AutoCloseable {
     /**
      * Get view of the response headers and their object values.
      *
-     * The underlying header data may be subsequently modified by the JAX-RS runtime on the
+     * The underlying header data may be subsequently modified by the runtime on the
      * server side. Changes in the underlying header data are reflected in this view.
      * <p>
      * On the server-side, when the message is sent, the non-string values will be serialized
@@ -491,7 +490,7 @@ public abstract class Response implements AutoCloseable {
     /**
      * Get view of the response headers and their string values.
      *
-     * The underlying header data may be subsequently modified by the JAX-RS runtime on
+     * The underlying header data may be subsequently modified by the runtime on
      * the server side. Changes in the underlying header data are reflected in this view.
      *
      * @return response headers as a string view of header values.
@@ -749,7 +748,7 @@ public abstract class Response implements AutoCloseable {
      * and a strong entity tag. This is a shortcut
      * for <code>notModified(new EntityTag(<i>value</i>))</code>.
      *
-     * @param tag the string content of a strong entity tag. The JAX-RS
+     * @param tag the string content of a strong entity tag. The
      *            runtime will quote the supplied value when creating the
      *            header.
      * @return a new response builder.
@@ -1132,7 +1131,7 @@ public abstract class Response implements AutoCloseable {
          * <p/>
          * This is a shortcut for <code>tag(new EntityTag(<i>value</i>))</code>.
          *
-         * @param tag the string content of a strong entity tag. The JAX-RS
+         * @param tag the string content of a strong entity tag. The
          *            runtime will quote the supplied value when creating the header.
          *            If {@code null} any existing entity tag value will be removed.
          * @return the updated response builder.

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/ContextResolver.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/ContextResolver.java
@@ -25,9 +25,9 @@ package javax.ws.rs.ext;
  * which it will be considered suitable.
  * <p>
  * Providers implementing {@code ContextResolver} contract must be either programmatically
- * registered in a JAX-RS runtime or must be annotated with
+ * registered in an API runtime or must be annotated with
  * {@link javax.ws.rs.ext.Provider &#64;Provider} annotation to be automatically discovered
- * by the JAX-RS runtime during a provider scanning phase.
+ * by the runtime during a provider scanning phase.
  * </p>
  *
  * @param <T> type of the context

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/ExceptionMapper.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/ExceptionMapper.java
@@ -22,9 +22,9 @@ import javax.ws.rs.core.Response;
  * Contract for a provider that maps Java exceptions to {@link javax.ws.rs.core.Response}.
  * <p>
  * Providers implementing {@code ExceptionMapper} contract must be either programmatically
- * registered in a JAX-RS runtime or must be annotated with
+ * registered in an API runtime or must be annotated with
  * {@link javax.ws.rs.ext.Provider &#64;Provider} annotation to be automatically discovered
- * by the JAX-RS runtime during a provider scanning phase.
+ * by the runtime during a provider scanning phase.
  *
  * @param <E> exception type supported by the provider.
  * @author Paul Sandoz

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/InterceptorContext.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/InterceptorContext.java
@@ -16,11 +16,10 @@
 
 package javax.ws.rs.ext;
 
+import javax.ws.rs.core.MediaType;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.Collection;
-
-import javax.ws.rs.core.MediaType;
 
 /**
  * Context shared by message body interceptors that can be used to wrap
@@ -43,7 +42,7 @@ public interface InterceptorContext {
      * Returns the property with the given name registered in the current request/response
      * exchange context, or {@code null} if there is no property by that name.
      * <p>
-     * A property allows a JAX-RS filters and interceptors to exchange
+     * A property allows a filters and interceptors to exchange
      * additional custom information not already provided by this interface.
      * </p>
      * <p>
@@ -86,7 +85,7 @@ public interface InterceptorContext {
      * exchange context. If the name specified is already used for a property,
      * this method will replace the value of the property with the new value.
      * <p>
-     * A property allows a JAX-RS filters and interceptors to exchange
+     * A property allows a filters and interceptors to exchange
      * additional custom information not already provided by this interface.
      * </p>
      * <p>

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/MessageBodyReader.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/MessageBodyReader.java
@@ -16,12 +16,11 @@
 
 package javax.ws.rs.ext;
 
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
 
 /**
  * Contract for a provider that supports the conversion of a stream to a
@@ -32,9 +31,9 @@ import javax.ws.rs.core.MultivaluedMap;
  * be considered suitable.
  * <p>
  * Providers implementing {@code MessageBodyReader} contract must be either programmatically
- * registered in a JAX-RS runtime or must be annotated with
+ * registered in an API runtime or must be annotated with
  * {@link javax.ws.rs.ext.Provider &#64;Provider} annotation to be automatically discovered
- * by the JAX-RS runtime during a provider scanning phase.
+ * by the runtime during a provider scanning phase.
  * </p>
  *
  * @param <T> Java type supported by the provider
@@ -81,7 +80,7 @@ public interface MessageBodyReader<T> {
      * Java representation of a zero-length entity or throw a {@link javax.ws.rs.core.NoContentException}
      * in case no zero-length entity representation is defined for the supported Java type.
      * A {@code NoContentException}, if thrown by a message body reader while reading a server
-     * request entity, is automatically translated by JAX-RS server runtime into a {@link javax.ws.rs.BadRequestException}
+     * request entity, is automatically translated by the server runtime into a {@link javax.ws.rs.BadRequestException}
      * wrapping the original {@code NoContentException} and rethrown for a standard processing by
      * the registered {@link javax.ws.rs.ext.ExceptionMapper exception mappers}.
      * </p>

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/MessageBodyWriter.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/MessageBodyWriter.java
@@ -16,12 +16,11 @@
 
 package javax.ws.rs.ext;
 
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
 
 /**
  * Contract for a provider that supports the conversion of a Java type to a
@@ -32,9 +31,9 @@ import javax.ws.rs.core.MultivaluedMap;
  * be considered suitable.
  * <p>
  * Providers implementing {@code MessageBodyWriter} contract must be either programmatically
- * registered in a JAX-RS runtime or must be annotated with
+ * registered in an API runtime or must be annotated with
  * {@link javax.ws.rs.ext.Provider &#64;Provider} annotation to be automatically discovered
- * by the JAX-RS runtime during a provider scanning phase.
+ * by the runtime during a provider scanning phase.
  * </p>
  *
  * @param <T> the type that can be written.
@@ -66,10 +65,10 @@ public interface MessageBodyWriter<T> {
      * the serialized form of {@code t}. A non-negative return value has been used in a HTTP
      * {@code Content-Length} header.
      * <p>
-     * As of JAX-RS 2.0, the method has been deprecated and the value returned by the method is ignored
-     * by a JAX-RS runtime. All {@code MessageBodyWriter} implementations are advised to return {@code -1}
+     * As of version 2.0 of this API, the method has been deprecated and the value returned by the method is ignored
+     * by an API runtime. All {@code MessageBodyWriter} implementations are advised to return {@code -1}
      * from the method. Responsibility to compute the actual {@code Content-Length} header value has been
-     * delegated to JAX-RS runtime.
+     * delegated to the runtime.
      * </p>
      *
      * @param t           the instance to write

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/ParamConverter.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/ParamConverter.java
@@ -16,13 +16,12 @@
 
 package javax.ws.rs.ext;
 
+import javax.ws.rs.DefaultValue;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
-import javax.ws.rs.DefaultValue;
 
 /**
  * Defines a contract for a delegate responsible for converting between a
@@ -34,13 +33,13 @@ import javax.ws.rs.DefaultValue;
  * {@link javax.ws.rs.MatrixParam &#64;MatrixParam}, {@link javax.ws.rs.FormParam &#64;FormParam},
  * {@link javax.ws.rs.CookieParam &#64;CookieParam} and {@link javax.ws.rs.HeaderParam &#64;HeaderParam}
  * is supported.
- * JAX-RS implementations MUST support the {@code ParamConverter} mechanism for all Java types.
+ * API implementations MUST support the {@code ParamConverter} mechanism for all Java types.
  * If a {@code ParamConverter} is available for a type, it MUST be preferred over all other 
  * conversion strategies mentioned in section 3.2 (i.e. single {@code String} argument constructor, 
  * static {@code valueOf} or {@code fromString} methods, etc.).
  * <p>
  * By default, when used for injection of parameter values, a selected {@code ParamConverter}
- * instance MUST be used eagerly by a JAX-RS runtime to convert any {@link DefaultValue
+ * instance MUST be used eagerly by an API runtime to convert any {@link DefaultValue
  * default value} in the resource or provider model, that is during the application deployment,
  * before any value &ndash; default or otherwise &ndash; is actually required.
  * This conversion strategy ensures that any errors in the default values are reported
@@ -52,9 +51,9 @@ import javax.ws.rs.DefaultValue;
  * </p>
  * <p>
  * NOTE: A service implementing this contract is not recognized as a registrable
- * JAX-RS extension provider. Instead, a {@link ParamConverterProvider} instance
+ * extension provider. Instead, a {@link ParamConverterProvider} instance
  * responsible for providing {@code ParamConverter} instances has to be registered
- * as one of the JAX-RS extension providers.
+ * as one of the extension providers.
  * </p>
  *
  * @param <T> the supported Java type convertible to/from a {@code String} format.
@@ -91,7 +90,7 @@ public interface ParamConverter<T> {
     /**
      * Convert the supplied value to a String.
      * <p>
-     * This method is reserved for future use. Proprietary JAX-RS extensions may leverage the method.
+     * This method is reserved for future use. Proprietary API extensions may leverage the method.
      * Users should be aware that any such support for the method comes at the expense of producing
      * non-portable code.
      * </p>

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/ParamConverterProvider.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/ParamConverterProvider.java
@@ -23,9 +23,9 @@ import java.lang.reflect.Type;
  * Contract for a provider of {@link ParamConverter} instances.
  * <p>
  * Providers implementing {@code ParamConverterProvider} contract must be either programmatically
- * registered in a JAX-RS runtime or must be annotated with
+ * registered in a runtime or must be annotated with
  * {@link javax.ws.rs.ext.Provider &#64;Provider} annotation to be automatically discovered
- * by the JAX-RS runtime during a provider scanning phase.
+ * by the the runtime during a provider scanning phase.
  * </p>
  *
  * @author Marek Potociar

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/Provider.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/Provider.java
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
 
 /**
  * Marks an implementation of an extension interface that should be discoverable
- * by JAX-RS runtime during a provider scanning phase.
+ * by the runtime during a provider scanning phase.
  *
  * @author Paul Sandoz
  * @author Marc Hadley

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/ReaderInterceptor.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/ReaderInterceptor.java
@@ -21,9 +21,9 @@ package javax.ws.rs.ext;
  * to {@link javax.ws.rs.ext.MessageBodyReader#readFrom}.
  * <p>
  * Providers implementing {@code ReaderInterceptor} contract must be either programmatically
- * registered in a JAX-RS runtime or must be annotated with
+ * registered in an API runtime or must be annotated with
  * {@link javax.ws.rs.ext.Provider &#64;Provider} annotation to be automatically discovered
- * by the JAX-RS runtime during a provider scanning phase.
+ * by the runtime during a provider scanning phase.
  * Message body interceptor instances may also be discovered and
  * bound {@link javax.ws.rs.container.DynamicFeature dynamically} to particular resource methods.
  * </p>

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/ReaderInterceptorContext.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/ReaderInterceptorContext.java
@@ -16,11 +16,10 @@
 
 package javax.ws.rs.ext;
 
-import java.io.IOException;
-import java.io.InputStream;
-
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MultivaluedMap;
+import java.io.IOException;
+import java.io.InputStream;
 
 /**
  * Context class used by {@link javax.ws.rs.ext.ReaderInterceptor}
@@ -52,7 +51,7 @@ public interface ReaderInterceptorContext extends InterceptorContext {
     public Object proceed() throws IOException, WebApplicationException;
 
     /**
-     * Get the input stream of the object to be read. The JAX-RS runtime is responsible
+     * Get the input stream of the object to be read. The runtime is responsible
      * for closing the input stream.
      *
      * @return input stream of the object to be read.
@@ -61,7 +60,7 @@ public interface ReaderInterceptorContext extends InterceptorContext {
 
     /**
      * Set the input stream of the object to be read. For example, by wrapping
-     * it with another input stream. The JAX-RS runtime is responsible for closing
+     * it with another input stream. The runtime is responsible for closing
      * the input stream that is set.
      *
      * @param is new input stream.

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/RuntimeDelegate.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/RuntimeDelegate.java
@@ -16,19 +16,18 @@
 
 package javax.ws.rs.ext;
 
-import java.lang.reflect.ReflectPermission;
-import java.net.URL;
-
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Link;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.Variant.VariantListBuilder;
+import java.lang.reflect.ReflectPermission;
+import java.net.URL;
 
 /**
- * Implementations of JAX-RS provide a concrete subclass of RuntimeDelegate and
- * various JAX-RS API methods defer to methods of RuntimeDelegate for their
- * functionality. Regular users of JAX-RS are not expected to use this class
+ * Implementations of this API provide a concrete subclass of RuntimeDelegate and
+ * various API methods defer to methods of RuntimeDelegate for their
+ * functionality. Regular users of the API are not expected to use this class
  * directly and overriding an implementation of this class with a user supplied
  * subclass may cause unexpected behavior.
  *
@@ -132,7 +131,7 @@ public abstract class RuntimeDelegate {
     }
 
     /**
-     * Set the runtime delegate that will be used by JAX-RS classes. If this method
+     * Set the runtime delegate that will be used by classes. If this method
      * is not called prior to {@link #getInstance} then an implementation will
      * be sought as described in {@link #getInstance}.
      *
@@ -213,9 +212,9 @@ public abstract class RuntimeDelegate {
     /**
      * Defines the contract for a delegate that is responsible for
      * converting between the String form of a HTTP header and
-     * the corresponding JAX-RS type {@code T}.
+     * the corresponding type {@code T}.
      *
-     * @param <T> a JAX-RS type that corresponds to the value of a HTTP header.
+     * @param <T> an type that corresponds to the value of a HTTP header.
      */
     public static interface HeaderDelegate<T> {
 

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/WriterInterceptor.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/WriterInterceptor.java
@@ -22,9 +22,9 @@ package javax.ws.rs.ext;
  *
  * <p>
  * Providers implementing {@code WriterInterceptor} contract must be either programmatically
- * registered in a JAX-RS runtime or must be annotated with
+ * registered in an API runtime or must be annotated with
  * {@link javax.ws.rs.ext.Provider &#64;Provider} annotation to be automatically discovered
- * by the JAX-RS runtime during a provider scanning phase.
+ * by the runtime during a provider scanning phase.
  * Message body interceptor instances may also be discovered and
  * bound {@link javax.ws.rs.container.DynamicFeature dynamically} to particular resource methods.
  * </p>

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/WriterInterceptorContext.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/WriterInterceptorContext.java
@@ -16,11 +16,10 @@
 
 package javax.ws.rs.ext;
 
-import java.io.IOException;
-import java.io.OutputStream;
-
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MultivaluedMap;
+import java.io.IOException;
+import java.io.OutputStream;
 
 /**
  * Context class used by {@link javax.ws.rs.ext.WriterInterceptor}
@@ -65,7 +64,7 @@ public interface WriterInterceptorContext extends InterceptorContext {
     void setEntity(Object entity);
 
     /**
-     * Get the output stream for the object to be written. The JAX-RS runtime
+     * Get the output stream for the object to be written. The runtime
      * is responsible for closing the output stream.
      *
      * @return output stream for the object to be written.
@@ -74,7 +73,7 @@ public interface WriterInterceptorContext extends InterceptorContext {
 
     /**
      * Set a new output stream for the object to be written. For example, by wrapping
-     * it with another output stream. The JAX-RS runtime is responsible for closing
+     * it with another output stream. The runtime is responsible for closing
      * the output stream that is set.
      *
      * @param os new output stream for the object to be written.

--- a/jaxrs-api/src/main/java/javax/ws/rs/ext/package-info.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/ext/package-info.java
@@ -15,6 +15,6 @@
  */
 
 /**
- * APIs that provide extensions to the types supported by the JAX-RS API.
+ * APIs that provide extensions to the types supported by the API.
  */
 package javax.ws.rs.ext;

--- a/jaxrs-api/src/main/java/javax/ws/rs/sse/SseEventSource.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/sse/SseEventSource.java
@@ -16,12 +16,11 @@
 
 package javax.ws.rs.sse;
 
+import javax.ws.rs.client.WebTarget;
 import java.net.URL;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
-
-import javax.ws.rs.client.WebTarget;
 
 /**
  * Client for reading and processing {@link InboundSseEvent incoming Server-Sent Events}.
@@ -49,17 +48,17 @@ import javax.ws.rs.client.WebTarget;
  * <p>
  * By default, when a connection the the SSE endpoint is lost, the event source will wait 500&nbsp;ms
  * before attempting to reconnect to the SSE endpoint. The SSE endpoint can however control the client-side retry delay
- * by including a special {@code retry} field value in the any send event. JAX-RS {@code SseEventSource} tracks any
+ * by including a special {@code retry} field value in the any send event. {@code SseEventSource} tracks any
  * received SSE event {@code retry} field values set by the endpoint and adjusts the reconnect delay accordingly,
  * using the last received {@code retry} field value as the reconnect delay.
  * <p>
- * In addition to handling the standard connection loss failures, JAX-RS {@code SseEventSource} automatically deals with any
+ * In addition to handling the standard connection loss failures, {@code SseEventSource} automatically deals with any
  * {@code HTTP 503 Service Unavailable} responses from an SSE endpoint, that contain a
  * <code>{@value javax.ws.rs.core.HttpHeaders#RETRY_AFTER}</code> HTTP header with a valid value. The
  * <code>HTTP 503 + {@value javax.ws.rs.core.HttpHeaders#RETRY_AFTER}</code> technique is often used by HTTP endpoints
  * as a means of connection and traffic throttling.
  * In case a <code>HTTP 503 + {@value javax.ws.rs.core.HttpHeaders#RETRY_AFTER}</code> response is received in return to a connection
- * request, JAX-RS SSE event source will automatically schedule a new reconnect attempt and use the received
+ * request, SSE event source will automatically schedule a new reconnect attempt and use the received
  * <code>{@value javax.ws.rs.core.HttpHeaders#RETRY_AFTER}</code> HTTP header value as a one-time override of the reconnect delay.
  *
  * @author Marek Potociar
@@ -68,7 +67,7 @@ import javax.ws.rs.client.WebTarget;
 public interface SseEventSource extends AutoCloseable {
 
     /**
-     * JAX-RS {@link SseEventSource} builder class.
+     * {@link SseEventSource} builder class.
      * <p>
      * Event source builder provides methods that let you conveniently configure and subsequently build
      * a new {@code SseEventSource} instance. You can obtain a new event source builder instance using
@@ -104,7 +103,7 @@ public interface SseEventSource extends AutoCloseable {
         }
 
         /**
-         * Create a new SSE event source instance using the default implementation class provided by the JAX-RS
+         * Create a new SSE event source instance using the default implementation class provided by the
          * implementation provider.
          *
          * @return new SSE event source builder instance.

--- a/jaxrs-api/src/main/javadoc/overview.html
+++ b/jaxrs-api/src/main/javadoc/overview.html
@@ -18,8 +18,8 @@
 
 <html xmlns="http://www.w3.org/1999/html" xmlns="http://www.w3.org/1999/html" xmlns="http://www.w3.org/1999/html">
 <body>
-<p>The Java API for RESTful Web Services provides portable APIs for developing, exposing and accessing
-    Web applications designed and implemented in compliance with principles of REST architectural style.</p>
+<p>Jakarta RESTful Web Services provides a specification document, TCK and foundational API to develop web services
+    following the Representational State Transfer (REST) architectural pattern.</p>
 
 <h2>Web resources</h2>
 

--- a/jaxrs-api/src/main/javadoc/overview.html
+++ b/jaxrs-api/src/main/javadoc/overview.html
@@ -23,13 +23,13 @@
 
 <h2>Web resources</h2>
 
-<p>JAX-RS core APIs enable developers to rapidly build Web applications in Java that are characteristic
+<p>The core APIs enable developers to rapidly build Web applications in Java that are characteristic
     of the best designed parts of the Web. The API brings in support for designing and implementing
     Web resources and application that follow principles of
     <a href="http://www.ics.uci.edu/~fielding/pubs/dissertation/rest_arch_style.htm">REST (Representational
         State Transfer)</a> architectural style to the Java Platform.</p>
 
-<p>In JAX-RS, Java POJOs can be exposed as RESTful Web resources independent of the underlying technology
+<p>With this API, Java POJOs can be exposed as RESTful Web resources independent of the underlying technology
     using a high level easy-to-use declarative annotation-based API. E.g.:</p>
 
 <pre>
@@ -55,19 +55,19 @@ public class WidgetResource {
 
 <h2>Web resource clients</h2>
 
-<p>JAX-RS client API is a Java based API used to access resources on the Web. It is not restricted
-    to resources implemented using JAX-RS. It provides a higher-level abstraction compared to a
+<p>The Client API is a Java based API used to access resources on the Web. It is not restricted
+    to resources implemented using the Server API. It provides a higher-level abstraction compared to a
     {@link java.net.HttpURLConnection plain HTTP communication API} as well as integration with the
-    JAX-RS extension providers, in order to enable concise and efficient implementation of
+    API extension providers, in order to enable concise and efficient implementation of
     reusable client-side solutions that leverage existing and well
     established client-side implementations of HTTP-based communication.</p>
 
-<p>The JAX-RS Client API also encapsulates the Uniform Interface Constraint &ndash;
+<p>The Client API also encapsulates the Uniform Interface Constraint &ndash;
     a key constraint of the REST architectural style &ndash; and associated data
     elements as client-side Java artifacts and supports a pluggable architecture
     by defining multiple extension points.</p>
 
-<p>Following example demonstrates a simple JAX-RS client API usage scenario:</p>
+<p>Following example demonstrates a simple Client API usage scenario:</p>
 
 <pre>
     Client client = ClientBuilder.newClient();
@@ -82,7 +82,7 @@ public class WidgetResource {
 
 <h2>Provider extensions</h2>
 
-<p>JAX-RS applications may provide custom extensions to the client and server runtime using the
+<p>Applications may provide custom extensions to the client and server runtime using the
     common extension APIs defined in <a href="javax/ws/rs/ext/package-summary.html">javax.ws.rs.ext</a>
     package, namely entity providers and entity provider interceptors. Additionally, request and
     response processing chains on client as well as server side can be further customized by

--- a/jaxrs-api/src/test/java/javax/ws/rs/core/JaxbLinkTest.java
+++ b/jaxrs-api/src/test/java/javax/ws/rs/core/JaxbLinkTest.java
@@ -35,7 +35,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
 /**
- * Unit test for JAX-RS Link marshalling and unmarshalling via JAXB.
+ * Unit test for Link marshalling and unmarshalling via JAXB.
  *
  * @author Marek Potociar (marek.potociar at oracle.com)
  */


### PR DESCRIPTION
Purpose of this PR is to eliminate the use of the JAX-RS acronym where appropriate. In most cases, the use of the acronym as an adjective was redundant and easily inferred from context. Still some ongoing discussions about the use of a new acronym/short name, but this PR does _not_ propose the use of one, instead refers to "this API" when necessary. 

See https://wiki.eclipse.org/How_to_Prepare_API_Projects_to_Jakarta_EE_8_Release

Since there are no real API changes, I propose to fast-track review period of just one day.

Signed-off-by: Santiago Pericas-Geertsen <santiago.pericasgeertsen@oracle.com>