### PR TITLE
Preparing API POM for v3.1

### DIFF
--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -365,7 +365,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.0.1</version>
+                    <version>3.2.1</version>
                     <executions>
                         <execution>
                             <id>attach-sources</id>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -543,7 +543,7 @@
         <api.package>jakarta.ws.rs</api.package>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <skip.release.tests>false</skip.release.tests>
-        <spec.version>3.0</spec.version>
+        <spec.version>3.1</spec.version>
         <spec.version.revision /> <!-- e.g. (Rev a) -->
 
         <jaxb.api.version>3.0.0</jaxb.api.version>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -538,7 +538,7 @@
 
         <maven.bundle.plugin.version>5.1.2</maven.bundle.plugin.version>
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
-        <maven.javadoc.plugin.version>3.1.0</maven.javadoc.plugin.version>
+        <maven.javadoc.plugin.version>3.3.0</maven.javadoc.plugin.version>
 
         <api.package>jakarta.ws.rs</api.package>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -527,7 +527,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.6.0</version>
+            <version>3.11.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -547,7 +547,7 @@
         <spec.version.revision /> <!-- e.g. (Rev a) -->
 
         <jaxb.api.version>3.0.1</jaxb.api.version>
-        <jaxb.impl.version>3.0.0-M4</jaxb.impl.version>
+        <jaxb.impl.version>3.0.2-b01</jaxb.impl.version>
         <activation.api.version>2.0.0</activation.api.version>
         <legal.doc.folder>${project.basedir}/..</legal.doc.folder>
     </properties>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -266,7 +266,7 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <!-- This plugin generates the buildNumber property used in maven-bundle-plugin -->

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -515,7 +515,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.7.0</version>
+            <version>5.8.0-M1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.6</version>
+        <version>1.0.7</version>
     </parent>
 
     <groupId>jakarta.ws.rs</groupId>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -404,7 +404,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-jxr-plugin</artifactId>
-                    <version>2.5</version>
+                    <version>3.1.1</version>
                     <executions>
                         <execution>
                             <goals>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -199,7 +199,7 @@
             <build>
                 <plugins>
                     <plugin>
-                        <!-- TODO: overriding paren pom (profile jvnet-release) - we should find nicer way -->
+                        <!-- TODO: overriding parent pom (profile jvnet-release) - we should find nicer way -->
                         <!-- 1.8- javadoc cannot handle module-info -->
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <version>${maven.javadoc.plugin.version}</version>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -379,7 +379,7 @@
                     <!-- Adding files to jar-->
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.2.0</version>
                     <executions>
                         <execution>
                             <id>add-legal-resource</id>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -548,7 +548,7 @@
 
         <jaxb.api.version>3.0.1</jaxb.api.version>
         <jaxb.impl.version>3.0.2-b01</jaxb.impl.version>
-        <activation.api.version>2.0.0</activation.api.version>
+        <activation.api.version>2.0.1</activation.api.version>
         <legal.doc.folder>${project.basedir}/..</legal.doc.folder>
     </properties>
 

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -536,7 +536,7 @@
         <apidocs.title>Jakarta RESTful Web Services ${spec.version} API Specification ${spec.version.revision}</apidocs.title>
         <java.version>1.8</java.version>
 
-        <maven.bundle.plugin.version>3.5.0</maven.bundle.plugin.version>
+        <maven.bundle.plugin.version>5.1.2</maven.bundle.plugin.version>
         <maven.compiler.plugin.version>3.7.0</maven.compiler.plugin.version>
         <maven.javadoc.plugin.version>3.1.0</maven.javadoc.plugin.version>
 

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -537,7 +537,7 @@
         <java.version>1.8</java.version>
 
         <maven.bundle.plugin.version>5.1.2</maven.bundle.plugin.version>
-        <maven.compiler.plugin.version>3.7.0</maven.compiler.plugin.version>
+        <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
         <maven.javadoc.plugin.version>3.1.0</maven.javadoc.plugin.version>
 
         <api.package>jakarta.ws.rs</api.package>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -546,7 +546,7 @@
         <spec.version>3.1</spec.version>
         <spec.version.revision /> <!-- e.g. (Rev a) -->
 
-        <jaxb.api.version>3.0.0</jaxb.api.version>
+        <jaxb.api.version>3.0.1</jaxb.api.version>
         <jaxb.impl.version>3.0.0-M4</jaxb.impl.version>
         <activation.api.version>2.0.0</activation.api.version>
         <legal.doc.folder>${project.basedir}/..</legal.doc.folder>


### PR DESCRIPTION
Collection of useful steps towards API v3.1

**As these are no API changes, this is a fast-track review period of just one day as per our [committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**