### PR TITLE
[Spec] New method `#hasProperty(String)`

### DIFF
--- a/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-3.0-release.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-3.0-release.adoc
@@ -16,3 +16,4 @@ default exception mappers.
 * <<resource_field>>: Array types may be specified for `@CookieParam`,
 `@FormParam`, `@HeaderParam`, `@MatrixParam` and `@QueryParam` parameters.
 * Deprecated Link.JaxbLink and Link.JaxbAdapter inner classes.
+* New method `#hasProperty(String)` wherever `#getProperty(String)` exists


### PR DESCRIPTION
Added to history that we introduced `#hasProperty(String)` since release 3.1.