### PR TITLE
JUnit 5

### DIFF
--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -513,9 +513,15 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.7.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/SeBootstrapTest.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/SeBootstrapTest.java
@@ -2,7 +2,7 @@ package jakarta.ws.rs;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -13,9 +13,9 @@ import java.util.concurrent.CompletionStage;
 
 import javax.net.ssl.SSLContext;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.ws.rs.SeBootstrap;
 import jakarta.ws.rs.SeBootstrap.Configuration;
@@ -35,7 +35,7 @@ public final class SeBootstrapTest {
      * Installs a new {@code RuntimeDelegate} mock before each test case, as some test cases need to find a pristine
      * <em>installed</em> RuntimeDelegate.
      */
-    @Before
+    @BeforeEach
     public final void setUp() {
         RuntimeDelegate.setInstance(mock(RuntimeDelegate.class));
     }
@@ -44,7 +44,7 @@ public final class SeBootstrapTest {
      * Uninstalls the {@code RuntimeDelegate} mock after each test case to be sure that the <em>next</em> test case does not
      * use a possibly cluttered instance.
      */
-    @After
+    @AfterEach
     public final void tearDown() {
         RuntimeDelegate.setInstance(null);
     }

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/SerializationTest.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/SerializationTest.java
@@ -16,7 +16,7 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SerializationTest {
 

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/core/AbstractMultivaluedMapTest.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/core/AbstractMultivaluedMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,9 +16,9 @@
 
 package jakarta.ws.rs.core;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 /**

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/core/CacheControlTest.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/core/CacheControlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,9 +19,9 @@ package jakarta.ws.rs.core;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.ws.rs.ext.RuntimeDelegate;
 
@@ -32,12 +32,12 @@ import jakarta.ws.rs.ext.RuntimeDelegate;
  */
 public class CacheControlTest {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         RuntimeDelegate.setInstance(new RuntimeDelegateStub());
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         RuntimeDelegate.setInstance(null);
     }

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/core/CookieTest.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/core/CookieTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,23 +16,23 @@
 
 package jakarta.ws.rs.core;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.ws.rs.ext.RuntimeDelegate;
 
 public class CookieTest {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         RuntimeDelegate.setInstance(new RuntimeDelegateStub());
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         RuntimeDelegate.setInstance(null);
     }

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/core/EntityTagTest.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/core/EntityTagTest.java
@@ -17,11 +17,11 @@
 package jakarta.ws.rs.core;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.ws.rs.ext.RuntimeDelegate;
 
@@ -29,12 +29,12 @@ import static org.mockito.Mockito.*;
 
 public class EntityTagTest {
 
-    @Before
+    @BeforeEach
     public void setUp() {
         RuntimeDelegate.setInstance(mock(RuntimeDelegate.class));
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         RuntimeDelegate.setInstance(null);
     }

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/core/GenericEntityTest.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/core/GenericEntityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,9 +16,9 @@
 
 package jakarta.ws.rs.core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Method;
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class GenericEntityTest {
 

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/core/GenericTypeTest.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/core/GenericTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,7 +16,8 @@
 
 package jakarta.ws.rs.core;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
@@ -24,7 +25,7 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Type literal construction unit tests.
@@ -90,12 +91,12 @@ public class GenericTypeTest {
         assertEquals(arrayListOfStringsType, type.getType());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testInvalidGenericType() throws NoSuchMethodException {
         ArrayList<String> al = new ArrayList<String>();
         Method addMethod = al.getClass().getMethod("add", Object.class);
         final Type type = addMethod.getGenericParameterTypes()[0];
-        new GenericType<>(type);
+        assertThrows(IllegalArgumentException.class, () -> new GenericType<>(type));
     }
 
     @Test
@@ -119,9 +120,9 @@ public class GenericTypeTest {
         }.getRawType());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNullGenericType() {
-        new GenericType<>(null);
+        assertThrows(IllegalArgumentException.class, () -> new GenericType<>(null));
     }
 
     // Regression test for JAX_RS_SPEC-274

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/core/JaxbLinkTest.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/core/JaxbLinkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,7 +18,7 @@ package jakarta.ws.rs.core;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.StringReader;
 import java.io.StringWriter;
@@ -29,7 +29,7 @@ import java.util.Map;
 import javax.xml.namespace.QName;
 import javax.xml.transform.stream.StreamSource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBElement;
@@ -63,9 +63,9 @@ public class JaxbLinkTest {
         final Link.JaxbLink actual = unmarshaller.unmarshal(new StreamSource(
                 new StringReader(writer.toString())), Link.JaxbLink.class).getValue();
 
-        assertEquals("Unmarshalled JaxbLink instance not equal to the marshalled one.", expected, actual);
-        assertEquals("Unmarshalled JaxbLink instance URI not equal to original.", expectedUri, actual.getUri());
-        assertEquals("Unmarshalled JaxbLink instance params not equal to original.", expectedParams, actual.getParams());
+        assertEquals(expected, actual, "Unmarshalled JaxbLink instance not equal to the marshalled one.");
+        assertEquals(expectedUri, actual.getUri(), "Unmarshalled JaxbLink instance URI not equal to original.");
+        assertEquals(expectedParams, actual.getParams(), "Unmarshalled JaxbLink instance params not equal to original.");
     }
 
     @Test

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/core/MediaTypeTest.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/core/MediaTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,13 +17,13 @@
 package jakarta.ws.rs.core;
 
 import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.hamcrest.Description;
 import org.hamcrest.DiagnosingMatcher;
 import org.hamcrest.Matcher;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -39,14 +39,14 @@ public class MediaTypeTest {
      */
     @Test
     public void testWithCharset() {
-        assertEquals("Unexpected produced media type content.",
-                "UTF-8",
+        assertEquals("UTF-8",
                 MediaType.APPLICATION_XML_TYPE.withCharset("UTF-8")
-                        .getParameters().get(MediaType.CHARSET_PARAMETER));
-        assertEquals("Unexpected produced media type content.",
-                "ISO-8859-13",
+                        .getParameters().get(MediaType.CHARSET_PARAMETER),
+                "Unexpected produced media type content.");
+        assertEquals("ISO-8859-13",
                 MediaType.APPLICATION_XML_TYPE.withCharset("UTF-8").withCharset("ISO-8859-13")
-                        .getParameters().get(MediaType.CHARSET_PARAMETER));
+                        .getParameters().get(MediaType.CHARSET_PARAMETER),
+                "Unexpected produced media type content.");
     }
 
     /**

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/core/MultivaluedHashMapTest.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/core/MultivaluedHashMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,9 +16,9 @@
 
 package jakarta.ws.rs.core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -26,20 +26,20 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.ws.rs.ext.RuntimeDelegate;
 
 public class MultivaluedHashMapTest {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         RuntimeDelegate.setInstance(new RuntimeDelegateStub());
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         RuntimeDelegate.setInstance(null);
     }

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/core/NewCookieTest.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/core/NewCookieTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,24 +16,24 @@
 
 package jakarta.ws.rs.core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.ws.rs.ext.RuntimeDelegate;
 
 public class NewCookieTest {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         RuntimeDelegate.setInstance(new RuntimeDelegateStub());
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         RuntimeDelegate.setInstance(null);
     }

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/core/RxClientTest.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/core/RxClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,8 +20,8 @@ import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutorService;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.CompletionStageRxInvoker;
@@ -42,7 +42,7 @@ public class RxClientTest {
      * without any arguments.
      */
     @Test
-    @Ignore
+    @Disabled
     public void testRxClient() {
         CompletionStage<List<String>> cs = client.target("remote/forecast/{destination}")
                 .resolveTemplate("destination", "mars")
@@ -61,7 +61,7 @@ public class RxClientTest {
      * {@link jakarta.ws.rs.client.Invocation.Builder#rx(Class)}.
      */
     @Test
-    @Ignore
+    @Disabled
     public void testRxClient2() {
         Client rxClient = client.register(CompletionStageRxInvokerProvider.class, RxInvokerProvider.class);
 
@@ -82,7 +82,7 @@ public class RxClientTest {
      * {@link jakarta.ws.rs.client.Invocation.Builder#rx(Class)}.
      */
     @Test
-    @Ignore
+    @Disabled
     public void testRxClient3() {
         Client rxClient = client.register(CompletionStageRxInvokerProvider.class, RxInvokerProvider.class);
 

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/core/VariantTest.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/core/VariantTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,9 +16,9 @@
 
 package jakarta.ws.rs.core;
 
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Variant regression unit tests.

--- a/jaxrs-api/src/test/java/jakarta/ws/rs/ext/RuntimeDelegateTest.java
+++ b/jaxrs-api/src/test/java/jakarta/ws/rs/ext/RuntimeDelegateTest.java
@@ -1,9 +1,9 @@
 package jakarta.ws.rs.ext;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * {@link jakarta.ws.rs.ext.RuntimeDelegate} unit tests.


### PR DESCRIPTION
This PR replaces JUnit 4 by JUnit 5

I do not see a need to stick with the rather old JUnit 4 now that JUnit 5 is around for considerable time.

**As these are no API changes, this is a fast-track review period of just one day as per our [committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**