### PR TITLE
Update EFSL for Specifications and Javadoc

### DIFF
--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -297,11 +297,9 @@
                         <configuration combine.self="override">
                             <doctitle>${apidocs.title}</doctitle>
                             <bottom>
-                                <![CDATA[Copyright &#169; 1996-2017,
-                                <a href="http://www.oracle.com">Oracle</a>
-                                and/or its affiliates. All Rights Reserved.
-                                ]]>
+                                <![CDATA[<p align="left">Copyright &#169; 2018, 2020 Eclipse Foundation.<br>Use is subject to <a href="{@docRoot}/resources/EFSL.html" target="_top">license terms</a>.]]>
                             </bottom>
+                            <docfilessubdirs>true</docfilessubdirs>
                             <!--javaApiLinks>
                                 <property>
                                     <name>api_1.3</name>
@@ -422,10 +420,9 @@
                         <doctitle>${apidocs.title}</doctitle>
                         <docfilessubdirs>true</docfilessubdirs>
                         <bottom>
-                            <![CDATA[Copyright (c) 2019 Eclipse Foundation.
-                            Licensed under <a href="resources/EFSL.html">Eclipse Foundation
-                            Specification License</a>.]]>
+                            <![CDATA[<p align="left">Copyright &#169; 2018, 2020 Eclipse Foundation.<br>Use is subject to <a href="{@docRoot}/resources/EFSL.html" target="_top">license terms</a>.]]>
                         </bottom>
+                        <docfilessubdirs>true</docfilessubdirs>
                         <!--javaApiLinks>
                             <property>
                                 <name>api_1.3</name>

--- a/jaxrs-api/src/main/javadoc/resources/EFSL.html
+++ b/jaxrs-api/src/main/javadoc/resources/EFSL.html
@@ -20,8 +20,9 @@
     <li>All existing copyright notices, or if one does not exist, a notice
         (hypertext is preferred, but a textual representation is permitted)
         of the form: &quot;Copyright &copy; [$date-of-document]
-        &ldquo;Eclipse Foundation, Inc. &lt;&lt;url to this license&gt;&gt;
-        &quot;
+        Eclipse Foundation, Inc.
+        <a href="https://www.eclipse.org/legal/efsl.php">
+            https://www.eclipse.org/legal/efsl.php</a>&quot;
     </li>
 </ul>
 
@@ -42,9 +43,10 @@
 
 <p>The notice is:</p>
 
-<p>&quot;Copyright &copy; 2018 Eclipse Foundation. This software or
-    document includes material copied from or derived from [title and URI
-    of the Eclipse Foundation specification document].&quot;</p>
+<p>&quot;Copyright &copy; 2018, 2020 Eclipse Foundation. This software or
+    document includes material copied from or derived from
+    Jakarta RESTful Web Services <a href="https://jakarta.ee/specifications/restful-ws/3.0/">
+    https://jakarta.ee/specifications/restful-ws/3.0/</a>.&quot;</p>
 
 <h2>Disclaimers</h2>
 

--- a/jaxrs-spec/src/main/asciidoc/chapters/license/_license-efsl.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/license/_license-efsl.adoc
@@ -23,9 +23,10 @@ endif::[]
 
 Release: {revdate}
 ....
-=== Copyright
+== Copyright
 
-Copyright (c) 2019 Eclipse Foundation.
+Copyright (c) 2018, 2020 Eclipse Foundation.
+https://www.eclipse.org/legal/efsl.php[]
 
 === Eclipse Foundation Specification License
 
@@ -44,7 +45,7 @@ document, or portions thereof, that you use:
 * All existing copyright notices, or if one does not exist, a notice
   (hypertext is preferred, but a textual representation is permitted)
   of the form: "Copyright (c) [$date-of-document]
-  Eclipse Foundation, Inc. \<<url to this license>>"
+  Eclipse Foundation, Inc. https://www.eclipse.org/legal/efsl.php[]"
 
 Inclusion of the full text of this NOTICE must be provided. We
 request that authorship attribution be provided in any software,
@@ -63,9 +64,9 @@ specification is expressly prohibited.
 
 The notice is:
 
-"Copyright (c) 2018 Eclipse Foundation. This software or
-document includes material copied from or derived from [title and URI
-of the Eclipse Foundation specification document]."
+"Copyright (c) 2018, 2020 Eclipse Foundation. This software or
+document includes material copied from or derived from Jakarta(R) RESTful
+Web Services https://jakarta.ee/specifications/restful-ws/3.0/[]."
 
 ==== Disclaimers
 


### PR DESCRIPTION
This pull request applies the changes requested in #871.

Please note that the configuration of the javadocs plugin was broken, as it didn't include the `EFSL.html `. This has been fixed as part of the PR.

Please review the changes carefully. I'm not 100% sure if everything is fine this way, but the changes are essentially the same as for the EJB spec.

**As these are no API changes, this is a fast-track review period of just one day as per our committer rules.**