### PR TITLE
Preparing spec doc v3.1

### DIFF
--- a/jaxrs-spec/pom.xml
+++ b/jaxrs-spec/pom.xml
@@ -29,7 +29,7 @@
         <maven.site.skip>true</maven.site.skip>
         <asciidoctor.maven.plugin.version>2.1.0</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.5.1</asciidoctorj.version>
-        <asciidoctorj.pdf.version>1.5.0-alpha.17</asciidoctorj.pdf.version>
+        <asciidoctorj.pdf.version>1.6.0</asciidoctorj.pdf.version>
         <jruby.version>9.2.7.0</jruby.version>
         <!-- status: DRAFT, BETA, etc., or blank for final -->
         <status></status>

--- a/jaxrs-spec/pom.xml
+++ b/jaxrs-spec/pom.xml
@@ -28,7 +28,7 @@
         <site.output.dir>${project.build.directory}/staging</site.output.dir>
         <maven.site.skip>true</maven.site.skip>
         <asciidoctor.maven.plugin.version>2.1.0</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.0.0</asciidoctorj.version>
+        <asciidoctorj.version>2.5.1</asciidoctorj.version>
         <asciidoctorj.pdf.version>1.5.0-alpha.17</asciidoctorj.pdf.version>
         <jruby.version>9.2.7.0</jruby.version>
         <!-- status: DRAFT, BETA, etc., or blank for final -->

--- a/jaxrs-spec/pom.xml
+++ b/jaxrs-spec/pom.xml
@@ -35,6 +35,7 @@
         <status>DRAFT</status>
         <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>
         <revisiondate>${maven.build.timestamp}</revisiondate>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <scm>

--- a/jaxrs-spec/pom.xml
+++ b/jaxrs-spec/pom.xml
@@ -32,7 +32,7 @@
         <asciidoctorj.pdf.version>1.6.0</asciidoctorj.pdf.version>
         <jruby.version>9.2.19.0</jruby.version>
         <!-- status: DRAFT, BETA, etc., or blank for final -->
-        <status></status>
+        <status>DRAFT</status>
         <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>
         <revisiondate>${maven.build.timestamp}</revisiondate>
     </properties>

--- a/jaxrs-spec/pom.xml
+++ b/jaxrs-spec/pom.xml
@@ -27,7 +27,7 @@
     <properties>
         <site.output.dir>${project.build.directory}/staging</site.output.dir>
         <maven.site.skip>true</maven.site.skip>
-        <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
+        <asciidoctor.maven.plugin.version>2.1.0</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.0.0</asciidoctorj.version>
         <asciidoctorj.pdf.version>1.5.0-alpha.17</asciidoctorj.pdf.version>
         <jruby.version>9.2.7.0</jruby.version>
@@ -90,6 +90,7 @@
                         <configuration>
                             <backend>xhtml</backend>
                             <attributes>
+				<imagesdir>images</imagesdir>
                                 <revnumber>${project.version}</revnumber>
                                 <revremark>${status}</revremark>
                                 <revdate>${revisiondate}</revdate>
@@ -115,6 +116,7 @@
                         <configuration>
                             <backend>pdf</backend>
                             <attributes>
+				<imagesdir>images</imagesdir>
                                 <pdf-stylesdir>${project.basedir}/src/theme</pdf-stylesdir>
                                 <pdf-style>jakartaee</pdf-style>
                                 <revnumber>${project.version}</revnumber>

--- a/jaxrs-spec/pom.xml
+++ b/jaxrs-spec/pom.xml
@@ -30,7 +30,7 @@
         <asciidoctor.maven.plugin.version>2.1.0</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.5.1</asciidoctorj.version>
         <asciidoctorj.pdf.version>1.6.0</asciidoctorj.pdf.version>
-        <jruby.version>9.2.7.0</jruby.version>
+        <jruby.version>9.2.19.0</jruby.version>
         <!-- status: DRAFT, BETA, etc., or blank for final -->
         <status></status>
         <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>

--- a/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-3.0-release.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/appendix/_changes-since-3.0-release.adoc
@@ -23,7 +23,7 @@ automatically register certain service providers.
 default exception mappers.
 * <<resource_field>>: Array types may be specified for `@CookieParam`,
 `@FormParam`, `@HeaderParam`, `@MatrixParam` and `@QueryParam` parameters.
-* Deprecated Link.JaxbLink and Link.JaxbAdapter inner classes.
+* Deprecated `Link.JaxbLink` and `Link.JaxbAdapter` inner classes.
 * New method `#hasProperty(String)` wherever `#getProperty(String)` exists
 * `Response.created(URI)` now resolves relative URIs into an absolute URI
 against the *base* URI, not against the *request* URI anymore.

--- a/jaxrs-spec/src/main/asciidoc/chapters/introduction/_status.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/introduction/_status.adoc
@@ -11,7 +11,7 @@
 [[status]]
 === Status
 
-This is the final release of version 3.1. The issue tracking system for
+This is a draft of version 3.1. The issue tracking system for
 this release can be found at:
 
 https://github.com/eclipse-ee4j/jaxrs-api/issues


### PR DESCRIPTION
Collection of useful steps towards spec doc v3.1

**As these are no API changes, this is a fast-track review period of just one day as per our [committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**