### PR TITLE
[#804] Modifying references to the JCP with corresponding Eclipse processes (excluding Activation and JAX-WS)

### DIFF
--- a/jaxrs-spec/src/main/asciidoc/chapters/appendix/_bibliography.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/appendix/_bibliography.adoc
@@ -21,8 +21,8 @@
 - [[[bib7,7]]]  J.C. Gregorio and B. de hOra. The Atom Publishing Protocol. Internet Draft, IETF, March 2007. See
                https://bitworking.org/projects/atom/draft-ietf-atompub-protocol-14.html.
 
-- [[[bib8,8]]]  G. Murray. Java Servlet Specification Version 2.5. JSR, JCP, October 2006. See
-               https://java.sun.com/products/servlet.
+- [[[bib8,8]]]  Jakarta™ Servlet Specification, Version 4.0. Available at:
+               https://jakarta.ee/specifications/servlet/4.0
 
 - [[[bib9,9]]]  R. Chinnici, M. Hadley, and R. Mordani. Java API for XML Web Services. JSR, JCP, August 2005.
                See https://jcp.org/en/jsr/detail?id=224.
@@ -36,25 +36,25 @@
 - [[[bib12,12]]]  RxJava 2.0: What’s different in 2.0. See
                https://github.com/ReactiveX/RxJava/wiki/What’s-different-in-2.0.
 
-- [[[bib13,13]]]  Anthony Lai. Concurrency Utilities for Java EE. JSR, JCP, March 2013. See
-               https://jcp.org/en/jsr/detail?id=236.
+- [[[bib13,13]]]  Jakarta™ Concurrency Specification, Version 1.1. Available at:
+               https://jakarta.ee/specifications/concurrency/1.1
 
-- [[[bib14,14]]]  Gavin King. Context and Dependency Injection for the Java Platform. JSR, JCP, December 2009.
-               See https://jcp.org/en/jsr/detail?id=299.
+- [[[bib14,14]]]  Jakarta™ Contexts and Dependency Injection Specification, Version 2.0. Available at:
+               https://jakarta.ee/specifications/cdi/2.0
 
-- [[[bib15,15]]]  Rajiv Mordani. Common Annotations for the Java Platform. JSR, JCP, July 2005. See
-               https://jcp.org/en/jsr/detail?id=250.
+- [[[bib15,15]]]  Jakarta™ Annotations Specification, Version 1.3. Available at:
+               https://jakarta.ee/specifications/annotations/1.3
 
-- [[[bib16,16]]]  Emmanuel Bernard. Bean Validation 1.1. JSR, JCP, March 2013. See
-               https://jcp.org/en/jsr/detail?id=349.
+- [[[bib16,16]]]  Jakarta™ Bean Validation Specification, Version 2.0. Available at:
+               https://jakarta.ee/specifications/bean-validation/2.0
 
 - [[[bib17,17]]]  Server-Sent Events. See https://html.spec.whatwg.org/#server-sent-events.
 
-- [[[bib18,18]]]  Dmitry Kornilov. Java API for JSON Processing 1.1. JSR, JCP, May 2017. See
-               https://jcp.org/en/jsr/detail?id=374.
+- [[[bib18,18]]]  Jakarta™ JSON Processing Specification, Version 1.1. Available at:
+               https://jakarta.ee/specifications/jsonp/1.1
 
-- [[[bib19,19]]]  Dmitry Kornilov. Java API for JSON Binding. JSR, JCP, July 2017. See
-               https://jcp.org/en/jsr/detail?id=367.
+- [[[bib19,19]]]  Jakarta™ JSON Binding Specification, Version 1.0. Available at:
+               https://jakarta.ee/specifications/jsonb/1.0
 
 - [[[bib20,20]]]  Bill Shannon. JavaBeans Activation Framework. JSR, JCP, May 2006. See
                https://jcp.org/en/jsr/detail?id=925.


### PR DESCRIPTION
Modifying references to the JCP with corresponding Eclipse processes (excluding Activation and JAX-WS)

**As these are no API changes, this is a fast-track review period of just one day as per our [committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**