### PR TITLE
General style improvements in spec doc

### DIFF
--- a/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-2.0-early-draft-second-edition.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-2.0-early-draft-second-edition.adoc
@@ -50,7 +50,7 @@ new semantics of `@Provider` for automatic discovery.
 be implemented by filters and entity interceptors, is replaced by
 `DynamicBinder`. A dynamic binder is a new type of provider that binds
 filters and entity interceptors with resource methods.
-* Chapter "Validation": Use media type names instead of Java constants
+* Chapter <<validation>>: Use media type names instead of Java constants
 for clarity. More descriptive names for constraint annotations. Changed
 inheritance rules for constraint annotations to follow those defined in
 <<bib16>>. New note about `@Valid` support for return values. Fixed

--- a/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-2.0-early-draft.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-2.0-early-draft.adoc
@@ -37,7 +37,7 @@ been dropped.
 filter chain based on binding priorities.
 * Appendix C: Removed from this version after changes to Chapter
 <<filters_and_interceptors>>.
-* Chapter "Validation": Moved to an instantiate-then-validate strategy
+* Chapter <<validation>>: Moved to an instantiate-then-validate strategy
 in which validation of constructor parameters and setters is no longer
 supported. Simplified validation process to better align with Bean
 Validation 1.1 <<bib16>>. In particular, validation of resource

--- a/jaxrs-spec/src/main/asciidoc/chapters/appendix/_headersupport.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/appendix/_headersupport.adoc
@@ -31,7 +31,7 @@ application uses `Request.selectVariant` method, see <<conneg_and_preconditions>
 |`Accept-Language`  |Processed by runtime if
 application uses `Request.selectVariant` method, see <<conneg_and_preconditions>>.
 |`Allow`            |Included in automatically
-generated 405 error responses (see Section [request_matching]) and
+generated 405 error responses (see <<request_matching>>) and
 automatically generated responses to OPTIONS requests (see <<head_and_options>>).
 |`Authorization`    |Depends on container, information
 available via `SecurityContext`, see <<security_context>>.
@@ -61,8 +61,8 @@ automatically as per HTTP/1.1.
 |`Expect`           |Depends on underlying container.
 |`Expires`          |Set by application using the `ResponseBuilder.expires` method.
 |`If-Match`         |Processed by runtime if application uses corresponding
-`Request.evaluatePreconditions` method, see Section
-[conneg_and_preconditions]. `If-Modified-Since` & Processed by runtime
+`Request.evaluatePreconditions` method, see
+<<conneg_and_preconditions>>. `If-Modified-Since` & Processed by runtime
 if application uses corresponding `Request.evaluatePreconditions`
 method, see <<conneg_and_preconditions>>.
 |`If-None-Match`    |Processed by runtime if application uses corresponding

--- a/jaxrs-spec/src/main/asciidoc/chapters/client_api/_client-targets.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/client_api/_client-targets.adoc
@@ -45,5 +45,5 @@ In this example, two instances of `WebTarget` are created. The instance
 `hello` inherits the configuration from `base` and it is further
 configured by registering `MyProvider.class`. Note that changes to
 `hello`’s configuration do not affect `base`, i.e. inheritance performs
-a _deep_ copy of the configuration. See Section [configurable_types] for
+a _deep_ copy of the configuration. See <<configurable_types>> for
 additional information on configurable types.

--- a/jaxrs-spec/src/main/asciidoc/chapters/client_api/_configurable_types.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/client_api/_configurable_types.adoc
@@ -24,7 +24,7 @@ Features::
   can be used to configure a JAX-RS implementation.
 Providers::
   Classes or instances of classes that implement one or more of the
-  provider interfaces from Chapter [providers]. A provider can be a
+  provider interfaces from Chapter <<providers>>. A provider can be a
   message body reader, a filter, a context resolver, etc.
 
 The configuration defined on an instance of any of the aforementioned

--- a/jaxrs-spec/src/main/asciidoc/chapters/client_api/_invocations.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/client_api/_invocations.adoc
@@ -36,16 +36,13 @@ Collection<Invocation> invs = Arrays.asList(inv1, inv2);
 
 // Executed by the submitter
 Collection<Response> ress =
