### PR TITLE
Additionally building on JDK 16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ jdk:
   - openjdk13
   - openjdk14
   - openjdk15
+  - openjdk16
 
 cache:
   directories:


### PR DESCRIPTION
This PR provides all needed changes to also build on JDK 16:

- Travis CI uses Open JDK 16

**As these are no API changes, this is a fast-track review period of just one day as per our [committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**