### PR TITLE
[#835] Clarify injection wrt `getSingletons`

### DIFF
--- a/jaxrs-spec/src/main/asciidoc/chapters/environment/_javaee.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/environment/_javaee.adoc
@@ -197,12 +197,13 @@ The following additional requirements apply when using Managed Beans,
 CDI-style Beans or EJBs as resource classes, providers or `Application`
 subclasses:
 
-* For JAX-RS resources where the JAX-RS implementation participates in
-it's creation and initialization, field and property injection in these
-resources MUST be performed prior to the container invoking any 
-`@PostConstruct` annotated method. For resources created by the
-application (i.e. instances returned via the `Application.getSingletons()`
-method), this requirement does not apply.
+* For JAX-RS resources and providers where the JAX-RS implementation 
+participates in their creation and initialization, field and property
+injection in these resources and providers MUST be performed prior to the
+container invoking any `@PostConstruct` annotated method. For resources
+and providers created by the application (e.g. instances returned via the
+`Application.getSingletons()` method, or instances passed via
+`Configurable.register`), this requirement does not apply.
 * Support for constructor injection of JAX-RS resources is OPTIONAL.
 Portable applications MUST instead use fields or bean properties in
 conjunction with a `@PostConstruct` annotated method. Implementations

--- a/jaxrs-spec/src/main/asciidoc/chapters/environment/_javaee.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/environment/_javaee.adoc
@@ -197,8 +197,12 @@ The following additional requirements apply when using Managed Beans,
 CDI-style Beans or EJBs as resource classes, providers or `Application`
 subclasses:
 
-* Field and property injection of JAX-RS resources MUST be performed
-prior to the container invoking any `@PostConstruct` annotated method.
+* For JAX-RS resources where the JAX-RS implementation participates in
+it's creation and initialization, field and property injection in these
+resources MUST be performed prior to the container invoking any 
+`@PostConstruct` annotated method. For resources created by the
+application (i.e. instances returned via the `Application.getSingletons()`
+method), this requirement does not apply.
 * Support for constructor injection of JAX-RS resources is OPTIONAL.
 Portable applications MUST instead use fields or bean properties in
 conjunction with a `@PostConstruct` annotated method. Implementations


### PR DESCRIPTION
This partially addresses issue #835, updating the spec to clarify that the CDI integration requirements do not apply to resources or providers returned from the `getSingletons` method.

This should also be pushed to 3.1-SNAPSHOT branch.