### PR TITLE
Remove compiler warnings a sysouts in unit tests

### DIFF
--- a/jaxrs-api/src/test/java/jakarta/ws/rs/core/AbstractMultivaluedMapTest.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/core/AbstractMultivaluedMapTest.java
@@ -16,11 +16,10 @@
 
 package jakarta.ws.rs.core;
 
-import static junit.framework.Assert.fail;
+import static org.junit.Assert.fail;
 
 import org.junit.Test;
 
-import jakarta.ws.rs.core.AbstractMultivaluedMap;
 
 /**
  * AbstractMultivaluedMap unit tests.
@@ -36,6 +35,7 @@ public class AbstractMultivaluedMapTest {
     public void testNpeThrownFromMap() {
         try {
             new AbstractMultivaluedMap<String, Object>(null) {
+                private static final long serialVersionUID = -1290572505924705859L;
             };
             fail("NullPointerException expected.");
         } catch (NullPointerException npe) {

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/core/CacheControlTest.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/core/CacheControlTest.java
@@ -23,7 +23,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import jakarta.ws.rs.core.CacheControl;
 import jakarta.ws.rs.ext.RuntimeDelegate;
 
 /**

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/core/CookieTest.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/core/CookieTest.java
@@ -23,8 +23,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import jakarta.ws.rs.core.Cookie;
-import jakarta.ws.rs.core.NewCookie;
 import jakarta.ws.rs.ext.RuntimeDelegate;
 
 public class CookieTest {
@@ -44,7 +42,6 @@ public class CookieTest {
      */
     @Test
     public void testEquals() {
-        System.out.println("equals");
         Object nullObj = null;
         Cookie cookie = new Cookie("name", "value");
         Cookie cookie1 = new Cookie("name", "value");

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/core/EntityTagTest.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/core/EntityTagTest.java
@@ -23,7 +23,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import jakarta.ws.rs.core.EntityTag;
 import jakarta.ws.rs.ext.RuntimeDelegate;
 
 import static org.mockito.Mockito.*;

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/core/GenericEntityTest.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/core/GenericEntityTest.java
@@ -33,13 +33,10 @@ import java.util.Set;
 
 import org.junit.Test;
 
-import jakarta.ws.rs.core.GenericEntity;
-
 public class GenericEntityTest {
 
     @Test
     public void testListOfString() {
-        System.out.println("testListOfString");
         List<String> list = new ArrayList<String>();
         GenericEntity<List<String>> listOfString = new GenericEntity<List<String>>(list) {
         };
@@ -57,7 +54,6 @@ public class GenericEntityTest {
 
     @Test
     public void testMapOfStringInteger() {
-        System.out.println("testMapOfStringInteger");
         Map<String, Integer> map = new HashMap<String, Integer>();
         GenericEntity<Map<String, Integer>> mapOfString = new GenericEntity<Map<String, Integer>>(map) {
         };
@@ -79,7 +75,6 @@ public class GenericEntityTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testArrayOfListOfString() {
-        System.out.println("testArrayOfListOfString");
         List<String> array[] = new List[1];
         GenericEntity<List<String>[]> arrayOfListOfString = new GenericEntity<List<String>[]>(array) {
         };
@@ -99,8 +94,7 @@ public class GenericEntityTest {
 
     @Test
     public void testNumber() {
-        System.out.println("testNumber");
-        Number n = new Integer(0);
+        Number n = Integer.valueOf(0);
         GenericEntity<Number> number = new GenericEntity<Number>(n) {
         };
         Class<?> rawType = number.getRawType();
@@ -114,15 +108,14 @@ public class GenericEntityTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testCtor() {
-        System.out.println("testCtor");
         try {
             // check GenericEntity(Integer, Number) works
             Method getNumber = this.getClass().getDeclaredMethod("getNumber");
             Type rt = getNumber.getGenericReturnType();
-            GenericEntity ge = new GenericEntity(1, rt);
+            new GenericEntity<>(1, rt);
             // check GenericEntity(String, Number) fails
             try {
-                ge = new GenericEntity("foo", rt);
+                new GenericEntity<>("foo", rt);
                 fail("Expected IllegalArgumentException");
             } catch (IllegalArgumentException e) {
             }
@@ -130,11 +123,11 @@ public class GenericEntityTest {
             Method getNumbers = this.getClass().getDeclaredMethod("getNumbers");
             rt = getNumbers.getGenericReturnType();
             Integer ints[] = { 1, 2 };
-            ge = new GenericEntity(ints, rt);
+            new GenericEntity<>(ints, rt);
             // check GenericEntity(String[], Number[]) fails
             try {
                 String strings[] = { "foo", "bar" };
-                ge = new GenericEntity(strings, rt);
+                new GenericEntity<>(strings, rt);
                 fail("Expected IllegalArgumentException");
             } catch (IllegalArgumentException e) {
             }
@@ -142,15 +135,15 @@ public class GenericEntityTest {
             Method getList = this.getClass().getDeclaredMethod("getList");
             rt = getList.getGenericReturnType();
             ArrayList<String> als = new ArrayList<String>();
-            ge = new GenericEntity(als, rt);
+            new GenericEntity<>(als, rt);
             // check GenericEntity(ArrayList<Integer>, List<String>) works
             // note that erasure loses the generic type of the ArrayList
             ArrayList<Integer> ali = new ArrayList<Integer>();
-            ge = new GenericEntity(ali, rt);
+            new GenericEntity<>(ali, rt);
             // check GenericEntity(Set<String>, List<String>) fails
             try {
                 Set<String> ss = new HashSet<String>();
-                ge = new GenericEntity(ss, rt);
+                new GenericEntity<>(ss, rt);
                 fail("Expected IllegalArgumentException");
             } catch (IllegalArgumentException e) {
             }
@@ -158,36 +151,40 @@ public class GenericEntityTest {
             Method getLists = this.getClass().getDeclaredMethod("getLists");
             rt = getLists.getGenericReturnType();
             ArrayList<String>[] lists = new ArrayList[1];
-            ge = new GenericEntity(lists, rt);
+            new GenericEntity<>(lists, rt);
             // check GenericEntity(ArrayList<Integer>[], List<String>[]) works
             // note that erasure loses the generic type of the ArrayList
             ArrayList<Integer>[] ilists = new ArrayList[1];
-            ge = new GenericEntity(ilists, rt);
+            new GenericEntity<>(ilists, rt);
             // check GenericEntity(Set<String>[], List<String>[]) fails
             try {
                 Set<String>[] ss = new Set[1];
-                ge = new GenericEntity(ss, rt);
+                new GenericEntity<>(ss, rt);
                 fail("Expected IllegalArgumentException");
             } catch (IllegalArgumentException e) {
             }
         } catch (Exception e) {
             e.printStackTrace();
-            fail("Unhandled Exception");
+            fail("Unhandled Exception: " + e);
         }
     }
 
+    @SuppressWarnings("unused")
     private Number getNumber() {
         return null;
     }
 
+    @SuppressWarnings("unused")
     private Number[] getNumbers() {
         return null;
     }
 
+    @SuppressWarnings("unused")
     private List<String> getList() {
         return null;
     }
 
+    @SuppressWarnings("unused")
     private List<String>[] getLists() {
         return null;
     }

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/core/GenericTypeTest.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/core/GenericTypeTest.java
@@ -26,8 +26,6 @@ import java.util.List;
 
 import org.junit.Test;
 
-import jakarta.ws.rs.core.GenericType;
-
 /**
  * Type literal construction unit tests.
  *
@@ -71,7 +69,7 @@ public class GenericTypeTest {
     @Test
     public void testConstructor() {
 
-        GenericType type = new GenericType(new ParameterizedType() {
+        GenericType<?> type = new GenericType<>(new ParameterizedType() {
             @Override
             public Type[] getActualTypeArguments() {
                 return new Type[] { String.class };
@@ -97,12 +95,12 @@ public class GenericTypeTest {
         ArrayList<String> al = new ArrayList<String>();
         Method addMethod = al.getClass().getMethod("add", Object.class);
         final Type type = addMethod.getGenericParameterTypes()[0];
-        new GenericType(type);
+        new GenericType<>(type);
     }
 
     @Test
     public void testConstructor2() {
-        GenericType gt = new GenericType(arrayListOfStringsType);
+        GenericType<?> gt = new GenericType<>(arrayListOfStringsType);
         assertEquals(ArrayList.class, gt.getRawType());
         assertEquals(arrayListOfStringsType, gt.getType());
     }
@@ -123,7 +121,7 @@ public class GenericTypeTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testNullGenericType() {
-        new GenericType(null);
+        new GenericType<>(null);
     }
 
     // Regression test for JAX_RS_SPEC-274

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/core/MediaTypeTest.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/core/MediaTypeTest.java
@@ -25,8 +25,6 @@ import org.hamcrest.DiagnosingMatcher;
 import org.hamcrest.Matcher;
 import org.junit.Test;
 
-import jakarta.ws.rs.core.MediaType;
-
 import java.util.Map;
 
 /**

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/core/MultivaluedHashMapTest.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/core/MultivaluedHashMapTest.java
@@ -30,7 +30,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.ext.RuntimeDelegate;
 
 public class MultivaluedHashMapTest {

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/core/NewCookieTest.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/core/NewCookieTest.java
@@ -23,8 +23,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import jakarta.ws.rs.core.Cookie;
-import jakarta.ws.rs.core.NewCookie;
 import jakarta.ws.rs.ext.RuntimeDelegate;
 
 public class NewCookieTest {
@@ -44,7 +42,6 @@ public class NewCookieTest {
      */
     @Test
     public void testCtor() {
-        System.out.println("ctor");
         Cookie c = new Cookie("name", "value");
         NewCookie nc = new NewCookie(c);
         assertEquals(nc.getName(), c.getName());

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/core/RxClientTest.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/core/RxClientTest.java
@@ -27,7 +27,6 @@ import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.CompletionStageRxInvoker;
 import jakarta.ws.rs.client.RxInvokerProvider;
 import jakarta.ws.rs.client.SyncInvoker;
-import jakarta.ws.rs.core.GenericType;
 
 /**
  * Class RxClientTest.
@@ -53,6 +52,7 @@ public class RxClientTest {
                 .get(new GenericType<List<String>>() {
                 });
 
+        // TODO: replace system out with in-memory stream and verify expected results
         cs.thenAccept(System.out::println);
     }
 
@@ -73,6 +73,7 @@ public class RxClientTest {
                 .get(new GenericType<List<String>>() {
                 });
 
+        // TODO: replace system out with in-memory stream and verify expected results
         cs.thenAccept(System.out::println);
     }
 
@@ -92,6 +93,7 @@ public class RxClientTest {
                 .rx(CompletionStageRxInvoker.class)
                 .get(String.class);
 
+        // TODO: replace system out with in-memory stream and verify expected results
         cs.thenAccept(System.out::println);
     }
 

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/core/VariantTest.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/core/VariantTest.java
@@ -20,9 +20,6 @@ import static org.junit.Assert.assertNull;
 
 import org.junit.Test;
 
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Variant;
-
 /**
  * Variant regression unit tests.
  *

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/ext/RuntimeDelegateTest.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/ext/RuntimeDelegateTest.java
@@ -5,8 +5,6 @@ import static org.junit.Assert.fail;
 
 import org.junit.Test;
 
-import jakarta.ws.rs.ext.RuntimeDelegate;
-
 /**
  * {@link jakarta.ws.rs.ext.RuntimeDelegate} unit tests.
  *


### PR DESCRIPTION
This PR simply removes compiler warnings and `System.out.println` statements from the unit tests.

There are some ignored tests that if the `@Ignore` annotation is removed would still write to System.out, so I added "TODO" comments to change those at that point - I'm not sure, but I think the intent of those tests was to write to STDOUT and then read the output for test verification.  If so, then an in-memory stream might be preferable.

Since this only affects unit tests (not spec or API), I would like to request fast-track approval for this PR. 