### PR TITLE
Migrated to https://jakarta.oss.sonatype.org

### DIFF
--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -155,7 +155,7 @@
                         </executions>
                         <configuration>
                             <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <nexusUrl>https://jakarta.oss.sonatype.org/</nexusUrl>
                             <autoReleaseAfterClose>false</autoReleaseAfterClose>
                         </configuration>
                     </plugin>
@@ -166,13 +166,13 @@
                 <repository>
                     <id>ossrh</id>
                     <name>Sonatype Nexus Releases</name>
-                    <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+                    <url>https://jakarta.oss.sonatype.org/service/local/staging/deploy/maven2</url>
                 </repository>
 
                 <snapshotRepository>
                     <id>ossrh</id>
                     <name>Sonatype Nexus Snapshots</name>
-                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+                    <url>https://jakarta.oss.sonatype.org/content/repositories/snapshots</url>
                 </snapshotRepository>
             </distributionManagement>
         </profile>
@@ -249,7 +249,7 @@
                 <!-- JAXB and JAF are not found in Maven Central yet, so we pull it from OSSRH staging instead. -->
                 <repository>
                     <id>ossrh-staging</id>
-                    <url>https://oss.sonatype.org/content/repositories/staging</url>
+                    <url>https://jakarta.oss.sonatype.org/content/repositories/staging</url>
                 </repository>
             </repositories>
         </profile>


### PR DESCRIPTION
PMC member @dblevins announced that between January 2nd and 6th we have to migrate to the dedicated host `jakarta.oss.sonatype.org`:

>All,
>
>We've struggled with the 30 day expiration of oss.sonatype.org.  Sonatype has very generously agreed to dedicate an instance of Nexus Pro specifically to us and our Jakarta efforts that will give us a 60 day retention policy.
>
>Here's the information I have:
>
>- Thursday, January 2nd new instance available for testing at jakarta.oss.sonatype.org
>
>- Monday, January 6th cutover -- publishing to Central from oss.sonatype.org will cease to work
>
>- Users in the "Migrate" tab will be migrated.  Users in the "Hold" tab are welcome to opt-in (there will be another batch) 
>
>https://docs.google.com/spreadsheets/d/10eQJ46CyqcK8lco2z8dEN_9c29Wql_E_eSU8feYejcQ/edit?usp=sharing
>
>I haven't confirmed, but I assume all users will still work as-is, same password, just with jakarta.oss.sonatype.org instead of oss.sonatype.org.
>
>In that regard the migration should be fairly simple.  However we still need a volunteer to update the EE4J parent pom.  Any takers?
>
>Terry, is there a sneaky way we could do that now if someone was motivated?  Maybe publish it and just not use it till January?
>
>
>--
>David Blevins
>http://twitter.com/dblevins
>http://www.tomitribe.com

**As these are no API changes, this is a fast-track review period of just one day as per our [committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**