### PR TITLE
Set JDK version to 11 on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
 		pollSCM('H H * * *')
 	}
 	tools {
-		jdk 'openjdk-latest'
+		jdk 'openjdk-jdk11-latest'
 		maven 'apache-maven-latest'
 	}
 	environment {


### PR DESCRIPTION
Nightly builds on Jenkins have been failing for a while. Setting JDK to latest 11.