### PR TITLE
Add list of current committers to the spec document

### DIFF
--- a/jaxrs-spec/src/main/asciidoc/chapters/introduction/_project_team.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/introduction/_project_team.adoc
@@ -15,6 +15,18 @@ This specification is being developed as part of Jakarta RESTful Web Services pr
 Jakarta EE Specification Process. It is the result of the collaborative work
 of the project team and various contributors.
 
+The following are the current committers of the Jakarta RESTful Web Services specification project:
+
+-- Sebastian Daschner (IBM)
+
+-- Christian Kaltepoth (individual)
+
+-- Markus Karg (individual)
+
+-- Andy McCright (IBM)
+
+-- Santiago Pericas-Geertsen (Oracle)
+
 JAX-RS 2.1 has been developed as part of JSR 370 under the Java Community
 Process. The following are former group members of the JSR 370 Expert Group:
 


### PR DESCRIPTION
Previous versions of the spec contained a list of all expert group members in the introduction chapter. I guess it makes sense to continue with this. Therefore, I added this list to the document.

Three weeks ago [I asked the committers on the mailing list](https://www.eclipse.org/lists/jaxrs-dev/msg00829.html) how they want to be listed, but this request was ignored by 90% of the committers. Only 2(!) of 20 committers responded to my mail. However, I added a few more committers for which I know the company they represent. All other committers can add themselves in a subsequent pull request if they want to be listed.

**As these are no API changes, this is a fast-track review period of just one day as per our committer rules.**