### PR TITLE
Remove out-of-support JDKs from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,9 @@ language: java
 
 jdk:
   - oraclejdk8
-  - oraclejdk9
   - oraclejdk11
   - openjdk8
-  - openjdk9
-  - openjdk10
   - openjdk11
-  - openjdk12
-  - openjdk13
-  - openjdk14
-  - openjdk15
   - openjdk16
 
 cache:


### PR DESCRIPTION
With the current LTS strategy, only Java SE versions 8, 11, and 16 are currently supported (and 16 will soon give way to 17 - 16 is not LTS, while 17 is).  As such, I'd like to reduce CI cycles by removing out-of-support JDKs from the CI pipeline.

This isn't an API/spec/TCK change, so it should be fast-tracked.