### PR TITLE
Minimal multi-module pom to allow "mvn -am -pl" builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Markus KARG. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Distribution License v. 1.0, which is available at
+    http://www.eclipse.org/org/documents/edl-v10.php.
+
+    SPDX-License-Identifier: BSD-3-Clause
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>jakarta.ws.rs</groupId>
+    <artifactId>all</artifactId>
+    <version>3.1-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>Jakarta RESTful Web Service Multi-Module Project</name>
+
+    <modules>
+	<module>jaxrs-api</module>
+	<module>jaxrs-spec</module>
+	<module>jaxrs-tck</module>
+	<module>examples</module>
+	<module>jersey-tck</module>
+    </modules>
+</project>


### PR DESCRIPTION
This minimal multi-module POM allows convenient use of Maven to do things *on the root dir* like...

* ...build API and Examples in a single line by only naming the "last one" in the chain: `mvn -am -pl examples compile`
* ...build API, Spec, TCK, Examples... in one turn: `mvn package`
* ...change the API, compile the TCK, and run the TCK against Jersey in a single shot: `mvn -am -pl jersey-tck verify`
* ...reclaim lots of disk space: `mvn clean`
* ...and much more...

This makes working with our code base easier, so please review and vote!

**As these are no API changes, this is a fast-track review period of just one day as per our [committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**