### PR TITLE
Cleanup of pom names and relative paths to avoid warnings

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -19,13 +19,14 @@
         <groupId>net.java</groupId>
         <artifactId>jvnet-parent</artifactId>
         <version>1</version>
+        <relativePath/>
     </parent>
 
     <groupId>jakarta.ws.rs</groupId>
     <artifactId>jakarta.ws.rs-examples</artifactId>
     <version>3.1-SNAPSHOT</version>
     <packaging>jar</packaging>
-    <name>jakarta.ws.rs-examples</name>
+    <name>Jakarta RESTful WS Examples</name>
 
     <url>https://github.com/jax-rs/api</url>
 

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -24,14 +24,16 @@
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
         <version>1.0.6</version>
+        <relativePath/>
     </parent>
 
     <groupId>jakarta.ws.rs</groupId>
     <artifactId>jakarta.ws.rs-api</artifactId>
     <version>3.1-SNAPSHOT</version>
 
+
     <packaging>bundle</packaging>
-    <name>jakarta.ws.rs-api</name>
+    <name>Jakarta RESTful WS API</name>
     <description>Jakarta RESTful Web Services</description>
 
     <url>https://github.com/eclipse-ee4j/jaxrs-api</url>

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/EntityPart.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/EntityPart.java
@@ -131,6 +131,7 @@ public interface EntityPart {
      * 
      * @param type the {@code Class} that the implementation should convert this
      *             part to
+     * @param <T> the entity type
      * @return an instance of the specified {@code Class} representing the content
      *         of this part
      * @throws IllegalArgumentException if no
@@ -167,6 +168,7 @@ public interface EntityPart {
      * 
      * @param type the generic type that the implementation should convert this part
      *             to
+     * @param <T> the entity type
      * @return an instance of the specified generic type representing the content of
      *         this part
      * @throws IllegalArgumentException if no
@@ -207,7 +209,7 @@ public interface EntityPart {
      * 
      * @since 3.1
      */
-    public interface Builder {
+    interface Builder {
 
         /**
          * Sets the media type for the EntityPart. This will also set the
@@ -217,7 +219,7 @@ public interface EntityPart {
          * @return the updated builder
          * @throws IllegalArgumentException if {@code mediaType} is {@code null}
          */
-        public Builder mediaType(MediaType mediaType) throws IllegalArgumentException;
+        Builder mediaType(MediaType mediaType) throws IllegalArgumentException;
 
         /**
          * Convenience method for setting the media type for the EntityPart. This will
@@ -230,7 +232,7 @@ public interface EntityPart {
          * @throws IllegalArgumentException if {@code mediaTypeString} cannot be parsed
          *                                  or is {@code null}
          */
-        public Builder mediaType(String mediaTypeString) throws IllegalArgumentException;
+        Builder mediaType(String mediaTypeString) throws IllegalArgumentException;
 
         /**
          * Adds a new header or replaces a previously added header and sets the header
@@ -241,7 +243,7 @@ public interface EntityPart {
          * @return the updated builder
          * @throws IllegalArgumentException if {@code headerName} is {@code null}
          */
-        public Builder header(String headerName, String... headerValues) throws IllegalArgumentException;
+        Builder header(String headerName, String... headerValues) throws IllegalArgumentException;
 
         /**
          * Adds new headers or replaces previously added headers. The behavior of this
@@ -252,7 +254,7 @@ public interface EntityPart {
          * @return the updated builder
          * @throws IllegalArgumentException if {@code newHeaders} is {@code null}
          */
-        public Builder headers(MultivaluedMap<String, String> newHeaders) throws IllegalArgumentException;
+        Builder headers(MultivaluedMap<String, String> newHeaders) throws IllegalArgumentException;
 
         /**
          * Sets the file name for this part. The file name will be specified as an
@@ -264,7 +266,7 @@ public interface EntityPart {
          * @return the updated builder
          * @throws IllegalArgumentException if {@code fileName} is {@code null}
          */
-        public Builder fileName(String fileName) throws IllegalArgumentException;
+        Builder fileName(String fileName) throws IllegalArgumentException;
 
         /**
          * Sets the content for this part. The content of this builder must be specified
@@ -279,7 +281,7 @@ public interface EntityPart {
          * @return the updated builder
          * @throws IllegalArgumentException if {@code content} is {@code null}
          */
-        public Builder content(InputStream content) throws IllegalArgumentException;
+        Builder content(InputStream content) throws IllegalArgumentException;
 
         /**
          * Convenience method, equivalent to calling
@@ -290,7 +292,7 @@ public interface EntityPart {
          * @return the updated builder.
          * @throws IllegalArgumentException if either parameter is {@code null}.
          */
-        public default Builder content(String fileName, InputStream content) throws IllegalArgumentException {
+        default Builder content(String fileName, InputStream content) throws IllegalArgumentException {
             return this.fileName(fileName).content(content);
         }
 
@@ -311,10 +313,11 @@ public interface EntityPart {
          * @param content the object to be used as the content
          * @param type    the type of this object which will be used when selecting the
          *                appropriate {@link jakarta.ws.rs.ext.MessageBodyWriter}
+         * @param <T>     the entity type
          * @return the updated builder.
          * @throws IllegalArgumentException if {@code content} is {@code null}
          */
-        public <T> Builder content(T content, Class<? extends T> type) throws IllegalArgumentException;
+        <T> Builder content(T content, Class<? extends T> type) throws IllegalArgumentException;
 
         /**
          * Sets the content for this part. The content of this builder must be specified
@@ -336,8 +339,9 @@ public interface EntityPart {
          * 
          * @param content the object to be used as the content
          * @throws IllegalArgumentException if {@code content} is {@code null}
+         * @return the updated builder.
          */
-        public default Builder content(Object content) throws IllegalArgumentException {
+        default Builder content(Object content) throws IllegalArgumentException {
             return this.content(content, content.getClass());
         }
 
@@ -359,10 +363,11 @@ public interface EntityPart {
          * @param type    the generic type of this object which will be used when
          *                selecting the appropriate
          *                {@link jakarta.ws.rs.ext.MessageBodyWriter}
+         * @param <T> the entity type
          * @return the updated builder.
          * @throws IllegalArgumentException if {@code content} is {@code null}
          */
-        public <T> Builder content(T content, GenericType<T> type) throws IllegalArgumentException;
+        <T> Builder content(T content, GenericType<T> type) throws IllegalArgumentException;
 
         /**
          * Builds a new EntityPart instance using the provided property values.
@@ -379,6 +384,6 @@ public interface EntityPart {
          *                                 {@link jakarta.ws.rs.ext.MessageBodyWriter}
          *                                 throws a {@code WebApplicationException}
          */
-        public EntityPart build() throws IllegalStateException, IOException, WebApplicationException;
+        EntityPart build() throws IllegalStateException, IOException, WebApplicationException;
     }
 }

--- a/jaxrs-spec/pom.xml
+++ b/jaxrs-spec/pom.xml
@@ -22,7 +22,7 @@
     <artifactId>jakarta.ws.rs-spec</artifactId>
     <version>3.1-SNAPSHOT</version>
     <packaging>pom</packaging>
-    <name>Jakarta RESTful Web Services Specification</name>
+    <name>Jakarta RESTful WS Specification</name>
 
     <properties>
         <site.output.dir>${project.build.directory}/staging</site.output.dir>

--- a/jaxrs-tck/pom.xml
+++ b/jaxrs-tck/pom.xml
@@ -24,7 +24,7 @@
     <artifactId>jakarta.ws.rs-tck</artifactId>
     <version>3.1-SNAPSHOT</version>
 
-    <name>Jakarta REST TCK</name>
+    <name>Jakarta RESTful WS TCK</name>
     <description>Technology Compatibility Kit for Jakarta RESTful Web Services</description>
     <url>https://github.com/eclipse-ee4j/jaxrs-api</url>
 

--- a/jersey-tck/pom.xml
+++ b/jersey-tck/pom.xml
@@ -7,7 +7,7 @@
     <version>3.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
-    <name>Jakarta REST Compliance</name>
+    <name>Jakarta RESTful WS Compliance</name>
     <description>This test verifies the compliance of Eclipse Jersey with Jakarta REST</description>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -19,13 +19,13 @@
     <artifactId>all</artifactId>
     <version>3.1-SNAPSHOT</version>
     <packaging>pom</packaging>
-    <name>Jakarta RESTful Web Service Multi-Module Project</name>
+    <name>Jakarta RESTful WS Project</name>
 
     <modules>
-	<module>jaxrs-api</module>
-	<module>jaxrs-spec</module>
-	<module>jaxrs-tck</module>
-	<module>examples</module>
-	<module>jersey-tck</module>
+        <module>jaxrs-api</module>
+        <module>jaxrs-spec</module>
+        <module>jaxrs-tck</module>
+        <module>examples</module>
+        <module>jersey-tck</module>
     </modules>
 </project>


### PR DESCRIPTION
Cleanup of pom names, and changes to relative paths to avoid warnings when building modules. Some minor updates to Javadocs to avoid warnings as well.

Requesting fast track.