### PR TITLE
Adding 3.1-SNAPSHOT ontop of master

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -261,7 +261,7 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>3.1-SNAPSHOT</version>
+            <version>3.1.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>
@@ -299,6 +299,7 @@
             <artifactId>microprofile-config-api</artifactId>
             <version>${microprofile.config.version}</version>
         </dependency>
+
     </dependencies>
 
     <distributionManagement>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -31,6 +31,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <microprofile.config.version>1.3</microprofile.config.version>
     </properties>
 
     <organization>
@@ -291,6 +292,12 @@
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
             <version>3.0.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+            <version>${microprofile.config.version}</version>
         </dependency>
     </dependencies>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -261,7 +261,7 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>3.1.0-SNAPSHOT</version>
+            <version>3.1-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>jakarta.ws.rs</groupId>
     <artifactId>jakarta.ws.rs-examples</artifactId>
-    <version>3.0.0</version>
+    <version>3.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>jakarta.ws.rs-examples</name>
 
@@ -260,7 +260,7 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>3.0.0</version>
+            <version>3.1-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/examples/src/main/java/jaxrs/examples/bootstrap/BasicJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/BasicJavaSeBootstrapExample.java
@@ -33,7 +33,7 @@ import jakarta.ws.rs.core.UriBuilder;
  * </p>
  *
  * @author Markus KARG (markus@headcrashing.eu)
