### PR TITLE
GH-770 Rename JAXRS interface

### DIFF
--- a/examples/src/main/java/jaxrs/examples/bootstrap/BasicJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/BasicJavaSeBootstrapExample.java
@@ -18,8 +18,8 @@ package jaxrs.examples.bootstrap;
 
 import java.net.URI;
 
-import jakarta.ws.rs.JAXRS;
-import jakarta.ws.rs.JAXRS.Configuration;
+import jakarta.ws.rs.SeBootstrap;
+import jakarta.ws.rs.SeBootstrap.Configuration;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.UriBuilder;
 
@@ -46,9 +46,9 @@ public final class BasicJavaSeBootstrapExample {
     public static final void main(final String[] args) throws InterruptedException {
         final Application application = new HelloWorld();
 
-        final JAXRS.Configuration requestedConfiguration = JAXRS.Configuration.builder().build();
+        final SeBootstrap.Configuration requestedConfiguration = SeBootstrap.Configuration.builder().build();
 
-        JAXRS.start(application, requestedConfiguration).thenAccept(instance -> {
+        SeBootstrap.start(application, requestedConfiguration).thenAccept(instance -> {
             Runtime.getRuntime()
                     .addShutdownHook(new Thread(() -> instance.stop()
                             .thenAccept(stopResult -> System.out.printf("Stop result: %s [Native stop result: %s].%n",

--- a/examples/src/main/java/jaxrs/examples/bootstrap/ClientAuthenticationJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/ClientAuthenticationJavaSeBootstrapExample.java
@@ -18,9 +18,9 @@ package jaxrs.examples.bootstrap;
 
 import java.net.URI;
 
-import jakarta.ws.rs.JAXRS;
-import jakarta.ws.rs.JAXRS.Configuration;
-import jakarta.ws.rs.JAXRS.Configuration.SSLClientAuthentication;
+import jakarta.ws.rs.SeBootstrap;
+import jakarta.ws.rs.SeBootstrap.Configuration;
+import jakarta.ws.rs.SeBootstrap.Configuration.SSLClientAuthentication;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.UriBuilder;
 
@@ -61,10 +61,10 @@ public final class ClientAuthenticationJavaSeBootstrapExample {
     public static final void main(final String[] args) throws InterruptedException {
         final Application application = new HelloWorld();
 
-        final JAXRS.Configuration requestedConfiguration = JAXRS.Configuration.builder().protocol("HTTPS")
+        final SeBootstrap.Configuration requestedConfiguration = SeBootstrap.Configuration.builder().protocol("HTTPS")
                 .sslClientAuthentication(SSLClientAuthentication.MANDATORY).build();
 
-        JAXRS.start(application, requestedConfiguration).thenAccept(instance -> {
+        SeBootstrap.start(application, requestedConfiguration).thenAccept(instance -> {
             Runtime.getRuntime()
                     .addShutdownHook(new Thread(() -> instance.stop()
                             .thenAccept(stopResult -> System.out.printf("Stop result: %s [Native stop result: %s].%n",

--- a/examples/src/main/java/jaxrs/examples/bootstrap/ExplicitJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/ExplicitJavaSeBootstrapExample.java
@@ -18,9 +18,9 @@ package jaxrs.examples.bootstrap;
 
 import java.net.URI;
 
-import jakarta.ws.rs.JAXRS;
-import jakarta.ws.rs.JAXRS.Configuration;
-import jakarta.ws.rs.JAXRS.Configuration.SSLClientAuthentication;
+import jakarta.ws.rs.SeBootstrap;
+import jakarta.ws.rs.SeBootstrap.Configuration;
+import jakarta.ws.rs.SeBootstrap.Configuration.SSLClientAuthentication;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.UriBuilder;
 
@@ -62,10 +62,10 @@ public final class ExplicitJavaSeBootstrapExample {
         final String rootPath = args[3];
         final SSLClientAuthentication clientAuth = SSLClientAuthentication.valueOf(args[4]);
 
-        final JAXRS.Configuration requestedConfiguration = JAXRS.Configuration.builder().protocol(protocol).host(host)
+        final SeBootstrap.Configuration requestedConfiguration = SeBootstrap.Configuration.builder().protocol(protocol).host(host)
                 .port(port).rootPath(rootPath).sslClientAuthentication(clientAuth).build();
 
-        JAXRS.start(application, requestedConfiguration).thenAccept(instance -> {
+        SeBootstrap.start(application, requestedConfiguration).thenAccept(instance -> {
             Runtime.getRuntime()
                     .addShutdownHook(new Thread(() -> instance.stop()
                             .thenAccept(stopResult -> System.out.printf("Stop result: %s [Native stop result: %s].%n",

--- a/examples/src/main/java/jaxrs/examples/bootstrap/ExternalConfigJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/ExternalConfigJavaSeBootstrapExample.java
@@ -18,13 +18,13 @@ package jaxrs.examples.bootstrap;
 
 import java.net.URI;
 
-import jakarta.ws.rs.JAXRS;
-import jakarta.ws.rs.JAXRS.Configuration;
-import jakarta.ws.rs.core.Application;
-import jakarta.ws.rs.core.UriBuilder;
-
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
+
+import jakarta.ws.rs.SeBootstrap;
+import jakarta.ws.rs.SeBootstrap.Configuration;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.UriBuilder;
 
 /**
  * Java SE bootstrap example utilizing an external configuration system.
@@ -40,8 +40,8 @@ import org.eclipse.microprofile.config.ConfigProvider;
  * </p>
  *
  * <pre>
- * export jakarta.ws.rs.JAXRS.Port=8888;
- * java -Djakarta.ws.rs.JAXRS.Host=127.0.0.1 ExternalConfigJavaSeBootstrapExample;
+ * export jakarta.ws.rs.SeBootstrap.Port=8888;
+ * java -Djakarta.ws.rs.SeBootstrap.Host=127.0.0.1 ExternalConfigJavaSeBootstrapExample;
  * </pre>
  * <p>
  * This example uses some basic <em>external</em> JSSE configuration:
@@ -73,10 +73,10 @@ public final class ExternalConfigJavaSeBootstrapExample {
 
         final Config config = ConfigProvider.getConfig();
 
-        final JAXRS.Configuration requestedConfiguration = JAXRS.Configuration.builder().from(config).protocol("HTTPS")
+        final SeBootstrap.Configuration requestedConfiguration = SeBootstrap.Configuration.builder().from(config).protocol("HTTPS")
                 .build();
 
-        JAXRS.start(application, requestedConfiguration).thenAccept(instance -> {
+        SeBootstrap.start(application, requestedConfiguration).thenAccept(instance -> {
             Runtime.getRuntime()
                     .addShutdownHook(new Thread(() -> instance.stop()
                             .thenAccept(stopResult -> System.out.printf("Stop result: %s [Native stop result: %s].%n",

--- a/examples/src/main/java/jaxrs/examples/bootstrap/HttpsJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/HttpsJavaSeBootstrapExample.java
@@ -18,8 +18,8 @@ package jaxrs.examples.bootstrap;
 
 import java.net.URI;
 
-import jakarta.ws.rs.JAXRS;
-import jakarta.ws.rs.JAXRS.Configuration;
+import jakarta.ws.rs.SeBootstrap;
+import jakarta.ws.rs.SeBootstrap.Configuration;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.UriBuilder;
 
@@ -56,9 +56,9 @@ public final class HttpsJavaSeBootstrapExample {
     public static final void main(final String[] args) throws InterruptedException {
         final Application application = new HelloWorld();
 
-        final JAXRS.Configuration requestedConfiguration = JAXRS.Configuration.builder().protocol("HTTPS").build();
+        final SeBootstrap.Configuration requestedConfiguration = SeBootstrap.Configuration.builder().protocol("HTTPS").build();
 
-        JAXRS.start(application, requestedConfiguration).thenAccept(instance -> {
+        SeBootstrap.start(application, requestedConfiguration).thenAccept(instance -> {
             Runtime.getRuntime()
                     .addShutdownHook(new Thread(() -> instance.stop()
                             .thenAccept(stopResult -> System.out.printf("Stop result: %s [Native stop result: %s].%n",

--- a/examples/src/main/java/jaxrs/examples/bootstrap/NativeJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/NativeJavaSeBootstrapExample.java
@@ -18,8 +18,8 @@ package jaxrs.examples.bootstrap;
 
 import java.net.URI;
 
-import jakarta.ws.rs.JAXRS;
-import jakarta.ws.rs.JAXRS.Configuration;
+import jakarta.ws.rs.SeBootstrap;
+import jakarta.ws.rs.SeBootstrap.Configuration;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.UriBuilder;
 
@@ -56,12 +56,12 @@ public final class NativeJavaSeBootstrapExample {
     public static final void main(final String[] args) throws InterruptedException, ClassNotFoundException {
         final Application application = new HelloWorld();
 
-        final JAXRS.Configuration requestedConfiguration = JAXRS.Configuration.builder()
+        final SeBootstrap.Configuration requestedConfiguration = SeBootstrap.Configuration.builder()
                 .property("jersey.config.server.httpServerClass",
                         Class.forName("org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServer"))
                 .build();
 
-        JAXRS.start(application, requestedConfiguration).thenAccept(instance -> {
+        SeBootstrap.start(application, requestedConfiguration).thenAccept(instance -> {
             Runtime.getRuntime()
                     .addShutdownHook(new Thread(() -> instance.stop()
                             .thenAccept(stopResult -> System.out.printf("Stop result: %s [Native stop result: %s].%n",

--- a/examples/src/main/java/jaxrs/examples/bootstrap/PropertyProviderJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/PropertyProviderJavaSeBootstrapExample.java
@@ -18,13 +18,13 @@ package jaxrs.examples.bootstrap;
 
 import java.net.URI;
 
-import jakarta.ws.rs.JAXRS;
-import jakarta.ws.rs.JAXRS.Configuration;
-import jakarta.ws.rs.core.Application;
-import jakarta.ws.rs.core.UriBuilder;
-
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
+
+import jakarta.ws.rs.SeBootstrap;
+import jakarta.ws.rs.SeBootstrap.Configuration;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.UriBuilder;
 
 /**
  * Java SE bootstrap example utilizing a property provider.
@@ -40,8 +40,8 @@ import org.eclipse.microprofile.config.ConfigProvider;
  * </p>
  *
  * <pre>
- * export jakarta.ws.rs.JAXRS.Port=8888;
- * java -Djakarta.ws.rs.JAXRS.Host=127.0.0.1 PropertyProviderJavaSeBootstrapExample;
+ * export jakarta.ws.rs.SeBootstrap.Port=8888;
+ * java -Djakarta.ws.rs.SeBootstrap.Host=127.0.0.1 PropertyProviderJavaSeBootstrapExample;
  * </pre>
  * <p>
  * Thanks to the <em>explicit</em> use of Microprofile Config in the application, this example is completely portable.
@@ -71,10 +71,10 @@ public final class PropertyProviderJavaSeBootstrapExample {
 
         final Config config = ConfigProvider.getConfig();
 
-        final JAXRS.Configuration requestedConfiguration = JAXRS.Configuration.builder().from(config::getOptionalValue)
+        final SeBootstrap.Configuration requestedConfiguration = SeBootstrap.Configuration.builder().from(config::getOptionalValue)
                 .protocol("HTTPS").build();
 
-        JAXRS.start(application, requestedConfiguration).thenAccept(instance -> {
+        SeBootstrap.start(application, requestedConfiguration).thenAccept(instance -> {
             Runtime.getRuntime()
                     .addShutdownHook(new Thread(() -> instance.stop()
                             .thenAccept(stopResult -> System.out.printf("Stop result: %s [Native stop result: %s].%n",

--- a/examples/src/main/java/jaxrs/examples/bootstrap/TlsJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/TlsJavaSeBootstrapExample.java
@@ -26,8 +26,8 @@ import java.security.KeyStore;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
-import jakarta.ws.rs.JAXRS;
-import jakarta.ws.rs.JAXRS.Configuration;
+import jakarta.ws.rs.SeBootstrap;
+import jakarta.ws.rs.SeBootstrap.Configuration;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.UriBuilder;
 
@@ -68,10 +68,10 @@ public final class TlsJavaSeBootstrapExample {
         final SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
         sslContext.init(keyManagerFactory.getKeyManagers(), null, null);
 
-        final JAXRS.Configuration requestedConfiguration = JAXRS.Configuration.builder().protocol("HTTPS")
+        final SeBootstrap.Configuration requestedConfiguration = SeBootstrap.Configuration.builder().protocol("HTTPS")
                 .sslContext(sslContext).build();
 
-        JAXRS.start(application, requestedConfiguration).thenAccept(instance -> {
+        SeBootstrap.start(application, requestedConfiguration).thenAccept(instance -> {
             Runtime.getRuntime()
                     .addShutdownHook(new Thread(() -> instance.stop()
                             .thenAccept(stopResult -> System.out.printf("Stop result: %s [Native stop result: %s].%n",

--- a/examples/src/main/java/jaxrs/examples/bootstrap/package-info.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/package-info.java
@@ -17,6 +17,6 @@
  *
  * @author Markus KARG (markus@headcrashing.eu)
  * @since 2.2
- * @see jakarta.ws.rs.JAXRS;
+ * @see jakarta.ws.rs.SeBootstrap;
  */
 package jaxrs.examples.bootstrap;

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/SeBootstrap.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/SeBootstrap.java
@@ -28,7 +28,7 @@ import jakarta.ws.rs.ext.RuntimeDelegate;
 /**
  * Bootstrap class used to startup a JAX-RS application in Java SE environments.
  * <p>
- * The {@code JAXRS} class is available in a Jakarta EE container environment as well; however, support for the Java SE
+ * The {@code SeBootstrap} class is available in a Jakarta EE container environment as well; however, support for the Java SE
  * bootstrapping APIs is <em>not required</em> in container environments.
  * </p>
  * <p>
@@ -41,8 +41,8 @@ import jakarta.ws.rs.ext.RuntimeDelegate;
  *
  * <pre>
  * Application app = new MyApplication();
- * JAXRS.Configuration config = JAXRS.Configuration.builder().build();
- * JAXRS.start(app, config).thenAccept(instance -&gt; instance.configuration().port());
+ * SeBootstrap.Configuration config = SeBootstrap.Configuration.builder().build();
+ * SeBootstrap.start(app, config).thenAccept(instance -&gt; instance.configuration().port());
  * </pre>
  *
  * <p>
@@ -50,7 +50,7 @@ import jakarta.ws.rs.ext.RuntimeDelegate;
  * </p>
  *
  * <pre>
- * JAXRS.start(app, config).thenAccept(instance -&gt; { ... instance.stop(); } );
+ * SeBootstrap.start(app, config).thenAccept(instance -&gt; { ... instance.stop(); } );
  * </pre>
  *
  * <p>
@@ -70,7 +70,7 @@ import jakarta.ws.rs.ext.RuntimeDelegate;
  * </p>
  *
  * <pre>
- * JAXRS.Configuration.builder().protocol("HTTPS").host("0.0.0.0").port(8443).rootPath("api").build();
+ * SeBootstrap.Configuration.builder().protocol("HTTPS").host("0.0.0.0").port(8443).rootPath("api").build();
  * </pre>
  *
  * <p>
@@ -80,7 +80,7 @@ import jakarta.ws.rs.ext.RuntimeDelegate;
  * <pre>
  * SSLContext tls = SSLContext.getInstance("TLSv1.2");
  * // ...further initialize context here (see JSSE API)...
- * JAXRS.Configuration.builder().protocol("HTTPS").sslContext(tls).build();
+ * SeBootstrap.Configuration.builder().protocol("HTTPS").sslContext(tls).build();
  * </pre>
  *
  * <p>
@@ -88,7 +88,7 @@ import jakarta.ws.rs.ext.RuntimeDelegate;
  * </p>
  *
  * <pre>
- * JAXRS.Configuration.builder().protocol("HTTPS").sslClientAuthentication(SSLClientAuthentication.MANDATORY).build();
+ * SeBootstrap.Configuration.builder().protocol("HTTPS").sslClientAuthentication(SSLClientAuthentication.MANDATORY).build();
  * </pre>
  *
  * <p>
@@ -97,7 +97,7 @@ import jakarta.ws.rs.ext.RuntimeDelegate;
  * </p>
  *
  * <pre>
- * JAXRS.Configuration.builder().property("productname.foo", "bar").build()
+ * SeBootstrap.Configuration.builder().property("productname.foo", "bar").build()
  * </pre>
  *
  * <p>
@@ -109,17 +109,17 @@ import jakarta.ws.rs.ext.RuntimeDelegate;
  *
  * <pre>
  * // Explicit use of particular configuration mechanics is portable
- * JAXRS.Configuration.builder().from((name, type) -&gt; externalConfigurationSystem.getValue(name, type)).build();
+ * SeBootstrap.Configuration.builder().from((name, type) -&gt; externalConfigurationSystem.getValue(name, type)).build();
  *
  * // Implicitly relying on the support of particular configuration mechanics by
  * // the actual JAX-RS implementation is not necessarily portable
- * JAXRS.Configuration.builder().from(externalConfigurationSystem).build();
+ * SeBootstrap.Configuration.builder().from(externalConfigurationSystem).build();
  * </pre>
  *
  * @author Markus KARG (markus@headcrashing.eu)
  * @since 2.2
  */
-public interface JAXRS {
+public interface SeBootstrap {
 
     /**
      * Starts the provided application using the specified configuration.
@@ -132,7 +132,7 @@ public interface JAXRS {
      * @param application The application to start up.
      * @param configuration Provides information needed for bootstrapping the application.
      * @return {@code CompletionStage} (possibly asynchronously) producing handle of the running application
-     * {@link JAXRS.Instance instance}.
+     * {@link SeBootstrap.Instance instance}.
      * @see Configuration
      * @since 2.2
      */
@@ -144,7 +144,7 @@ public interface JAXRS {
      * Provides information needed by the JAX-RS implementation for bootstrapping an application.
      * <p>
      * The configuration essentially consists of a set of parameters. While the set of actually effective keys is product
-     * specific, the key constants defined by the {@link JAXRS.Configuration} interface MUST be effective on all compliant
+     * specific, the key constants defined by the {@link SeBootstrap.Configuration} interface MUST be effective on all compliant
      * products. Any unknown key MUST be silently ignored.
      * </p>
      *
@@ -165,7 +165,7 @@ public interface JAXRS {
          *
          * @since 2.2
          */
-        static final String PROTOCOL = "jakarta.ws.rs.JAXRS.Protocol";
+        static final String PROTOCOL = "jakarta.ws.rs.SeBootstrap.Protocol";
 
         /**
          * Configuration key for the hostname or IP address an application is bound to.
@@ -182,7 +182,7 @@ public interface JAXRS {
          *
          * @since 2.2
          */
-        static final String HOST = "jakarta.ws.rs.JAXRS.Host";
+        static final String HOST = "jakarta.ws.rs.SeBootstrap.Host";
 
         /**
          * Configuration key for the TCP port an application is bound to.
@@ -199,7 +199,7 @@ public interface JAXRS {
          *
          * @since 2.2
          */
-        static final String PORT = "jakarta.ws.rs.JAXRS.Port";
+        static final String PORT = "jakarta.ws.rs.SeBootstrap.Port";
 
         /**
          * Configuration key for the root path an application is bound to.
@@ -209,7 +209,7 @@ public interface JAXRS {
          *
          * @since 2.2
          */
-        static final String ROOT_PATH = "jakarta.ws.rs.JAXRS.RootPath";
+        static final String ROOT_PATH = "jakarta.ws.rs.SeBootstrap.RootPath";
 
         /**
          * Configuration key for the secure socket configuration to be used.
@@ -219,7 +219,7 @@ public interface JAXRS {
          *
          * @since 2.2
          */
-        static final String SSL_CONTEXT = "jakarta.ws.rs.JAXRS.SSLContext";
+        static final String SSL_CONTEXT = "jakarta.ws.rs.SeBootstrap.SSLContext";
 
         /**
          * Configuration key for the secure socket client authentication policy.
@@ -233,7 +233,7 @@ public interface JAXRS {
          *
          * @since 2.2
          */
-        static final String SSL_CLIENT_AUTHENTICATION = "jakarta.ws.rs.JAXRS.SSLClientAuthentication";
+        static final String SSL_CLIENT_AUTHENTICATION = "jakarta.ws.rs.SeBootstrap.SSLClientAuthentication";
 
         /**
          * Secure socket client authentication policy
@@ -314,7 +314,7 @@ public interface JAXRS {
          *
          * @return protocol to be used (e. g. {@code "HTTP")}.
          * @throws ClassCastException if protocol is not a {@link String}.
-         * @see JAXRS.Configuration#PROTOCOL
+         * @see SeBootstrap.Configuration#PROTOCOL
          * @since 2.2
          */
         default String protocol() {
@@ -329,7 +329,7 @@ public interface JAXRS {
          *
          * @return host name or IP address to be used (e. g. {@code "localhost"} or {@code "0.0.0.0"}).
          * @throws ClassCastException if host is not a {@link String}.
-         * @see JAXRS.Configuration#HOST
+         * @see SeBootstrap.Configuration#HOST
          * @since 2.2
          */
         default String host() {
@@ -348,7 +348,7 @@ public interface JAXRS {
          *
          * @return port number <em>actually</em> used (e. g. {@code 8080}).
          * @throws ClassCastException if port is not an {@code Integer}.
-         * @see JAXRS.Configuration#PORT
+         * @see SeBootstrap.Configuration#PORT
          * @since 2.2
          */
         default int port() {
@@ -363,7 +363,7 @@ public interface JAXRS {
          *
          * @return root path to be used, e. g. {@code "/"}.
          * @throws ClassCastException if root path is not a {@link String}.
-         * @see JAXRS.Configuration#ROOT_PATH
+         * @see SeBootstrap.Configuration#ROOT_PATH
          * @since 2.2
          */
         default String rootPath() {
@@ -378,7 +378,7 @@ public interface JAXRS {
          *
          * @return root path to be used, e. g. {@code "/"}.
          * @throws ClassCastException if sslContext is not a {@link SSLContext}.
-         * @see JAXRS.Configuration#SSL_CONTEXT
+         * @see SeBootstrap.Configuration#SSL_CONTEXT
          * @since 2.2
          */
         default SSLContext sslContext() {
@@ -393,7 +393,7 @@ public interface JAXRS {
          *
          * @return client authentication mode, e. g. {@code NONE}.
          * @throws ClassCastException if sslClientAuthentication is not a {@link SSLClientAuthentication}.
-         * @see JAXRS.Configuration#SSL_CLIENT_AUTHENTICATION
+         * @see SeBootstrap.Configuration#SSL_CLIENT_AUTHENTICATION
          * @since 2.2
          */
         default SSLClientAuthentication sslClientAuthentication() {
@@ -447,7 +447,7 @@ public interface JAXRS {
              *
              * @param protocol protocol parameter of this configuration, or {@code null} to use the default value.
              * @return the updated builder.
-             * @see JAXRS.Configuration#PROTOCOL
+             * @see SeBootstrap.Configuration#PROTOCOL
              * @since 2.2
              */
             default Builder protocol(String protocol) {
@@ -462,7 +462,7 @@ public interface JAXRS {
              *
              * @param host host parameter (IP address or hostname) of this configuration, or {@code null} to use the default value.
              * @return the updated builder.
-             * @see JAXRS.Configuration#HOST
+             * @see SeBootstrap.Configuration#HOST
              * @since 2.2
              */
             default Builder host(String host) {
@@ -477,7 +477,7 @@ public interface JAXRS {
              *
              * @param port port parameter of this configuration, or {@code null} to use the default value.
              * @return the updated builder.
-             * @see JAXRS.Configuration#PORT
+             * @see SeBootstrap.Configuration#PORT
              * @since 2.2
              */
             default Builder port(Integer port) {
@@ -492,7 +492,7 @@ public interface JAXRS {
              *
              * @param rootPath rootPath parameter of this configuration, or {@code null} to use the default value.
              * @return the updated builder.
-             * @see JAXRS.Configuration#ROOT_PATH
+             * @see SeBootstrap.Configuration#ROOT_PATH
              * @since 2.2
              */
             default Builder rootPath(String rootPath) {
@@ -507,7 +507,7 @@ public interface JAXRS {
              *
              * @param sslContext sslContext parameter of this configuration, or {@code null} to use the default value.
              * @return the updated builder.
-             * @see JAXRS.Configuration#SSL_CONTEXT
+             * @see SeBootstrap.Configuration#SSL_CONTEXT
              * @since 2.2
              */
             default Builder sslContext(SSLContext sslContext) {
@@ -522,7 +522,7 @@ public interface JAXRS {
              *
              * @param sslClientAuthentication SSL client authentication mode of this configuration
              * @return the updated builder.
-             * @see JAXRS.Configuration#SSL_CLIENT_AUTHENTICATION
+             * @see SeBootstrap.Configuration#SSL_CLIENT_AUTHENTICATION
              * @since 2.2
              */
             default Builder sslClientAuthentication(SSLClientAuthentication sslClientAuthentication) {
@@ -581,7 +581,7 @@ public interface JAXRS {
         /**
          * Provides access to the configuration <em>actually</em> used by the implementation used to create this instance.
          * <p>
-         * This may, or may not, be the same instance passed to {@link JAXRS#start(Application, Configuration)}, not even an
+         * This may, or may not, be the same instance passed to {@link SeBootstrap#start(Application, Configuration)}, not even an
          * equal instance, as implementations MAY create a new intance and MUST update at least the {@code PORT} property with
          * the actually used value. Portable applications should not make any assumptions but always explicitly read the actual
          * values from the configuration returned from this method.

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/ext/RuntimeDelegate.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/ext/RuntimeDelegate.java
@@ -20,8 +20,8 @@ import java.lang.reflect.ReflectPermission;
 import java.net.URL;
 import java.util.concurrent.CompletionStage;
 
-import jakarta.ws.rs.JAXRS;
-import jakarta.ws.rs.JAXRS.Instance;
+import jakarta.ws.rs.SeBootstrap;
+import jakarta.ws.rs.SeBootstrap.Instance;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Link;
 import jakarta.ws.rs.core.UriBuilder;
@@ -224,28 +224,28 @@ public abstract class RuntimeDelegate {
     public abstract Link.Builder createLinkBuilder();
 
     /**
-     * Create a new instance of a {@link jakarta.ws.rs.JAXRS.Configuration.Builder}.
+     * Create a new instance of a {@link jakarta.ws.rs.SeBootstrap.Configuration.Builder}.
      * <p>
-     * <em>This method is not intended to be invoked by applications. Call {@link JAXRS.Configuration#builder()}
+     * <em>This method is not intended to be invoked by applications. Call {@link SeBootstrap.Configuration#builder()}
      * instead.</em>
      * </p>
      *
-     * @return new {@code JAXRS.Configuration.Builder} instance.
-     * @see JAXRS.Configuration.Builder
+     * @return new {@code SeBootstrap.Configuration.Builder} instance.
+     * @see SeBootstrap.Configuration.Builder
      */
-    public abstract JAXRS.Configuration.Builder createConfigurationBuilder();
+    public abstract SeBootstrap.Configuration.Builder createConfigurationBuilder();
 
     /**
      * Perform startup of the application in Java SE environments.
      * <p>
-     * <em>This method is not intended to be invoked by applications. Call {@link JAXRS#start(Application, Configuration)}
+     * <em>This method is not intended to be invoked by applications. Call {@link SeBootstrap#start(Application, Configuration)}
      * instead.</em>
      * </p>
      *
      * @param application The application to start up.
      * @param configuration The bootstrap configuration.
-     * @return {@code CompletionStage} asynchronously producing handle of the running application {@link JAXRS.Instance
+     * @return {@code CompletionStage} asynchronously producing handle of the running application {@link SeBootstrap.Instance
      * instance}.
      */
-    public abstract CompletionStage<Instance> bootstrap(Application application, JAXRS.Configuration configuration);
+    public abstract CompletionStage<Instance> bootstrap(Application application, SeBootstrap.Configuration configuration);
 }

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/SeBootstrapTest.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/SeBootstrapTest.java
@@ -17,19 +17,19 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import jakarta.ws.rs.JAXRS;
-import jakarta.ws.rs.JAXRS.Configuration;
-import jakarta.ws.rs.JAXRS.Configuration.SSLClientAuthentication;
+import jakarta.ws.rs.SeBootstrap;
+import jakarta.ws.rs.SeBootstrap.Configuration;
+import jakarta.ws.rs.SeBootstrap.Configuration.SSLClientAuthentication;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.ext.RuntimeDelegate;
 
 /**
- * Unit tests for {@link JAXRS}
+ * Unit tests for {@link SeBootstrap}
  *
  * @author Markus KARG (markus@headcrashing.eu)
  * @since 2.2
  */
-public final class JAXRSTest {
+public final class SeBootstrapTest {
 
     /**
      * Installs a new {@code RuntimeDelegate} mock before each test case, as some test cases need to find a pristine
@@ -50,7 +50,7 @@ public final class JAXRSTest {
     }
 
     /**
-     * Assert that {@link JAXRS#start(Application, Configuration)} will delegate to
+     * Assert that {@link SeBootstrap#start(Application, Configuration)} will delegate to
      * {@link RuntimeDelegate#bootstrap(Application, Configuration)}.
      *
      * @since 2.2
@@ -61,18 +61,18 @@ public final class JAXRSTest {
         final Application application = mock(Application.class);
         final Configuration configuration = mock(Configuration.class);
         @SuppressWarnings("unchecked")
-        final CompletionStage<JAXRS.Instance> nativeCompletionStage = mock(CompletionStage.class);
+        final CompletionStage<SeBootstrap.Instance> nativeCompletionStage = mock(CompletionStage.class);
         given(RuntimeDelegate.getInstance().bootstrap(application, configuration)).willReturn(nativeCompletionStage);
 
         // when
-        final CompletionStage<JAXRS.Instance> actualCompletionStage = JAXRS.start(application, configuration);
+        final CompletionStage<SeBootstrap.Instance> actualCompletionStage = SeBootstrap.start(application, configuration);
 
         // then
         assertThat(actualCompletionStage, is(sameInstance(nativeCompletionStage)));
     }
 
     /**
-     * Assert that {@link JAXRS.Configuration#builder()} will delegate to
+     * Assert that {@link SeBootstrap.Configuration#builder()} will delegate to
      * {@link RuntimeDelegate#createConfigurationBuilder()}.
      *
      * @since 2.2
@@ -80,11 +80,11 @@ public final class JAXRSTest {
     @Test
     public final void shouldDelegateConfigurationBuilderCreationToRuntimeDelegate() {
         // given
-        final JAXRS.Configuration.Builder nativeConfigurationBuilder = mock(JAXRS.Configuration.Builder.class);
+        final SeBootstrap.Configuration.Builder nativeConfigurationBuilder = mock(SeBootstrap.Configuration.Builder.class);
         given(RuntimeDelegate.getInstance().createConfigurationBuilder()).willReturn(nativeConfigurationBuilder);
 
         // when
-        final JAXRS.Configuration.Builder actualConfigurationBuilder = JAXRS.Configuration.builder();
+        final SeBootstrap.Configuration.Builder actualConfigurationBuilder = SeBootstrap.Configuration.builder();
 
         // then
         assertThat(actualConfigurationBuilder, is(sameInstance(nativeConfigurationBuilder)));
@@ -99,11 +99,11 @@ public final class JAXRSTest {
     @Test
     public final void shouldReturnSameConfigurationBuilderInstanceWhenLoadingExternalConfiguration() {
         // given
-        final JAXRS.Configuration.Builder previousConfigurationBuilder = spy(JAXRS.Configuration.Builder.class);
+        final SeBootstrap.Configuration.Builder previousConfigurationBuilder = spy(SeBootstrap.Configuration.Builder.class);
         final Object someExternalConfiguration = mock(Object.class);
 
         // when
-        final JAXRS.Configuration.Builder currentConfigurationBuilder = previousConfigurationBuilder
+        final SeBootstrap.Configuration.Builder currentConfigurationBuilder = previousConfigurationBuilder
                 .from(someExternalConfiguration);
 
         // then
@@ -127,7 +127,7 @@ public final class JAXRSTest {
         final String someRootPathValue = mockString();
         final SSLContext someSSLContextValue = mock(SSLContext.class);
         final SSLClientAuthentication someSSLClientAuthenticationValue = SSLClientAuthentication.MANDATORY;
-        final JAXRS.Configuration.Builder configurationBuilder = spy(JAXRS.Configuration.Builder.class);
+        final SeBootstrap.Configuration.Builder configurationBuilder = spy(SeBootstrap.Configuration.Builder.class);
 
         // when
         configurationBuilder.protocol(someProtocolValue);
@@ -138,12 +138,12 @@ public final class JAXRSTest {
         configurationBuilder.sslClientAuthentication(someSSLClientAuthenticationValue);
 
         // then
-        verify(configurationBuilder).property(JAXRS.Configuration.PROTOCOL, someProtocolValue);
-        verify(configurationBuilder).property(JAXRS.Configuration.HOST, someHostValue);
-        verify(configurationBuilder).property(JAXRS.Configuration.PORT, somePortValue);
-        verify(configurationBuilder).property(JAXRS.Configuration.ROOT_PATH, someRootPathValue);
-        verify(configurationBuilder).property(JAXRS.Configuration.SSL_CONTEXT, someSSLContextValue);
-        verify(configurationBuilder).property(JAXRS.Configuration.SSL_CLIENT_AUTHENTICATION,
+        verify(configurationBuilder).property(SeBootstrap.Configuration.PROTOCOL, someProtocolValue);
+        verify(configurationBuilder).property(SeBootstrap.Configuration.HOST, someHostValue);
+        verify(configurationBuilder).property(SeBootstrap.Configuration.PORT, somePortValue);
+        verify(configurationBuilder).property(SeBootstrap.Configuration.ROOT_PATH, someRootPathValue);
+        verify(configurationBuilder).property(SeBootstrap.Configuration.SSL_CONTEXT, someSSLContextValue);
+        verify(configurationBuilder).property(SeBootstrap.Configuration.SSL_CLIENT_AUTHENTICATION,
                 someSSLClientAuthenticationValue);
     }
 
@@ -162,13 +162,13 @@ public final class JAXRSTest {
         final String someRootPathValue = mockString();
         final SSLContext someSSLContextValue = mock(SSLContext.class);
         final SSLClientAuthentication someSSLClientAuthenticationValue = SSLClientAuthentication.MANDATORY;
-        final JAXRS.Configuration configuration = spy(JAXRS.Configuration.class);
-        given(configuration.property(JAXRS.Configuration.PROTOCOL)).willReturn(someProtocolValue);
-        given(configuration.property(JAXRS.Configuration.HOST)).willReturn(someHostValue);
-        given(configuration.property(JAXRS.Configuration.PORT)).willReturn(somePortValue);
-        given(configuration.property(JAXRS.Configuration.ROOT_PATH)).willReturn(someRootPathValue);
-        given(configuration.property(JAXRS.Configuration.SSL_CONTEXT)).willReturn(someSSLContextValue);
-        given(configuration.property(JAXRS.Configuration.SSL_CLIENT_AUTHENTICATION))
+        final SeBootstrap.Configuration configuration = spy(SeBootstrap.Configuration.class);
+        given(configuration.property(SeBootstrap.Configuration.PROTOCOL)).willReturn(someProtocolValue);
+        given(configuration.property(SeBootstrap.Configuration.HOST)).willReturn(someHostValue);
+        given(configuration.property(SeBootstrap.Configuration.PORT)).willReturn(somePortValue);
+        given(configuration.property(SeBootstrap.Configuration.ROOT_PATH)).willReturn(someRootPathValue);
+        given(configuration.property(SeBootstrap.Configuration.SSL_CONTEXT)).willReturn(someSSLContextValue);
+        given(configuration.property(SeBootstrap.Configuration.SSL_CLIENT_AUTHENTICATION))
                 .willReturn(someSSLClientAuthenticationValue);
 
         // when

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/core/RuntimeDelegateStub.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/core/RuntimeDelegateStub.java
@@ -18,9 +18,9 @@ package jakarta.ws.rs.core;
 
 import java.util.concurrent.CompletionStage;
 
-import jakarta.ws.rs.JAXRS;
-import jakarta.ws.rs.JAXRS.Configuration;
-import jakarta.ws.rs.JAXRS.Instance;
+import jakarta.ws.rs.SeBootstrap;
+import jakarta.ws.rs.SeBootstrap.Configuration;
+import jakarta.ws.rs.SeBootstrap.Instance;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.core.Link.Builder;
@@ -66,7 +66,7 @@ public class RuntimeDelegateStub extends RuntimeDelegate {
     }
 
     @Override
-    public CompletionStage<Instance> bootstrap(final Application application, final JAXRS.Configuration configuration) {
+    public CompletionStage<Instance> bootstrap(final Application application, final SeBootstrap.Configuration configuration) {
         return null;
     }
 }


### PR DESCRIPTION
Renamed Java SE Bootstrap interface from `JAXRS` to `SeBootstrap` as proposed by @jansupol and objected by nobody (see discussion in #770).

Closes #770.

*According to our [Committer Conventions](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions) the review time for this PR is two full weeks.*