### PR TITLE
Reverting PR 983 that causes build failure

### DIFF
--- a/etc/config/checkstyle.xml
+++ b/etc/config/checkstyle.xml
@@ -85,10 +85,13 @@
         <!-- Checks for Javadoc comments.                     -->
         <!-- See http://checkstyle.sf.net/config_javadoc.html -->
 
+        <!--
+          - Turned off for now due to https://github.com/checkstyle/checkstyle/issues/5088
+          -
         <module name="JavadocMethod">
-            <property name="accessModifiers" value="protected"/>
+            <property name="scope" value="protected"/>
             <property name="validateThrows" value="false"/>
-        </module>
+        </module -->
 
         <module name="JavadocType">
             <property name="scope" value="protected"/>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -174,13 +174,6 @@
                         <outputFile>${project.build.directory}/checkstyle/checkstyle-result.xml</outputFile>
                         <configLocation>${basedir}/../etc/config/checkstyle.xml</configLocation>
                     </configuration>
-                    <dependencies>
-                        <dependency>
-                            <groupId>com.puppycrawl.tools</groupId>
-                            <artifactId>checkstyle</artifactId>
-                            <version>8.43</version>
-                        </dependency>
-                    </dependencies>
                     <executions>
                         <execution>
                             <goals>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -423,13 +423,6 @@
                         <configLocation>${basedir}/../etc/config/checkstyle.xml</configLocation>
                         <excludes>**/module-info.java</excludes>
                     </configuration>
-                    <dependencies>
-                        <dependency>
-                            <groupId>com.puppycrawl.tools</groupId>
-                            <artifactId>checkstyle</artifactId>
-                            <version>8.43</version>
-                        </dependency>
-                    </dependencies>
                     <executions>
                         <execution>
                             <goals>


### PR DESCRIPTION
This reverts PR 983 in case we cannot find an easy way to upgrade Checkstyle. Current pipeline and local builds are failing. If we find an alternative, we can just drop this PR. 

Fasttrack.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>