### PR TITLE
Disable PDF version of the spec document

### DIFF
--- a/jaxrs-spec/pom.xml
+++ b/jaxrs-spec/pom.xml
@@ -106,6 +106,8 @@
                             </attributes>
                         </configuration>
                     </execution>
+                    <!-- Currently broken, because asciidoctorj-pdf doesn't support the 'stem' attribute for rendering math expressions -->
+                    <!--
                     <execution>
                         <id>asciidoc-to-pdf</id>
                         <phase>generate-resources</phase>
@@ -135,6 +137,7 @@
                             </attributes>
                         </configuration>
                     </execution>
+                    -->
                 </executions>
             </plugin>
         </plugins>


### PR DESCRIPTION
Unfortunately the PDF version of the spec is currently broken, because `asciidoctorj-pdf` doesn't render math expressions correctly. See for example:

![pdf](https://user-images.githubusercontent.com/159245/83962828-11cbee80-a8a1-11ea-9f0d-4d8a9fb14ba0.png)

In #865 we fixed the HTML version, so the HTML output looks fine:

![html](https://user-images.githubusercontent.com/159245/83962843-358f3480-a8a1-11ea-8fb5-4fdcf362cb49.png)

According to my research, this issue cannot be solved easily. Therefore, I think we should disable the PDF output for now. IMO it would be fine to just release the HTML version. Maybe we can fix this issue later on, but for the moment disabling the PDF seems to be the best option.

**As these are no API changes, this is a fast-track review period of just one day as per our committer rules.**