### PR TITLE
[Spec] History: Mention Response.created(URI) (PR 810)

### DIFF
--- a/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-3.0-release.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-3.0-release.adoc
@@ -16,3 +16,5 @@ default exception mappers.
 * <<resource_field>>: Array types may be specified for `@CookieParam`,
 `@FormParam`, `@HeaderParam`, `@MatrixParam` and `@QueryParam` parameters.
 * Deprecated Link.JaxbLink and Link.JaxbAdapter inner classes.
+* `Response.created(URI)` now resolves relative URIs into an absolute URI
+against the *base* URI, not against the *request* URI anymore.


### PR DESCRIPTION
Mentioning the change done by PR #810 in the history chapter of the spec.

**The underlying Java code already exists in `master`. This PR *only documents* this already existing feature.**