### PR TITLE
Update release notes

### DIFF
--- a/jaxrs-spec/src/main/asciidoc/chapters/appendix/_change-log.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/appendix/_change-log.adoc
@@ -12,7 +12,7 @@
 [[change-log]]
 == Change Log
 
-include::_changes-since-2.2-snapshot.adoc[]
+include::_changes-since-2.1-release.adoc[]
 
 include::_changes-since-2.1-public-review.adoc[]
 

--- a/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-2.1-release.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-2.1-release.adoc
@@ -8,8 +8,10 @@
 *******************************************************************
 ////
 
-[[changes-since-2.2-snapshot]]
-=== Changes Since 2.2-SNAPSHOT
+[[changes-since-2.1-release]]
+=== Changes Since 2.1 Release
 
 * Referencing Jakarta EE instead of Java EE
-* JAXB API is now optional
+* Package changes from `javax.ws.rs.*` to `jakarta.ws.rs.*`
+* <<jaxb>>: JAXB API is now optional
+* <<additional_reqs>>: Clarified injection with regard to `getSingletons()` method


### PR DESCRIPTION
- Changes 2.2-SNAPSHOT to 2.1 Release
- Adds the  package changes and getSingletons updates to the "since 2.1 release" release notes.

This change should go into master (3.0) and 3.1-SNAPSHOT.

Once approved, I will plan to manually merge into the 3.1-SNAPSHOT stream.