### PR TITLE
Additionally building on JDK 15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ jdk:
   - openjdk12
   - openjdk13
   - openjdk14
+  - openjdk15
 
 cache:
   directories:


### PR DESCRIPTION
This PR provides all needed changes to also build on JDK 15:

- Travis CI uses Open JDK 15

**As these are no API changes, this is a fast-track review period of just one day as per our [committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**