### PR TITLE
[853] Deprecate Link JAXB inner classes

### DIFF
--- a/examples/src/main/java/jaxrs/examples/link/ResourceExample.java
+++ b/examples/src/main/java/jaxrs/examples/link/ResourceExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -15,12 +15,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Link;
-import jakarta.ws.rs.core.Link.JaxbAdapter;
 import jakarta.ws.rs.core.UriInfo;
-
-import jakarta.xml.bind.annotation.XmlElement;
-import jakarta.xml.bind.annotation.XmlRootElement;
-import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 /**
  * ResourceExample class.
@@ -34,7 +29,7 @@ public class ResourceExample {
     private UriInfo uriInfo;
 
     @GET
-    @Produces({ "application/xml", "application/json" })
+    @Produces({ "application/json" })
     public MyModel getIt() {
         Link self = Link.fromMethod(getClass(), "getIt").baseUri(uriInfo.getBaseUri())
                 .rel("self").buildRelativized(uriInfo.getRequestUri());
@@ -44,7 +39,6 @@ public class ResourceExample {
         return m;
     }
 
-    @XmlRootElement
     public static class MyModel {
 
         private Link link;
@@ -53,8 +47,6 @@ public class ResourceExample {
         public MyModel() {
         }
 
-        @XmlElement(name = "link")
-        @XmlJavaTypeAdapter(JaxbAdapter.class)
         public Link getLink() {
             return link;
         }
@@ -63,8 +55,6 @@ public class ResourceExample {
             this.link = link;
         }
 
-        @XmlElement(namespace = "http://www.w3.org/2005/Atom", name = "link")
-        @XmlJavaTypeAdapter(JaxbAdapter.class)
         public Link getAtomLink() {
             return atomLink;
         }

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/Link.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/Link.java
@@ -412,7 +412,9 @@ public abstract class Link {
      * 
      * @see jakarta.ws.rs.core.Link.JaxbAdapter
      * @since 2.0
+     * @deprecated
      */
+    @Deprecated
     public static class JaxbLink {
 
         private URI uri;
@@ -547,7 +549,9 @@ public abstract class Link {
      * 
      * @see jakarta.ws.rs.core.Link.JaxbLink
      * @since 2.0
+     * @deprecated
      */
+    @Deprecated
     public static class JaxbAdapter extends XmlAdapter<JaxbLink, Link> {
 
         /**

--- a/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-3.0-release.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-3.0-release.adoc
@@ -15,3 +15,4 @@
 default exception mappers.
 * <<resource_field>>: Array types may be specified for `@CookieParam`,
 `@FormParam`, `@HeaderParam`, `@MatrixParam` and `@QueryParam` parameters.
+* Deprecated Link.JaxbLink and Link.JaxbAdapter inner classes.


### PR DESCRIPTION
Deprecates the JAXB inner classes in the Link class, and modifies the example code use JSON instead of XML so as to avoid any dependencies on JAXB / Jakarta XML Binding. 

This closes #853.