### PR TITLE
Version: 3.0.0-M1 -> 3.0.0-SNAPSHOT

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>jakarta.ws.rs</groupId>
     <artifactId>jakarta.ws.rs-examples</artifactId>
-    <version>3.0.0-M1</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>jakarta.ws.rs-examples</name>
 
@@ -260,7 +260,7 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>3.0.0-M1</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>jakarta.ws.rs</groupId>
     <artifactId>jakarta.ws.rs-api</artifactId>
-    <version>3.0.0-M1</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>jakarta.ws.rs-api</name>
     <description>Jakarta RESTful Web Services</description>

--- a/jaxrs-spec/pom.xml
+++ b/jaxrs-spec/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>jakarta.ws.rs</groupId>
     <artifactId>jakarta.ws.rs-spec</artifactId>
-    <version>3.0.0-M1</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Jakarta RESTful Web Services Specification</name>
 


### PR DESCRIPTION
3.0.0-M1 is already published to Maven Central, so the *current* version of `master` MUST be `3.0.0-SNAPSHOT` again to prevent confusion when building the source locally.

(In fact, this should be done *immediately* after a version was published)

**As these are no API changes, this is a fast-track review period of just one day as per our [committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**