### PR TITLE
[#909] Rename Java SE XML transform class in spec

### DIFF
--- a/jaxrs-spec/src/main/asciidoc/chapters/providers/_entity_providers.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/providers/_entity_providers.adoc
@@ -140,7 +140,7 @@ type combinations:
   All media types (`\*/*`).
 `jakarta.activation.DataSource`::
   All media types (`\*/*`).
-`jakarta.xml.transform.Source`::
+`javax.xml.transform.Source`::
   XML types (`text/xml`, `application/xml` and media types of the form
   `application/*+xml`).
 `MultivaluedMap<String,String>`::


### PR DESCRIPTION
Fixes #909. Confirmed that this is a Java SE class: https://docs.oracle.com/en/java/javase/11/docs/api/java.xml/javax/xml/transform/Source.html

This too, really ought to be fast-tracked, but it is a spec change... I think we ought to add a clause for fast-tracking trivial bug fixes to avoid waiting two weeks for obvious fixes (i.e. fixing typos, etc.), but for now, I can wait.  :) 