### PR TITLE
[#815] Indicate that JAXB is optional

### DIFF
--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/Link.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/Link.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -404,8 +404,12 @@ public abstract class Link {
     }
 
     /**
-     * Value type for {@link jakarta.ws.rs.core.Link} that can be marshalled and unmarshalled by JAXB.
+     * Value type for {@link jakarta.ws.rs.core.Link} that can be marshalled and
+     * unmarshalled by JAXB.
      *
+     * Note that usage of this class requires the Jakarta XML Binding API and an implementation. The Jakarta RESTful Web
+     * Services implementation is not required to provide these dependencies.
+     * 
      * @see jakarta.ws.rs.core.Link.JaxbAdapter
      * @since 2.0
      */
@@ -538,6 +542,9 @@ public abstract class Link {
      * }
      * </pre>
      *
+     * Note that usage of this class requires the Jakarta XML Binding API and an implementation. The Jakarta RESTful Web
+     * Services implementation is not required to provide these dependencies.
+     * 
      * @see jakarta.ws.rs.core.Link.JaxbLink
      * @since 2.0
      */

--- a/jaxrs-spec/src/main/asciidoc/chapters/appendix/_bibliography.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/appendix/_bibliography.adoc
@@ -1,6 +1,6 @@
 ﻿////
 *******************************************************************
-* Copyright (c) 2019 Eclipse Foundation
+* Copyright (c) 2019, 2020 Eclipse Foundation
 *
 * This specification document is made available under the terms
 * of the Eclipse Foundation Specification License v1.0, which is
@@ -67,4 +67,7 @@
                https://jakarta.ee/specifications/jsonb/1.0
 
 - [[[bib20,20]]]  Jakarta Activation, Version 1.2
-               https://jakarta.ee/specifications/activation/1.2/.
+               https://jakarta.ee/specifications/activation/1.2/
+
+- [[[bib21,21]]]  Jakarta XML Binding, Version 3.0
+               https://jakarta.ee/specifications/xml-binding/3.0/

--- a/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-2.2-snapshot.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-2.2-snapshot.adoc
@@ -1,6 +1,6 @@
 ////
 *******************************************************************
-* Copyright (c) 2019 Eclipse Foundation
+* Copyright (c) 2019, 2020 Eclipse Foundation
 *
 * This specification document is made available under the terms
 * of the Eclipse Foundation Specification License v1.0, which is
@@ -12,3 +12,4 @@
 === Changes Since 2.2-SNAPSHOT
 
 * Referencing Jakarta EE instead of Java EE
+* JAXB API is now optional

--- a/jaxrs-spec/src/main/asciidoc/chapters/environment/_javaee.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/environment/_javaee.adoc
@@ -1,6 +1,6 @@
 ////
 *******************************************************************
-* Copyright (c) 2019 Eclipse Foundation
+* Copyright (c) 2019, 2020 Eclipse Foundation
 *
 * This specification document is made available under the terms
 * of the Eclipse Foundation Specification License v1.0, which is
@@ -189,6 +189,16 @@ matching `/json` or `/*+json`.
 Note that if JSON-B and JSON-P are both supported in the same
 environment, entity providers for JSON-B take precedence over those for
 JSON-P for all types except `JsonValue` and its sub-types.
+
+[[jaxb]]
+==== Jakarta XML Binding
+
+In a product that supports the Jakarta XML Binding API (JAXB)
+<<bib21>>, implementations MUST support entity providers for the type,
+`jakarta.xml.bind.JAXBElement`, and application-supplied JAXB classes
+in combination with the following XML-based media types:
+`text/xml` and `application/xml` and media types of the
+form `application/*+xml`.
 
 [[additional_reqs]]
 ==== Additional Requirements

--- a/jaxrs-spec/src/main/asciidoc/chapters/providers/_contextprovider.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/providers/_contextprovider.adoc
@@ -1,6 +1,6 @@
 ////
 *******************************************************************
-* Copyright (c) 2019 Eclipse Foundation
+* Copyright (c) 2019, 2020 Eclipse Foundation
 *
 * This specification document is made available under the terms
 * of the Eclipse Foundation Specification License v1.0, which is
@@ -23,6 +23,9 @@ do not wish to provide their context for a particular Java type. E.g. a
 JAXB context provider may wish to only provide the context for certain
 JAXB classes. Context providers MAY also manage multiple contexts of the
 same type keyed to different Java types.
+
+Note that a context provider for JAXB is only applicable in products that
+support <<jaxb>>.
 
 [[context_media_type]]
 ==== Declaring Media Type Capabilities

--- a/jaxrs-spec/src/main/asciidoc/chapters/providers/_entity_providers.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/providers/_entity_providers.adoc
@@ -1,6 +1,6 @@
 ////
 *******************************************************************
-* Copyright (c) 2019 Eclipse Foundation
+* Copyright (c) 2019, 2020 Eclipse Foundation
 *
 * This specification document is made available under the terms
 * of the Eclipse Foundation Specification License v1.0, which is
@@ -143,9 +143,6 @@ type combinations:
 `jakarta.xml.transform.Source`::
   XML types (`text/xml`, `application/xml` and media types of the form
   `application/*+xml`).
-`jakarta.xml.bind.JAXBElement` and application-supplied JAXB classes::
-  XML types (`text/xml` and `application/xml` and media types of the
-  form `application/*+xml`).
 `MultivaluedMap<String,String>`::
   Form content (`application/x-www-form-urlencoded`).
 `StreamingOutput`::
@@ -155,8 +152,8 @@ type combinations:
   boxing/unboxing conversion.
 
 Depending on the environment, the list of standard entity providers MUST
-also include those for JSON. For more information about these providers
-see <<jsonp>> and <<jsonb>>.
+also include those for JSON or XML. For more information about these providers
+see <<jsonp>>, <<jsonb>> and <<jaxb>>.
 
 When reading zero-length message entities all pre-packaged
 `MessageBodyReader` implementations, except the JAXB one and those for


### PR DESCRIPTION
Modifications to the spec doc and javadoc that indicate that JAXB is optional.  Where possible, I tried to keep the language consistent with JSON-P / JSON-B - i.e. if the product supports JSON-B, then it must have a built-in entity provider to handle JSON requests - likewise for JAXB / XML.  

This change is targeted for the `master` branch (3.0), and should also go into the `3.1-SNAPSHOT` branch.

Fixes #815
