### PR TITLE
[#816] Update the license names in pom.xml to use proper SPDX identifier

### DIFF
--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -57,12 +57,12 @@
 
     <licenses>
         <license>
-            <name>EPL 2.0</name>
+            <name>EPL-2.0</name>
             <url>http://www.eclipse.org/legal/epl-2.0</url>
             <distribution>repo</distribution>
         </license>
         <license>
-            <name>GPL2 w/ CPE</name>
+            <name>GPL-2.0-with-classpath-exception</name>
             <url>https://www.gnu.org/software/classpath/license.html</url>
             <distribution>repo</distribution>
         </license>


### PR DESCRIPTION
Replacing license names in `pom.xml` by [SPDX indentifiers](https://spdx.org/licenses/) to allow *unambiguous and automatic* identification of the actual license.

Closes #816.

**As these are no API changes, this is a fast-track review period of just one day as per our [committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**