### PR TITLE
Update Jakarta dependencies to latest versions

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -266,13 +266,13 @@
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>3.0.0-RC1</version>
+            <version>3.0.0-RC3</version>
         </dependency>
 
         <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
-            <version>3.0.0-M1</version>
+            <version>3.0.0-M2</version>
         </dependency>
 
         <dependency>
@@ -284,7 +284,7 @@
         <dependency>
             <groupId>jakarta.ejb</groupId>
             <artifactId>jakarta.ejb-api</artifactId>
-            <version>3.2.6</version>
+            <version>4.0.0-RC1</version>
         </dependency>
 
         <dependency>

--- a/examples/src/main/java/jaxrs/examples/async/LongRunningEjbResource.java
+++ b/examples/src/main/java/jaxrs/examples/async/LongRunningEjbResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -10,13 +10,12 @@
 
 package jaxrs.examples.async;
 
+import jakarta.ejb.Asynchronous;
+import jakarta.ejb.Stateless;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.container.AsyncResponse;
 import jakarta.ws.rs.container.Suspended;
-
-import javax.ejb.Asynchronous;
-import javax.ejb.Stateless;
 
 /**
  * TODO: javadoc.

--- a/examples/src/main/java/jaxrs/examples/filter/caching/ServerCachingFilter.java
+++ b/examples/src/main/java/jaxrs/examples/filter/caching/ServerCachingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -12,14 +12,13 @@ package jaxrs.examples.filter.caching;
 
 import java.io.IOException;
 
+import jakarta.annotation.Priority;
 import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.Provider;
-
-import javax.annotation.Priority;
 
 /**
  * ServerCachingFilter class.

--- a/examples/src/main/java/jaxrs/examples/filter/compression/GzipEntityInterceptor.java
+++ b/examples/src/main/java/jaxrs/examples/filter/compression/GzipEntityInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -16,14 +16,13 @@ import java.io.OutputStream;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
+import jakarta.annotation.Priority;
 import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.ext.Provider;
 import jakarta.ws.rs.ext.ReaderInterceptor;
 import jakarta.ws.rs.ext.ReaderInterceptorContext;
 import jakarta.ws.rs.ext.WriterInterceptor;
 import jakarta.ws.rs.ext.WriterInterceptorContext;
-
-import javax.annotation.Priority;
 
 /**
  * Example of GZIP entity interceptor.

--- a/examples/src/main/java/jaxrs/examples/filter/logging/LoggingFilter.java
+++ b/examples/src/main/java/jaxrs/examples/filter/logging/LoggingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -12,14 +12,13 @@ package jaxrs.examples.filter.logging;
 
 import java.io.IOException;
 
+import jakarta.annotation.Priority;
 import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.container.ContainerResponseContext;
 import jakarta.ws.rs.container.ContainerResponseFilter;
 import jakarta.ws.rs.ext.Provider;
-
-import javax.annotation.Priority;
 
 /**
  * Example of a logging resource filter (server-side).

--- a/examples/src/main/java/jaxrs/examples/sse/ServerSentEventsResource.java
+++ b/examples/src/main/java/jaxrs/examples/sse/ServerSentEventsResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -12,6 +12,10 @@ package jaxrs.examples.sse;
 
 import java.io.IOException;
 
+import jakarta.annotation.Resource;
+import jakarta.enterprise.concurrent.ManagedExecutorService;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
@@ -22,11 +26,6 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.sse.Sse;
 import jakarta.ws.rs.sse.SseEventSink;
-
-import javax.annotation.Resource;
-import jakarta.enterprise.concurrent.ManagedExecutorService;
-import jakarta.inject.Inject;
-import jakarta.inject.Singleton;
 
 /**
  * @author Pavel Bucek (pavel.bucek at oracle.com)

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -669,9 +669,9 @@
         <spec.version>2.2</spec.version>
         <spec.version.revision /> <!-- e.g. (Rev a) -->
 
-        <jaxb.api.version>3.0.0-RC1</jaxb.api.version>
-        <jaxb.impl.version>2.3.2</jaxb.impl.version>
-        <activation.api.version>2.0.0-rc1</activation.api.version>
+        <jaxb.api.version>3.0.0-RC3</jaxb.api.version>
+        <jaxb.impl.version>3.0.0-M2</jaxb.impl.version>
+        <activation.api.version>2.0.0-RC3</activation.api.version>
         <legal.doc.folder>${project.basedir}/..</legal.doc.folder>
     </properties>
 

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/Priorities.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/Priorities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,7 +18,7 @@ package jakarta.ws.rs;
 
 /**
  * A collection of built-in priority constants for the JAX-RS components that are supposed to be ordered based on their
- * {@code javax.annotation.Priority} class-level annotation value when used or applied by JAX-RS runtime.
+ * {@code jakarta.annotation.Priority} class-level annotation value when used or applied by JAX-RS runtime.
  * <p>
  * For example, JAX-RS filters and interceptors are grouped in chains for each of the message processing extension
  * points: Pre, PreMatch, Post as well as ReadFrom and WriteTo. Each of these chains is sorted based on priorities which

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientRequestFilter.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientRequestFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -34,7 +34,7 @@ public interface ClientRequestFilter {
     /**
      * Filter method called before a request has been dispatched to a client transport layer.
      *
-     * Filters in the filter chain are ordered according to their {@code javax.annotation.Priority} class-level annotation
+     * Filters in the filter chain are ordered according to their {@code jakarta.annotation.Priority} class-level annotation
      * value.
      *
      * @param requestContext request context.

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientResponseFilter.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientResponseFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -35,7 +35,7 @@ public interface ClientResponseFilter {
      * Filter method called after a response has been provided for a request (either by a {@link ClientRequestFilter request
      * filter} or when the HTTP invocation returns).
      *
-     * Filters in the filter chain are ordered according to their {@code javax.annotation.Priority} class-level annotation
+     * Filters in the filter chain are ordered according to their {@code jakarta.annotation.Priority} class-level annotation
      * value.
      *
      * @param requestContext request context.

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerRequestFilter.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerRequestFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -55,7 +55,7 @@ public interface ContainerRequestFilter {
      * Filter method called before a request has been dispatched to a resource.
      *
      * <p>
-     * Filters in the filter chain are ordered according to their {@code javax.annotation.Priority} class-level annotation
+     * Filters in the filter chain are ordered according to their {@code jakarta.annotation.Priority} class-level annotation
      * value. If a request filter produces a response by calling {@link ContainerRequestContext#abortWith} method, the
      * execution of the (either pre-match or post-match) request filter chain is stopped and the response is passed to the
      * corresponding response filter chain (either pre-match or post-match). For example, a pre-match caching filter may

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerResponseFilter.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerResponseFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -49,7 +49,7 @@ public interface ContainerResponseFilter {
      * Filter method called after a response has been provided for a request (either by a {@link ContainerRequestFilter
      * request filter} or by a matched resource method.
      * <p>
-     * Filters in the filter chain are ordered according to their {@code javax.annotation.Priority} class-level annotation
+     * Filters in the filter chain are ordered according to their {@code jakarta.annotation.Priority} class-level annotation
      * value.
      * </p>
      *

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/Configurable.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/Configurable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -187,7 +187,7 @@ public interface Configurable<C extends Configurable> {
      * feature} meta-provider) to be instantiated and used in the scope of this configurable context.
      * <p>
      * This registration method provides the same functionality as {@link #register(Class)} except that any priority
-     * specified on the registered JAX-RS component class via {@code javax.annotation.Priority} annotation is overridden
+     * specified on the registered JAX-RS component class via {@code jakarta.annotation.Priority} annotation is overridden
      * with the supplied {@code priority} value.
      * </p>
      * <p>
@@ -226,7 +226,7 @@ public interface Configurable<C extends Configurable> {
      * feature} meta-provider) to be instantiated and used in the scope of this configurable context.
      * <p>
      * This registration method provides same functionality as {@link #register(Class, Class[])} except that any priority
-     * specified on the registered JAX-RS component class via {@code javax.annotation.Priority} annotation is overridden for
+     * specified on the registered JAX-RS component class via {@code jakarta.annotation.Priority} annotation is overridden for
      * each extension provider contract type separately with an integer priority value specified as a value in the supplied
      * map of [contract type, priority] pairs.
      * </p>
@@ -274,7 +274,7 @@ public interface Configurable<C extends Configurable> {
      * feature} meta-provider) to be instantiated and used in the scope of this configurable context.
      * <p>
      * This registration method provides the same functionality as {@link #register(Object)} except that any priority
-     * specified on the registered JAX-RS component class via {@code javax.annotation.Priority} annotation is overridden
+     * specified on the registered JAX-RS component class via {@code jakarta.annotation.Priority} annotation is overridden
      * with the supplied {@code priority} value.
      * </p>
      * <p>
@@ -313,7 +313,7 @@ public interface Configurable<C extends Configurable> {
      * feature} meta-provider) to be instantiated and used in the scope of this configurable context.
      * <p>
      * This registration method provides same functionality as {@link #register(Object, Class[])} except that any priority
-     * specified on the registered JAX-RS component class via {@code javax.annotation.Priority} annotation is overridden for
+     * specified on the registered JAX-RS component class via {@code jakarta.annotation.Priority} annotation is overridden for
      * each extension provider contract type separately with an integer priority value specified as a value in the supplied
      * map of [contract type, priority] pairs.
      * </p>

--- a/jaxrs-api/src/main/javadoc/overview.html
+++ b/jaxrs-api/src/main/javadoc/overview.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -84,14 +84,14 @@ public class WidgetResource {
 <h1>Provider extensions</h1>
 
 <p>JAX-RS applications may provide custom extensions to the client and server runtime using the
-    common extension APIs defined in <a href="javax/ws/rs/ext/package-summary.html">jakarta.ws.rs.ext</a>
+    common extension APIs defined in <a href="jakarta/ws/rs/ext/package-summary.html">jakarta.ws.rs.ext</a>
     package, namely entity providers and entity provider interceptors. Additionally, request and
     response processing chains on client as well as server side can be further customized by
     implemening custom request and response filters - see the
-    <a href="javax/ws/rs/client/ClientRequestFilter.html">ClientRequestFilter</a>,
-    <a href="javax/ws/rs/client/ClientResponseFilter.html">ClientResponseFilter</a>,
-    <a href="javax/ws/rs/container/ContainerRequestFilter.html">ContainerRequestFilter</a>,
-    <a href="javax/ws/rs/container/ContainerResponseFilter.html">ContainerResponseFilter</a>
+    <a href="jakarta/ws/rs/client/ClientRequestFilter.html">ClientRequestFilter</a>,
+    <a href="jakarta/ws/rs/client/ClientResponseFilter.html">ClientResponseFilter</a>,
+    <a href="jakarta/ws/rs/container/ContainerRequestFilter.html">ContainerRequestFilter</a>,
+    <a href="jakarta/ws/rs/container/ContainerResponseFilter.html">ContainerResponseFilter</a>
     APIs.</p>
 </body>
 </html>

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/core/JaxbLinkTest.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/core/JaxbLinkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -29,7 +29,6 @@ import java.util.Map;
 import javax.xml.namespace.QName;
 import javax.xml.transform.stream.StreamSource;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import jakarta.xml.bind.JAXBContext;
@@ -44,7 +43,6 @@ import jakarta.xml.bind.Unmarshaller;
  */
 public class JaxbLinkTest {
 
-    @Ignore("JAXB implementation does not yet support jakarta.* namespace")
     @Test
     public void testSerializationOfJaxbLink() throws Exception {
         JAXBContext jaxbContext = JAXBContext.newInstance(Link.JaxbLink.class);


### PR DESCRIPTION
This pull request contains the following changes:

* Update all Jakarta dependencies to their latest versions
* Migration of `javax.ejb` imports to `jakarta.ejb`
* Migration of `javax.annotation` imports and other references to `jakarta.annotation`
* Removed `@Ignore` from `JaxbLinkTest` (see #846)
* Fixed JAX-RS package names in `overview.html`

**As these are no API changes, this is a fast-track review period of just one day as per our committer rules.**