### PR TITLE
[#845] Update API dependencies for JAXB+Activation

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -260,14 +260,41 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>3.0-SNAPSHOT</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>7.0</version>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>3.0.0-RC1</version>
         </dependency>
+
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <version>3.0.0-M1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.enterprise.concurrent</groupId>
+            <artifactId>jakarta.enterprise.concurrent-api</artifactId>
+            <version>2.0.0-RC1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.ejb</groupId>
+            <artifactId>jakarta.ejb-api</artifactId>
+            <version>3.2.6</version>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>3.0.0-M1</version>
+        </dependency>
+
+
+
     </dependencies>
 
     <distributionManagement>

--- a/examples/src/main/java/jaxrs/examples/client/BasicExamples.java
+++ b/examples/src/main/java/jaxrs/examples/client/BasicExamples.java
@@ -41,7 +41,7 @@ import jakarta.ws.rs.ext.WriterInterceptor;
 import jakarta.ws.rs.ext.WriterInterceptorContext;
 
 import javax.net.ssl.SSLContext;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import jaxrs.examples.client.custom.ThrottledClient;
 import static jakarta.ws.rs.client.Entity.form;

--- a/examples/src/main/java/jaxrs/examples/client/spec/SpecExamples.java
+++ b/examples/src/main/java/jaxrs/examples/client/spec/SpecExamples.java
@@ -21,8 +21,7 @@ import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Response;
 import static jakarta.ws.rs.client.Entity.entity;
 
-import javax.xml.bind.annotation.XmlRootElement;
-
+import jakarta.xml.bind.annotation.XmlRootElement;
 import jaxrs.examples.client.custom.ThrottledClient;
 
 /**

--- a/examples/src/main/java/jaxrs/examples/client/validator/NotNull.java
+++ b/examples/src/main/java/jaxrs/examples/client/validator/NotNull.java
@@ -10,20 +10,20 @@
 
 package jaxrs.examples.client.validator;
 
-import javax.enterprise.util.AnnotationLiteral;
-import javax.validation.Payload;
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.validation.Payload;
 
 /**
  * @author Santiago Pericas-Geertsen
  */
-public class NotNull extends AnnotationLiteral<javax.validation.constraints.NotNull>
-        implements javax.validation.constraints.NotNull {
+public class NotNull extends AnnotationLiteral<jakarta.validation.constraints.NotNull>
+        implements jakarta.validation.constraints.NotNull {
 
     private static final long serialVersionUID = -5352564534866654470L;
 
     @Override
     public String message() {
-        return "{javax.validation.constraints.NotNull.message}";
+        return "{jakarta.validation.constraints.NotNull.message}";
     }
 
     @Override

--- a/examples/src/main/java/jaxrs/examples/client/validator/Pattern.java
+++ b/examples/src/main/java/jaxrs/examples/client/validator/Pattern.java
@@ -10,14 +10,14 @@
 
 package jaxrs.examples.client.validator;
 
-import javax.enterprise.util.AnnotationLiteral;
-import javax.validation.Payload;
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.validation.Payload;
 
 /**
  * @author sp106478
  */
-public class Pattern extends AnnotationLiteral<javax.validation.constraints.Pattern>
-        implements javax.validation.constraints.Pattern {
+public class Pattern extends AnnotationLiteral<jakarta.validation.constraints.Pattern>
+        implements jakarta.validation.constraints.Pattern {
     private static final long serialVersionUID = 920895043686145958L;
 
     private String regexp;
@@ -28,7 +28,7 @@ public class Pattern extends AnnotationLiteral<javax.validation.constraints.Patt
 
     @Override
     public String message() {
-        return "{javax.validation.constraints.Pattern.message}";
+        return "{jakarta.validation.constraints.Pattern.message}";
     }
 
     @Override

--- a/examples/src/main/java/jaxrs/examples/client/validator/ValidatorExample.java
+++ b/examples/src/main/java/jaxrs/examples/client/validator/ValidatorExample.java
@@ -14,11 +14,11 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
-import javax.enterprise.util.AnnotationLiteral;
-import javax.validation.Constraint;
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
-import javax.validation.Payload;
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.validation.Constraint;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.Payload;
 
 public class ValidatorExample {
 
@@ -54,7 +54,7 @@ public class ValidatorExample {
 
         @Override
         public String message() {
-            return "{javax.validation.constraints.NotNull.message}";
+            return "{jakarta.validation.constraints.NotNull.message}";
         }
 
         @Override

--- a/examples/src/main/java/jaxrs/examples/link/ResourceExample.java
+++ b/examples/src/main/java/jaxrs/examples/link/ResourceExample.java
@@ -18,9 +18,9 @@ import jakarta.ws.rs.core.Link;
 import jakarta.ws.rs.core.Link.JaxbAdapter;
 import jakarta.ws.rs.core.UriInfo;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 /**
  * ResourceExample class.

--- a/examples/src/main/java/jaxrs/examples/link/clusterservice/Cluster.java
+++ b/examples/src/main/java/jaxrs/examples/link/clusterservice/Cluster.java
@@ -13,7 +13,7 @@ package jaxrs.examples.link.clusterservice;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 /**
  * Cluster class.

--- a/examples/src/main/java/jaxrs/examples/link/clusterservice/Machine.java
+++ b/examples/src/main/java/jaxrs/examples/link/clusterservice/Machine.java
@@ -10,7 +10,7 @@
 
 package jaxrs.examples.link.clusterservice;
 
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 /**
  * Machine class.

--- a/examples/src/main/java/jaxrs/examples/sse/ItemStoreResource.java
+++ b/examples/src/main/java/jaxrs/examples/sse/ItemStoreResource.java
@@ -35,8 +35,8 @@ import jakarta.ws.rs.sse.Sse;
 import jakarta.ws.rs.sse.SseBroadcaster;
 import jakarta.ws.rs.sse.SseEventSink;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 
 /**
  * A resource for storing named items.

--- a/examples/src/main/java/jaxrs/examples/sse/ServerSentEventsResource.java
+++ b/examples/src/main/java/jaxrs/examples/sse/ServerSentEventsResource.java
@@ -24,9 +24,9 @@ import jakarta.ws.rs.sse.Sse;
 import jakarta.ws.rs.sse.SseEventSink;
 
 import javax.annotation.Resource;
-import javax.enterprise.concurrent.ManagedExecutorService;
-import javax.inject.Inject;
-import javax.inject.Singleton;
+import jakarta.enterprise.concurrent.ManagedExecutorService;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 
 /**
  * @author Pavel Bucek (pavel.bucek at oracle.com)

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -181,26 +181,6 @@
             <activation>
                 <jdk>[11,)</jdk>
             </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.xml.bind</groupId>
-                    <artifactId>jakarta.xml.bind-api</artifactId>
-                    <version>${jaxb.api.version}</version>
-                    <scope>provided</scope>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.activation</groupId>
-                    <artifactId>jakarta.activation-api</artifactId>
-                    <version>${activation.api.version}</version>
-                    <scope>provided</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.glassfish.jaxb</groupId>
-                    <artifactId>jaxb-runtime</artifactId>
-                    <version>${jaxb.impl.version}</version>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
             <build>
                 <pluginManagement>
                     <plugins>
@@ -643,6 +623,24 @@
     </build>
 
     <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>${jaxb.api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
+            <version>${activation.api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>${jaxb.impl.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>jakarta.ws.rs</groupId>
     <artifactId>jakarta.ws.rs-api</artifactId>
-    <version>3.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>jakarta.ws.rs-api</name>
     <description>Jakarta RESTful Web Services</description>
@@ -671,9 +671,9 @@
         <spec.version>2.2</spec.version>
         <spec.version.revision /> <!-- e.g. (Rev a) -->
 
-        <jaxb.api.version>2.3.2</jaxb.api.version>
+        <jaxb.api.version>3.0.0-RC1</jaxb.api.version>
         <jaxb.impl.version>2.3.2</jaxb.impl.version>
-        <activation.api.version>1.2.1</activation.api.version>
+        <activation.api.version>2.0.0-rc1</activation.api.version>
         <legal.doc.folder>${project.basedir}/..</legal.doc.folder>
     </properties>
 

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/Link.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/Link.java
@@ -519,7 +519,7 @@ public abstract class Link {
     }
 
     /**
-     * An implementation of JAXB {@link javax.xml.bind.annotation.adapters.XmlAdapter} that maps the JAX-RS
+     * An implementation of JAXB {@link jakarta.xml.bind.annotation.adapters.XmlAdapter} that maps the JAX-RS
      * {@link jakarta.ws.rs.core.Link} type to a value that can be marshalled and unmarshalled by JAXB. The following example
      * shows how to use this adapter on a JAXB bean class:
      *

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/Link.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/Link.java
@@ -22,12 +22,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import javax.xml.bind.annotation.XmlAnyAttribute;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.adapters.XmlAdapter;
 import javax.xml.namespace.QName;
 
 import jakarta.ws.rs.ext.RuntimeDelegate;
+import jakarta.xml.bind.annotation.XmlAnyAttribute;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
 
 /**
  * <p>

--- a/jaxrs-api/src/main/java/module-info.java
+++ b/jaxrs-api/src/main/java/module-info.java
@@ -16,7 +16,7 @@
 
 module jakarta.ws.rs {
 
-    requires transitive java.xml.bind;
+    requires transitive jakarta.xml.bind;
 
     requires java.logging;
 
@@ -30,4 +30,6 @@ module jakarta.ws.rs {
     uses jakarta.ws.rs.client.ClientBuilder;
     uses jakarta.ws.rs.ext.RuntimeDelegate;
     uses jakarta.ws.rs.sse.SseEventSource.Builder;
+
+    opens jakarta.ws.rs.core to jakarta.xml.bind;
 }

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/core/JaxbLinkTest.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/core/JaxbLinkTest.java
@@ -26,16 +26,16 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBElement;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
 import javax.xml.namespace.QName;
 import javax.xml.transform.stream.StreamSource;
 
 import org.junit.Test;
 
 import jakarta.ws.rs.core.Link;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBElement;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
 
 /**
  * Unit test for JAX-RS Link marshalling and unmarshalling via JAXB.

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/core/JaxbLinkTest.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/core/JaxbLinkTest.java
@@ -29,9 +29,9 @@ import java.util.Map;
 import javax.xml.namespace.QName;
 import javax.xml.transform.stream.StreamSource;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
-import jakarta.ws.rs.core.Link;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.Marshaller;
@@ -44,6 +44,7 @@ import jakarta.xml.bind.Unmarshaller;
  */
 public class JaxbLinkTest {
 
+    @Ignore("JAXB implementation does not yet support jakarta.* namespace")
     @Test
     public void testSerializationOfJaxbLink() throws Exception {
         JAXBContext jaxbContext = JAXBContext.newInstance(Link.JaxbLink.class);


### PR DESCRIPTION
This change updates the JAXB and Activation API dependencies to the Jakarta EE 9 levels - using release candidates for now. This change should be considered a work in progress until the JAXB-RI is also published at the EE 9 level.  Until then the JaxbLinkTest unit test will fail.

Feedback welcome, but no need to approve until the JAXB-RI change is made.

Thanks!

This will resolve issue #845 - though we should leave the issue open until we can pull in GA releases as opposed to release candidates.