### PR TITLE
2.1.6-Rollup

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,4 +1,4 @@
-# Notices for Eclipse Project for JAX-RS
+# Notices for Jakarta RESTful Web Services
 
 This content is produced and maintained by the **Jakarta RESTful Web Services**
 project.

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -440,6 +440,7 @@
                     <configuration>
                         <source>8</source>
                         <doctitle>${apidocs.title}</doctitle>
+                        <docfilessubdirs>true</docfilessubdirs>
                         <bottom>
                             <![CDATA[Copyright &#169; 1996-2017,
                                 <a href="http://www.oracle.com">Oracle</a>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -442,10 +442,9 @@
                         <doctitle>${apidocs.title}</doctitle>
                         <docfilessubdirs>true</docfilessubdirs>
                         <bottom>
-                            <![CDATA[Copyright &#169; 1996-2017,
-                                <a href="http://www.oracle.com">Oracle</a>
-                                and/or its affiliates. All Rights Reserved.
-                            ]]>
+                            <![CDATA[Copyright (c) 2019 Eclipse Foundation.
+                            Licensed under <a href="resources/EFSL.html">Eclipse Foundation
+                            Specification License</a>.]]>
                         </bottom>
                         <!--javaApiLinks>
                             <property>

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientBuilder.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientBuilder.java
@@ -209,7 +209,7 @@ public abstract class ClientBuilder implements Configurable<ClientBuilder> {
      * <p>
      * Provided executor service will be used for executing asynchronous tasks.
      * <p>
-     * When running in a Java EE container, implementations are required to use the container-managed executor service by
+     * When running in a Jakarta EE container, implementations are required to use the container-managed executor service by
      * default. In Java SE, the default is implementation-specific. In either case, calling this method will override the
      * default.
      *
@@ -227,7 +227,7 @@ public abstract class ClientBuilder implements Configurable<ClientBuilder> {
      * <p>
      * Provided executor service will be used for executing scheduled asynchronous tasks.
      * <p>
-     * When running in a Java EE container, implementations are required to use the container-managed scheduled executor
+     * When running in a Jakarta EE container, implementations are required to use the container-managed scheduled executor
      * service by default. In Java SE the default is implementation-specific. In either case, calling this method will
      * override the default.
      *

--- a/jaxrs-api/src/main/javadoc/overview.html
+++ b/jaxrs-api/src/main/javadoc/overview.html
@@ -18,8 +18,9 @@
 
 <html xmlns="http://www.w3.org/1999/html" xmlns="http://www.w3.org/1999/html" xmlns="http://www.w3.org/1999/html">
 <body>
-<p>Jakarta RESTful Web Services provides a specification document, TCK and foundational API to develop web services
-    following the Representational State Transfer (REST) architectural pattern.</p>
+<p>Jakarta RESTful Web Services provides a foundational API to develop web services
+    following the Representational State Transfer (REST) architectural pattern.
+    This API is distributed under the <a href="resources/EFSL.html">Eclipse Foundation Specification License</a>.</p>
 
 <h1>Web resources</h1>
 

--- a/jaxrs-api/src/main/javadoc/resources/EFSL.html
+++ b/jaxrs-api/src/main/javadoc/resources/EFSL.html
@@ -1,0 +1,72 @@
+<html>
+<head>
+    <title>Eclipse Foundation Specification License - v1.0</title>
+</head>
+<body>
+<h1>Eclipse Foundation Specification License - v1.0</h1>
+<p>By using and/or copying this document, or the Eclipse Foundation
+    document from which this statement is linked, you (the licensee) agree
+    that you have read, understood, and will comply with the following
+    terms and conditions:</p>
+
+<p>Permission to copy, and distribute the contents of this document, or
+    the Eclipse Foundation document from which this statement is linked, in
+    any medium for any purpose and without fee or royalty is hereby
+    granted, provided that you include the following on ALL copies of the
+    document, or portions thereof, that you use:</p>
+
+<ul>
+    <li> link or URL to the original Eclipse Foundation document.</li>
+    <li>All existing copyright notices, or if one does not exist, a notice
+        (hypertext is preferred, but a textual representation is permitted)
+        of the form: &quot;Copyright &copy; [$date-of-document]
+        &ldquo;Eclipse Foundation, Inc. &lt;&lt;url to this license&gt;&gt;
+        &quot;
+    </li>
+</ul>
+
+<p>Inclusion of the full text of this NOTICE must be provided. We
+    request that authorship attribution be provided in any software,
+    documents, or other items or products that you create pursuant to the
+    implementation of the contents of this document, or any portion
+    thereof.</p>
+
+<p>No right to create modifications or derivatives of Eclipse Foundation
+    documents is granted pursuant to this license, except anyone may
+    prepare and distribute derivative works and portions of this document
+    in software that implements the specification, in supporting materials
+    accompanying such software, and in documentation of such software,
+    PROVIDED that all such works include the notice below. HOWEVER, the
+    publication of derivative works of this document for use as a technical
+    specification is expressly prohibited.</p>
+
+<p>The notice is:</p>
+
+<p>&quot;Copyright &copy; 2018 Eclipse Foundation. This software or
+    document includes material copied from or derived from [title and URI
+    of the Eclipse Foundation specification document].&quot;</p>
+
+<h2>Disclaimers</h2>
+
+<p>THIS DOCUMENT IS PROVIDED &quot;AS IS,&quot; AND THE COPYRIGHT
+    HOLDERS AND THE ECLIPSE FOUNDATION MAKE NO REPRESENTATIONS OR
+    WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+    WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
+    NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE
+    SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS
+    WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR
+    OTHER RIGHTS.</p>
+
+<p>THE COPYRIGHT HOLDERS AND THE ECLIPSE FOUNDATION WILL NOT BE LIABLE
+    FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT
+    OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE
+    CONTENTS THEREOF.</p>
+
+<p>The name and trademarks of the copyright holders or the Eclipse
+    Foundation may NOT be used in advertising or publicity pertaining to
+    this document or its contents without specific, written prior
+    permission. Title to copyright in this document will at all times
+    remain with copyright holders.</p>
+
+</body>
+</html>


### PR DESCRIPTION
This PR is a *rollup* of all commits between 2.1.5 and 2.1.6 (`2.1-Maintenance`, formerly `EE4J_8`) into `3.1-SNAPSHOT` (`master`).

**As these are no API changes, and as all these changes are already contained in `EE4J_8` I propose a fast-track review period of just one day as per our [committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**