### PR TITLE
Additionally building on JDK 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 dist: trusty
 language: java
-sudo: false
 
 jdk:
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+os: linux
 dist: trusty
 language: java
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ jdk:
   - openjdk11
   - openjdk12
   - openjdk13
+  - openjdk14
 
 cache:
   directories:


### PR DESCRIPTION
This PR provides all needed changes to also build on JDK 14:

- Travis CI uses Open JDK 14
- Fixing Travis Warning: Removing 'sudo' clause
- Fixing Travis Info: Adding 'os' clause

**As these are no API changes, this is a fast-track review period of just one day as per our [committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**