- * @since 2.2
+ * @since 3.1
  */
 public final class BasicJavaSeBootstrapExample {
 

--- a/examples/src/main/java/jaxrs/examples/bootstrap/BasicJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/BasicJavaSeBootstrapExample.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2018 Markus KARG. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jaxrs.examples.bootstrap;
+
+import java.net.URI;
+
+import jakarta.ws.rs.SeBootstrap;
+import jakarta.ws.rs.SeBootstrap.Configuration;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.UriBuilder;
+
+/**
+ * Basic Java SE bootstrap example.
+ * <p>
+ * This example demonstrates bootstrapping on Java SE platforms solely using defaults. It will effectively startup the
+ * {@link HelloWorld} application at the URL {@code http://localhost/} on an implementation-specific default IP port (e.
+ * g. 80, 8080, or something completely different). The actual configuration needs to be queried after bootstrapping,
+ * otherwise callers would be unaware of the actual chosen port.
+ * </p>
+ *
+ * @author Markus KARG (markus@headcrashing.eu)
+ * @since 2.2
+ */
+public final class BasicJavaSeBootstrapExample {
+
+    /**
+     * Runs this example.
+     *
+     * @param args unused command line arguments
+     * @throws InterruptedException when process is killed
+     */
+    public static final void main(final String[] args) throws InterruptedException {
+        final Application application = new HelloWorld();
+
+        final SeBootstrap.Configuration requestedConfiguration = SeBootstrap.Configuration.builder().build();
+
+        SeBootstrap.start(application, requestedConfiguration).thenAccept(instance -> {
+            Runtime.getRuntime()
+                    .addShutdownHook(new Thread(() -> instance.stop()
+                            .thenAccept(stopResult -> System.out.printf("Stop result: %s [Native stop result: %s].%n",
+                                    stopResult, stopResult.unwrap(Object.class)))));
+
+            final Configuration actualConfigurarion = instance.configuration();
+            final URI uri = UriBuilder.newInstance().scheme(actualConfigurarion.protocol().toLowerCase())
+                    .host(actualConfigurarion.host()).port(actualConfigurarion.port())
+                    .path(actualConfigurarion.rootPath()).build();
+            System.out.printf("Instance %s running at %s [Native handle: %s].%n", instance, uri,
+                    instance.unwrap(Object.class));
+            System.out.println("Send SIGKILL to shutdown.");
+        });
+
+        Thread.currentThread().join();
+    }
+
+}

--- a/examples/src/main/java/jaxrs/examples/bootstrap/ClientAuthenticationJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/ClientAuthenticationJavaSeBootstrapExample.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2018 Markus KARG. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jaxrs.examples.bootstrap;
+
+import java.net.URI;
+
+import jakarta.ws.rs.SeBootstrap;
+import jakarta.ws.rs.SeBootstrap.Configuration;
+import jakarta.ws.rs.SeBootstrap.Configuration.SSLClientAuthentication;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.UriBuilder;
+
+/**
+ * Java SE Bootstrap Example using TLS Client Authentication.
+ * <p>
+ * This example demonstrates bootstrapping on Java SE platforms using HTTPS with <em>bidirectional</em> TLS
+ * authentication (i. e. only <em>trustworthy</em> clients may connect). It relies mostly on defaults but explicitly
+ * sets the protocol to HTTPS and mandates TLS client certificate validation. The example will effectively startup the
+ * {@link HelloWorld} application at the URL {@code https://localhost/} on an implementation-specific default IP port
+ * (e. g. 443, 8443, or someting completely different). The actual configuration needs to be queried after
+ * bootstrapping, otherwise callers would be unaware of the actual chosen port. If the client's certificate is invalid
+ * or cannot be validated, the server will reject the connection.
+ * </p>
+ * <p>
+ * This example uses some basic <em>external</em> JSSE configuration:
+ * </p>
+ * <ul>
+ * <li>{@code javax.net.ssl.keyStore=~/.keystore} - HTTPS: Path to a keystore holding an X.509 certificate for
+ * {@code CN=localhost}</li>
+ * <li>{@code javax.net.ssl.keyStorePassword=...} - HTTPS: Password of that keystore</li>
+ * <li>Client Authentication: The default truststore ({@code $JAVA_HOME/lib/security/cacerts}) must hold the root
+ * certificate of the CA and all intermediate certificates used for signing the client's certificate.</li>
+ * </ul>
+ * </p>
+ *
+ * @author Markus KARG (markus@headcrashing.eu)
+ * @since 2.2
+ */
+public final class ClientAuthenticationJavaSeBootstrapExample {
+
+    /**
+     * Runs this example.
+     *
+     * @param args unused command line arguments
+     * @throws InterruptedException when process is killed
+     */
+    public static final void main(final String[] args) throws InterruptedException {
+        final Application application = new HelloWorld();
+
+        final SeBootstrap.Configuration requestedConfiguration = SeBootstrap.Configuration.builder().protocol("HTTPS")
+                .sslClientAuthentication(SSLClientAuthentication.MANDATORY).build();
+
+        SeBootstrap.start(application, requestedConfiguration).thenAccept(instance -> {
+            Runtime.getRuntime()
+                    .addShutdownHook(new Thread(() -> instance.stop()
+                            .thenAccept(stopResult -> System.out.printf("Stop result: %s [Native stop result: %s].%n",
+                                    stopResult, stopResult.unwrap(Object.class)))));
+
+            final Configuration actualConfigurarion = instance.configuration();
+            final URI uri = UriBuilder.newInstance().scheme(actualConfigurarion.protocol().toLowerCase())
+                    .host(actualConfigurarion.host()).port(actualConfigurarion.port())
+                    .path(actualConfigurarion.rootPath()).build();
+            System.out.printf("Instance %s running at %s [Native handle: %s].%n", instance, uri,
+                    instance.unwrap(Object.class));
+            System.out.println("Send SIGKILL to shutdown.");
+        });
+
+        Thread.currentThread().join();
+    }
+
+}

--- a/examples/src/main/java/jaxrs/examples/bootstrap/ClientAuthenticationJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/ClientAuthenticationJavaSeBootstrapExample.java
@@ -48,7 +48,7 @@ import jakarta.ws.rs.core.UriBuilder;
  * </p>
  *
  * @author Markus KARG (markus@headcrashing.eu)
- * @since 2.2
+ * @since 3.1
  */
 public final class ClientAuthenticationJavaSeBootstrapExample {
 

--- a/examples/src/main/java/jaxrs/examples/bootstrap/ExplicitJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/ExplicitJavaSeBootstrapExample.java
@@ -41,7 +41,7 @@ import jakarta.ws.rs.core.UriBuilder;
  * </ul>
  *
  * @author Markus KARG (markus@headcrashing.eu)
- * @since 2.2
+ * @since 3.1
  */
 public final class ExplicitJavaSeBootstrapExample {
 

--- a/examples/src/main/java/jaxrs/examples/bootstrap/ExplicitJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/ExplicitJavaSeBootstrapExample.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2018 Markus KARG. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jaxrs.examples.bootstrap;
+
+import java.net.URI;
+
+import jakarta.ws.rs.SeBootstrap;
+import jakarta.ws.rs.SeBootstrap.Configuration;
+import jakarta.ws.rs.SeBootstrap.Configuration.SSLClientAuthentication;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.UriBuilder;
+
+/**
+ * Java SE bootstrap example with explicit configuration.
+ * <p>
+ * This example demonstrates bootstrapping on Java SE platforms using hardly no defaults at all (besides JSSE defaults).
+ * It applies parameters passed at the command line.
+ * </p>
+ * <p>
+ * Depending of the actual parameters passed at the command line (i. e. with protocol set up {@code HTTPS}), this
+ * example might need to have additional <em>external</em> JSSE configuration:
+ * </p>
+ * <ul>
+ * <li>{@code javax.net.ssl.keyStore=~/.keystore} - HTTPS: Path to a keystore holding an X.509 certificate for
+ * {@code CN=localhost}</li>
+ * <li>{@code javax.net.ssl.keyStorePassword=...} - HTTPS: Password of that keystore</li>
+ * </ul>
+ *
+ * @author Markus KARG (markus@headcrashing.eu)
+ * @since 2.2
+ */
+public final class ExplicitJavaSeBootstrapExample {
+
+    /**
+     * Runs this example.
+     *
+     * @param args configuration to be used in exact this order: {@code PROTOCOL HOST PORT ROOT_PATH CLIENT_AUTH} where the
+     * protocol can be either {@code HTTP} or {@code HTTPS} and the client authentication is one of
+     * {@code NONE, OPTIONAL, MANDATORY}.
+     * @throws InterruptedException when process is killed
+     */
+    public static final void main(final String[] args) throws InterruptedException {
+        final Application application = new HelloWorld();
+
+        final String protocol = args[0];
+        final String host = args[1];
+        final int port = Integer.parseInt(args[2]);
+        final String rootPath = args[3];
+        final SSLClientAuthentication clientAuth = SSLClientAuthentication.valueOf(args[4]);
+
+        final SeBootstrap.Configuration requestedConfiguration = SeBootstrap.Configuration.builder().protocol(protocol).host(host)
+                .port(port).rootPath(rootPath).sslClientAuthentication(clientAuth).build();
+
+        SeBootstrap.start(application, requestedConfiguration).thenAccept(instance -> {
+            Runtime.getRuntime()
+                    .addShutdownHook(new Thread(() -> instance.stop()
+                            .thenAccept(stopResult -> System.out.printf("Stop result: %s [Native stop result: %s].%n",
+                                    stopResult, stopResult.unwrap(Object.class)))));
+
+            final Configuration actualConfigurarion = instance.configuration();
+            final URI uri = UriBuilder.newInstance().scheme(actualConfigurarion.protocol().toLowerCase())
+                    .host(actualConfigurarion.host()).port(actualConfigurarion.port())
+                    .path(actualConfigurarion.rootPath()).build();
+            System.out.printf("Instance %s running at %s [Native handle: %s].%n", instance, uri,
+                    instance.unwrap(Object.class));
+            System.out.println("Send SIGKILL to shutdown.");
+        });
+
+        Thread.currentThread().join();
+    }
+
+}

--- a/examples/src/main/java/jaxrs/examples/bootstrap/ExternalConfigJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/ExternalConfigJavaSeBootstrapExample.java
@@ -58,7 +58,7 @@ import jakarta.ws.rs.core.UriBuilder;
  * </p>
  *
  * @author Markus KARG (markus@headcrashing.eu)
- * @since 2.2
+ * @since 3.1
  */
 public final class ExternalConfigJavaSeBootstrapExample {
 

--- a/examples/src/main/java/jaxrs/examples/bootstrap/ExternalConfigJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/ExternalConfigJavaSeBootstrapExample.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2018 Markus KARG. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jaxrs.examples.bootstrap;
+
+import java.net.URI;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import jakarta.ws.rs.SeBootstrap;
+import jakarta.ws.rs.SeBootstrap.Configuration;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.UriBuilder;
+
+/**
+ * Java SE bootstrap example utilizing an external configuration system.
+ * <p>
+ * This example demonstrates bootstrapping on Java SE platforms using values retrieved from an external configuration
+ * system plus statically overriden properties. In particular, this demo first uses Eclipse Microprofile Config to let
+ * the actual implementation retrieve all properties from an external source of configuration, but then explicitly
+ * enforces HTTPS within the bootstrap code.
+ * </p>
+ * <p>
+ * To actually run this example, an implementation of Eclipse Microprofile Config has to be added to the classpath, and
+ * the configuration options to be customized have to be provided, e. g. as environment variables:
+ * </p>
+ *
+ * <pre>
+ * export jakarta.ws.rs.SeBootstrap.Port=8888;
+ * java -Djakarta.ws.rs.SeBootstrap.Host=127.0.0.1 ExternalConfigJavaSeBootstrapExample;
+ * </pre>
+ * <p>
+ * This example uses some basic <em>external</em> JSSE configuration:
+ * </p>
+ * <ul>
+ * <li>{@code javax.net.ssl.keyStore=~/.keystore} - HTTPS: Path to a keystore holding an X.509 certificate for
+ * {@code CN=localhost}</li>
+ * <li>{@code javax.net.ssl.keyStorePassword=...} - HTTPS: Password of that keystore</li>
+ * </ul>
+ * <p>
+ * Due to the <em>implicit</em> use of Microprofile Config in the implementation, this example is <em>not
+ * necessarily</em> portable: Support for external configuration is <em>not mandatory</em>. Implementations could choose
+ * to not implement it, or to support other external configuration mechanics not mentioned here.
+ * </p>
+ *
+ * @author Markus KARG (markus@headcrashing.eu)
+ * @since 2.2
+ */
+public final class ExternalConfigJavaSeBootstrapExample {
+
+    /**
+     * Runs this example.
+     *
+     * @param args unused command line arguments
+     * @throws InterruptedException when process is killed
+     */
+    public static final void main(final String[] args) throws InterruptedException {
+        final Application application = new HelloWorld();
+
+        final Config config = ConfigProvider.getConfig();
+
+        final SeBootstrap.Configuration requestedConfiguration = SeBootstrap.Configuration.builder().from(config).protocol("HTTPS")
+                .build();
+
+        SeBootstrap.start(application, requestedConfiguration).thenAccept(instance -> {
+            Runtime.getRuntime()
+                    .addShutdownHook(new Thread(() -> instance.stop()
+                            .thenAccept(stopResult -> System.out.printf("Stop result: %s [Native stop result: %s].%n",
+                                    stopResult, stopResult.unwrap(Object.class)))));
+
+            final Configuration actualConfigurarion = instance.configuration();
+            final URI uri = UriBuilder.newInstance().scheme(actualConfigurarion.protocol().toLowerCase())
+                    .host(actualConfigurarion.host()).port(actualConfigurarion.port())
+                    .path(actualConfigurarion.rootPath()).build();
+            System.out.printf("Instance %s running at %s [Native handle: %s].%n", instance, uri,
+                    instance.unwrap(Object.class));
+            System.out.println("Send SIGKILL to shutdown.");
+        });
+
+        Thread.currentThread().join();
+    }
+
+}

--- a/examples/src/main/java/jaxrs/examples/bootstrap/HelloWorld.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/HelloWorld.java
@@ -28,7 +28,7 @@ import jakarta.ws.rs.core.Application;
  * Demo application simply returning the string {@code "Hello, World!"}.
  *
  * @author Markus KARG (markus@headcrashing.eu)
- * @since 2.2
+ * @since 3.1
  */
 @ApplicationPath("helloworld")
 @Path("hello")

--- a/examples/src/main/java/jaxrs/examples/bootstrap/HelloWorld.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/HelloWorld.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2018 Markus KARG. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jaxrs.examples.bootstrap;
+
+import java.util.Collections;
+import java.util.Set;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Application;
+
+/**
+ * Demo application simply returning the string {@code "Hello, World!"}.
+ *
+ * @author Markus KARG (markus@headcrashing.eu)
+ * @since 2.2
+ */
+@ApplicationPath("helloworld")
+@Path("hello")
+public class HelloWorld extends Application {
+
+    /**
+     * Returns the sole, singleton resource.
+     */
+    @Override
+    public Set<Class<?>> getClasses() {
+        return Collections.singleton(HelloWorld.class);
+    }
+
+    /**
+     * @return {@code "Hello, World!"}
+     */
+    @GET
+    public String sayHello() {
+        return "Hello, World!";
+    }
+
+}

--- a/examples/src/main/java/jaxrs/examples/bootstrap/HttpsJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/HttpsJavaSeBootstrapExample.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2018 Markus KARG. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jaxrs.examples.bootstrap;
+
+import java.net.URI;
+
+import jakarta.ws.rs.SeBootstrap;
+import jakarta.ws.rs.SeBootstrap.Configuration;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.UriBuilder;
+
+/**
+ * Java SE bootstrap example using HTTPS.
+ * <p>
+ * This example demonstrates bootstrapping on Java SE platforms using HTTPS. It relies mostly on defaults but explicitly
+ * sets the protocol to HTTPS. The example will effectively startup the {@link HelloWorld} application at the URL
+ * {@code https://localhost/} on an implementation-specific default IP port (e. g. 443, 8443, or someting completely
+ * different). The actual configuration needs to be queried after bootstrapping, otherwise callers would be unaware of
+ * the actual chosen port.
+ * </p>
+ * <p>
+ * This example uses some basic <em>external</em> JSSE configuration:
+ * </p>
+ * <ul>
+ * <li>{@code javax.net.ssl.keyStore=~/.keystore} - HTTPS: Path to a keystore holding an X.509 certificate for
+ * {@code CN=localhost}</li>
+ * <li>{@code javax.net.ssl.keyStorePassword=...} - HTTPS: Password of that keystore</li>
+ * </ul>
+ * </p>
+ *
+ * @author Markus KARG (markus@headcrashing.eu)
+ * @since 2.2
+ */
+public final class HttpsJavaSeBootstrapExample {
+
+    /**
+     * Runs this example.
+     *
+     * @param args unused command line arguments
+     * @throws InterruptedException when process is killed
+     */
+    public static final void main(final String[] args) throws InterruptedException {
+        final Application application = new HelloWorld();
+
+        final SeBootstrap.Configuration requestedConfiguration = SeBootstrap.Configuration.builder().protocol("HTTPS").build();
+
+        SeBootstrap.start(application, requestedConfiguration).thenAccept(instance -> {
+            Runtime.getRuntime()
+                    .addShutdownHook(new Thread(() -> instance.stop()
+                            .thenAccept(stopResult -> System.out.printf("Stop result: %s [Native stop result: %s].%n",
+                                    stopResult, stopResult.unwrap(Object.class)))));
+
+            final Configuration actualConfigurarion = instance.configuration();
+            final URI uri = UriBuilder.newInstance().scheme(actualConfigurarion.protocol().toLowerCase())
+                    .host(actualConfigurarion.host()).port(actualConfigurarion.port())
+                    .path(actualConfigurarion.rootPath()).build();
+            System.out.printf("Instance %s running at %s [Native handle: %s].%n", instance, uri,
+                    instance.unwrap(Object.class));
+            System.out.println("Send SIGKILL to shutdown.");
+        });
+
+        Thread.currentThread().join();
+    }
+
+}

--- a/examples/src/main/java/jaxrs/examples/bootstrap/HttpsJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/HttpsJavaSeBootstrapExample.java
@@ -43,7 +43,7 @@ import jakarta.ws.rs.core.UriBuilder;
  * </p>
  *
  * @author Markus KARG (markus@headcrashing.eu)
- * @since 2.2
+ * @since 3.1
  */
 public final class HttpsJavaSeBootstrapExample {
 

--- a/examples/src/main/java/jaxrs/examples/bootstrap/NativeJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/NativeJavaSeBootstrapExample.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2018 Markus KARG. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jaxrs.examples.bootstrap;
+
+import java.net.URI;
+
+import jakarta.ws.rs.SeBootstrap;
+import jakarta.ws.rs.SeBootstrap.Configuration;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.UriBuilder;
+
+/**
+ * Java SE bootstrap example demonstrating the use of native properties.
+ * <p>
+ * This example demonstrates bootstrapping on Java SE platforms with native properties, in particular by explicitly
+ * selecting the Grizzly2 backend in Jersey. It will effectively startup the {@link HelloWorld} application at the URL
+ * {@code http://localhost:80/}, i. e. the Grizzly2 backend selects exactly port 80 as this is its default IP port. The
+ * actual configuration needs to be queried after bootstrapping, otherwise callers would be unaware of the actual chosen
+ * port, as Grizzly2's default behavior is not publicly documented.
+ * </p>
+ * <p>
+ * This is a native example, hence it only works with Jersey, and in particular only with its Grizzly2 backend. To
+ * actually run this demo, the following libraries have to be found on the classpath:
+ * </p>
+ * <ul>
+ * <li>jersey-server</li>
+ * <li>jersey-container-grizzly2-http</li>
+ * </ul>
+ *
+ * @author Markus KARG (markus@headcrashing.eu)
+ * @since 2.2
+ */
+public final class NativeJavaSeBootstrapExample {
+
+    /**
+     * Runs this example.
+     *
+     * @param args unused command line arguments
+     * @throws InterruptedException when process is killed
+     * @throws ClassNotFoundException when Jersey's Grizzly backend is not on the classpath
+     */
+    public static final void main(final String[] args) throws InterruptedException, ClassNotFoundException {
+        final Application application = new HelloWorld();
+
+        final SeBootstrap.Configuration requestedConfiguration = SeBootstrap.Configuration.builder()
+                .property("jersey.config.server.httpServerClass",
+                        Class.forName("org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServer"))
+                .build();
+
+        SeBootstrap.start(application, requestedConfiguration).thenAccept(instance -> {
+            Runtime.getRuntime()
+                    .addShutdownHook(new Thread(() -> instance.stop()
+                            .thenAccept(stopResult -> System.out.printf("Stop result: %s [Native stop result: %s].%n",
+                                    stopResult, stopResult.unwrap(Object.class)))));
+
+            final Configuration actualConfigurarion = instance.configuration();
+            final URI uri = UriBuilder.newInstance().scheme(actualConfigurarion.protocol().toLowerCase())
+                    .host(actualConfigurarion.host()).port(actualConfigurarion.port())
+                    .path(actualConfigurarion.rootPath()).build();
+            System.out.printf("Instance %s running at %s [Native handle: %s].%n", instance, uri,
+                    instance.unwrap(Object.class));
+            System.out.println("Send SIGKILL to shutdown.");
+        });
+
+        Thread.currentThread().join();
+    }
+
+}

--- a/examples/src/main/java/jaxrs/examples/bootstrap/NativeJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/NativeJavaSeBootstrapExample.java
@@ -42,7 +42,7 @@ import jakarta.ws.rs.core.UriBuilder;
  * </ul>
  *
  * @author Markus KARG (markus@headcrashing.eu)
- * @since 2.2
+ * @since 3.1
  */
 public final class NativeJavaSeBootstrapExample {
 

--- a/examples/src/main/java/jaxrs/examples/bootstrap/PropertyProviderJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/PropertyProviderJavaSeBootstrapExample.java
@@ -56,7 +56,7 @@ import jakarta.ws.rs.core.UriBuilder;
  * </ul>
  *
  * @author Markus KARG (markus@headcrashing.eu)
- * @since 2.2
+ * @since 3.1
  */
 public final class PropertyProviderJavaSeBootstrapExample {
 

--- a/examples/src/main/java/jaxrs/examples/bootstrap/PropertyProviderJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/PropertyProviderJavaSeBootstrapExample.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2018 Markus KARG. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jaxrs.examples.bootstrap;
+
+import java.net.URI;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import jakarta.ws.rs.SeBootstrap;
+import jakarta.ws.rs.SeBootstrap.Configuration;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.UriBuilder;
+
+/**
+ * Java SE bootstrap example utilizing a property provider.
+ * <p>
+ * This example demonstrates bootstrapping on Java SE platforms using values explicitly bulk-loaded from a property
+ * provider plus statically overridden properties. In particular, this demo first uses Eclipse Microprofile Config as a
+ * property provider for all properties supported by the implementation, but then explicitly enforces HTTPS within the
+ * bootstrap code.
+ * </p>
+ * <p>
+ * To actually run this example, an implementation of Eclipse Microprofile Config has to be added to the classpath, and
+ * the configuration options to be customized have to be provided, e. g. as environment variables:
+ * </p>
+ *
+ * <pre>
+ * export jakarta.ws.rs.SeBootstrap.Port=8888;
+ * java -Djakarta.ws.rs.SeBootstrap.Host=127.0.0.1 PropertyProviderJavaSeBootstrapExample;
+ * </pre>
+ * <p>
+ * Thanks to the <em>explicit</em> use of Microprofile Config in the application, this example is completely portable.
+ * </p>
+ * <p>
+ * This example uses some basic <em>external</em> JSSE configuration:
+ * </p>
+ * <ul>
+ * <li>{@code javax.net.ssl.keyStore=~/.keystore} - HTTPS: Path to a keystore holding an X.509 certificate for
+ * {@code CN=localhost}</li>
+ * <li>{@code javax.net.ssl.keyStorePassword=...} - HTTPS: Password of that keystore</li>
+ * </ul>
+ *
+ * @author Markus KARG (markus@headcrashing.eu)
+ * @since 2.2
+ */
+public final class PropertyProviderJavaSeBootstrapExample {
+
+    /**
+     * Runs this example.
+     *
+     * @param args unused command line arguments
+     * @throws InterruptedException when process is killed
+     */
+    public static final void main(final String[] args) throws InterruptedException {
+        final Application application = new HelloWorld();
+
+        final Config config = ConfigProvider.getConfig();
+
+        final SeBootstrap.Configuration requestedConfiguration = SeBootstrap.Configuration.builder().from(config::getOptionalValue)
+                .protocol("HTTPS").build();
+
+        SeBootstrap.start(application, requestedConfiguration).thenAccept(instance -> {
+            Runtime.getRuntime()
+                    .addShutdownHook(new Thread(() -> instance.stop()
+                            .thenAccept(stopResult -> System.out.printf("Stop result: %s [Native stop result: %s].%n",
+                                    stopResult, stopResult.unwrap(Object.class)))));
+
+            final Configuration actualConfigurarion = instance.configuration();
+            final URI uri = UriBuilder.newInstance().scheme(actualConfigurarion.protocol().toLowerCase())
+                    .host(actualConfigurarion.host()).port(actualConfigurarion.port())
+                    .path(actualConfigurarion.rootPath()).build();
+            System.out.printf("Instance %s running at %s [Native handle: %s].%n", instance, uri,
+                    instance.unwrap(Object.class));
+            System.out.println("Send SIGKILL to shutdown.");
+        });
+
+        Thread.currentThread().join();
+    }
+
+}

--- a/examples/src/main/java/jaxrs/examples/bootstrap/TlsJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/TlsJavaSeBootstrapExample.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2018 Markus KARG. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jaxrs.examples.bootstrap;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import jakarta.ws.rs.SeBootstrap;
+import jakarta.ws.rs.SeBootstrap.Configuration;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.UriBuilder;
+
+/**
+ * Java SE bootstrap example using TLS customization.
+ * <p>
+ * This example demonstrates bootstrapping on Java SE platforms using HTTPS with TLS 1.2 and a <em>particular</em>
+ * keystore. It explicitly sets the protocol to {@code HTTPS} using port 443 and provides a {@link SSLContext}
+ * customized to TLS v1.2 using a provided keystore file. The example will effectively startup the {@link HelloWorld}
+ * application at the URL {@code https://localhost:443/}.
+ * </p>
+ *
+ * @author Markus KARG (markus@headcrashing.eu)
+ * @since 2.2
+ */
+public final class TlsJavaSeBootstrapExample {
+
+    /**
+     * Runs this example.
+     *
+     * @param args KEYSTORE_PATH KEYSTORE_PASSWORD
+     * @throws GeneralSecurityException in case JSSE fails
+     * @throws IOException in case file access fails
+     * @throws InterruptedException when process is killed
+     */
+    public static final void main(final String[] args)
+            throws GeneralSecurityException, IOException, InterruptedException {
+        final Application application = new HelloWorld();
+
+        final Path keyStorePath = Paths.get(args[0]);
+        final char[] passphrase = args[1].toCharArray();
+
+        final KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        keyStore.load(Files.newInputStream(keyStorePath), passphrase);
+        final KeyManagerFactory keyManagerFactory = KeyManagerFactory
+                .getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        keyManagerFactory.init(keyStore, passphrase);
+        final SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
+        sslContext.init(keyManagerFactory.getKeyManagers(), null, null);
+
+        final SeBootstrap.Configuration requestedConfiguration = SeBootstrap.Configuration.builder().protocol("HTTPS")
+                .sslContext(sslContext).build();
+
+        SeBootstrap.start(application, requestedConfiguration).thenAccept(instance -> {
+            Runtime.getRuntime()
+                    .addShutdownHook(new Thread(() -> instance.stop()
+                            .thenAccept(stopResult -> System.out.printf("Stop result: %s [Native stop result: %s].%n",
+                                    stopResult, stopResult.unwrap(Object.class)))));
+
+            final Configuration actualConfigurarion = instance.configuration();
+            final URI uri = UriBuilder.newInstance().scheme(actualConfigurarion.protocol().toLowerCase())
+                    .host(actualConfigurarion.host()).port(actualConfigurarion.port())
+                    .path(actualConfigurarion.rootPath()).build();
+            System.out.printf("Instance %s running at %s [Native handle: %s].%n", instance, uri,
+                    instance.unwrap(Object.class));
+            System.out.println("Send SIGKILL to shutdown.");
+        });
+
+        Thread.currentThread().join();
+    }
+
+}

--- a/examples/src/main/java/jaxrs/examples/bootstrap/TlsJavaSeBootstrapExample.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/TlsJavaSeBootstrapExample.java
@@ -41,7 +41,7 @@ import jakarta.ws.rs.core.UriBuilder;
  * </p>
  *
  * @author Markus KARG (markus@headcrashing.eu)
- * @since 2.2
+ * @since 3.1
  */
 public final class TlsJavaSeBootstrapExample {
 

--- a/examples/src/main/java/jaxrs/examples/bootstrap/package-info.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/package-info.java
@@ -1,0 +1,22 @@
+/**
+ * Java SE bootstrap examples.
+ *
+ * <ul>
+ * <li>{@link BasicJavaSeBootstrapExample} - Basic example solely using defaults</li>
+ * <li>{@link ExplicitJavaSeBootstrapExample} - Explicit configuration instead of defaults</li>
+ * <li>{@link HttpsJavaSeBootstrapExample} - HTTPS instead of HTTP</li>
+ * <li>{@link TlsJavaSeBootstrapExample} - TLS customization</li>
+ * <li>{@link ClientAuthenticationJavaSeBootstrapExample} - HTTPS with <em>bidirectional</em> authentication</li>
+ * <li>{@link NativeJavaSeBootstrapExample} - Custom (non-portable) properties (using Jersey's Grizzly2 backend)</li>
+ * <li>{@link PropertyProviderJavaSeBootstrapExample} - Bulk-loading configuration using a property provider (using
+ * Microprofile Config <em>explicitly</em>, hence in a non-optional, portable way)
+ * <li>{@link ExternalConfigJavaSeBootstrapExample} - Bulk-loading configuration from external configuration mechanics
+ * (using Microprofile Config <em>implicitly</em>, hence in an optional, <em>not necessarily</em> portable way)
+ * </ul>
+ *
+ *
+ * @author Markus KARG (markus@headcrashing.eu)
+ * @since 2.2
+ * @see jakarta.ws.rs.SeBootstrap;
+ */
+package jaxrs.examples.bootstrap;

--- a/examples/src/main/java/jaxrs/examples/bootstrap/package-info.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/package-info.java
@@ -16,7 +16,7 @@
  *
  *
  * @author Markus KARG (markus@headcrashing.eu)
- * @since 2.2
+ * @since 3.1
  * @see jakarta.ws.rs.SeBootstrap;
  */
 package jaxrs.examples.bootstrap;

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -29,6 +29,7 @@
     <groupId>jakarta.ws.rs</groupId>
     <artifactId>jakarta.ws.rs-api</artifactId>
     <version>3.1-SNAPSHOT</version>
+
     <packaging>bundle</packaging>
     <name>jakarta.ws.rs-api</name>
     <description>Jakarta RESTful Web Services</description>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>jakarta.ws.rs</groupId>
     <artifactId>jakarta.ws.rs-api</artifactId>
-    <version>3.0.0</version>
+    <version>3.1-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>jakarta.ws.rs-api</name>
     <description>Jakarta RESTful Web Services</description>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -521,7 +521,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.1.0</version>
+            <version>3.6.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/CookieParam.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/CookieParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -35,8 +35,8 @@ import java.lang.annotation.Target;
  * example, {@link Integer#valueOf(String)})</li>
  * <li>Have a registered implementation of {@link jakarta.ws.rs.ext.ParamConverterProvider} JAX-RS extension SPI that
  * returns a {@link jakarta.ws.rs.ext.ParamConverter} instance capable of a "from string" conversion for the type.</li>
- * <li>Be {@code List<T>}, {@code Set<T>} or {@code SortedSet<T>}, where {@code T} satisfies 2, 3, 4 or 5 above. The
- * resulting collection is read-only.</li>
+ * <li>Be {@code List<T>}, {@code Set<T>}, {@code SortedSet<T>} or {@code T[]} array, where {@code T} satisfies 2, 3, 4
+ * or 5 above. The resulting collection is read-only.</li>
  * </ol>
  *
  * <p>

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/FormParam.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/FormParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -36,8 +36,8 @@ import java.lang.annotation.Target;
  * (see, for example, {@link Integer#valueOf(String)})</li>
  * <li>Have a registered implementation of {@link jakarta.ws.rs.ext.ParamConverterProvider} JAX-RS extension SPI that
  * returns a {@link jakarta.ws.rs.ext.ParamConverter} instance capable of a "from string" conversion for the type.</li>
- * <li>Be {@code List<T>}, {@code Set<T>} or {@code SortedSet<T>}, where {@code T} satisfies 2, 3 or 4 above. The
- * resulting collection is read-only.</li>
+ * <li>Be {@code List<T>}, {@code Set<T>}, {@code SortedSet<T>} or {@code T[]} array, where {@code T} satisfies 2, 3 or
+ * 4 above. The resulting collection is read-only.</li>
  * </ol>
  *
  * <p>

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/HeaderParam.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/HeaderParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -34,8 +34,8 @@ import java.lang.annotation.Target;
  * (see, for example, {@link Integer#valueOf(String)})</li>
  * <li>Have a registered implementation of {@link jakarta.ws.rs.ext.ParamConverterProvider} JAX-RS extension SPI that
  * returns a {@link jakarta.ws.rs.ext.ParamConverter} instance capable of a "from string" conversion for the type.</li>
- * <li>Be {@code List<T>}, {@code Set<T>} or {@code SortedSet<T>}, where {@code T} satisfies 2, 3 or 4 above. The
- * resulting collection is read-only.</li>
+ * <li>Be {@code List<T>}, {@code Set<T>}, {@code SortedSet<T>} or {@code T[]} array, where {@code T} satisfies 2, 3 or
+ * 4 above. The resulting collection is read-only.</li>
  * </ol>
  *
  * <p>

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/MatrixParam.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/MatrixParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -41,8 +41,8 @@ import java.lang.annotation.Target;
  * (see, for example, {@link Integer#valueOf(String)})</li>
  * <li>Have a registered implementation of {@link jakarta.ws.rs.ext.ParamConverterProvider} JAX-RS extension SPI that
  * returns a {@link jakarta.ws.rs.ext.ParamConverter} instance capable of a "from string" conversion for the type.</li>
- * <li>Be {@code List<T>}, {@code Set<T>} or {@code SortedSet<T>}, where {@code T} satisfies 2, 3 or 4 above. The
- * resulting collection is read-only.</li>
+ * <li>Be {@code List<T>}, {@code Set<T>}, {@code SortedSet<T>} or {@code T[]} array, where {@code T} satisfies 2, 3 or
+ * 4 above. The resulting collection is read-only.</li>
  * </ol>
  *
  * <p>

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/QueryParam.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/QueryParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -35,8 +35,8 @@ import java.lang.annotation.Target;
  * (see, for example, {@link Integer#valueOf(String)})</li>
  * <li>Have a registered implementation of {@link jakarta.ws.rs.ext.ParamConverterProvider} JAX-RS extension SPI that
  * returns a {@link jakarta.ws.rs.ext.ParamConverter} instance capable of a "from string" conversion for the type.</li>
- * <li>Be {@code List<T>}, {@code Set<T>} or {@code SortedSet<T>}, where {@code T} satisfies 2, 3 or 4 above. The
- * resulting collection is read-only.</li>
+ * <li>Be {@code List<T>}, {@code Set<T>}, {@code SortedSet<T>} or {@code T[]} array, where {@code T} satisfies 2, 3 or
+ * 4 above. The resulting collection is read-only.</li>
  * </ol>
  *
  * <p>

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/SeBootstrap.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/SeBootstrap.java
@@ -117,7 +117,7 @@ import jakarta.ws.rs.ext.RuntimeDelegate;
  * </pre>
  *
  * @author Markus KARG (markus@headcrashing.eu)
- * @since 2.2
+ * @since 3.1
  */
 public interface SeBootstrap {
 
@@ -134,7 +134,7 @@ public interface SeBootstrap {
      * @return {@code CompletionStage} (possibly asynchronously) producing handle of the running application
      * {@link SeBootstrap.Instance instance}.
      * @see Configuration
-     * @since 2.2
+     * @since 3.1
      */
     static CompletionStage<Instance> start(final Application application, final Configuration configuration) {
         return RuntimeDelegate.getInstance().bootstrap(application, configuration);
@@ -149,7 +149,7 @@ public interface SeBootstrap {
      * </p>
      *
      * @author Markus KARG (markus@headcrashing.eu)
-     * @since 2.2
+     * @since 3.1
      */
     public static interface Configuration {
 
@@ -163,7 +163,7 @@ public interface SeBootstrap {
          * The default value is {@code "HTTP"}.
          * </p>
          *
-         * @since 2.2
+         * @since 3.1
          */
         static final String PROTOCOL = "jakarta.ws.rs.SeBootstrap.Protocol";
 
@@ -180,7 +180,7 @@ public interface SeBootstrap {
          * The default value is {@code "localhost"}.
          * </p>
          *
-         * @since 2.2
+         * @since 3.1
          */
         static final String HOST = "jakarta.ws.rs.SeBootstrap.Host";
 
@@ -197,7 +197,7 @@ public interface SeBootstrap {
          * range-scanning algorithms.
          * </p>
          *
-         * @since 2.2
+         * @since 3.1
          */
         static final String PORT = "jakarta.ws.rs.SeBootstrap.Port";
 
@@ -207,7 +207,7 @@ public interface SeBootstrap {
          * The default value is {@code "/"}.
          * </p>
          *
-         * @since 2.2
+         * @since 3.1
          */
         static final String ROOT_PATH = "jakarta.ws.rs.SeBootstrap.RootPath";
 
@@ -217,7 +217,7 @@ public interface SeBootstrap {
          * The default value is {@link SSLContext#getDefault()}.
          * </p>
          *
-         * @since 2.2
+         * @since 3.1
          */
         static final String SSL_CONTEXT = "jakarta.ws.rs.SeBootstrap.SSLContext";
 
@@ -231,7 +231,7 @@ public interface SeBootstrap {
          * The default value is {@code SSLClientAuthentication#NONE}.
          * </p>
          *
-         * @since 2.2
+         * @since 3.1
          */
         static final String SSL_CLIENT_AUTHENTICATION = "jakarta.ws.rs.SeBootstrap.SSLClientAuthentication";
 
@@ -245,28 +245,28 @@ public interface SeBootstrap {
          * </p>
          *
          * @author Markus KARG (markus@headcrashing.eu)
-         * @since 2.2
+         * @since 3.1
          */
         public enum SSLClientAuthentication {
 
             /**
              * Server will <em>not request</em> client authentication.
              *
-             * @since 2.2
+             * @since 3.1
              */
             NONE,
 
             /**
              * Client authentication is performed, but invalid clients are <em>accepted</em>.
              *
-             * @since 2.2
+             * @since 3.1
              */
             OPTIONAL,
 
             /**
              * Client authentication is performed, and invalid clients are <em>rejected</em>.
              *
-             * @since 2.2
+             * @since 3.1
              */
             MANDATORY
         }
@@ -274,14 +274,14 @@ public interface SeBootstrap {
         /**
          * Special value for {@link #PORT} property indicating that the implementation MUST scan for a free port.
          *
-         * @since 2.2
+         * @since 3.1
          */
         static final int FREE_PORT = 0;
 
         /**
          * Special value for {@link #PORT} property indicating that the implementation MUST use its default port.
          *
-         * @since 2.2
+         * @since 3.1
          */
         static final int DEFAULT_PORT = -1;
 
@@ -291,7 +291,7 @@ public interface SeBootstrap {
          * @param name a {@code String} specifying the name of the property.
          * @return an {@code Object} containing the value of the property, or {@code null} if no property exists matching the
          * given name.
-         * @since 2.2
+         * @since 3.1
          */
         Object property(String name);
 
@@ -300,7 +300,7 @@ public interface SeBootstrap {
          *
          * @param name a {@code String} specifying the name of the property.
          * @return {@code false} if no property exists matching the given name, {@code true} otherwise.
-         * @since 2.2
+         * @since 3.1
          */
         default boolean hasProperty(String name) {
             return property(name) != null;
@@ -315,7 +315,7 @@ public interface SeBootstrap {
          * @return protocol to be used (e. g. {@code "HTTP")}.
          * @throws ClassCastException if protocol is not a {@link String}.
          * @see SeBootstrap.Configuration#PROTOCOL
-         * @since 2.2
+         * @since 3.1
          */
         default String protocol() {
             return (String) property(PROTOCOL);
@@ -330,7 +330,7 @@ public interface SeBootstrap {
          * @return host name or IP address to be used (e. g. {@code "localhost"} or {@code "0.0.0.0"}).
          * @throws ClassCastException if host is not a {@link String}.
          * @see SeBootstrap.Configuration#HOST
-         * @since 2.2
+         * @since 3.1
          */
         default String host() {
             return (String) property(HOST);
@@ -349,7 +349,7 @@ public interface SeBootstrap {
          * @return port number <em>actually</em> used (e. g. {@code 8080}).
          * @throws ClassCastException if port is not an {@code Integer}.
          * @see SeBootstrap.Configuration#PORT
-         * @since 2.2
+         * @since 3.1
          */
         default int port() {
             return (int) property(PORT);
@@ -364,7 +364,7 @@ public interface SeBootstrap {
          * @return root path to be used, e. g. {@code "/"}.
          * @throws ClassCastException if root path is not a {@link String}.
          * @see SeBootstrap.Configuration#ROOT_PATH
-         * @since 2.2
+         * @since 3.1
          */
         default String rootPath() {
             return (String) property(ROOT_PATH);
@@ -379,7 +379,7 @@ public interface SeBootstrap {
          * @return root path to be used, e. g. {@code "/"}.
          * @throws ClassCastException if sslContext is not a {@link SSLContext}.
          * @see SeBootstrap.Configuration#SSL_CONTEXT
-         * @since 2.2
+         * @since 3.1
          */
         default SSLContext sslContext() {
             return (SSLContext) property(SSL_CONTEXT);
@@ -394,7 +394,7 @@ public interface SeBootstrap {
          * @return client authentication mode, e. g. {@code NONE}.
          * @throws ClassCastException if sslClientAuthentication is not a {@link SSLClientAuthentication}.
          * @see SeBootstrap.Configuration#SSL_CLIENT_AUTHENTICATION
-         * @since 2.2
+         * @since 3.1
          */
         default SSLClientAuthentication sslClientAuthentication() {
             return (SSLClientAuthentication) property(SSL_CLIENT_AUTHENTICATION);
@@ -404,7 +404,7 @@ public interface SeBootstrap {
          * Creates a new bootstrap configuration builder instance.
          *
          * @return {@link Builder} for bootstrap configuration.
-         * @since 2.2
+         * @since 3.1
          */
         static Builder builder() {
             return RuntimeDelegate.getInstance().createConfigurationBuilder();
@@ -414,7 +414,7 @@ public interface SeBootstrap {
          * Builder for bootstrap {@link Configuration}.
          *
          * @author Markus KARG (markus@headcrashing.eu)
-         * @since 2.2
+         * @since 3.1
          */
         static interface Builder {
 
@@ -422,7 +422,7 @@ public interface SeBootstrap {
              * Builds a bootstrap configuration instance from the provided property values.
              *
              * @return {@link Configuration} built from provided property values.
-             * @since 2.2
+             * @since 3.1
              */
             Configuration build();
 
@@ -435,7 +435,7 @@ public interface SeBootstrap {
              * @param name name of the parameter to set.
              * @param value value to set, or {@code null} to use the default value.
              * @return the updated builder.
-             * @since 2.2
+             * @since 3.1
              */
             Builder property(String name, Object value);
 
@@ -448,7 +448,7 @@ public interface SeBootstrap {
              * @param protocol protocol parameter of this configuration, or {@code null} to use the default value.
              * @return the updated builder.
              * @see SeBootstrap.Configuration#PROTOCOL
-             * @since 2.2
+             * @since 3.1
              */
             default Builder protocol(String protocol) {
                 return property(PROTOCOL, protocol);
@@ -463,7 +463,7 @@ public interface SeBootstrap {
              * @param host host parameter (IP address or hostname) of this configuration, or {@code null} to use the default value.
              * @return the updated builder.
              * @see SeBootstrap.Configuration#HOST
-             * @since 2.2
+             * @since 3.1
              */
             default Builder host(String host) {
                 return property(HOST, host);
@@ -478,7 +478,7 @@ public interface SeBootstrap {
              * @param port port parameter of this configuration, or {@code null} to use the default value.
              * @return the updated builder.
              * @see SeBootstrap.Configuration#PORT
-             * @since 2.2
+             * @since 3.1
              */
             default Builder port(Integer port) {
                 return property(PORT, port);
@@ -493,7 +493,7 @@ public interface SeBootstrap {
              * @param rootPath rootPath parameter of this configuration, or {@code null} to use the default value.
              * @return the updated builder.
              * @see SeBootstrap.Configuration#ROOT_PATH
-             * @since 2.2
+             * @since 3.1
              */
             default Builder rootPath(String rootPath) {
                 return property(ROOT_PATH, rootPath);
@@ -508,7 +508,7 @@ public interface SeBootstrap {
              * @param sslContext sslContext parameter of this configuration, or {@code null} to use the default value.
              * @return the updated builder.
              * @see SeBootstrap.Configuration#SSL_CONTEXT
-             * @since 2.2
+             * @since 3.1
              */
             default Builder sslContext(SSLContext sslContext) {
                 return property(SSL_CONTEXT, sslContext);
@@ -523,7 +523,7 @@ public interface SeBootstrap {
              * @param sslClientAuthentication SSL client authentication mode of this configuration
              * @return the updated builder.
              * @see SeBootstrap.Configuration#SSL_CLIENT_AUTHENTICATION
-             * @since 2.2
+             * @since 3.1
              */
             default Builder sslClientAuthentication(SSLClientAuthentication sslClientAuthentication) {
                 return property(SSL_CLIENT_AUTHENTICATION, sslClientAuthentication);
@@ -541,7 +541,7 @@ public interface SeBootstrap {
              * @param <T> Type of the requested property value.
              * @param propertiesProvider Retrieval function of externally managed properties. MUST NOT return {@code null}.
              * @return the updated builder.
-             * @since 2.2
+             * @since 3.1
              */
             <T> Builder from(BiFunction<String, Class<T>, Optional<T>> propertiesProvider);
 
@@ -561,7 +561,7 @@ public interface SeBootstrap {
              *
              * @param externalConfig source of externally managed properties
              * @return the updated builder.
-             * @since 2.2
+             * @since 3.1
              */
             default Builder from(Object externalConfig) {
                 return this;
@@ -574,7 +574,7 @@ public interface SeBootstrap {
      * Handle of the running application instance.
      *
      * @author Markus KARG (markus@headcrashing.eu)
-     * @since 2.2
+     * @since 3.1
      */
     public interface Instance {
 
@@ -588,7 +588,7 @@ public interface SeBootstrap {
          * </p>
          *
          * @return The configuration actually used to create this instance.
-         * @since 2.2
+         * @since 3.1
          */
         public Configuration configuration();
 
@@ -596,7 +596,7 @@ public interface SeBootstrap {
          * Initiate immediate shutdown of running application instance.
          *
          * @return {@code CompletionStage} asynchronously shutting down this application instance.
-         * @since 2.2
+         * @since 3.1
          */
         public CompletionStage<StopResult> stop();
 
@@ -604,7 +604,7 @@ public interface SeBootstrap {
          * Result of stopping the application instance.
          *
          * @author Markus KARG (markus@headcrashing.eu)
-         * @since 2.2
+         * @since 3.1
          */
         public interface StopResult {
 
@@ -620,7 +620,7 @@ public interface SeBootstrap {
              * @return Native result of shutting down the running application instance or {@code null} if the implementation has no
              * native result.
              * @throws ClassCastException if the result is not {@code null} or is not assignable to the type {@code T}.
-             * @since 2.2
+             * @since 3.1
              */
             public <T> T unwrap(Class<T> nativeClass);
         }
@@ -636,7 +636,7 @@ public interface SeBootstrap {
          * @param nativeClass Requested type of the native handle to return.
          * @return Native handle of the running application instance or {@code null} if the implementation has no native handle.
          * @throws ClassCastException if the handle is not {@code null} and is not assignable to the type {@code T}.
-         * @since 2.2
+         * @since 3.1
          */
         public <T> T unwrap(Class<T> nativeClass);
     }

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/SeBootstrap.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/SeBootstrap.java
@@ -1,0 +1,644 @@
+/*
+ * Copyright (c) 2018 Markus KARG. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs;
+
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import java.util.function.BiFunction;
+
+import javax.net.ssl.SSLContext;
+
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.ext.RuntimeDelegate;
+
+/**
+ * Bootstrap class used to startup a JAX-RS application in Java SE environments.
+ * <p>
+ * The {@code SeBootstrap} class is available in a Jakarta EE container environment as well; however, support for the Java SE
+ * bootstrapping APIs is <em>not required</em> in container environments.
+ * </p>
+ * <p>
+ * In a Java SE environment an application is getting started by the following command using default configuration
+ * values (i. e. mounting application at {@code http://localhost:80/} <em>or a different port</em> (there is <em>no
+ * particular default port</em> mandated by this specification). As the JAX-RS implementation is free to choose any port
+ * by default, the caller will not know the actual port unless explicitly checking the actual configuration of the
+ * instance started:
+ * </p>
+ *
+ * <pre>
+ * Application app = new MyApplication();
+ * SeBootstrap.Configuration config = SeBootstrap.Configuration.builder().build();
+ * SeBootstrap.start(app, config).thenAccept(instance -&gt; instance.configuration().port());
+ * </pre>
+ *
+ * <p>
+ * Running instances can be instructed to stop serving the application:
+ * </p>
+ *
+ * <pre>
+ * SeBootstrap.start(app, config).thenAccept(instance -&gt; { ... instance.stop(); } );
+ * </pre>
+ *
+ * <p>
+ * A shutdown callback can be registered which will get invoked once the implementation stops serving the application:
+ * </p>
+ *
+ * <pre>
+ * instance.stop().thenAccept(stopResult -&gt; ...));
+ * </pre>
+ *
+ * {@code stopResult} is not further defined but solely acts as a wrapper around a native result provided by the
+ * particular JAX-RS implementation. Portable applications should not assume any particular data type or value.
+ *
+ * <p>
+ * Protocol, host address, port and root path can be overridden explicitly. As the JAX-RS implementation is bound to
+ * that values, no querying of the actual configuration is needed in that case:
+ * </p>
+ *
+ * <pre>
+ * SeBootstrap.Configuration.builder().protocol("HTTPS").host("0.0.0.0").port(8443).rootPath("api").build();
+ * </pre>
+ *
+ * <p>
+ * TLS can be configured by explicitly passing a customized {@link SSLContext}:
+ * </p>
+ *
+ * <pre>
+ * SSLContext tls = SSLContext.getInstance("TLSv1.2");
+ * // ...further initialize context here (see JSSE API)...
+ * SeBootstrap.Configuration.builder().protocol("HTTPS").sslContext(tls).build();
+ * </pre>
+ *
+ * <p>
+ * In case of HTTPS, client authentication can be enforced to ensure that only <em>trustworthy</em> clients can connect:
+ * </p>
+ *
+ * <pre>
+ * SeBootstrap.Configuration.builder().protocol("HTTPS").sslClientAuthentication(SSLClientAuthentication.MANDATORY).build();
+ * </pre>
+ *
+ * <p>
+ * Implementations are free to support more use cases by native properties, which effectively render the application
+ * non-portable:
+ * </p>
+ *
+ * <pre>
+ * SeBootstrap.Configuration.builder().property("productname.foo", "bar").build()
+ * </pre>
+ *
+ * <p>
+ * Bulk-loading allows to attach configuration storages easily without the need to write down all properties to be
+ * transferred. Hence, even properties unknown to the application author will get channeled into the implementation.
+ * This can be done both, explicitly (hence portable) and implicitly (hence <em>not necessarily</em> portable as no
+ * particular configuration mechanics are required to be supported by compliant implementations):
+ * </p>
+ *
+ * <pre>
+ * // Explicit use of particular configuration mechanics is portable
+ * SeBootstrap.Configuration.builder().from((name, type) -&gt; externalConfigurationSystem.getValue(name, type)).build();
+ *
+ * // Implicitly relying on the support of particular configuration mechanics by
+ * // the actual JAX-RS implementation is not necessarily portable
+ * SeBootstrap.Configuration.builder().from(externalConfigurationSystem).build();
+ * </pre>
+ *
+ * @author Markus KARG (markus@headcrashing.eu)
+ * @since 2.2
+ */
+public interface SeBootstrap {
+
+    /**
+     * Starts the provided application using the specified configuration.
+     *
+     * <p>
+     * This method is intended to be used in Java SE environments only. The outcome of invocations in Jakarta EE container
+     * environments is undefined.
+     * </p>
+     *
+     * @param application The application to start up.
+     * @param configuration Provides information needed for bootstrapping the application.
+     * @return {@code CompletionStage} (possibly asynchronously) producing handle of the running application
+     * {@link SeBootstrap.Instance instance}.
+     * @see Configuration
+     * @since 2.2
+     */
+    static CompletionStage<Instance> start(final Application application, final Configuration configuration) {
+        return RuntimeDelegate.getInstance().bootstrap(application, configuration);
+    }
+
+    /**
+     * Provides information needed by the JAX-RS implementation for bootstrapping an application.
+     * <p>
+     * The configuration essentially consists of a set of parameters. While the set of actually effective keys is product
+     * specific, the key constants defined by the {@link SeBootstrap.Configuration} interface MUST be effective on all compliant
+     * products. Any unknown key MUST be silently ignored.
+     * </p>
+     *
+     * @author Markus KARG (markus@headcrashing.eu)
+     * @since 2.2
+     */
+    public static interface Configuration {
+
+        /**
+         * Configuration key for the protocol an application is bound to.
+         * <p>
+         * A compliant implementation at least MUST accept the strings {@code "HTTP"} and {@code "HTTPS"} if these protocols are
+         * supported.
+         * </p>
+         * <p>
+         * The default value is {@code "HTTP"}.
+         * </p>
+         *
+         * @since 2.2
+         */
+        static final String PROTOCOL = "jakarta.ws.rs.SeBootstrap.Protocol";
+
+        /**
+         * Configuration key for the hostname or IP address an application is bound to.
+         * <p>
+         * A compliant implementation at least MUST accept string values bearing hostnames, IP4 address text representations,
+         * and IP6 address text representations. If a hostname string, the special IP4 address string {@code "0.0.0.0"} or
+         * {@code "::"} for IP6 is provided, the application MUST be bound to <em>all</em> IP addresses assigned to that
+         * hostname. If the hostname string is {@code "localhost"} the application MUST be bound to the local host's loopback
+         * adapter <em>only</em>.
+         * </p>
+         * <p>
+         * The default value is {@code "localhost"}.
+         * </p>
+         *
+         * @since 2.2
+         */
+        static final String HOST = "jakarta.ws.rs.SeBootstrap.Host";
+
+        /**
+         * Configuration key for the TCP port an application is bound to.
+         *
+         * <p>
+         * A compliant implementation MUST accept {@code java.lang.Integer} values.
+         * </p>
+         * <p>
+         * There is no default <em>port</em> mandated by this specification, but the default <em>value</em> of this property is
+         * {@link #DEFAULT_PORT} (i. e. <code>-1</code>). A compliant implementation MUST use its own default <em>port</em> when
+         * the <em>value</em> <code>-1</code> is provided, and MAY apply (but is not obligated to) auto-selection and
+         * range-scanning algorithms.
+         * </p>
+         *
+         * @since 2.2
+         */
+        static final String PORT = "jakarta.ws.rs.SeBootstrap.Port";
+
+        /**
+         * Configuration key for the root path an application is bound to.
+         * <p>
+         * The default value is {@code "/"}.
+         * </p>
+         *
+         * @since 2.2
+         */
+        static final String ROOT_PATH = "jakarta.ws.rs.SeBootstrap.RootPath";
+
+        /**
+         * Configuration key for the secure socket configuration to be used.
+         * <p>
+         * The default value is {@link SSLContext#getDefault()}.
+         * </p>
+         *
+         * @since 2.2
+         */
+        static final String SSL_CONTEXT = "jakarta.ws.rs.SeBootstrap.SSLContext";
+
+        /**
+         * Configuration key for the secure socket client authentication policy.
+         *
+         * <p>
+         * A compliant implementation MUST accept {@link SSLClientAuthentication} enums.
+         * </p>
+         * <p>
+         * The default value is {@code SSLClientAuthentication#NONE}.
+         * </p>
+         *
+         * @since 2.2
+         */
+        static final String SSL_CLIENT_AUTHENTICATION = "jakarta.ws.rs.SeBootstrap.SSLClientAuthentication";
+
+        /**
+         * Secure socket client authentication policy
+         *
+         * <p>
+         * This policy is used in secure socket handshake to control whether the server <em>requests</em> client authentication,
+         * and whether <em>successful</em> client authentication is <em>mandatory</em> (i. e. connection attempt will fail for
+         * invalid clients).
+         * </p>
+         *
+         * @author Markus KARG (markus@headcrashing.eu)
+         * @since 2.2
+         */
+        public enum SSLClientAuthentication {
+
+            /**
+             * Server will <em>not request</em> client authentication.
+             *
+             * @since 2.2
+             */
+            NONE,
+
+            /**
+             * Client authentication is performed, but invalid clients are <em>accepted</em>.
+             *
+             * @since 2.2
+             */
+            OPTIONAL,
+
+            /**
+             * Client authentication is performed, and invalid clients are <em>rejected</em>.
+             *
+             * @since 2.2
+             */
+            MANDATORY
+        }
+
+        /**
+         * Special value for {@link #PORT} property indicating that the implementation MUST scan for a free port.
+         *
+         * @since 2.2
+         */
+        static final int FREE_PORT = 0;
+
+        /**
+         * Special value for {@link #PORT} property indicating that the implementation MUST use its default port.
+         *
+         * @since 2.2
+         */
+        static final int DEFAULT_PORT = -1;
+
+        /**
+         * Returns the value of the property with the given name, or {@code null} if there is no property of that name.
+         *
+         * @param name a {@code String} specifying the name of the property.
+         * @return an {@code Object} containing the value of the property, or {@code null} if no property exists matching the
+         * given name.
+         * @since 2.2
+         */
+        Object property(String name);
+
+        /**
+         * Returns whether the property with the given name is configured, either explicitly or by default.
+         *
+         * @param name a {@code String} specifying the name of the property.
+         * @return {@code false} if no property exists matching the given name, {@code true} otherwise.
+         * @since 2.2
+         */
+        default boolean hasProperty(String name) {
+            return property(name) != null;
+        }
+
+        /**
+         * Convenience method to get the {@code protocol} to be used.
+         * <p>
+         * Same as if calling {@link #property(String) (String) property(PROTOCOL)}.
+         * </p>
+         *
+         * @return protocol to be used (e. g. {@code "HTTP")}.
+         * @throws ClassCastException if protocol is not a {@link String}.
+         * @see SeBootstrap.Configuration#PROTOCOL
+         * @since 2.2
+         */
+        default String protocol() {
+            return (String) property(PROTOCOL);
+        }
+
+        /**
+         * Convenience method to get the {@code host} to be used.
+         * <p>
+         * Same as if calling {@link #property(String) (String) property(HOST)}.
+         * </p>
+         *
+         * @return host name or IP address to be used (e. g. {@code "localhost"} or {@code "0.0.0.0"}).
+         * @throws ClassCastException if host is not a {@link String}.
+         * @see SeBootstrap.Configuration#HOST
+         * @since 2.2
+         */
+        default String host() {
+            return (String) property(HOST);
+        }
+
+        /**
+         * Convenience method to get the actually used {@code port}.
+         * <p>
+         * Same as if calling {@link #property(String) (int) property(PORT)}.
+         * </p>
+         * <p>
+         * If the port was <em>not explicitly</em> given, this will return the port chosen implicitly by the JAX-RS
+         * implementation.
+         * </p>
+         *
+         * @return port number <em>actually</em> used (e. g. {@code 8080}).
+         * @throws ClassCastException if port is not an {@code Integer}.
+         * @see SeBootstrap.Configuration#PORT
+         * @since 2.2
+         */
+        default int port() {
+            return (int) property(PORT);
+        }
+
+        /**
+         * Convenience method to get the {@code rootPath} to be used.
+         * <p>
+         * Same as if calling {@link #property(String) (String) property(ROOT_PATH)}.
+         * </p>
+         *
+         * @return root path to be used, e. g. {@code "/"}.
+         * @throws ClassCastException if root path is not a {@link String}.
+         * @see SeBootstrap.Configuration#ROOT_PATH
+         * @since 2.2
+         */
+        default String rootPath() {
+            return (String) property(ROOT_PATH);
+        }
+
+        /**
+         * Convenience method to get the {@code sslContext} to be used.
+         * <p>
+         * Same as if calling {@link #property(String) (SSLContext) property(SSL_CONTEXT)}.
+         * </p>
+         *
+         * @return root path to be used, e. g. {@code "/"}.
+         * @throws ClassCastException if sslContext is not a {@link SSLContext}.
+         * @see SeBootstrap.Configuration#SSL_CONTEXT
+         * @since 2.2
+         */
+        default SSLContext sslContext() {
+            return (SSLContext) property(SSL_CONTEXT);
+        }
+
+        /**
+         * Convenience method to get the secure socket client authentication policy.
+         * <p>
+         * Same as if calling {@link #property(String) (SSLClientAuthentication) property(SSL_CLIENT_AUTHENTICATION)}.
+         * </p>
+         *
+         * @return client authentication mode, e. g. {@code NONE}.
+         * @throws ClassCastException if sslClientAuthentication is not a {@link SSLClientAuthentication}.
+         * @see SeBootstrap.Configuration#SSL_CLIENT_AUTHENTICATION
+         * @since 2.2
+         */
+        default SSLClientAuthentication sslClientAuthentication() {
+            return (SSLClientAuthentication) property(SSL_CLIENT_AUTHENTICATION);
+        }
+
+        /**
+         * Creates a new bootstrap configuration builder instance.
+         *
+         * @return {@link Builder} for bootstrap configuration.
+         * @since 2.2
+         */
+        static Builder builder() {
+            return RuntimeDelegate.getInstance().createConfigurationBuilder();
+        };
+
+        /**
+         * Builder for bootstrap {@link Configuration}.
+         *
+         * @author Markus KARG (markus@headcrashing.eu)
+         * @since 2.2
+         */
+        static interface Builder {
+
+            /**
+             * Builds a bootstrap configuration instance from the provided property values.
+             *
+             * @return {@link Configuration} built from provided property values.
+             * @since 2.2
+             */
+            Configuration build();
+
+            /**
+             * Sets the property {@code name} to the provided {@code value}.
+             * <p>
+             * This method does not check the validity, type or syntax of the provided value.
+             * </p>
+             *
+             * @param name name of the parameter to set.
+             * @param value value to set, or {@code null} to use the default value.
+             * @return the updated builder.
+             * @since 2.2
+             */
+            Builder property(String name, Object value);
+
+            /**
+             * Convenience method to set the {@code protocol} to be used.
+             * <p>
+             * Same as if calling {@link #property(String, Object) property(PROTOCOL, value)}.
+             * </p>
+             *
+             * @param protocol protocol parameter of this configuration, or {@code null} to use the default value.
+             * @return the updated builder.
+             * @see SeBootstrap.Configuration#PROTOCOL
+             * @since 2.2
+             */
+            default Builder protocol(String protocol) {
+                return property(PROTOCOL, protocol);
+            }
+
+            /**
+             * Convenience method to set the {@code host} to be used.
+             * <p>
+             * Same as if calling {@link #property(String, Object) property(HOST, value)}.
+             * </p>
+             *
+             * @param host host parameter (IP address or hostname) of this configuration, or {@code null} to use the default value.
+             * @return the updated builder.
+             * @see SeBootstrap.Configuration#HOST
+             * @since 2.2
+             */
+            default Builder host(String host) {
+                return property(HOST, host);
+            }
+
+            /**
+             * Convenience method to set the {@code port} to be used.
+             * <p>
+             * Same as if calling {@link #property(String, Object) property(PORT, value)}.
+             * </p>
+             *
+             * @param port port parameter of this configuration, or {@code null} to use the default value.
+             * @return the updated builder.
+             * @see SeBootstrap.Configuration#PORT
+             * @since 2.2
+             */
+            default Builder port(Integer port) {
+                return property(PORT, port);
+            }
+
+            /**
+             * Convenience method to set the {@code rootPath} to be used.
+             * <p>
+             * Same as if calling {@link #property(String, Object) property(ROOT_PATH, value)}.
+             * </p>
+             *
+             * @param rootPath rootPath parameter of this configuration, or {@code null} to use the default value.
+             * @return the updated builder.
+             * @see SeBootstrap.Configuration#ROOT_PATH
+             * @since 2.2
+             */
+            default Builder rootPath(String rootPath) {
+                return property(ROOT_PATH, rootPath);
+            }
+
+            /**
+             * Convenience method to set the {@code sslContext} to be used.
+             * <p>
+             * Same as if calling {@link #property(String, Object) property(SSL_CONTEXT, value)}.
+             * </p>
+             *
+             * @param sslContext sslContext parameter of this configuration, or {@code null} to use the default value.
+             * @return the updated builder.
+             * @see SeBootstrap.Configuration#SSL_CONTEXT
+             * @since 2.2
+             */
+            default Builder sslContext(SSLContext sslContext) {
+                return property(SSL_CONTEXT, sslContext);
+            }
+
+            /**
+             * Convenience method to set SSL client authentication policy.
+             * <p>
+             * Same as if calling {@link #property(String, Object) property(SSL_CLIENT_AUTHENTICATION, value)}.
+             * </p>
+             *
+             * @param sslClientAuthentication SSL client authentication mode of this configuration
+             * @return the updated builder.
+             * @see SeBootstrap.Configuration#SSL_CLIENT_AUTHENTICATION
+             * @since 2.2
+             */
+            default Builder sslClientAuthentication(SSLClientAuthentication sslClientAuthentication) {
+                return property(SSL_CLIENT_AUTHENTICATION, sslClientAuthentication);
+            }
+
+            /**
+             * Convenience method for bulk-loading configuration from a property supplier.
+             * <p>
+             * Implementations ask the passed provider function for the actual values of all their supported properties, before
+             * returning from this configuration method. For each single request the implementation provides the name of the
+             * property and the expected data type of the value. If no such property exists (i. e. either the name is unknown or
+             * misspelled, or the type does not exactly match), the {@link Optional} is {@link Optional#empty() empty}.
+             * </p>
+             *
+             * @param <T> Type of the requested property value.
+             * @param propertiesProvider Retrieval function of externally managed properties. MUST NOT return {@code null}.
+             * @return the updated builder.
+             * @since 2.2
+             */
+            <T> Builder from(BiFunction<String, Class<T>, Optional<T>> propertiesProvider);
+
+            /**
+             * Optional convenience method to bulk-load external configuration.
+             * <p>
+             * Implementations are free to support any external configuration mechanics, or none at all. It is completely up to the
+             * implementation what set of properties is effectively loaded from the provided external configuration, possibly none
+             * at all.
+             * </p>
+             * <p>
+             * If the passed external configuration mechanics is unsupported, this method MUST simply do nothing.
+             * </p>
+             * <p>
+             * Portable applications should not call this method, as the outcome is completely implementation-specific.
+             * </p>
+             *
+             * @param externalConfig source of externally managed properties
+             * @return the updated builder.
+             * @since 2.2
+             */
+            default Builder from(Object externalConfig) {
+                return this;
+            }
+
+        }
+    }
+
+    /**
+     * Handle of the running application instance.
+     *
+     * @author Markus KARG (markus@headcrashing.eu)
+     * @since 2.2
+     */
+    public interface Instance {
+
+        /**
+         * Provides access to the configuration <em>actually</em> used by the implementation used to create this instance.
+         * <p>
+         * This may, or may not, be the same instance passed to {@link SeBootstrap#start(Application, Configuration)}, not even an
+         * equal instance, as implementations MAY create a new intance and MUST update at least the {@code PORT} property with
+         * the actually used value. Portable applications should not make any assumptions but always explicitly read the actual
+         * values from the configuration returned from this method.
+         * </p>
+         *
+         * @return The configuration actually used to create this instance.
+         * @since 2.2
+         */
+        public Configuration configuration();
+
+        /**
+         * Initiate immediate shutdown of running application instance.
+         *
+         * @return {@code CompletionStage} asynchronously shutting down this application instance.
+         * @since 2.2
+         */
+        public CompletionStage<StopResult> stop();
+
+        /**
+         * Result of stopping the application instance.
+         *
+         * @author Markus KARG (markus@headcrashing.eu)
+         * @since 2.2
+         */
+        public interface StopResult {
+
+            /**
+             * Provides access to the wrapped native shutdown result.
+             * <p>
+             * Implementations may, or may not, have native shutdown results. Portable applications should not invoke this method,
+             * as the outcome is undefined.
+             * </p>
+             *
+             * @param <T> Requested type of the native result to return.
+             * @param nativeClass Requested type of the native result to return.
+             * @return Native result of shutting down the running application instance or {@code null} if the implementation has no
+             * native result.
+             * @throws ClassCastException if the result is not {@code null} or is not assignable to the type {@code T}.
+             * @since 2.2
+             */
+            public <T> T unwrap(Class<T> nativeClass);
+        }
+
+        /**
+         * Provides access to the wrapped native handle of the application instance.
+         * <p>
+         * Implementations may, or may not, have native handles. Portable applications should not invoke this method, as the
+         * outcome is undefined.
+         * </p>
+         *
+         * @param <T> Requested type of the native handle to return.
+         * @param nativeClass Requested type of the native handle to return.
+         * @return Native handle of the running application instance or {@code null} if the implementation has no native handle.
+         * @throws ClassCastException if the handle is not {@code null} and is not assignable to the type {@code T}.
+         * @since 2.2
+         */
+        public <T> T unwrap(Class<T> nativeClass);
+    }
+
+}

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/WebApplicationException.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/WebApplicationException.java
@@ -32,7 +32,7 @@ import jakarta.ws.rs.core.Response;
 public class WebApplicationException extends RuntimeException {
 
     private static final long serialVersionUID = 8273970399584007146L;
-    private final Response response;
+    private final transient Response response;
 
     /**
      * Construct a new instance with a default HTTP status code of 500 and a default message generated from the HTTP status

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/client/Client.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/client/Client.java
@@ -39,7 +39,7 @@ import jakarta.ws.rs.core.UriBuilder;
  * @see jakarta.ws.rs.core.Configurable
  * @since 2.0
  */
-public interface Client extends Configurable<Client> {
+public interface Client extends Configurable<Client>, AutoCloseable {
 
     /**
      * <p>
@@ -51,6 +51,7 @@ public interface Client extends Configurable<Client> {
      * Invoking any method on such targets once the client is closed would result in an {@link IllegalStateException} being
      * thrown.
      */
+    @Override
     public void close();
 
     /**

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientRequestContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/client/ClientRequestContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -75,6 +75,22 @@ public interface ClientRequestContext {
      * @see #getProperty
      */
     public Collection<String> getPropertyNames();
+
+    /**
+     * Returns {@code true} if the property with the given name is registered in the current request/response exchange
+     * context, or {@code false} if there is no property by that name.
+     * <p>
+     * Use the {@link #getProperty} method with a property name to get the value of a property.
+     * </p>
+     *
+     * @param name a {@code String} specifying the name of the property.
+     * @return {@code true} if this property is registered in the context, or {@code false} if no property exists matching
+     * the given name.
+     * @see #getPropertyNames()
+     */
+    default public boolean hasProperty(String name) {
+        return getProperty(name) != null;
+    }
 
     /**
      * Binds an object to a given property name in the current request/response exchange context. If the name specified is

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerRequestContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/container/ContainerRequestContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -67,6 +67,22 @@ public interface ContainerRequestContext {
      * @see #getPropertyNames()
      */
     public Object getProperty(String name);
+
+    /**
+     * Returns {@code true} if the property with the given name is registered in the current request/response exchange
+     * context, or {@code false} if there is no property by that name.
+     * <p>
+     * Use the {@link #getProperty} method with a property name to get the value of a property.
+     * </p>
+     *
+     * @param name a {@code String} specifying the name of the property.
+     * @return {@code true} if this property is registered in the context, or {@code false} if no property exists matching
+     * the given name.
+     * @see #getPropertyNames()
+     */
+    default public boolean hasProperty(String name) {
+        return getProperty(name) != null;
+    }
 
     /**
      * Returns an immutable {@link java.util.Collection collection} containing the property names available within the

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/Application.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/Application.java
@@ -75,7 +75,10 @@ public class Application {
      *
      * @return a set of root resource and provider instances. Returning {@code null} is equivalent to returning an empty
      * set.
+     * @deprecated Automatic discovery of resources and providers or the {@code getClasses} method is preferred over
+      * {@code getSingletons}.
      */
+    @Deprecated
     public Set<Object> getSingletons() {
         return Collections.emptySet();
     }

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/Configuration.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/Configuration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -62,6 +62,16 @@ public interface Configuration {
      * configured.
      */
     public Object getProperty(String name);
+
+    /**
+     * Check whether the property with a given name is configured.
+     *
+     * @param name property name.
+     * @return {@code false} if the property with such name is not configured, {@code true} otherwise.
+     */
+    default public boolean hasProperty(String name) {
+        return getProperty(name) != null;
+    }
 
     /**
      * Returns an immutable {@link java.util.Collection collection} containing the property names available within the

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/HttpHeaders.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/HttpHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -197,6 +197,10 @@ public interface HttpHeaders {
      * See <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.19">HTTP/1.1 documentation</a>.
      */
     public static final String ETAG = "ETag";
+    /**
+     * See <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.20">HTTP/1.1 documentation</a>.
+     */
+    public static final String EXPECT = "Expect";
     /**
      * See <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.21">HTTP/1.1 documentation</a>.
      */

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/NewCookie.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/NewCookie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -47,6 +47,7 @@ public class NewCookie extends Cookie {
     private final Date expiry;
     private final boolean secure;
     private final boolean httpOnly;
+    private final SameSite sameSite;
 
     /**
      * Create a new instance.
@@ -56,7 +57,7 @@ public class NewCookie extends Cookie {
      * @throws IllegalArgumentException if name is {@code null}.
      */
     public NewCookie(final String name, final String value) {
-        this(name, value, null, null, DEFAULT_VERSION, null, DEFAULT_MAX_AGE, null, false, false);
+        this(name, value, null, null, DEFAULT_VERSION, null, DEFAULT_MAX_AGE, null, false, false, null);
     }
 
     /**
@@ -78,7 +79,7 @@ public class NewCookie extends Cookie {
             final String comment,
             final int maxAge,
             final boolean secure) {
-        this(name, value, path, domain, DEFAULT_VERSION, comment, maxAge, null, secure, false);
+        this(name, value, path, domain, DEFAULT_VERSION, comment, maxAge, null, secure, false, null);
     }
 
     /**
@@ -103,7 +104,7 @@ public class NewCookie extends Cookie {
             final int maxAge,
             final boolean secure,
             final boolean httpOnly) {
-        this(name, value, path, domain, DEFAULT_VERSION, comment, maxAge, null, secure, httpOnly);
+        this(name, value, path, domain, DEFAULT_VERSION, comment, maxAge, null, secure, httpOnly, null);
     }
 
     /**
@@ -127,7 +128,7 @@ public class NewCookie extends Cookie {
             final String comment,
             final int maxAge,
             final boolean secure) {
-        this(name, value, path, domain, version, comment, maxAge, null, secure, false);
+        this(name, value, path, domain, version, comment, maxAge, null, secure, false, null);
     }
 
     /**
@@ -156,12 +157,44 @@ public class NewCookie extends Cookie {
             final Date expiry,
             final boolean secure,
             final boolean httpOnly) {
+        this(name, value, path, domain, version, comment, maxAge, expiry, secure, httpOnly, null);
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param name the name of the cookie
+     * @param value the value of the cookie
+     * @param path the URI path for which the cookie is valid
+     * @param domain the host domain for which the cookie is valid
+     * @param version the version of the specification to which the cookie complies
+     * @param comment the comment
+     * @param maxAge the maximum age of the cookie in seconds
+     * @param expiry the cookie expiry date.
+     * @param secure specifies whether the cookie will only be sent over a secure connection
+     * @param httpOnly if {@code true} make the cookie HTTP only, i.e. only visible as part of an HTTP request.
+     * @param sameSite specifies the value of the {@code SameSite} cookie attribute
+     * @throws IllegalArgumentException if name is {@code null}.
+     * @since 3.1
+     */
+    public NewCookie(final String name,
+            final String value,
+            final String path,
+            final String domain,
+            final int version,
+            final String comment,
+            final int maxAge,
+            final Date expiry,
+            final boolean secure,
+            final boolean httpOnly,
+            final SameSite sameSite) {
         super(name, value, path, domain, version);
         this.comment = comment;
         this.maxAge = maxAge;
         this.expiry = expiry;
         this.secure = secure;
         this.httpOnly = httpOnly;
+        this.sameSite = sameSite;
     }
 
     /**
@@ -171,7 +204,7 @@ public class NewCookie extends Cookie {
      * @throws IllegalArgumentException if cookie is {@code null}.
      */
     public NewCookie(final Cookie cookie) {
-        this(cookie, null, DEFAULT_MAX_AGE, null, false, false);
+        this(cookie, null, DEFAULT_MAX_AGE, null, false, false, null);
     }
 
     /**
@@ -184,7 +217,7 @@ public class NewCookie extends Cookie {
      * @throws IllegalArgumentException if cookie is {@code null}.
      */
     public NewCookie(final Cookie cookie, final String comment, final int maxAge, final boolean secure) {
-        this(cookie, comment, maxAge, null, secure, false);
+        this(cookie, comment, maxAge, null, secure, false, null);
     }
 
     /**
@@ -200,6 +233,25 @@ public class NewCookie extends Cookie {
      * @since 2.0
      */
     public NewCookie(final Cookie cookie, final String comment, final int maxAge, final Date expiry, final boolean secure, final boolean httpOnly) {
+        this(cookie, comment, maxAge, expiry, secure, httpOnly, null);
+    }
+
+
+    /**
+     * Create a new instance supplementing the information in the supplied cookie.
+     *
+     * @param cookie the cookie to clone.
+     * @param comment the comment.
+     * @param maxAge the maximum age of the cookie in seconds.
+     * @param expiry the cookie expiry date.
+     * @param secure specifies whether the cookie will only be sent over a secure connection.
+     * @param httpOnly if {@code true} make the cookie HTTP only, i.e. only visible as part of an HTTP request.
+     * @param sameSite specifies the value of the {@code SameSite} cookie attribute
+     * @throws IllegalArgumentException if cookie is {@code null}.
+     * @since 3.1
+     */
+    public NewCookie(final Cookie cookie, final String comment, final int maxAge, final Date expiry, final boolean secure, final boolean httpOnly,
+            SameSite sameSite) {
         super(cookie == null ? null : cookie.getName(),
                 cookie == null ? null : cookie.getValue(),
                 cookie == null ? null : cookie.getPath(),
@@ -210,6 +262,7 @@ public class NewCookie extends Cookie {
         this.expiry = expiry;
         this.secure = secure;
         this.httpOnly = httpOnly;
+        this.sameSite = sameSite;
     }
 
     /**
@@ -289,6 +342,18 @@ public class NewCookie extends Cookie {
     }
 
     /**
+     * Returns the value of the {@code SameSite} attribute for this cookie or {@code null} if the attribute is not set.
+     * This attributes controls whether the cookie is sent with cross-origin requests, providing protection against
+     * cross-site request forgery.
+     *
+     * @return the value of the {@code SameSite} cookie attribute or {@code null}.
+     * @since 3.1
+     */
+    public SameSite getSameSite() {
+        return sameSite;
+    }
+
+    /**
      * Obtain a new instance of a {@link Cookie} with the same name, value, path, domain and version as this
      * {@code NewCookie}. This method can be used to obtain an object that can be compared for equality with another
      * {@code Cookie}; since a {@code Cookie} will never compare equal to a {@code NewCookie}.
@@ -327,6 +392,7 @@ public class NewCookie extends Cookie {
         hash = 59 + hash + (this.expiry != null ? this.expiry.hashCode() : 0);
         hash = 59 * hash + (this.secure ? 1 : 0);
         hash = 59 * hash + (this.httpOnly ? 1 : 0);
+        hash = 59 * hash + this.sameSite.ordinal();
         return hash;
     }
 
@@ -379,6 +445,34 @@ public class NewCookie extends Cookie {
         if (this.httpOnly != other.httpOnly) {
             return false;
         }
+        if (this.sameSite != other.sameSite) {
+            return false;
+        }
         return true;
     }
+
+    /**
+     * The available values for the {@code SameSite} cookie attribute.
+     * 
+     * @since 3.1
+     */
+    public enum SameSite {
+
+        /**
+         * The {@code None} mode disables protection provided by the {@code SameSite} cookie attribute.
+         */
+        NONE,
+
+        /**
+         * The {@code Lax} mode only allows to send cookies for cross-site top level navigation requests.
+         */
+        LAX,
+
+        /**
+         * The {@code Strict} mode prevents clients from sending cookies with any cross-site request.
+         */
+        STRICT
+
+    }
+
 }

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/Request.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/Request.java
@@ -105,12 +105,12 @@ public interface Request {
 
     /**
      * Evaluate request preconditions for a resource that does not currently exist. The primary use of this method is to
-     * support the <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.24"> If-Match: *</a> and
-     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.26"> If-None-Match: *</a> preconditions.
+     * support the <a href="https://tools.ietf.org/html/rfc7232#section-3.1"> If-Match: *</a> and
+     * <a href="https://tools.ietf.org/html/rfc7232#section-3.2"> If-None-Match: *</a> preconditions.
      *
      * <p>
-     * Note that both preconditions {@code If-None-Match: *} and <code>If-None-Match: <i>something</i></code> will always be
-     * considered to have been met and it is the applications responsibility to enforce any additional method-specific
+     * Note that precondition <code>If-None-Match: <i>something</i></code> will never be
+     * considered to have been met, and it is the application's responsibility to enforce any additional method-specific
      * semantics. E.g. a {@code PUT} on a resource that does not exist might succeed whereas a {@code GET} on a resource
      * that does not exist would likely result in a 404 response. It would be the responsibility of the application to
      * generate the 404 response.

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/ext/Extension.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/ext/Extension.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2018 Markus KARG. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.ext;
+
+import java.util.ServiceLoader;
+
+/**
+ * <p>
+ * An extension to the JAX-RS runtime.
+ * </p>
+ * <p>
+ * All kinds of JAX-RS components (i. e. filters and interceptors, features, providers, etc.) can be marked as an
+ * extension to the JAX-RS runtime, hence will become available to <em>all</em> applications running on thusly extended
+ * runtimes.
+ * </p>
+ * <p>
+ * JAX-RS implementations MUST automatically register a class in {@link jakarta.ws.rs.core.Configuration runtime
+ * configurations} if the class is a <em>provider class</em> for the {@link Extension} <em>service type</em> according
+ * to the rules set out in the description of {@link ServiceLoader}.
+ * </p>
+ *
+ * @author Markus KARG (markus@headcrashing.eu)
+ */
+public interface Extension {
+}

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/ext/InterceptorContext.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/ext/InterceptorContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -59,6 +59,22 @@ public interface InterceptorContext {
      * @see #getPropertyNames()
      */
     public Object getProperty(String name);
+
+    /**
+     * Returns {@code true} if the property with the given name is registered in the current request/response exchange
+     * context, or {@code false} if there is no property by that name.
+     * <p>
+     * Use the {@link #getProperty} method with a property name to get the value of a property.
+     * </p>
+     *
+     * @param name a {@code String} specifying the name of the property.
+     * @return {@code true} if this property is registered in the context, or {@code false} if no property exists matching
+     * the given name.
+     * @see #getPropertyNames()
+     */
+    default public boolean hasProperty(String name) {
+        return getProperty(name) != null;
+    }
 
     /**
      * Returns an immutable {@link java.util.Collection collection} containing the property names available within the

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/ext/RuntimeDelegate.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/ext/RuntimeDelegate.java
@@ -18,11 +18,14 @@ package jakarta.ws.rs.ext;
 
 import java.lang.reflect.ReflectPermission;
 import java.net.URL;
+import java.util.concurrent.CompletionStage;
 
+import jakarta.ws.rs.SeBootstrap;
+import jakarta.ws.rs.SeBootstrap.Instance;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Link;
-import jakarta.ws.rs.core.Response.ResponseBuilder;
 import jakarta.ws.rs.core.UriBuilder;
+import jakarta.ws.rs.core.Response.ResponseBuilder;
 import jakarta.ws.rs.core.Variant.VariantListBuilder;
 
 /**
@@ -219,4 +222,30 @@ public abstract class RuntimeDelegate {
      * @see jakarta.ws.rs.core.Link.Builder
      */
     public abstract Link.Builder createLinkBuilder();
+
+    /**
+     * Create a new instance of a {@link jakarta.ws.rs.SeBootstrap.Configuration.Builder}.
+     * <p>
+     * <em>This method is not intended to be invoked by applications. Call {@link SeBootstrap.Configuration#builder()}
+     * instead.</em>
+     * </p>
+     *
+     * @return new {@code SeBootstrap.Configuration.Builder} instance.
+     * @see SeBootstrap.Configuration.Builder
+     */
+    public abstract SeBootstrap.Configuration.Builder createConfigurationBuilder();
+
+    /**
+     * Perform startup of the application in Java SE environments.
+     * <p>
+     * <em>This method is not intended to be invoked by applications. Call {@link SeBootstrap#start(Application, Configuration)}
+     * instead.</em>
+     * </p>
+     *
+     * @param application The application to start up.
+     * @param configuration The bootstrap configuration.
+     * @return {@code CompletionStage} asynchronously producing handle of the running application {@link SeBootstrap.Instance
+     * instance}.
+     */
+    public abstract CompletionStage<Instance> bootstrap(Application application, SeBootstrap.Configuration configuration);
 }

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/sse/SseBroadcaster.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/sse/SseBroadcaster.java
@@ -77,14 +77,23 @@ public interface SseBroadcaster extends AutoCloseable {
     CompletionStage<?> broadcast(final OutboundSseEvent event);
 
     /**
-     * Close the broadcaster and all registered {@link SseEventSink} instances.
+     * Close the broadcaster and all registered {@link SseEventSink} instances. Any other resources associated with the
+     * {@link SseBroadcaster} should be released. This method is equivalent to calling {@code close(true)}.
      * <p>
-     * Any other resources associated with the {@link SseBroadcaster} should be released.
-     * <p>
-     * Subsequent calls have no effect and are ignored. Once the {@link SseBroadcaster} is closed,
-     * invoking any other method on the broadcaster instance would result in an {@link IllegalStateException}
-     * being thrown.
+     * Subsequent calls have no effect and are ignored. Once the {@link SseBroadcaster} is closed, invoking any other method
+     * on the broadcaster instance would result in an {@link IllegalStateException} being thrown.
      */
     @Override
     void close();
+
+    /**
+     * Close the broadcaster and release any resources associated with it. The closing of registered {@link SseEventSink} is
+     * controlled by the {@code cascading} parameter.
+     * <p>
+     * Subsequent calls have no effect and are ignored. Once the {@link SseBroadcaster} is closed, invoking any other method
+     * on the broadcaster instance would result in an {@link IllegalStateException} being thrown.
+     *
+     * @param cascading Boolean value that controls closing of registered {@link SseEventSink} instances.
+     */
+    void close(boolean cascading);
 }

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/SeBootstrapTest.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/SeBootstrapTest.java
@@ -1,0 +1,199 @@
+package jakarta.ws.rs;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.util.concurrent.CompletionStage;
+
+import javax.net.ssl.SSLContext;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import jakarta.ws.rs.SeBootstrap;
+import jakarta.ws.rs.SeBootstrap.Configuration;
+import jakarta.ws.rs.SeBootstrap.Configuration.SSLClientAuthentication;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.ext.RuntimeDelegate;
+
+/**
+ * Unit tests for {@link SeBootstrap}
+ *
+ * @author Markus KARG (markus@headcrashing.eu)
+ * @since 2.2
+ */
+public final class SeBootstrapTest {
+
+    /**
+     * Installs a new {@code RuntimeDelegate} mock before each test case, as some test cases need to find a pristine
+     * <em>installed</em> RuntimeDelegate.
+     */
+    @Before
+    public final void setUp() {
+        RuntimeDelegate.setInstance(mock(RuntimeDelegate.class));
+    }
+
+    /**
+     * Uninstalls the {@code RuntimeDelegate} mock after each test case to be sure that the <em>next</em> test case does not
+     * use a possibly cluttered instance.
+     */
+    @After
+    public final void tearDown() {
+        RuntimeDelegate.setInstance(null);
+    }
+
+    /**
+     * Assert that {@link SeBootstrap#start(Application, Configuration)} will delegate to
+     * {@link RuntimeDelegate#bootstrap(Application, Configuration)}.
+     *
+     * @since 2.2
+     */
+    @Test
+    public final void shouldDelegateApplicationStartupToRuntimeDelegate() {
+        // given
+        final Application application = mock(Application.class);
+        final Configuration configuration = mock(Configuration.class);
+        @SuppressWarnings("unchecked")
+        final CompletionStage<SeBootstrap.Instance> nativeCompletionStage = mock(CompletionStage.class);
+        given(RuntimeDelegate.getInstance().bootstrap(application, configuration)).willReturn(nativeCompletionStage);
+
+        // when
+        final CompletionStage<SeBootstrap.Instance> actualCompletionStage = SeBootstrap.start(application, configuration);
+
+        // then
+        assertThat(actualCompletionStage, is(sameInstance(nativeCompletionStage)));
+    }
+
+    /**
+     * Assert that {@link SeBootstrap.Configuration#builder()} will delegate to
+     * {@link RuntimeDelegate#createConfigurationBuilder()}.
+     *
+     * @since 2.2
+     */
+    @Test
+    public final void shouldDelegateConfigurationBuilderCreationToRuntimeDelegate() {
+        // given
+        final SeBootstrap.Configuration.Builder nativeConfigurationBuilder = mock(SeBootstrap.Configuration.Builder.class);
+        given(RuntimeDelegate.getInstance().createConfigurationBuilder()).willReturn(nativeConfigurationBuilder);
+
+        // when
+        final SeBootstrap.Configuration.Builder actualConfigurationBuilder = SeBootstrap.Configuration.builder();
+
+        // then
+        assertThat(actualConfigurationBuilder, is(sameInstance(nativeConfigurationBuilder)));
+    }
+
+    /**
+     * Assert that {@code Configuration.Builder}'s {@code from(external configuration)} bulk-loading method simply returns
+     * {@code this}, but does nothing else, as it is a no-op implementation.
+     *
+     * @since 2.2
+     */
+    @Test
+    public final void shouldReturnSameConfigurationBuilderInstanceWhenLoadingExternalConfiguration() {
+        // given
+        final SeBootstrap.Configuration.Builder previousConfigurationBuilder = spy(SeBootstrap.Configuration.Builder.class);
+        final Object someExternalConfiguration = mock(Object.class);
+
+        // when
+        final SeBootstrap.Configuration.Builder currentConfigurationBuilder = previousConfigurationBuilder
+                .from(someExternalConfiguration);
+
+        // then
+        assertThat(currentConfigurationBuilder, is(sameInstance(previousConfigurationBuilder)));
+        verify(previousConfigurationBuilder).from(someExternalConfiguration);
+        verifyNoMoreInteractions(previousConfigurationBuilder);
+    }
+
+    /**
+     * Assert that {@code Configuration.Builder}'s convenience methods delegate to its generic {@code property(name, value)}
+     * method using the <em>right</em> property name.
+     *
+     * @since 2.2
+     */
+    @Test
+    public final void shouldPushCorrespondingPropertiesIntoConfigurationBuilder() {
+        // given
+        final String someProtocolValue = mockString();
+        final String someHostValue = mockString();
+        final int somePortValue = mockInt();
+        final String someRootPathValue = mockString();
+        final SSLContext someSSLContextValue = mock(SSLContext.class);
+        final SSLClientAuthentication someSSLClientAuthenticationValue = SSLClientAuthentication.MANDATORY;
+        final SeBootstrap.Configuration.Builder configurationBuilder = spy(SeBootstrap.Configuration.Builder.class);
+
+        // when
+        configurationBuilder.protocol(someProtocolValue);
+        configurationBuilder.host(someHostValue);
+        configurationBuilder.port(somePortValue);
+        configurationBuilder.rootPath(someRootPathValue);
+        configurationBuilder.sslContext(someSSLContextValue);
+        configurationBuilder.sslClientAuthentication(someSSLClientAuthenticationValue);
+
+        // then
+        verify(configurationBuilder).property(SeBootstrap.Configuration.PROTOCOL, someProtocolValue);
+        verify(configurationBuilder).property(SeBootstrap.Configuration.HOST, someHostValue);
+        verify(configurationBuilder).property(SeBootstrap.Configuration.PORT, somePortValue);
+        verify(configurationBuilder).property(SeBootstrap.Configuration.ROOT_PATH, someRootPathValue);
+        verify(configurationBuilder).property(SeBootstrap.Configuration.SSL_CONTEXT, someSSLContextValue);
+        verify(configurationBuilder).property(SeBootstrap.Configuration.SSL_CLIENT_AUTHENTICATION,
+                someSSLClientAuthenticationValue);
+    }
+
+    /**
+     * Assert that {@code Configuration}'s convenience methods delegate to its generic {@code property(name)} method using
+     * the <em>right</em> property name.
+     *
+     * @since 2.2
+     */
+    @Test
+    public final void shouldPullCorrespondingPropertiesFromConfiguration() {
+        // given
+        final String someProtocolValue = mockString();
+        final String someHostValue = mockString();
+        final int somePortValue = mockInt();
+        final String someRootPathValue = mockString();
+        final SSLContext someSSLContextValue = mock(SSLContext.class);
+        final SSLClientAuthentication someSSLClientAuthenticationValue = SSLClientAuthentication.MANDATORY;
+        final SeBootstrap.Configuration configuration = spy(SeBootstrap.Configuration.class);
+        given(configuration.property(SeBootstrap.Configuration.PROTOCOL)).willReturn(someProtocolValue);
+        given(configuration.property(SeBootstrap.Configuration.HOST)).willReturn(someHostValue);
+        given(configuration.property(SeBootstrap.Configuration.PORT)).willReturn(somePortValue);
+        given(configuration.property(SeBootstrap.Configuration.ROOT_PATH)).willReturn(someRootPathValue);
+        given(configuration.property(SeBootstrap.Configuration.SSL_CONTEXT)).willReturn(someSSLContextValue);
+        given(configuration.property(SeBootstrap.Configuration.SSL_CLIENT_AUTHENTICATION))
+                .willReturn(someSSLClientAuthenticationValue);
+
+        // when
+        final String actualProtocolValue = configuration.protocol();
+        final String actualHostValue = configuration.host();
+        final int actualPortValue = configuration.port();
+        final String actualRootPathValue = configuration.rootPath();
+        final SSLContext actualSSLContextValue = configuration.sslContext();
+        final SSLClientAuthentication actualSSLClientAuthenticationValue = configuration.sslClientAuthentication();
+
+        // then
+        assertThat(actualProtocolValue, is(sameInstance(someProtocolValue)));
+        assertThat(actualHostValue, is(sameInstance(someHostValue)));
+        assertThat(actualPortValue, is(somePortValue));
+        assertThat(actualRootPathValue, is(sameInstance(someRootPathValue)));
+        assertThat(actualSSLContextValue, is(sameInstance(someSSLContextValue)));
+        assertThat(actualSSLClientAuthenticationValue, is(sameInstance(someSSLClientAuthenticationValue)));
+    }
+
+    private static String mockString() {
+        return Integer.toString(mockInt());
+    }
+
+    private static int mockInt() {
+        return (int) Math.round(Integer.MAX_VALUE * Math.random());
+    }
+
+}

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/SeBootstrapTest.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/SeBootstrapTest.java
@@ -27,7 +27,7 @@ import jakarta.ws.rs.ext.RuntimeDelegate;
  * Unit tests for {@link SeBootstrap}
  *
  * @author Markus KARG (markus@headcrashing.eu)
- * @since 2.2
+ * @since 3.1
  */
 public final class SeBootstrapTest {
 
@@ -53,7 +53,7 @@ public final class SeBootstrapTest {
      * Assert that {@link SeBootstrap#start(Application, Configuration)} will delegate to
      * {@link RuntimeDelegate#bootstrap(Application, Configuration)}.
      *
-     * @since 2.2
+     * @since 3.1
      */
     @Test
     public final void shouldDelegateApplicationStartupToRuntimeDelegate() {
@@ -75,7 +75,7 @@ public final class SeBootstrapTest {
      * Assert that {@link SeBootstrap.Configuration#builder()} will delegate to
      * {@link RuntimeDelegate#createConfigurationBuilder()}.
      *
-     * @since 2.2
+     * @since 3.1
      */
     @Test
     public final void shouldDelegateConfigurationBuilderCreationToRuntimeDelegate() {
@@ -94,7 +94,7 @@ public final class SeBootstrapTest {
      * Assert that {@code Configuration.Builder}'s {@code from(external configuration)} bulk-loading method simply returns
      * {@code this}, but does nothing else, as it is a no-op implementation.
      *
-     * @since 2.2
+     * @since 3.1
      */
     @Test
     public final void shouldReturnSameConfigurationBuilderInstanceWhenLoadingExternalConfiguration() {
@@ -116,7 +116,7 @@ public final class SeBootstrapTest {
      * Assert that {@code Configuration.Builder}'s convenience methods delegate to its generic {@code property(name, value)}
      * method using the <em>right</em> property name.
      *
-     * @since 2.2
+     * @since 3.1
      */
     @Test
     public final void shouldPushCorrespondingPropertiesIntoConfigurationBuilder() {
@@ -151,7 +151,7 @@ public final class SeBootstrapTest {
      * Assert that {@code Configuration}'s convenience methods delegate to its generic {@code property(name)} method using
      * the <em>right</em> property name.
      *
-     * @since 2.2
+     * @since 3.1
      */
     @Test
     public final void shouldPullCorrespondingPropertiesFromConfiguration() {

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/SerializationTest.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/SerializationTest.java
@@ -1,0 +1,173 @@
+package jakarta.ws.rs;
+
+import jakarta.ws.rs.core.EntityTag;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Link;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.NewCookie;
+import jakarta.ws.rs.core.Response;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.lang.annotation.Annotation;
+import java.net.URI;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Test;
+
+public class SerializationTest {
+
+    class TestResponse extends Response {
+
+        @Override
+        public int getStatus() {
+            return 0;
+        }
+
+        @Override
+        public StatusType getStatusInfo() {
+            return null;
+        }
+
+        @Override
+        public Object getEntity() {
+            return null;
+        }
+
+        @Override
+        public <T> T readEntity(Class<T> entityType) {
+            return null;
+        }
+
+        @Override
+        public <T> T readEntity(GenericType<T> entityType) {
+            return null;
+        }
+
+        @Override
+        public <T> T readEntity(Class<T> entityType, Annotation[] annotations) {
+            return null;
+        }
+
+        @Override
+        public <T> T readEntity(GenericType<T> entityType, Annotation[] annotations) {
+            return null;
+        }
+
+        @Override
+        public boolean hasEntity() {
+            return false;
+        }
+
+        @Override
+        public boolean bufferEntity() {
+            return false;
+        }
+
+        @Override
+        public void close() {
+
+        }
+
+        @Override
+        public MediaType getMediaType() {
+            return null;
+        }
+
+        @Override
+        public Locale getLanguage() {
+            return null;
+        }
+
+        @Override
+        public int getLength() {
+            return 0;
+        }
+
+        @Override
+        public Set<String> getAllowedMethods() {
+            return null;
+        }
+
+        @Override
+        public Map<String, NewCookie> getCookies() {
+            return null;
+        }
+
+        @Override
+        public EntityTag getEntityTag() {
+            return null;
+        }
+
+        @Override
+        public Date getDate() {
+            return null;
+        }
+
+        @Override
+        public Date getLastModified() {
+            return null;
+        }
+
+        @Override
+        public URI getLocation() {
+            return null;
+        }
+
+        @Override
+        public Set<Link> getLinks() {
+            return null;
+        }
+
+        @Override
+        public boolean hasLink(String relation) {
+            return false;
+        }
+
+        @Override
+        public Link getLink(String relation) {
+            return null;
+        }
+
+        @Override
+        public Link.Builder getLinkBuilder(String relation) {
+            return null;
+        }
+
+        @Override
+        public MultivaluedMap<String, Object> getMetadata() {
+            return null;
+        }
+
+        @Override
+        public MultivaluedMap<String, String> getStringHeaders() {
+            return null;
+        }
+
+        @Override
+        public String getHeaderString(String name) {
+            return null;
+        }
+    }
+
+    @Test
+    public void testSerializaWebApplicationException() throws Exception {
+        final WebApplicationException exceptionWithResponse = new WebApplicationException("message", new RuntimeException("cause"), new TestResponse());
+        serialize(exceptionWithResponse);
+
+    }
+
+    private void serialize(WebApplicationException exception) throws IOException {
+        try (
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            ObjectOutputStream oos = new ObjectOutputStream(bos);
+        ) {
+            oos.writeObject(exception);
+            oos.flush();
+            byte[] data = bos.toByteArray();
+        }
+    }
+}

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/core/NewCookieTest.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/core/NewCookieTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,6 +18,7 @@ package jakarta.ws.rs.core;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.junit.Assert.assertNull;
 
 import org.junit.After;
 import org.junit.Before;
@@ -56,4 +57,25 @@ public class NewCookieTest {
         } catch (IllegalArgumentException e) {
         }
     }
+
+    @Test
+    public void testSameSite() {
+
+        NewCookie sameSiteOmit = new NewCookie("name", "value", "/", "localhost", 1, null, 0, null, false, false);
+        assertNull(sameSiteOmit.getSameSite());
+
+        NewCookie sameSiteNull = new NewCookie("name", "value", "/", "localhost", 1, null, 0, null, false, false, null);
+        assertNull(sameSiteNull.getSameSite());
+
+        NewCookie sameSiteNone = new NewCookie("name", "value", "/", "localhost", 1, null, 0, null, false, false, NewCookie.SameSite.NONE);
+        assertEquals(NewCookie.SameSite.NONE, sameSiteNone.getSameSite());
+
+        NewCookie sameSiteLax = new NewCookie("name", "value", "/", "localhost", 1, null, 0, null, false, false, NewCookie.SameSite.LAX);
+        assertEquals(NewCookie.SameSite.LAX, sameSiteLax.getSameSite());
+
+        NewCookie sameSiteStrict = new NewCookie("name", "value", "/", "localhost", 1, null, 0, null, false, false, NewCookie.SameSite.STRICT);
+        assertEquals(NewCookie.SameSite.STRICT, sameSiteStrict.getSameSite());
+
+    }
+
 }

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/core/RuntimeDelegateStub.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/core/RuntimeDelegateStub.java
@@ -16,6 +16,13 @@
 
 package jakarta.ws.rs.core;
 
+import java.util.concurrent.CompletionStage;
+
+import jakarta.ws.rs.SeBootstrap;
+import jakarta.ws.rs.SeBootstrap.Configuration;
+import jakarta.ws.rs.SeBootstrap.Instance;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.core.Link.Builder;
 import jakarta.ws.rs.core.Response.ResponseBuilder;
 import jakarta.ws.rs.core.Variant.VariantListBuilder;
@@ -50,6 +57,16 @@ public class RuntimeDelegateStub extends RuntimeDelegate {
 
     @Override
     public Builder createLinkBuilder() {
+        return null;
+    }
+
+    @Override
+    public Configuration.Builder createConfigurationBuilder() {
+        return null;
+    }
+
+    @Override
+    public CompletionStage<Instance> bootstrap(final Application application, final SeBootstrap.Configuration configuration) {
         return null;
     }
 }

--- a/jaxrs-spec/pom.xml
+++ b/jaxrs-spec/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>jakarta.ws.rs</groupId>
     <artifactId>jakarta.ws.rs-spec</artifactId>
-    <version>3.0.0</version>
+    <version>3.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Jakarta RESTful Web Services Specification</name>
 

--- a/jaxrs-spec/src/main/asciidoc/chapters/appendix/_change-log.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/appendix/_change-log.adoc
@@ -12,6 +12,8 @@
 [[change-log]]
 == Change Log
 
+include::_changes-since-3.0-release.adoc[]
+
 include::_changes-since-2.1-release.adoc[]
 
 include::_changes-since-2.1-public-review.adoc[]

--- a/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-2.1-release.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-2.1-release.adoc
@@ -15,5 +15,3 @@
 * Package changes from `javax.ws.rs.*` to `jakarta.ws.rs.*`
 * <<jaxb>>: JAXB API is now optional
 * <<additional_reqs>>: Clarified injection with regard to `getSingletons()` method
-* <<exceptionmapper>>: Added requirement that JAX-RS implementations have 
-default exception mappers.

--- a/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-2.1-release.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-2.1-release.adoc
@@ -15,3 +15,5 @@
 * Package changes from `javax.ws.rs.*` to `jakarta.ws.rs.*`
 * <<jaxb>>: JAXB API is now optional
 * <<additional_reqs>>: Clarified injection with regard to `getSingletons()` method
+* <<exceptionmapper>>: Added requirement that JAX-RS implementations have 
+default exception mappers.

--- a/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-3.0-release.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-3.0-release.adoc
@@ -1,0 +1,16 @@
+////
+*******************************************************************
+* Copyright (c) 2020 Eclipse Foundation
+*
+* This specification document is made available under the terms
+* of the Eclipse Foundation Specification License v1.0, which is
+* available at https://www.eclipse.org/legal/efsl.php.
+*******************************************************************
+////
+
+[[changes-since-3.0-release]]
+=== Changes Since 3.0 Release
+
+* <<exceptionmapper>>: Added requirement that JAX-RS implementations have 
+default exception mappers.
+

--- a/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-3.0-release.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-3.0-release.adoc
@@ -13,4 +13,5 @@
 
 * <<exceptionmapper>>: Added requirement that JAX-RS implementations have 
 default exception mappers.
-
+* <<resource_field>>: Array types may be specified for `@CookieParam`,
+`@FormParam`, `@HeaderParam`, `@MatrixParam` and `@QueryParam` parameters.

--- a/jaxrs-spec/src/main/asciidoc/chapters/filters_and_interceptors/_exceptions_filters_and_interceptors.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/filters_and_interceptors/_exceptions_filters_and_interceptors.adoc
@@ -17,7 +17,8 @@
 When a filter or interceptor method throws an exception, the server
 runtime will process the exception as described in
 <<exceptions_providers_server>>. As explained in
-<<exceptionmapper>>, an application can supply exception mapping
+<<exceptionmapper>>, a JAX-RS implementation will supply a default
+exception mapping provider and an application can supply additional exception mapping
 providers. At most one exception mapper MUST be used in a single request
 processing cycle to avoid potentially infinite loops.
 

--- a/jaxrs-spec/src/main/asciidoc/chapters/providers/_exceptionmapper.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/providers/_exceptionmapper.adoc
@@ -16,8 +16,8 @@ instance of `Response`. An exception mapping provider implements the
 `ExceptionMapper<T>` interface and may be annotated with `@Provider` for
 automatic discovery.
 
-When a resource class or provider method throws an exception for which
-there is an exception mapping provider, the matching provider is used to
+When a resource class or provider method throws an exception,
+the matching provider is used to
 obtain a `Response` instance. The resulting `Response` is processed as
 if a web resource method had returned the `Response`, see
 <<resource_method_return>>. In particular, a mapped `Response` MUST be
@@ -29,6 +29,13 @@ implementation MUST use the provider whose generic type is the nearest
 superclass of the exception. If two or more exception providers are
 applicable, the one with the highest priority MUST be chosen as
 described in <<provider_priorities>>.
+
+A JAX-RS implementation MUST include a default exception mapping provider
+that implements ExceptionMapper<Throwable> and which SHOULD
+set the response status to 500.
+
+When the default exception mapping provider handles a WebApplicationException, it MUST
+return the embedded Response, and it MUST respect the status code in the Response.
 
 To avoid a potentially infinite loop, a single exception mapper must be
 used during the processing of a request and its corresponding response.

--- a/jaxrs-spec/src/main/asciidoc/chapters/resources/_resource_field.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/resources/_resource_field.adoc
@@ -59,8 +59,8 @@ to limitations of the built-in `valueOf` method that is part of all Java
 enumerations, a `fromString` method is often defined by the enum
 writers. Consequently, the `fromString` method is preferred when
 available.].
-5.  `List<T>`, `Set<T>`, or `SortedSet<T>`, where `T` satisfies
-1,3 or 4 above.
+5.  `List<T>`, `Set<T>`, `SortedSet<T>` or an array `T[]`, where
+`T` satisfies 1, 3 or 4 above.
 
 The `DefaultValue` annotation may be used to supply a default value for
 some of the above, see the Javadoc for `DefaultValue` for usage details

--- a/jaxrs-spec/src/main/asciidoc/chapters/resources/_resource_method.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/resources/_resource_method.adoc
@@ -134,34 +134,19 @@ exceptions and process them in the following order:
 
 1.  Instances of `WebApplicationException` and its subclasses MUST be
 mapped to a response as follows. If the `response` property of the
-exception does not contain an entity and an exception mapping provider
-(see <<exceptionmapper>>) is available for
-`WebApplicationException` or the corresponding subclass, an
-implementation MUST use the provider to create a new
-`Response` instance, otherwise the `response` property is used directly.
+exception is null, then an
+implementation MUST use the most appropriate
+exception mapping provider (see <<exceptionmapper>>) to create a new
+`Response` instance; otherwise the `response` property is used directly.
 The resulting `Response` instance is then processed according to
 <<resource_method_return>>.
-2.  If an exception mapping provider (see <<exceptionmapper>>) is
-available for the exception or one of its superclasses, an
-implementation MUST use the provider whose generic type is the nearest
+2. An implementation MUST use the exception mapping provider
+(see <<exceptionmapper>>) whose generic type is the nearest
 superclass of the exception to create a `Response` instance that is then
 processed according to <<resource_method_return>>. If the
 exception mapping provider throws an exception while creating a
 `Response` then return a server error (status code 500) response to the
 client.
-3.  Unchecked exceptions and errors that have not been
-mapped MUST be re-thrown and allowed to propagate to the underlying
-container.
-4.  Checked exceptions and throwables that have not been
-mapped and cannot be thrown directly MUST be wrapped in a
-container-specific exception that is then thrown and allowed to
-propagate to the underlying container. Servlet-based implementations
-MUST use `ServletException` as the wrapper. JAX-WS `Provider`-based
-implementations MUST use `WebServiceException` as the wrapper.
-
-*Note:* _Items 3 and 4 allow existing container facilities
-(e.g. a Servlet filter or error pages) to be used to handle the error if
-desired._
 
 [[head_and_options]]
 ==== HEAD and OPTIONS


### PR DESCRIPTION
This PR proposed to add the content of branch 3.1-SNAPSHOT ontop of branch master, hence make master the branch where we work towards 3.1. Also, this PR adds two fixes needed to effectively build the code / spec correctly, which had been missing on branch 3.1-SNAPSHOT so far.

**As these changes are effectively reviewed already, they are no *new* API changes, hence this is a fast-track review period of just one day as per our [committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**