### PR TITLE
Removing inactive committers

### DIFF
--- a/jaxrs-spec/src/main/asciidoc/chapters/introduction/_project_team.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/introduction/_project_team.adoc
@@ -17,8 +17,6 @@ of the project team and various contributors.
 
 The following are the current committers of the Jakarta RESTful Web Services specification project:
 
--- Sebastian Daschner (IBM)
-
 -- Christian Kaltepoth (individual)
 
 -- Markus Karg (individual)


### PR DESCRIPTION
This section of the spec is intended to provide a reference whom to call with question of the *current* spec and API revision, so it makes no sense to keep people listet not having contributed in any noticeable form *for many months*.

Either we agree on *frequent* updates to this list in the spec, or we replace the names with a link to the Github statistics.