### PR TITLE
Initial check-in of TCK w/Arquillian+TestNG

### DIFF
--- a/jaxrs-tck/pom.xml
+++ b/jaxrs-tck/pom.xml
@@ -86,12 +86,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>[5.5.2, 5.6-A00)</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
             <version>[2.2, 2.3-A00)</version>

--- a/jaxrs-tck/pom.xml
+++ b/jaxrs-tck/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-    Copyright (c) 2020 Markus Karg. All rights reserved.
+    Copyright (c) 2020, 2021 Markus Karg. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -29,8 +29,8 @@
     <url>https://github.com/eclipse-ee4j/jaxrs-api</url>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
     </properties>
 
     <organization>
@@ -95,6 +95,27 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
             <version>[2.2, 2.3-A00)</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>7.4.0</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.arquillian</groupId>
+            <artifactId>arquillian-bom</artifactId>
+            <version>1.6.0.Final</version>
+            <scope>import</scope>
+            <type>pom</type>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.arquillian.testng</groupId>
+            <artifactId>arquillian-testng-container</artifactId>
+            <version>1.6.0.Final</version>
         </dependency>
     </dependencies>
 </project>

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/basic/BasicApp.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/basic/BasicApp.java
@@ -1,0 +1,15 @@
+/*******************************************************************
+* Copyright (c) 2021 Eclipse Foundation
+*
+* This specification document is made available under the terms
+* of the Eclipse Foundation Specification License v1.0, which is
+* available at https://www.eclipse.org/legal/efsl.php.
+*******************************************************************/
+package jakarta.ws.rs.tck.basic;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("app")
+public class BasicApp extends Application {
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/basic/BasicResource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/basic/BasicResource.java
@@ -1,0 +1,56 @@
+/*******************************************************************
+* Copyright (c) 2021 Eclipse Foundation
+*
+* This specification document is made available under the terms
+* of the Eclipse Foundation Specification License v1.0, which is
+* available at https://www.eclipse.org/legal/efsl.php.
+*******************************************************************/
+package jakarta.ws.rs.tck.basic;
+
+import java.util.logging.Logger;
+
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PATCH;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Response;
+
+@Path("basic")
+public class BasicResource {
+    private static final Logger LOG = Logger.getLogger(BasicResource.class.getName());
+
+    @GET
+    @Path("/{id}")
+    public Response getResponse(@PathParam("id") String id) {
+        LOG.finest(() -> "getResponse " + id);
+        return Response.ok("GET basic " + id).build();
+    }
+
+    @POST
+    public Response postResponse(String entity) {
+        LOG.finest(() -> "postResponse " + entity);
+        return Response.ok("POST basic " + entity).build();
+    }
+
+    @PUT
+    public Response putResponse(String entity) {
+        LOG.finest(() -> "putResponse " + entity);
+        return Response.ok("PUT basic " + entity).build();
+    }
+
+    @PATCH
+    public Response patchResponse(String entity) {
+        LOG.finest(() -> "patchResponse " + entity);
+        return Response.ok("PATCH basic " + entity).build();
+    }
+
+    @DELETE
+    public Response deleteResponse(@QueryParam("id") String id) {
+        LOG.finest(() -> "deleteResponse " + id);
+        return Response.ok("DELETE basic " + id).build();
+    }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/basic/BasicResourceTest.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/basic/BasicResourceTest.java
@@ -36,7 +36,7 @@ public class BasicResourceTest extends Arquillian {
     }
 
     @Test
-    public void test_get() throws Exception {
+    public void get() throws Exception {
         String uri = Util.getUrlFor(CONTEXT_ROOT, "app", "basic", "123");
         LOG.finest(() -> "uri = " + uri);
         HttpClient client = HttpClient.newHttpClient();
@@ -49,7 +49,7 @@ public class BasicResourceTest extends Arquillian {
     }
 
     @Test
-    public void test_post() throws Exception {
+    public void post() throws Exception {
         String uri = Util.getUrlFor(CONTEXT_ROOT, "app", "basic");
         LOG.finest(() -> "uri = " + uri);
         HttpClient client = HttpClient.newHttpClient();

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/basic/BasicResourceTest.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/basic/BasicResourceTest.java
@@ -1,0 +1,64 @@
+/*******************************************************************
+* Copyright (c) 2021 Eclipse Foundation
+*
+* This specification document is made available under the terms
+* of the Eclipse Foundation Specification License v1.0, which is
+* available at https://www.eclipse.org/legal/efsl.php.
+*******************************************************************/
+package jakarta.ws.rs.tck.basic;
+
+import static org.testng.Assert.assertEquals;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpClient.Version;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.logging.Logger;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+public class BasicResourceTest extends Arquillian {
+    private final static Logger LOG = Logger.getLogger(BasicResourceTest.class.getName());
+
+    private final static String CONTEXT_ROOT = "basic";
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, "basic.war")
+                         .addPackage(BasicApp.class.getPackage());
+    }
+
+    @Test
+    public void test_get() throws Exception {
+        String uri = Util.getUrlFor(CONTEXT_ROOT, "app", "basic", "123");
+        LOG.finest(() -> "uri = " + uri);
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder()
+                                         .uri(URI.create(uri))
+                                         .version(Version.HTTP_1_1)
+                                         .build();
+        String response = client.send(request, BodyHandlers.ofString()).body();
+        assertEquals(response, "GET basic 123");
+    }
+
+    @Test
+    public void test_post() throws Exception {
+        String uri = Util.getUrlFor(CONTEXT_ROOT, "app", "basic");
+        LOG.finest(() -> "uri = " + uri);
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder()
+                                         .uri(URI.create(uri))
+                                         .POST(BodyPublishers.ofString("abc"))
+                                         .version(Version.HTTP_1_1)
+                                         .build();
+        String response = client.send(request, BodyHandlers.ofString()).body();
+        assertEquals(response, "POST basic abc");
+    }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/basic/Util.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/basic/Util.java
@@ -1,0 +1,20 @@
+/*******************************************************************
+* Copyright (c) 2021 Eclipse Foundation
+*
+* This specification document is made available under the terms
+* of the Eclipse Foundation Specification License v1.0, which is
+* available at https://www.eclipse.org/legal/efsl.php.
+*******************************************************************/
+package jakarta.ws.rs.tck.basic;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+public class Util {
+    public static final int HTTP_PORT = Integer.getInteger("http.port", 8010);
+
+    public static String getUrlFor(String contextRoot, String...paths) {
+        return "http://localhost:" + HTTP_PORT + "/" + contextRoot + "/" +
+            Arrays.stream(paths).collect(Collectors.joining("/"));
+    }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/sebootstrap/SeBootstrapIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/sebootstrap/SeBootstrapIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Markus Karg. All rights reserved.
+ * Copyright (c) 2020, 2021 Markus Karg. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,7 +16,6 @@
 
 package jakarta.ws.rs.tck.sebootstrap;
 
-import static java.util.concurrent.TimeUnit.HOURS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
@@ -29,11 +28,6 @@ import java.util.Set;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
-
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -43,13 +37,16 @@ import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.UriBuilder;
 
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
 /**
  * Compliance Test for Java SE Bootstrap API of Jakarta REST API
  *
  * @author Markus KARG (markus@headcrashing.eu)
  * @since 3.1
  */
-@Timeout(value = 1, unit = HOURS)
 public final class SeBootstrapIT {
 
     /**
@@ -328,12 +325,12 @@ public final class SeBootstrapIT {
 
     private static Client client;
 
-    @BeforeAll
+    @BeforeClass
     static void createClient() {
         SeBootstrapIT.client = ClientBuilder.newClient();
     }
 
-    @AfterAll
+    @AfterClass
     static void disposeClient() {
         SeBootstrapIT.client.close();
     }

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/uribuilder/UriBuilderIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/uribuilder/UriBuilderIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Markus Karg. All rights reserved.
+ * Copyright (c) 2020, 2021 Markus Karg. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,20 +16,17 @@
 
 package jakarta.ws.rs.tck.uribuilder;
 
-import static java.util.concurrent.TimeUnit.HOURS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.concurrent.ExecutionException;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
-
 import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.core.UriBuilderException;
+
+import org.testng.annotations.Test;
 
 /**
  * Compliance Test for URI Builder API of Jakarta REST API
@@ -37,7 +34,6 @@ import jakarta.ws.rs.core.UriBuilderException;
  * @author Markus KARG (markus@headcrashing.eu)
  * @since 3.1
  */
-@Timeout(value = 1, unit = HOURS)
 public final class UriBuilderIT {
 
     /**
@@ -67,12 +63,12 @@ public final class UriBuilderIT {
      * @throws InterruptedException if the test took much longer than usually
      *                              expected
      */
-    @Test
+    @Test(expectedExceptions = UriBuilderException.class)
     public final void shouldNotBuildInvalidUriFromScratch() throws InterruptedException, ExecutionException {
         // given
         final UriBuilder uriBuilder = UriBuilder.newInstance();
 
-        // then
-        assertThrows(UriBuilderException.class, /* when */ uriBuilder::build);
+        // then UriBuilderException is thrown when
+        uriBuilder.build();
     }
 }


### PR DESCRIPTION
This PR creates the Arquillian-based TCK. It is based on TestNG because I could not get JUnit 5 to work (it always claimed success on the test runs, but didn't actually run the tests).  FWIW, MicroProfile uses TestNG with Arquillian - very similar to what I have proposed here.

I have some more doc on how a vendor would run these tests here: https://github.com/andymc12/jakartaRest31TCK-openliberty - this will only work locally after building/installing the `jaxrs-tck`. 

This PR includes two very simple test cases (basic GET and POST).  Future PRs should migrate the existing Jakarta REST 3.0 TCK tests as well as create new tests for some of the 3.1-specific features.

Question: Do we want to convert @mkarg's Java SE based tests to use TestNG? Or should it stick with JUnit 5 since JUnit 5 works if we don't need Arquillian? I'm willing to convert the tests in this PR if we have consensus - or we can do it later in another PR.  Another option might be to stick with JUnit 5 for the SE tests and eventually move the Arquillian tests to JUnit 5 if we can resolve the test runtime issues.