### PR TITLE
Clarify matching rules 

### DIFF
--- a/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-3.0-release.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-3.0-release.adoc
@@ -26,3 +26,5 @@ default exception mappers.
 against the *base* URI, not against the *request* URI anymore.
 * <<context-injection>>: New section that mentions removal of `@Context`
 injection support in future versions.
+* <<declaring_method_capabilities>>: Clarified resoure matching when `Content-Type`
+or `Accept` are missing in request.

--- a/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-3.0-release.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-3.0-release.adoc
@@ -26,5 +26,5 @@ default exception mappers.
 against the *base* URI, not against the *request* URI anymore.
 * <<context-injection>>: New section that mentions removal of `@Context`
 injection support in future versions.
-* <<declaring_method_capabilities>>: Clarified resoure matching when `Content-Type`
+* <<declaring_method_capabilities>>: Clarified resource matching when `Content-Type`
 or `Accept` are missing in request.

--- a/jaxrs-spec/src/main/asciidoc/chapters/resources/_declaring_method_capabilities.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/resources/_declaring_method_capabilities.adoc
@@ -67,9 +67,14 @@ using the `WidgetProvider` class (see <<entity_providers>> for
 more information on `MessageBodyReader`).
 
 An implementation MUST NOT invoke a method whose effective value of
-`@Produces` does not match the request `Accept` header. An
-implementation MUST NOT invoke a method whose effective value of
+`@Produces` does not match the request `Accept` header.
+If no `Accept` header is present in the request, it is assumed that
+the client accepts any media type or `\*/*`.
+
+An implementation MUST NOT invoke a method whose effective value of
 `@Consumes` does not match the request `Content-Type` header.
+If no `Content-Type` header is present in the request, the default
+media type is assumed to be `application/octet-stream`.
 
 [[selecting_from_multiple_media_types]]
 ==== Selecting from multiple media types

--- a/jaxrs-spec/src/main/asciidoc/chapters/resources/_mapping_requests_to_java_methods.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/resources/_mapping_requests_to_java_methods.adoc
@@ -214,9 +214,10 @@ For convenience, we defined latexmath:[$p \ge {\perp}$] for every media
 type latexmath:[$p$].
 +
 Given these definitions, we can now sort latexmath:[$M$] in descending
-order based on latexmath:[$\ge$] as followsfootnote:[If any of these
-types or sets of types are unspecified, latexmath:[$\mbox{*/*}$] and
-latexmath:[$\mbox{\{*/*\}}$] are assumed.]:
+order based on latexmath:[$\ge$] as followsfootnote:[If the request content type
+is missing, it is assumed to be `application/octet-stream`. If any of the other
+types or sets of types here are unspecified, then
+latexmath:[$\mbox{*/*}$] and latexmath:[$\mbox{\{*/*\}}$] are assumed.]:
 +
 --
 * Let latexmath:[$t$] be the request content type and latexmath:[$C_M$]


### PR DESCRIPTION
Clarify matching rules in the case where Content-Type and/or Accept headers are absent. Prompted by discussion in issue #970 and some potential ambiguity in implementations.