### PR TITLE
Fix Javadoc Issues In Tck

### DIFF
--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/sebootstrap/SeBootstrapIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/sebootstrap/SeBootstrapIT.java
@@ -264,7 +264,7 @@ public final class SeBootstrapIT {
      */
     @Test
     public final void shouldBootInstanceUsingSelfDetectedFreeIpPort()
-            throws InterruptedException, ExecutionException, IOException {
+            throws InterruptedException, ExecutionException {
         // given
         final int expectedResponse = mockInt();
         final Application application = new StaticApplication(expectedResponse);
@@ -300,7 +300,7 @@ public final class SeBootstrapIT {
      */
     @Test
     public final void shouldBootInstanceUsingImplementationsDefaultIpPort()
-            throws InterruptedException, ExecutionException, IOException {
+            throws InterruptedException, ExecutionException {
         // given
         final int expectedResponse = mockInt();
         final Application application = new StaticApplication(expectedResponse);

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/uribuilder/UriBuilderIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/uribuilder/UriBuilderIT.java
@@ -49,7 +49,7 @@ public final class UriBuilderIT {
      */
     @Test
     public final void shouldBuildValidInstanceFromScratch()
-            throws InterruptedException, ExecutionException, URISyntaxException {
+            throws InterruptedException, ExecutionException {
         // given
         final UriBuilder uriBuilder = UriBuilder.newInstance();
 


### PR DESCRIPTION
* Removed unecessary exceptions from method throws clause
* Resolves issue of missing javadoc for exception
* If those exceptions are included for a reason, the PR can be rejected/closed