### PR TITLE
Version Bump: Checkstyle 8.43

### DIFF
--- a/etc/config/checkstyle.xml
+++ b/etc/config/checkstyle.xml
@@ -85,13 +85,10 @@
         <!-- Checks for Javadoc comments.                     -->
         <!-- See http://checkstyle.sf.net/config_javadoc.html -->
 
-        <!--
-          - Turned off for now due to https://github.com/checkstyle/checkstyle/issues/5088
-          -
         <module name="JavadocMethod">
-            <property name="scope" value="protected"/>
+            <property name="accessModifiers" value="protected"/>
             <property name="validateThrows" value="false"/>
-        </module -->
+        </module>
 
         <module name="JavadocType">
             <property name="scope" value="protected"/>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -190,6 +190,13 @@
                         <outputFile>${project.build.directory}/checkstyle/checkstyle-result.xml</outputFile>
                         <configLocation>${basedir}/../etc/config/checkstyle.xml</configLocation>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.puppycrawl.tools</groupId>
+                            <artifactId>checkstyle</artifactId>
+                            <version>8.43</version>
+                        </dependency>
+                    </dependencies>
                     <executions>
                         <execution>
                             <goals>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -423,6 +423,13 @@
                         <configLocation>${basedir}/../etc/config/checkstyle.xml</configLocation>
                         <excludes>**/module-info.java</excludes>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.puppycrawl.tools</groupId>
+                            <artifactId>checkstyle</artifactId>
+                            <version>8.43</version>
+                        </dependency>
+                    </dependencies>
                     <executions>
                         <execution>
                             <goals>


### PR DESCRIPTION
This PR re-enables JavaDoc checks previously commented out due to a known issue with Checkstyle.

Apparently the issue does not occur anymore with latest Checkstyle 8.43, at least in my environment (Windows 10, OpenJDK 16) I could not reproduce the mentioned problem.

I'd like to propose that we adopt this PR, even if there never had been an official solution to the Checkstyle issue. If the problem pops up again, we can simply comment out the JavaDoc check again.

**As these are no API changes, this is a fast-track review period of just one day as per our [committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**