### PR TITLE
Spec: Technical Fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,13 @@ install:
   - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
   - cd $TRAVIS_BUILD_DIR/examples
   - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+  - cd $TRAVIS_BUILD_DIR/jaxrs-spec
+  - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 
 script:
   - cd $TRAVIS_BUILD_DIR/jaxrs-api
   - mvn verify -B
   - cd $TRAVIS_BUILD_DIR/examples
+  - mvn verify -B
+  - cd $TRAVIS_BUILD_DIR/jaxrs-spec
   - mvn verify -B

--- a/jaxrs-spec/pom.xml
+++ b/jaxrs-spec/pom.xml
@@ -57,27 +57,6 @@
         <defaultGoal>package</defaultGoal>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.4.1</version>
-                <executions>
-                    <execution>
-                        <id>enforce-versions</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <requireJavaVersion>
-                                    <version>[1.8.0,1.9.0)</version>
-                                    <message>You need JDK8 or lower</message>
-                                </requireJavaVersion>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
                 <version>${asciidoctor.maven.plugin.version}</version>


### PR DESCRIPTION
- Spec: Can also build spec on JDK 9 and later now
- Spec: Travis CI/CD builds spec

**As these are no API changes, this is a fast-track review period of just one day as per our [committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**