### PR TITLE
Fix JavaDoc warnings

### DIFF
--- a/examples/src/main/java/jaxrs/examples/bootstrap/package-info.java
+++ b/examples/src/main/java/jaxrs/examples/bootstrap/package-info.java
@@ -17,6 +17,6 @@
  *
  * @author Markus KARG (markus@headcrashing.eu)
  * @since 3.1
- * @see jakarta.ws.rs.SeBootstrap;
+ * @see jakarta.ws.rs.SeBootstrap
  */
 package jaxrs.examples.bootstrap;

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/EntityPart.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/EntityPart.java
@@ -130,8 +130,6 @@ public interface EntityPart {
      * an {@code IllegalStateException} if it is called after calling
      * {@link #getContent} or {@link #getContent(GenericType)}.
      * 
-     * @param <T> type parameter of the value returned
-     * 
      * @param type the {@code Class} that the implementation should convert this
      *             part to
      * @param <T> the entity type
@@ -168,8 +166,6 @@ public interface EntityPart {
      * result in an {@code IllegalStateException}. Likewise this method will throw
      * an {@code IllegalStateException} if it is called after calling
      * {@link #getContent} or {@link #getContent(Class)}.
-     *
-     * @param <T> type parameter of the value returned
      * 
      * @param type the generic type that the implementation should convert this part
      *             to
@@ -315,7 +311,6 @@ public interface EntityPart {
          * methods.
          * </p>
          *
-         * @param <T> type parameter of the content
          * @param content the object to be used as the content
          * @param type    the type of this object which will be used when selecting the
          *                appropriate {@link jakarta.ws.rs.ext.MessageBodyWriter}
@@ -344,7 +339,6 @@ public interface EntityPart {
          * </p>
          * 
          * @param content the object to be used as the content
-         * @return the updated builder.
          * @throws IllegalArgumentException if {@code content} is {@code null}
          * @return the updated builder.
          */
@@ -366,7 +360,6 @@ public interface EntityPart {
          * methods.
          * </p>
          *
-         * @param <T> type parameter of the content
          * @param content the object to be used as the content
          * @param type    the generic type of this object which will be used when
          *                selecting the appropriate


### PR DESCRIPTION
This fixes the JavaDoc warnings in `EntityPart` as described by @mkarg in #979.  
It also fixes a JavaDoc error in the `package-info` of the bootstrap example (misplaced semicolon).

What maybe should be addressed as well are the JavaDoc Errors in `jaxrs-tck`.  
There are lots of errors because the code just got ported and focus was on the migration.  
Maybe we don't need to generate JavaDoc for this at all though and it can be excluded? WDYT?  
Should this be discussed in a seperate PR / issue?