### PR TITLE
Additionally building on JDK 13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ jdk:
   - openjdk10
   - openjdk11
   - openjdk12
+  - openjdk13
 
 cache:
   directories:

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -652,7 +652,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.22.0</version>
+            <version>3.1.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/client/package-info.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/client/package-info.java
@@ -15,7 +15,7 @@
  */
 
 /**
- * <h1>The JAX-RS client API</h1>
+ * <h2>The JAX-RS client API</h2>
  * <p>
  * The JAX-RS client API is a Java based API used to access Web resources. It is not restricted to resources implemented
  * using JAX-RS. It provides a higher-level abstraction compared to a {@link java.net.HttpURLConnection plain HTTP
@@ -27,7 +27,7 @@
  * architectural style &ndash; and associated data elements as client-side Java artifacts and supports a pluggable
  * architecture by defining multiple extension points.
  *
- * <h2>Client API Bootstrapping and Configuration</h2> The main entry point to the API is a
+ * <h3>Client API Bootstrapping and Configuration</h3> The main entry point to the API is a
  * {@link jakarta.ws.rs.client.ClientBuilder} that is used to bootstrap {@link jakarta.ws.rs.client.Client} instances -
  * {@link jakarta.ws.rs.core.Configurable configurable}, heavy-weight objects that manage the underlying communication
  * infrastructure and serve as the root objects for accessing any Web resource. The following example illustrates the
@@ -41,7 +41,7 @@
  *         .register(MyFeature.class);
  * </pre>
  *
- * <h2>Accessing Web Resources</h2> A Web resource can be accessed using a fluent API in which method invocations are
+ * <h3>Accessing Web Resources</h3> A Web resource can be accessed using a fluent API in which method invocations are
  * chained to configure and ultimately submit an HTTP request. The following example gets a {@code text/plain}
  * representation of the resource identified by {@code "http://example.org/hello"}:
  *
@@ -76,7 +76,7 @@
  * WebTarget msg456 = messages.resolveTemplate("id", 456);
  * </pre>
  *
- * <h2>Generic Invocations</h2> An {@link jakarta.ws.rs.client.Invocation} is a request that has been prepared and is
+ * <h3>Generic Invocations</h3> An {@link jakarta.ws.rs.client.Invocation} is a request that has been prepared and is
  * ready for execution. Invocations provide a generic interface that enables a separation of concerns between the
  * creator and the submitter. In particular, the submitter does not need to know how the invocation was prepared, but
  * only whether it should be executed synchronously or asynchronously.

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/Configurable.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/Configurable.java
@@ -33,13 +33,13 @@ import java.util.Map;
  * interface (such as {@link jakarta.ws.rs.client.Client} or {@link jakarta.ws.rs.client.WebTarget}). As such, the exact
  * scope of a configuration context is typically determined by a use case scenario in which the context is accessed.
  * </p>
- * <h3>Setting properties.</h3>
+ * <h2>Setting properties.</h2>
  * <p>
  * New properties can be set using the {@link #property} method. Similarly, updating a value of an existing property can
  * be achieved using the same method. Information about the configured set of properties is available via the underlying
  * {@code Configuration} object. An existing property can be removed by assigning a {@code null} value to the property.
  * </p>
- * <h3>Registering JAX-RS components.</h3>
+ * <h2>Registering JAX-RS components.</h2>
  * <p>
  * Registered custom JAX-RS component classes and instances are important part of the contextual configuration
  * information as these are the main factors that determine the capabilities of a configured runtime. Implementations

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/sse/SseEventSource.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/sse/SseEventSource.java
@@ -34,7 +34,7 @@ import jakarta.ws.rs.client.WebTarget;
  * {@link WebTarget web target}. After establishing the connection, the event source starts processing any incoming
  * inbound events. Whenever a new event is received, an {@link Consumer#accept(Object)
  * Consumer&lt;InboundSseEvent&gt;#accept(InboundSseEvent)} method is invoked on any registered event consumers.
- * <h3>Reconnect support</h3>
+ * <h2>Reconnect support</h2>
  * <p>
  * The {@code SseEventSource} supports automated recuperation from a connection loss, including negotiation of delivery
  * of any missed events based on the last received SSE event {@code id} field value, provided this field is set by the

--- a/jaxrs-api/src/main/javadoc/overview.html
+++ b/jaxrs-api/src/main/javadoc/overview.html
@@ -21,7 +21,7 @@
 <p>Jakarta RESTful Web Services provides a specification document, TCK and foundational API to develop web services
     following the Representational State Transfer (REST) architectural pattern.</p>
 
-<h2>Web resources</h2>
+<h1>Web resources</h1>
 
 <p>JAX-RS core APIs enable developers to rapidly build Web applications in Java that are characteristic
     of the best designed parts of the Web. The API brings in support for designing and implementing
@@ -53,7 +53,7 @@ public class WidgetResource {
 }
 </pre>
 
-<h2>Web resource clients</h2>
+<h1>Web resource clients</h1>
 
 <p>JAX-RS client API is a Java based API used to access resources on the Web. It is not restricted
     to resources implemented using JAX-RS. It provides a higher-level abstraction compared to a
@@ -80,7 +80,7 @@ public class WidgetResource {
     String message = res.readEntity(String.class);
  </pre>
 
-<h2>Provider extensions</h2>
+<h1>Provider extensions</h1>
 
 <p>JAX-RS applications may provide custom extensions to the client and server runtime using the
     common extension APIs defined in <a href="javax/ws/rs/ext/package-summary.html">jakarta.ws.rs.ext</a>


### PR DESCRIPTION
This PR provides all needed changes to also build on JDK 13:

- Travis CI uses Open JDK 13
- Mockito 3.1.0 needed as Mockito 2.x will not run anymore on JDK 13
- JavaDoc 13 implies new restrictions on the sequence of `<Hn>`

**As these are no API changes, this is a fast-track review period of just one day as per our [committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**