### PR TITLE
[#907] Make XML Bind pkgs optional for JPMS/OSGi

### DIFF
--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -134,7 +134,7 @@
                         <plugin>
                             <artifactId>maven-surefire-plugin</artifactId>
                             <configuration>
-                                <argLine>--add-opens jakarta.ws.rs/jakarta.ws.rs.core=java.xml.bind</argLine>
+                                <argLine>--add-modules jakarta.xml.bind</argLine>
                             </configuration>
                         </plugin>
                     </plugins>
@@ -497,6 +497,7 @@
             <artifactId>jakarta.xml.bind-api</artifactId>
             <version>${jaxb.api.version}</version>
             <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>jakarta.activation</groupId>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -183,7 +183,7 @@
                         <plugin>
                             <artifactId>maven-surefire-plugin</artifactId>
                             <configuration>
-                                <argLine>--add-opens jakarta.ws.rs/jakarta.ws.rs.core=java.xml.bind</argLine>
+                                <argLine>--add-modules jakarta.xml.bind</argLine>
                             </configuration>
                         </plugin>
                     </plugins>

--- a/jaxrs-api/src/main/java/module-info.java
+++ b/jaxrs-api/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,7 +16,7 @@
 
 module jakarta.ws.rs {
 
-    requires transitive jakarta.xml.bind;
+    requires static jakarta.xml.bind;
 
     requires java.logging;
 


### PR DESCRIPTION
Fixes #907.  The change to the surefire line is to ensure that Jakarta XML Binding APIs are present for unit testing. This will make the depending on XML Binding optional in both JPMS and OSGi environments.

I'd like to ask for fast-track approval on this, but I'm not sure if it qualifies or not.  The pom.xml change should qualify, but possibly the module-info.java file is considered part of the API?  I think we'll need this change in before we can release 3.0, so the sooner it gets in the better, but I don't want to thwart our process.