### PR TITLE
[#890] All array types to be used as parameters

### DIFF
--- a/jaxrs-api/src/main/java/jakarta/ws/rs/CookieParam.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/CookieParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -35,8 +35,8 @@ import java.lang.annotation.Target;
  * example, {@link Integer#valueOf(String)})</li>
  * <li>Have a registered implementation of {@link jakarta.ws.rs.ext.ParamConverterProvider} JAX-RS extension SPI that
  * returns a {@link jakarta.ws.rs.ext.ParamConverter} instance capable of a "from string" conversion for the type.</li>
- * <li>Be {@code List<T>}, {@code Set<T>} or {@code SortedSet<T>}, where {@code T} satisfies 2, 3, 4 or 5 above. The
- * resulting collection is read-only.</li>
+ * <li>Be {@code List<T>}, {@code Set<T>}, {@code SortedSet<T>} or {@code T[]} array, where {@code T} satisfies 2, 3, 4
+ * or 5 above. The resulting collection is read-only.</li>
  * </ol>
  *
  * <p>

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/FormParam.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/FormParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -36,8 +36,8 @@ import java.lang.annotation.Target;
  * (see, for example, {@link Integer#valueOf(String)})</li>
  * <li>Have a registered implementation of {@link jakarta.ws.rs.ext.ParamConverterProvider} JAX-RS extension SPI that
  * returns a {@link jakarta.ws.rs.ext.ParamConverter} instance capable of a "from string" conversion for the type.</li>
- * <li>Be {@code List<T>}, {@code Set<T>} or {@code SortedSet<T>}, where {@code T} satisfies 2, 3 or 4 above. The
- * resulting collection is read-only.</li>
+ * <li>Be {@code List<T>}, {@code Set<T>}, {@code SortedSet<T>} or {@code T[]} array, where {@code T} satisfies 2, 3 or
+ * 4 above. The resulting collection is read-only.</li>
  * </ol>
  *
  * <p>

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/HeaderParam.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/HeaderParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -34,8 +34,8 @@ import java.lang.annotation.Target;
  * (see, for example, {@link Integer#valueOf(String)})</li>
  * <li>Have a registered implementation of {@link jakarta.ws.rs.ext.ParamConverterProvider} JAX-RS extension SPI that
  * returns a {@link jakarta.ws.rs.ext.ParamConverter} instance capable of a "from string" conversion for the type.</li>
- * <li>Be {@code List<T>}, {@code Set<T>} or {@code SortedSet<T>}, where {@code T} satisfies 2, 3 or 4 above. The
- * resulting collection is read-only.</li>
+ * <li>Be {@code List<T>}, {@code Set<T>}, {@code SortedSet<T>} or {@code T[]} array, where {@code T} satisfies 2, 3 or
+ * 4 above. The resulting collection is read-only.</li>
  * </ol>
  *
  * <p>

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/MatrixParam.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/MatrixParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -41,8 +41,8 @@ import java.lang.annotation.Target;
  * (see, for example, {@link Integer#valueOf(String)})</li>
  * <li>Have a registered implementation of {@link jakarta.ws.rs.ext.ParamConverterProvider} JAX-RS extension SPI that
  * returns a {@link jakarta.ws.rs.ext.ParamConverter} instance capable of a "from string" conversion for the type.</li>
- * <li>Be {@code List<T>}, {@code Set<T>} or {@code SortedSet<T>}, where {@code T} satisfies 2, 3 or 4 above. The
- * resulting collection is read-only.</li>
+ * <li>Be {@code List<T>}, {@code Set<T>}, {@code SortedSet<T>} or {@code T[]} array, where {@code T} satisfies 2, 3 or
+ * 4 above. The resulting collection is read-only.</li>
  * </ol>
  *
  * <p>

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/QueryParam.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/QueryParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -35,8 +35,8 @@ import java.lang.annotation.Target;
  * (see, for example, {@link Integer#valueOf(String)})</li>
  * <li>Have a registered implementation of {@link jakarta.ws.rs.ext.ParamConverterProvider} JAX-RS extension SPI that
  * returns a {@link jakarta.ws.rs.ext.ParamConverter} instance capable of a "from string" conversion for the type.</li>
- * <li>Be {@code List<T>}, {@code Set<T>} or {@code SortedSet<T>}, where {@code T} satisfies 2, 3 or 4 above. The
- * resulting collection is read-only.</li>
+ * <li>Be {@code List<T>}, {@code Set<T>}, {@code SortedSet<T>} or {@code T[]} array, where {@code T} satisfies 2, 3 or
+ * 4 above. The resulting collection is read-only.</li>
  * </ol>
  *
  * <p>

--- a/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-3.0-release.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-3.0-release.adoc
@@ -1,0 +1,16 @@
+////
+*******************************************************************
+* Copyright (c) 2020 Eclipse Foundation
+*
+* This specification document is made available under the terms
+* of the Eclipse Foundation Specification License v1.0, which is
+* available at https://www.eclipse.org/legal/efsl.php.
+*******************************************************************
+////
+
+[[changes-since-3.0-release]]
+=== Changes Since 3.0 Release
+
+* <<exceptionmapper>>: Added requirement that JAX-RS implementations have 
+default exception mappers.
+

--- a/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-3.0-release.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-3.0-release.adoc
@@ -13,4 +13,5 @@
 
 * <<exceptionmapper>>: Added requirement that JAX-RS implementations have 
 default exception mappers.
-
+* <<resource_field>>: Array types may be specified for `@CookieParam`,
+`@FormParam`, `@HeaderParam`, `@MatrixParam` and `@QueryParam` parameters.

--- a/jaxrs-spec/src/main/asciidoc/chapters/resources/_resource_field.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/resources/_resource_field.adoc
@@ -59,8 +59,8 @@ to limitations of the built-in `valueOf` method that is part of all Java
 enumerations, a `fromString` method is often defined by the enum
 writers. Consequently, the `fromString` method is preferred when
 available.].
-5.  `List<T>`, `Set<T>`, or `SortedSet<T>`, where `T` satisfies
-1,3 or 4 above.
+5.  `List<T>`, `Set<T>`, `SortedSet<T>` or an array `T[]`, where
+`T` satisfies 1, 3 or 4 above.
 
 The `DefaultValue` annotation may be used to supply a default value for
 some of the above, see the Javadoc for `DefaultValue` for usage details


### PR DESCRIPTION
Fixes #890 - updates to spec and javadoc enabling users to specify array types as parameters.

The javadoc contained this text: "The resulting collection is read-only."  I left it alone, but I'm not sure that I like it... We could remove that text or re-word it to something like "If it is a `List`, `Set` or `SortedSet` it will be read-only" to avoid any confusion about "read-only arrays". 
Also, I think "read-only" is not the right word here - it should probably be "immutable" or "unmodifiable". "Read-only" implies (to me) that the objects in the collection cannot be modified, but we cannot really guarantee that.  IIUC, the intent is to tell the user that they can't change things like the order of the collection - or the number of entries, etc. By Java Collections terminology, that would be "unmodifiable".  But even that restriction doesn't seem to make a lot of sense to me. If we lifted that restriction, users could remove query param objects from the collection and pass the modified collection to other methods (like listeners) that would then have fewer entries to filter through.  That would be an argument for just removing the sentence outright.  What do you all think?

Lastly, while updating the release notes page, I noticed that we still have a "since 2.2" release note page.  I'll plan to remove that (from master and 3.1-SNAPSHOT) in a future PR.