### PR TITLE
Deprecate CompletionCallback#onComplete(Throwable)

### DIFF
--- a/jaxrs-api/src/main/java/jakarta/ws/rs/container/CompletionCallback.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/container/CompletionCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,8 +20,7 @@ package jakarta.ws.rs.container;
  * A request processing callback that receives request processing completion events.
  * <p>
  * A completion callback is invoked when the whole request processing is over, i.e. once a response for the request has
- * been processed and sent back to the client or in when an unmapped exception or error is being propagated to the
- * container.
+ * been processed and sent back to the client.
  * </p>
  *
  * @author Marek Potociar
@@ -30,19 +29,27 @@ package jakarta.ws.rs.container;
 public interface CompletionCallback {
     /**
      * A completion callback notification method that will be invoked when the request processing is finished, after a
-     * response is processed and is sent back to the client or when an unmapped throwable has been propagated to the hosting
-     * I/O container.
+     * response is processed and is sent back to the client.
      * <p>
-     * An unmapped throwable is propagated to the hosting I/O container in case no {@link jakarta.ws.rs.ext.ExceptionMapper
-     * exception mapper} has been found for a throwable indicating a request processing failure. In this case a
-     * non-{@code null} unmapped throwable instance is passed to the method. Note that the throwable instance represents the
-     * actual unmapped exception thrown during the request processing, before it has been wrapped into an I/O
-     * container-specific exception that was used to propagate the throwable to the hosting I/O container.
+     * Deprecated. Since 3.1, a possible throwable occurring during the request processing is always mapped to a response
+     * (either by a custom exception mapper or by a default exception mapper) and the method throwable
+     * argument is always null.
      * </p>
      *
-     * @param throwable is {@code null}, if the request processing has completed with a response that has been sent to the
-     * client. In case the request processing resulted in an unmapped exception or error that has been propagated to the
-     * hosting I/O container, this parameter contains the unmapped exception instance.
+     * @param throwable is always {@code null}.
+     * @deprecated  As of release 3.1, replaced by {@link #onComplete()}.
      */
-    public void onComplete(Throwable throwable);
+    @Deprecated(since="3.1", forRemoval = true)
+    void onComplete(Throwable throwable);
+
+    /**
+     * A completion callback notification method that will be invoked when the request processing is finished, after a
+     * response is processed and is sent back to the client.
+     *
+     * @since 3.1
+     */
+    @SuppressWarnings("deprecation")
+    default void onComplete() {
+        onComplete(null);
+    }
 }


### PR DESCRIPTION
Signed-off-by: jansupol <jan.supol@oracle.com>