### PR TITLE
Updating dependencies to use final version of JAXB and Activation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ cache:
 
 install:
   - cd $TRAVIS_BUILD_DIR/jaxrs-api
-  - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+  - mvn install -Pstaging -DskipTests=true -Dmaven.javadoc.skip=true -B -V
   - cd $TRAVIS_BUILD_DIR/examples
   - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
   - cd $TRAVIS_BUILD_DIR/jaxrs-spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
 
 script:
   - cd $TRAVIS_BUILD_DIR/jaxrs-api
-  - mvn verify -B
+  - mvn verify -Pstaging -B
   - cd $TRAVIS_BUILD_DIR/examples
   - mvn verify -B
   - cd $TRAVIS_BUILD_DIR/jaxrs-spec

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -182,6 +182,7 @@
                         </plugin>
                         <plugin>
                             <artifactId>maven-surefire-plugin</artifactId>
+                            <version>2.21.0</version>
                             <configuration>
                                 <argLine>--add-modules java.xml.bind --add-opens jakarta.ws.rs/jakarta.ws.rs.core=java.xml.bind</argLine>
                             </configuration>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -538,9 +538,9 @@
         <spec.version>2.2</spec.version>
         <spec.version.revision /> <!-- e.g. (Rev a) -->
 
-        <jaxb.api.version>3.0.0-RC3</jaxb.api.version>
+        <jaxb.api.version>3.0.0</jaxb.api.version>
         <jaxb.impl.version>3.0.0-M4</jaxb.impl.version>
-        <activation.api.version>2.0.0-RC3</activation.api.version>
+        <activation.api.version>2.0.0</activation.api.version>
         <legal.doc.folder>${project.basedir}/..</legal.doc.folder>
     </properties>
 


### PR DESCRIPTION
Updating dependencies to use final version of JAXB and Activation from staging. We need -Pstaging. Will fast track.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>