-    Collections.transform(invs,
-        new F<Invocation, Response>() {
+    Collections.transform(invs, new F<Invocation, Response>() {
         @Override
         public Response apply(Invocation inv) {
-            return inv.invoke(); } });
+            return inv.invoke();
+        }
+    });
 ----
-
-// Executed by the submitter Collection<Response> ress =
-Collections.transform(invs, new F<Invocation, Response>() @Override
-public Response apply(Invocation inv) return inv.invoke(); );
 
 In this example, two invocations are prepared and stored in a collection
 by the creator. The submitter then traverses the collection applying a

--- a/jaxrs-spec/src/main/asciidoc/chapters/environment/_environment.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/environment/_environment.adoc
@@ -13,7 +13,7 @@
 
 The container-managed resources available to a JAX-RS root resource
 class or provider depend on the environment in which it is deployed.
-Section [contexttypes] describes the types of context available
+Section <<contexttypes>> describes the types of context available
 regardless of container. The following sections describe the additional
 container-managed resources available to a JAX-RS root resource class or
 provider deployed in a variety of environments.

--- a/jaxrs-spec/src/main/asciidoc/chapters/environment/_javaee.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/environment/_javaee.adoc
@@ -20,7 +20,7 @@ following specifications.
 
 In a product that also supports the Servlet specification,
 implementations MUST support JAX-RS applications that are packaged as a
-Web application. See Section [servlet] for more information Web
+Web application. See <<servlet>> for more information Web
 application packaging.
 
 It is RECOMMENDED for a JAX-RS implementation to provide asynchronous

--- a/jaxrs-spec/src/main/asciidoc/chapters/filters_and_interceptors/_binding.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/filters_and_interceptors/_binding.adoc
@@ -28,7 +28,7 @@ a filter or interceptor can be registered manually (e.g., via
 that for a filter or interceptor to be automatically discovered it MUST
 be annotated with `@Provider` (see <<automatic_discovery>>).
 
-For example, the `LoggingFilter` defined in Section [filters] is both
+For example, the `LoggingFilter` defined in <<filters>> is both
 automatically discovered (it is annotated with `@Provider`) and bound
 globally. If this filter is part of an application, requests and
 responses will be logged for all resource methods.

--- a/jaxrs-spec/src/main/asciidoc/chapters/providers/_entity_providers.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/providers/_entity_providers.adoc
@@ -70,15 +70,15 @@ body:
 For a return type of `Response` or subclasses, the object is the value
 of the `entity` property, for other return types it is the returned
 object.
-2.  Determine the media type of the response, see Section
-[determine_response_type].
+2.  Determine the media type of the response, see
+<<determine_response_type>>.
 3.  Select the set of `MessageBodyWriter` providers that support (see
 <<declaring_provider_capabilities>>) the object and media type of
 the message entity body.
 4.  Sort the selected `MessageBodyWriter` providers with a
 primary key of generic type where providers whose generic type is the
 nearest superclass of the object class are sorted first and a secondary
-key of media type (see Section [declaring_provider_capabilities]).
+key of media type (see <<declaring_provider_capabilities>>).
 5.  Iterate through the sorted
 `MessageBodyWriter` providers and, utilizing the `isWriteable` method of
 each, choose an `MessageBodyWriter` that supports the object that will

--- a/jaxrs-spec/src/main/asciidoc/chapters/resources/_uritemplates.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/resources/_uritemplates.adoc
@@ -98,7 +98,7 @@ Methods of a resource class that are annotated with `@Path` are either
 sub-resource methods or sub-resource locators. Sub-resource methods
 handle a HTTP request directly whilst sub-resource locators return an
 object or class that will handle a HTTP request. The presence or absence
-of a request method designator (e.g. @GET) differentiates between the
+of a request method designator (e.g. `@GET`) differentiates between the
 two:
 
 Present::


### PR DESCRIPTION
- Fixes extraneous code outside of code block
- Fixes several broken links
- In-line code notation