### PR TITLE
Renamed 2.2-SNAPSHOT -> 3.1-SNAPSHOT

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>jakarta.ws.rs</groupId>
     <artifactId>jakarta.ws.rs-examples</artifactId>
-    <version>2.2-SNAPSHOT</version>
+    <version>3.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>jakarta.ws.rs-examples</name>
 
@@ -261,7 +261,7 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>2.2-SNAPSHOT</version>
+            <version>3.1-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>jakarta.ws.rs</groupId>
     <artifactId>jakarta.ws.rs-api</artifactId>
-    <version>2.2-SNAPSHOT</version>
+    <version>3.1-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>jakarta.ws.rs-api</name>
     <description>Jakarta RESTful Web Services</description>

--- a/jaxrs-spec/pom.xml
+++ b/jaxrs-spec/pom.xml
@@ -26,7 +26,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>jakarta.ws.rs</groupId>
     <artifactId>jakarta.ws.rs-spec</artifactId>
-    <version>2.2-SNAPSHOT</version>
+    <version>3.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Jakarta RESTful Web Services Specification</name>
 


### PR DESCRIPTION
According to our recently changed [roadmap](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Roadmap) the `master` branch actually is not working towards release 2.2 but actually towards releasse 3.1 (in fact it skips release 3.0 as it already contains new features).

**As these are no API changes, this is a fast-track review period of just one day as per our [committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**