### PR TITLE
[Spec] Fixed: Link to current spec

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,8 +7,8 @@ latestVersion: 2.1.6
 
 links:
   source: https://github.com/eclipse-ee4j/jaxrs-api
-  spec: https://eclipse-ee4j.github.io/jaxrs-api/spec
   javadocs: https://eclipse-ee4j.github.io/jaxrs-api/apidocs
+  docs: https://jakarta.ee/specifications/restful-ws/2.1/restful-ws-spec-2.1.html
   download: https://github.com/eclipse-ee4j/jaxrs-api/releases
   mailinglist: https://accounts.eclipse.org/mailing-list/jaxrs-dev
 


### PR DESCRIPTION
The link "Documentation" in the navigation bar now opens the JAX-RS 2.1 specification (HTML on jakarta.ee page).

Demo: https://mkarg.github.io/jaxrs-api/?version=f2e4af012eea9a60e9cc4d34e645060961215ce2.

We should discuss *later* (*after* this pure bug fix) to replace the link by the Jakarta EE 9's variant of the spec (i. e. replace the boilerplate spec by the actual spec). For that. But this is out of scope for *this* PR.

**As these are no API changes, this is a fast-track review period of just one day as per our [committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**