### PR TITLE
Removed references to JSRs

### DIFF
--- a/jaxrs-spec/src/main/asciidoc/chapters/appendix/_bibliography.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/appendix/_bibliography.adoc
@@ -34,8 +34,8 @@
 - [[[bib8,8]]]  Jakarta™ Servlet Specification, Version 4.0. Available at:
                https://jakarta.ee/specifications/servlet/4.0
 
-- [[[bib9,9]]]  R. Chinnici, M. Hadley, and R. Mordani. Java API for XML Web Services. JSR, JCP, August 2005.
-               See https://jcp.org/en/jsr/detail?id=224.
+- [[[bib9,9]]]  Jakarta XML Web Services, Version 3.0
+               https://jakarta.ee/specifications/xml-web-services/2.3/.
 
 - [[[bib10,10]]]  S. Bradner. RFC 2119: Keywords for use in RFCs to Indicate Requirement Levels. RFC, IETF,
                March 1997. See https://www.ietf.org/rfc/rfc2119.txt.
@@ -66,5 +66,5 @@
 - [[[bib19,19]]]  Jakarta™ JSON Binding Specification, Version 1.0. Available at:
                https://jakarta.ee/specifications/jsonb/1.0
 
-- [[[bib20,20]]]  Bill Shannon. JavaBeans Activation Framework. JSR, JCP, May 2006. See
-               https://jcp.org/en/jsr/detail?id=925.
+- [[[bib20,20]]]  Jakarta Activation, Version 1.2
+               https://jakarta.ee/specifications/activation/1.2/.

--- a/jaxrs-spec/src/main/asciidoc/chapters/asynchronous_processing/_server_api.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/asynchronous_processing/_server_api.adoc
@@ -54,8 +54,9 @@ is resumed and the response returned by calling `resume` on the injected
 instance of `AsyncResponse`.
 
 For more information on executors, concurrency and thread management in
-a Jakarta EE environment, the reader is referred to JSR 236 <<bib13>>. For
-more information about executors in the JAX-RS Client API see <<executor_services>>.
+a Jakarta EE environment, the reader is referred to Jakarta Concurrency
+Specification <<bib13>>. For more information about
+executors in the JAX-RS Client API see <<executor_services>>.
 
 [[timeouts_and_callbacks]]
 ===== Timeouts and Callbacks

--- a/jaxrs-spec/src/main/asciidoc/chapters/validation/_annotations_and_validators.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/validation/_annotations_and_validators.adoc
@@ -12,7 +12,7 @@
 === Annotations and Validators
 
 Annotation constraints and validators are defined in accordance with the
-Bean Validation specification <<bib16>>. The `@Email` annotation
+Bean Validation Specification <<bib16>>. The `@Email` annotation
 shown above is defined using the Bean Validation
 `@Constraint` meta-annotation:
 


### PR DESCRIPTION
According to the issue  Spec: Todo  #804 , I removed the last reference to JSR within the specification document. 

In the discussion #843 we deiced that Expert Group Members and Acknowledgements may stay as-is.