### PR TITLE
Updated references to the Jakarta XML Binding API

### DIFF
--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Link.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Link.java
@@ -422,7 +422,7 @@ public abstract class Link {
 
     /**
      * Value type for {@link javax.ws.rs.core.Link} that can be marshalled and
-     * unmarshalled by JAXB.
+     * unmarshalled using the Jakarta XML Binding API.
      *
      * @see javax.ws.rs.core.Link.JaxbAdapter
      * @since 2.0
@@ -484,7 +484,7 @@ public abstract class Link {
         /**
          * Set the underlying URI for this link.
          *
-         * This setter is needed for JAXB unmarshalling.
+         * This setter is needed for unmarshalling using the Jakarta XML Binding API.
          */
         void setUri(URI uri) {
             this.uri = uri;
@@ -493,7 +493,7 @@ public abstract class Link {
         /**
          * Set the parameter map for this link.
          *
-         * This setter is needed for JAXB unmarshalling.
+         * This setter is needed for unmarshalling using the Jakarta XML Binding API.
          */
         void setParams(Map<QName, Object> params) {
             this.params = params;
@@ -535,10 +535,10 @@ public abstract class Link {
     }
 
     /**
-     * An implementation of JAXB {@link javax.xml.bind.annotation.adapters.XmlAdapter}
+     * An implementation of {@link javax.xml.bind.annotation.adapters.XmlAdapter}
      * that maps the {@link javax.ws.rs.core.Link} type to a value that can be
-     * marshalled and unmarshalled by JAXB. The following example shows how to use
-     * this adapter on a JAXB bean class:
+     * marshalled and unmarshalled. The following example shows how to use
+     * this adapter on a Jakarta XML Binding bean class:
      *
      * <pre>
      * &#64;XmlRootElement

--- a/jaxrs-api/src/test/java/javax/ws/rs/core/JaxbLinkTest.java
+++ b/jaxrs-api/src/test/java/javax/ws/rs/core/JaxbLinkTest.java
@@ -35,7 +35,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
 /**
- * Unit test for Link marshalling and unmarshalling via JAXB.
+ * Unit test for Link marshalling and unmarshalling using the
+ * Jakarta XML Binding API.
  *
  * @author Marek Potociar (marek.potociar at oracle.com)
  */


### PR DESCRIPTION
For consistency with other changes and according to (1.3) of the Jakarta release document.

On **fast track** like all other Jakarta EE 8 PR's.

Signed-off-by: Santiago Pericas-Geertsen <santiago.pericasgeertsen@oracle.com>