### PR TITLE
Add Response.isClosed()

### DIFF
--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/Response.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/Response.java
@@ -464,6 +464,22 @@ public abstract class Response implements AutoCloseable {
     public abstract String getHeaderString(String name);
 
     /**
+     * Check if the response is closed. The method returns {@code true} if the response is closed,
+     * returns {@code false} otherwise.
+     *
+     * @return {@code true} if the response has been {@link #close() closed}, {@code false} otherwise.
+     * @since 3.1
+     */
+    public boolean isClosed() {
+        try {
+            hasEntity();
+            return false;
+        } catch (IllegalStateException ignored) {
+            return true;
+        }
+    }
+
+    /**
      * Create a new ResponseBuilder by performing a shallow copy of an existing Response.
      * <p>
      * The returned builder has its own {@link #getHeaders() response headers} but the header values are shared with the


### PR DESCRIPTION
This PR is the follow-up to the [issue](https://github.com/eclipse-ee4j/jaxrs-api/issues/706) and  [discussion](https://github.com/eclipse-ee4j/jaxrs-api/issues/736) we had with @ronsigal.

To sum up it was about adding a method in the `Response` class to know when a response instance is closed. So that we no longer need to write code like:
```

try {
   if (response.getEntity() != null) return response;
}
catch(IllegalStateException ise) {
   // IllegalStateException from ClientResponse.getEntity() means the response is closed and got no entity
} 
```

but instead: 

```
if (!response.isClosed() && response.getEntity() != null) {
   return response;
}
```
I agree that the default implementation I proposed is a bit weird, not intuitive etc . I did it so that vendors don't need to make changes on their side.
I'm OK to remove it if you think it's not necessary.

Thanks
