### PR TITLE
[742] Mandate usage of JSON-B instance provided by user's ContextResolver<Jsonb>

### DIFF
--- a/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-3.0-release.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-3.0-release.adoc
@@ -11,6 +11,9 @@
 [[changes-since-3.0-release]]
 === Changes Since 3.0 Release
 
+* <<standard_entity_providers>>: JSON-B entity providers MUST favor
+`Jsonb` instances provided by `ContextResolver<Jsonb>` over their own
+default context.
 * <<consuming_multipart_formdata>>: Added portable API for handling
 multipart/form-data.
 * <<services>>: Added requirement that JAX-RS implementations MUST

--- a/jaxrs-spec/src/main/asciidoc/chapters/providers/_entity_providers.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/providers/_entity_providers.adoc
@@ -178,6 +178,13 @@ supply a `JAXBContext` for a particular type, the
 implementation-supplied entity provider MUST use its own default context
 instead.
 
+The implementation-supplied entity provider(s) for application-supplied
+JSON-B classes MUST use `Jsonb` instances provided by application-supplied
+context resolvers, see <<contextprovider>>. If an application does not
+supply a `Jsonb` instance for a particular type, the
+implementation-supplied entity provider MUST use its own default context
+instead.
+
 When writing responses, implementations SHOULD respect
 application-supplied character set metadata and SHOULD use UTF-8 if a
 character set is not specified by the application or if the application


### PR DESCRIPTION
Adding minimum spec text to enforce respect of `ContextResolver<Jsonb>` as commonly discussed in #742 as an initial proposal.

Please discuss and vote. :-)

Closes #742