### PR TITLE
[Spec] Runtime Extensions

### DIFF
--- a/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-3.0-release.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-3.0-release.adoc
@@ -12,7 +12,7 @@
 === Changes Since 3.0 Release
 
 * <<extensions>>: Added requirement that JAX-RS implementations MUST load
-`Extension`s using the `ServiceLoader` mechanism.
+`Extension` implementations using the `ServiceLoader` mechanism.
 * <<exceptionmapper>>: Added requirement that JAX-RS implementations have 
 default exception mappers.
 * <<resource_field>>: Array types may be specified for `@CookieParam`,

--- a/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-3.0-release.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-3.0-release.adoc
@@ -11,6 +11,8 @@
 [[changes-since-3.0-release]]
 === Changes Since 3.0 Release
 
+* <<extensions>>: Added requirement that JAX-RS implementations MUST load
+extensions using the `ServiceLoader` mechanism.
 * <<exceptionmapper>>: Added requirement that JAX-RS implementations have 
 default exception mappers.
 * <<resource_field>>: Array types may be specified for `@CookieParam`,

--- a/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-3.0-release.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-3.0-release.adoc
@@ -12,7 +12,7 @@
 === Changes Since 3.0 Release
 
 * <<extensions>>: Added requirement that JAX-RS implementations MUST load
-extensions using the `ServiceLoader` mechanism.
+`Extension`s using the `ServiceLoader` mechanism.
 * <<exceptionmapper>>: Added requirement that JAX-RS implementations have 
 default exception mappers.
 * <<resource_field>>: Array types may be specified for `@CookieParam`,

--- a/jaxrs-spec/src/main/asciidoc/chapters/providers/_lifecycle_and_environment.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/providers/_lifecycle_and_environment.adoc
@@ -29,9 +29,20 @@ all of the lifecycle options provided by that framework.
 ==== Automatic Discovery
 
 The annotation `@Provider` is used by a JAX-RS runtime to automatically
-discover provider classes via mechanisms such as class scanning. A
-JAX-RS implementation that supports automatic discovery of classes MUST
-process only those classes that are annotated with `@Provider`.
+discover provider classes via mechanisms such as class scanning.
+
+[[extensions]]
+Providers MAY implement the `Extension` interface to declare it as an
+extension of the runtime.
+Compatible products MUST automatically register a class in
+`jakarta.ws.rs.core.Configuration` runtime configurations if the
+class is a _provider class_ for the `Extension` _service type_ according
+to the rules set out in the description of `ServiceLoader`.
+
+A JAX-RS implementation that supports automatic discovery of classes MUST
+process only those classes that are annotated with `@Provider` or are
+registered via the `Extension` mechanism described above.
+
 
 [[provider_class_constructor]]
 ==== Constructors

--- a/jaxrs-spec/src/main/asciidoc/chapters/providers/_providers.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/providers/_providers.adoc
@@ -16,18 +16,9 @@ such as filtering requests, converting representations into Java
 objects, mapping exceptions to responses, etc. A provider can be either
 _pre-packaged_ in the JAX-RS runtime or supplied by an application. All
 _application-supplied_ providers implement interfaces in the JAX-RS API
-and MAY be annotated with `@Provider` for automatic discovery purposes;
-the integration of pre-packaged providers into the JAX-RS runtime is
-implementation dependent.
-
-[[extensions]]
-Providers MAY implement the `Extension` interface to declare it as an
-extension of the runtime.
-
-Compatible products MUST automatically register a class in
-`jakarta.ws.rs.core.Configuration` runtime configurations if the
-class is a _provider class_ for the `Extension` _service type_ according
-to the rules set out in the description of `ServiceLoader`.
+and MAY be annotated with `@Provider` or implement the `Extension`
+interface for automatic discovery purposes; the integration of
+pre-packaged providers into the JAX-RS runtime is implementation dependent.
 
 This chapter introduces some of the basic JAX-RS providers; other
 providers are introduced in Chapter <<client_api>> and Chapter

--- a/jaxrs-spec/src/main/asciidoc/chapters/providers/_providers.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/providers/_providers.adoc
@@ -20,6 +20,15 @@ and MAY be annotated with `@Provider` for automatic discovery purposes;
 the integration of pre-packaged providers into the JAX-RS runtime is
 implementation dependent.
 
+[[extensions]]
+Providers MAY be annotated with `@Extension` to declare it as an
+extension of the runtime.
+
+Compatible products MUST automatically register a class in
+`jakarta.ws.rs.core.Configuration` runtime configurations if the
+class is a _provider class_ for the extension _service type_ according
+to the rules set out in the description of `ServiceLoader`.
+
 This chapter introduces some of the basic JAX-RS providers; other
 providers are introduced in Chapter <<client_api>> and Chapter
 <<filters_and_interceptors>>.

--- a/jaxrs-spec/src/main/asciidoc/chapters/providers/_providers.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/providers/_providers.adoc
@@ -21,12 +21,12 @@ the integration of pre-packaged providers into the JAX-RS runtime is
 implementation dependent.
 
 [[extensions]]
-Providers MAY be annotated with `@Extension` to declare it as an
+Providers MAY implement the `Extension` interface to declare it as an
 extension of the runtime.
 
 Compatible products MUST automatically register a class in
 `jakarta.ws.rs.core.Configuration` runtime configurations if the
-class is a _provider class_ for the extension _service type_ according
+class is a _provider class_ for the `Extension` _service type_ according
 to the rules set out in the description of `ServiceLoader`.
 
 This chapter introduces some of the basic JAX-RS providers; other


### PR DESCRIPTION
Core description of the `Extension` marker interface, as this is part of release 3.1 according to PR #751.

**The underlying Java code already exists in `master`. This PR *only documents* this already existing feature.**