### PR TITLE
Version Bump: Maven Checkstyle Plugin 3.1.2 + Checkstyle 8.44

### DIFF
--- a/etc/config/checkstyle.xml
+++ b/etc/config/checkstyle.xml
@@ -52,6 +52,8 @@
         <property name="basedir" value="${basedir}"/>
     -->
 
+    <property name="cacheFile" value="${checkstyle.cache.file}"/>
+
     <!-- Checks that each Java package has a Javadoc file used for commenting. -->
     <!-- See http://checkstyle.sf.net/config_javadoc.html#JavadocPackage       -->
     <module name="JavadocPackage" />
@@ -66,6 +68,11 @@
 
     <module name="FileLength"/>
 
+    <module name="LineLength">
+        <property name="max" value="160"/>
+        <property name="ignorePattern" value="@version|@see|@todo|TODO"/>
+    </module>
+
     <!-- Following interprets the header file as regular expressions. -->
     <!-- <module name="RegexpHeader"/>                                -->
 
@@ -79,7 +86,6 @@
     </module>
 
     <module name="TreeWalker">
-        <property name="cacheFile" value="${checkstyle.cache.file}"/>
         <property name="tabWidth" value="4"/>
 
         <!-- Checks for Javadoc comments.                     -->
@@ -137,10 +143,6 @@
 
         <!-- Checks for Size Violations.                    -->
         <!-- See http://checkstyle.sf.net/config_sizes.html -->
-        <module name="LineLength">
-            <property name="max" value="160"/>
-            <property name="ignorePattern" value="@version|@see|@todo|TODO"/>
-        </module>
         <module name="MethodLength"/>
         <module name="ParameterNumber">
 	   <property name="max" value="11"/>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -168,7 +168,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.1.2</version>
                     <configuration>
                         <outputDirectory>${project.build.directory}/checkstyle</outputDirectory>
                         <outputFile>${project.build.directory}/checkstyle/checkstyle-result.xml</outputFile>
@@ -178,7 +178,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>8.43</version>
+                            <version>8.44</version>
                         </dependency>
                     </dependencies>
                     <executions>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -416,7 +416,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.1.2</version>
                     <configuration>
                         <outputDirectory>${project.build.directory}/checkstyle</outputDirectory>
                         <outputFile>${project.build.directory}/checkstyle/checkstyle-result.xml</outputFile>
@@ -427,7 +427,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>8.43</version>
+                            <version>8.44</version>
                         </dependency>
                     </dependencies>
                     <executions>


### PR DESCRIPTION
This PR fixes a build fail caused by PR 983.

In contrast to the alternative [PR 999](https://github.com/eclipse-ee4j/jaxrs-api/pull/999), *this* is an actual **fix** instead of a simple undo: Both, Maven Checkstyle Plugin and Checkstyle, are updated to the latest version, so the build is running fine again (this implies minor modifications to the checkstyle configuration as part of this PR).

**As these are no API changes, this is a fast-track review period of just one day as per our [committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**