### PR TITLE
Set stem attribute to fix math expressions in HTML output

### DIFF
--- a/jaxrs-spec/src/main/asciidoc/spec.adoc
+++ b/jaxrs-spec/src/main/asciidoc/spec.adoc
@@ -19,6 +19,7 @@
 :toclevels: 3
 :sectnumlevels: 4
 :sectanchors:
+:stem:
 ifdef::backend-pdf[]
 :pagenums:
 :numbered:


### PR DESCRIPTION
Many of the math expressions (especially in section 3.7.2) are broken in the output. See the following screenshot for an example:

![before](https://user-images.githubusercontent.com/159245/80807162-b8dfab00-8bbc-11ea-8b1d-d7d8780d3bd3.png)

Setting the `stem` AsciiDoctor attribute enables support for such expressions and fixes the output. See the following screenshot of the updated output:

![after](https://user-images.githubusercontent.com/159245/80807185-cac14e00-8bbc-11ea-9b2d-d306c938202f.png)

Please note that this only fixes the HTML output. The PDF file is still broken as it doesn't support the `stem` attribute. However, there seems to be a AsciiDoctor plugin which allows to fix the math expressions also in the PDF files. However, this should be addressed in a subsequent pull request.

**As these are no API changes, this is a fast-track review period of just one day as per our committer rules.**