### PR TITLE
Migration of Jenkins files (Fixed Nightly Build)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,19 +19,13 @@ pipeline {
 				}
 			}
 			steps {
-				configFileProvider([
-					configFile(fileId: 'a79c37a7-bfd9-4699-8077-f992027b2c1b', targetLocation: '/home/jenkins/.m2/settings.xml'),
-					configFile(fileId: 'b78b4e15-215f-42bc-81ac-53cd3e2ef708', targetLocation: '/home/jenkins/.m2/')
-				]) {
-					dir ('jaxrs-api') {
-						sh "$MVN deploy"
-					}
-					dir ('examples') {
-						sh "$MVN deploy"
-					}
+				dir ('jaxrs-api') {
+					sh "$MVN deploy"
+				}
+				dir ('examples') {
+					sh "$MVN deploy"
 				}
 			}
 		}
 	}
 }
-


### PR DESCRIPTION
Fixed: Nightly Build fails after after migration to ci.eclipse.org

Solution: Not using configuration files for Jenkins jobs

**As these are no API changes, this is a fast-track review period of just one day as per our [committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**
