### PR TITLE
TCK Migration: Move pending tests from jakartaee-tck/src/com/sun/ts/tests/jaxrs/api (#1015)

### DIFF
--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/client/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/client/JAXRSClientIT.java
@@ -1,0 +1,1118 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.client.client;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Link;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.UriBuilder;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.MessageBodyWriter;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.common.provider.StringBeanEntityProvider;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = 7355465562476492891L;
+
+  public JAXRSClientIT() {
+    setClientAndWebTarget();
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  protected transient WebTarget target;
+
+  protected transient Client client;
+
+  /*
+   * @testName: closeOnClientConfigTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnClientConfigTest() throws Fault {
+    client.close();
+    assertException(IllegalStateException.class, client, "getConfiguration");
+  }
+
+  /*
+   * @testName: closeOnClientInvocationWithLinkTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnClientInvocationWithLinkTest() throws Fault {
+    client.close();
+    Link link = Link.fromUri("cts").build();
+    assertException(IllegalStateException.class, client, "invocation", link);
+  }
+
+  /*
+   * @testName: closeOnClientTargetWithLinkTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnClientTargetWithLinkTest() throws Fault {
+    client.close();
+    Link link = Link.fromUri("cts").build();
+    assertException(IllegalStateException.class, client, "target", link);
+  }
+
+  /*
+   * @testName: closeOnClientTargetWithStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnClientTargetWithStringTest() throws Fault {
+    client.close();
+    assertException(IllegalStateException.class, client, "target", "cts");
+  }
+
+  /*
+   * @testName: closeOnClientTargetWithUriTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnClientTargetWithUriTest() throws Fault {
+    client.close();
+    URI uri = URI.create("cts");
+    assertException(IllegalStateException.class, client, "target", uri);
+  }
+
+  /*
+   * @testName: closeOnClientRegisterClassTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnClientRegisterClassTest() throws Fault {
+    client.close();
+    assertException(IllegalStateException.class, client, "register",
+        StringBeanEntityProvider.class);
+  }
+
+  /*
+   * @testName: closeOnClientRegisterObjectTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnClientRegisterObjectTest() throws Fault {
+    client.close();
+    assertException(IllegalStateException.class, client, "register",
+        new StringBeanEntityProvider());
+  }
+
+  /*
+   * @testName: closeOnClientRegisterClassWithContractsTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnClientRegisterClassWithContractsTest() throws Fault {
+    client.close();
+    assertException(IllegalStateException.class, client, "register",
+        StringBeanEntityProvider.class,
+        new Class[] { MessageBodyWriter.class });
+  }
+
+  /*
+   * @testName: closeOnClientRegisterClassWithPriorityTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnClientRegisterClassWithPriorityTest() throws Fault {
+    client.close();
+    assertException(IllegalStateException.class, client, "register",
+        StringBeanEntityProvider.class, 100);
+  }
+
+  /*
+   * @testName: closeOnClientRegisterClassMapTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnClientRegisterClassMapTest() throws Fault {
+    client.close();
+    Map<Class<?>, Integer> contracts = new HashMap<Class<?>, Integer>();
+    contracts.put(MessageBodyReader.class, 100);
+    assertException(IllegalStateException.class, client, "register",
+        StringBeanEntityProvider.class, contracts);
+  }
+
+  /*
+   * @testName: closeOnClientRegisterObjectWithContractsTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnClientRegisterObjectWithContractsTest() throws Fault {
+    client.close();
+    assertException(IllegalStateException.class, client, "register",
+        new StringBeanEntityProvider(),
+        new Class[] { MessageBodyReader.class });
+  }
+
+  /*
+   * @testName: closeOnClientRegisterObjectWithPriorityTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnClientRegisterObjectWithPriorityTest() throws Fault {
+    client.close();
+    assertException(IllegalStateException.class, client, "register",
+        new StringBeanEntityProvider(), 100);
+  }
+
+  /*
+   * @testName: closeOnClientRegisterObjectWithMapTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnClientRegisterObjectWithMapTest() throws Fault {
+    client.close();
+    Map<Class<?>, Integer> contracts = new HashMap<Class<?>, Integer>();
+    contracts.put(MessageBodyReader.class, 100);
+    assertException(IllegalStateException.class, client, "register",
+        new StringBeanEntityProvider(), contracts);
+  }
+
+  /*
+   * @testName: closeOnClientPropertyTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnClientPropertyTest() throws Fault {
+    client.close();
+    Map<Class<?>, Integer> contracts = new HashMap<Class<?>, Integer>();
+    contracts.put(MessageBodyReader.class, 100);
+    assertException(IllegalStateException.class, client, "property", "A", "B");
+  }
+
+  /*
+   * @testName: closeOnClientTargetWithUriBuilderTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalTStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnClientTargetWithUriBuilderTest() throws Fault {
+    client.close();
+    Link link = Link.fromUri("cts").build();
+    UriBuilder builder = UriBuilder.fromUri(link.getUri());
+    assertException(IllegalStateException.class, client, "target", builder);
+  }
+
+  /*
+   * @testName: closeOnWebTargetConfigTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnWebTargetConfigTest() throws Fault {
+    client.close();
+    assertException(IllegalStateException.class, target, "getConfiguration");
+  }
+
+  /*
+   * @testName: closeOnWebTargetGetUriTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnWebTargetGetUriTest() throws Fault {
+    client.close();
+    assertException(IllegalStateException.class, target, "getUri");
+  }
+
+  /*
+   * @testName: closeOnWebTargetGetUriBuilderTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnWebTargetGetUriBuilderTest() throws Fault {
+    client.close();
+    assertException(IllegalStateException.class, target, "getUriBuilder");
+  }
+
+  /*
+   * @testName: closeOnWebTargetMatrixParamTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnWebTargetMatrixParamTest() throws Fault {
+    client.close();
+    assertException(IllegalStateException.class, target, "matrixParam", "cts",
+        new Object[] { "tck" });
+  }
+
+  /*
+   * @testName: closeOnWebTargetPathTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnWebTargetPathTest() throws Fault {
+    client.close();
+    assertException(IllegalStateException.class, target, "path", "cts");
+  }
+
+  /*
+   * @testName: closeOnWebTargetQueryParamTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnWebTargetQueryParamTest() throws Fault {
+    client.close();
+    assertException(IllegalStateException.class, target, "queryParam", "cts",
+        new Object[] { "tck" });
+  }
+
+  /*
+   * @testName: closeOnWebTargetRegisterClassTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnWebTargetRegisterClassTest() throws Fault {
+    client.close();
+    assertException(IllegalStateException.class, target, "register",
+        StringBeanEntityProvider.class);
+  }
+
+  /*
+   * @testName: closeOnWebTargetRegisterObjectTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnWebTargetRegisterObjectTest() throws Fault {
+    client.close();
+    assertException(IllegalStateException.class, target, "register",
+        new StringBeanEntityProvider());
+  }
+
+  /*
+   * @testName: closeOnWebTargetRegisterClassWithContractsTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnWebTargetRegisterClassWithContractsTest() throws Fault {
+    client.close();
+    assertException(IllegalStateException.class, target, "register",
+        StringBeanEntityProvider.class,
+        new Class[] { MessageBodyWriter.class });
+  }
+
+  /*
+   * @testName: closeOnWebTargetRegisterClassWithPriorityTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnWebTargetRegisterClassWithPriorityTest() throws Fault {
+    client.close();
+    assertException(IllegalStateException.class, target, "register",
+        StringBeanEntityProvider.class, 100);
+  }
+
+  /*
+   * @testName: closeOnWebTargetRegisterClassMapTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnWebTargetRegisterClassMapTest() throws Fault {
+    client.close();
+    Map<Class<?>, Integer> contracts = new HashMap<Class<?>, Integer>();
+    contracts.put(MessageBodyReader.class, 100);
+    assertException(IllegalStateException.class, target, "register",
+        StringBeanEntityProvider.class, contracts);
+  }
+
+  /*
+   * @testName: closeOnWebTargetRegisterObjectWithContractsTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnWebTargetRegisterObjectWithContractsTest() throws Fault {
+    client.close();
+    assertException(IllegalStateException.class, target, "register",
+        new StringBeanEntityProvider(),
+        new Class[] { MessageBodyReader.class });
+  }
+
+  /*
+   * @testName: closeOnWebTargetRegisterObjectWithPriorityTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnWebTargetRegisterObjectWithPriorityTest() throws Fault {
+    client.close();
+    assertException(IllegalStateException.class, target, "register",
+        new StringBeanEntityProvider(), 100);
+  }
+
+  /*
+   * @testName: closeOnWebTargetRegisterObjectWithMapTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnWebTargetRegisterObjectWithMapTest() throws Fault {
+    client.close();
+    Map<Class<?>, Integer> contracts = new HashMap<Class<?>, Integer>();
+    contracts.put(MessageBodyReader.class, 100);
+    assertException(IllegalStateException.class, target, "register",
+        new StringBeanEntityProvider(), contracts);
+  }
+
+  /*
+   * @testName: closeOnWebTargetRequestTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnWebTargetRequestTest() throws Fault {
+    client.close();
+    assertException(IllegalStateException.class, target, "request");
+  }
+
+  /*
+   * @testName: closeOnWebTargetRequestWithMediaTypeTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnWebTargetRequestWithMediaTypeTest() throws Fault {
+    client.close();
+    assertException(IllegalStateException.class, target, "request",
+        new Object[] { new MediaType[] { MediaType.APPLICATION_XML_TYPE } });
+  }
+
+  /*
+   * @testName: closeOnWebTargetRequestWithMediaTypeNameTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnWebTargetRequestWithMediaTypeNameTest() throws Fault {
+    client.close();
+    assertException(IllegalStateException.class, target, "request",
+        new Object[] { new String[] { MediaType.APPLICATION_XML } });
+  }
+
+  /*
+   * @testName: closeOnWebTargetResolveTemplateStringObjectTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnWebTargetResolveTemplateStringObjectTest() throws Fault {
+    client.close();
+    assertException(IllegalStateException.class, target, "resolveTemplate",
+        "name", "value");
+  }
+
+  /*
+   * @testName: closeOnWebTargetResolveTemplateStringObjectBooleanTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnWebTargetResolveTemplateStringObjectBooleanTest()
+      throws Fault {
+    client.close();
+    assertException(IllegalStateException.class, target, "resolveTemplate",
+        "name", "value", true);
+  }
+
+  /*
+   * @testName: closeOnWebTargetResolveTemplateFromEncodedTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnWebTargetResolveTemplateFromEncodedTest() throws Fault {
+    client.close();
+    assertException(IllegalStateException.class, target,
+        "resolveTemplateFromEncoded", "name", "value");
+  }
+
+  /*
+   * @testName: closeOnWebTargetResolveTemplatesMapTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnWebTargetResolveTemplatesMapTest() throws Fault {
+    client.close();
+    Map<String, Object> map = new HashMap<String, Object>();
+    assertException(IllegalStateException.class, target, "resolveTemplates",
+        map);
+  }
+
+  /*
+   * @testName: closeOnWebTargetResolveTemplatesMapBooleanTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnWebTargetResolveTemplatesMapBooleanTest() throws Fault {
+    client.close();
+    Map<String, Object> map = new HashMap<String, Object>();
+    assertException(IllegalStateException.class, target, "resolveTemplates",
+        map, true);
+  }
+
+  /*
+   * @testName: closeOnWebTargetPropertyTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnWebTargetPropertyTest() throws Fault {
+    client.close();
+    Map<Class<?>, Integer> contracts = new HashMap<Class<?>, Integer>();
+    contracts.put(MessageBodyReader.class, 100);
+    assertException(IllegalStateException.class, target, "property", "A", "B");
+  }
+
+  /*
+   * @testName: closeOnWebTargetResolveTemplatesFromEncodedTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:409;
+   * 
+   * @test_Strategy: Close client instance and all it's associated resources.
+   * Subsequent calls have no effect and are ignored. Once the client is closed,
+   * invoking any other method on the client instance would result in an
+   * IllegalStateException being thrown. Calling this method effectively
+   * invalidates all WebTarget resource targets produced by the client instance.
+   * Invoking any method on such targets once the client is closed would result
+   * in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeOnWebTargetResolveTemplatesFromEncodedTest() throws Fault {
+    client.close();
+    Map<String, Object> map = new HashMap<String, Object>();
+    assertException(IllegalStateException.class, target,
+        "resolveTemplatesFromEncoded", map);
+  }
+
+  /*
+   * @testName: invocationFromLinkExceptionNoLinkTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:411;
+   * 
+   * @test_Strategy: jakarta.ws.rs.client.Client.invocation( Link ) throws
+   * NullPointerException in case argument is null.
+   */
+  @Test
+  public void invocationFromLinkExceptionNoLinkTest() throws Fault {
+    String exceptionMessage = "NullPointerException successfully thrown when no link";
+    String noExceptionMessage = "NullPointerException not thrown when no link";
+    checkInvocationException(null, NullPointerException.class, exceptionMessage,
+        noExceptionMessage);
+  }
+
+  /*
+   * @testName: targetStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:413;
+   * 
+   * @test_Strategy: Build a new web resource target.
+   */
+  @Test
+  public void targetStringTest() throws Fault {
+    // setClientAndWebTarget is called in constructor
+    assertTrue(target != null, "WebTarget is null");
+  }
+
+  /*
+   * @testName: targetWithStringIllegalArgumentExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:413;
+   * 
+   * @test_Strategy: jakarta.ws.rs.client.Client.target( String ) throws
+   * IllegalArgumentException in case the supplied string is not a valid URI
+   * template.
+   */
+  @Test
+  public void targetWithStringIllegalArgumentExceptionTest() throws Fault {
+    String sWebTarget = ":cts:8080//tck:90090//jaxrs ";
+    try {
+      new URI(sWebTarget);
+      throw new Fault("URI(" + sWebTarget + ") is valid");
+    } catch (URISyntaxException e1) {
+      logMsg("Uri is not a valid URI as expected:", e1);
+    }
+    try {
+      target = client.target(sWebTarget);
+      throw new Fault(
+          "IllegalArgumentException was not thrown for target " + sWebTarget);
+    } catch (IllegalArgumentException e) {
+      TestUtil
+          .logMsg("IllegalArgumentException was successfully thrown for target "
+              + sWebTarget + " as expected");
+    }
+  }
+
+  /*
+   * @testName: targetWithStringNullPointerExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:413;
+   * 
+   * @test_Strategy: jakarta.ws.rs.client.Client.target( String ) throws throws
+   * NullPointerException in case the supplied argument is null.
+   */
+  @Test
+  public void targetWithStringNullPointerExceptionTest() throws Fault {
+    String sWebTarget = null;
+    try {
+      target = client.target(sWebTarget);
+      throw new Fault("NullPointerException was not thrown for null target");
+    } catch (NullPointerException e) {
+      TestUtil.logMsg(
+          "NullPointerException was successfully thrown for null target as expected");
+    }
+  }
+
+  /*
+   * @testName: targetUriTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:416;
+   * 
+   * @test_Strategy: Build a new web resource target.
+   */
+  @Test
+  public void targetUriTest() throws Fault {
+    URI uri = URI.create(getUrl("call"));
+    target = client.target(uri);
+    assertTrue(target != null, "WebTarget is null");
+  }
+
+  /*
+   * @testName: targetWithUriNullPointerExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:416;
+   * 
+   * @test_Strategy: jakarta.ws.rs.client.Client.target( URI ) throws throws
+   * NullPointerException in case the supplied argument is null.
+   */
+  @Test
+  public void targetWithUriNullPointerExceptionTest() throws Fault {
+    URI uri = null;
+    try {
+      target = client.target(uri);
+      throw new Fault("NullPointerException was not thrown for null target");
+    } catch (NullPointerException e) {
+      TestUtil.logMsg(
+          "NullPointerException was successfully thrown for null target as expected");
+    }
+  }
+
+  /*
+   * @testName: targetUriBuilderTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:418;
+   * 
+   * @test_Strategy: Build a new web resource target.
+   */
+  @Test
+  public void targetUriBuilderTest() throws Fault {
+    UriBuilder builder = UriBuilder.fromUri(getUrl("call"));
+    target = client.target(builder);
+    assertTrue(target != null, "WebTarget is null");
+  }
+
+  /*
+   * @testName: targetWithUriBuilderNullPointerExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:418;
+   * 
+   * @test_Strategy: jakarta.ws.rs.client.Client.target( URI ) throws throws
+   * NullPointerException in case the supplied argument is null.
+   */
+  @Test
+  public void targetWithUriBuilderNullPointerExceptionTest() throws Fault {
+    UriBuilder builder = null;
+    try {
+      target = client.target(builder);
+      throw new Fault("NullPointerException was not thrown for null target");
+    } catch (NullPointerException e) {
+      TestUtil.logMsg(
+          "NullPointerException was successfully thrown for null target as expected");
+    }
+  }
+
+  /*
+   * @testName: targetLinkTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:420;
+   * 
+   * @test_Strategy: Build a new web resource target.
+   */
+  @Test
+  public void targetLinkTest() throws Fault {
+    URI uri = UriBuilder.fromPath(getUrl("call")).build();
+    Link link = Link.fromUri(uri).build();
+    target = client.target(link);
+    assertTrue(target != null, "WebTarget is null");
+  }
+
+  /*
+   * @testName: targetWithLinkNullPointerExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:420;
+   * 
+   * @test_Strategy: jakarta.ws.rs.client.Client.target( URI ) throws throws
+   * NullPointerException in case the supplied argument is null.
+   */
+  @Test
+  public void targetWithLinkNullPointerExceptionTest() throws Fault {
+    Link link = null;
+    try {
+      target = client.target(link);
+      throw new Fault("NullPointerException was not thrown for null target");
+    } catch (NullPointerException e) {
+      TestUtil.logMsg(
+          "NullPointerException was successfully thrown for null target as expected");
+    }
+  }
+
+  // //////////////////////////////////////////////////////////////////////
+  /** Check exception when calling Client#invocation() and log */
+  protected static <T extends Exception> void checkInvocationException(
+      Link link, Class<T> exception, String messageOnException,
+      String messageNoException) throws Fault {
+    Client client = ClientBuilder.newClient();
+    try {
+      client.invocation(link);
+      throw new Fault(messageNoException);
+    } catch (Exception e) {
+      if (exception.isInstance(e))
+        TestUtil.logMsg(messageOnException);
+      else
+        throw new Fault(e);
+    }
+  }
+
+  protected void setClientAndWebTarget() {
+    client = ClientBuilder.newClient();
+    target = client.target("cts");
+  }
+
+  protected static void assertException(Class<? extends Exception> exception,
+      Object object, String method, Object... args) throws Fault {
+
+    Method m = getMethodByName(object.getClass(), method, args);
+    assertTrue(m != null, "No method " + method + " for object " +
+        object.getClass().getName() + " found");
+    System.out.println(m);
+    try {
+      m.invoke(object, args);
+      assertTrue(false, "Method " + method + " did not throw " +
+          exception.getSimpleName());
+    } catch (Exception e) {
+      if (e.getCause() == null
+          || !exception.isAssignableFrom(e.getCause().getClass()))
+        throw new Fault(e);
+      logMsg(exception.getName(), "has been successfully thrown", e.getCause());
+    }
+  }
+
+  protected static Method getMethodByName(Class<?> clazz, String name,
+      Object... args) {
+    Method[] methods = clazz.getMethods();
+    for (Method m : methods)
+      if (m.getName().equals(name) && fitsMethodArguments(m, args))
+        return m;
+    return null;
+  }
+
+  protected static boolean fitsMethodArguments(Method method, Object... args) {
+    if (method.getParameterTypes().length != args.length)
+      return false;
+    Class<?>[] argClass = method.getParameterTypes();
+    for (int i = 0; i != argClass.length; i++) {
+      if (args[i].getClass() == Class.class
+          && argClass[i].getClass() != Class.class)
+        return false;
+      if (!argClass[i].isPrimitive()
+          && !argClass[i].isAssignableFrom(args[i].getClass()))
+        return false;
+      if (argClass[i].isPrimitive()
+          && (!(args[i] instanceof Number || args[i] instanceof Boolean)))
+        return false;
+    }
+    return true;
+  }
+
+  protected String getUrl(String method) {
+    StringBuilder url = new StringBuilder();
+    url.append("http://").append(_hostname).append(":").append(_port);
+    url.append("/").append(method);
+    return url.toString();
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/clientbuilder/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/clientbuilder/JAXRSClientIT.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.client.clientbuilder;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Configuration;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = 7395392827433641768L;
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  /*
+   * @testName: newClientNoParamTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1019;
+   * 
+   * @test_Strategy: Create new client instance using the default client builder
+   * factory provided by the JAX-RS implementation provider.
+   */
+  @Test
+  public void newClientNoParamTest() throws Fault {
+    Client client = ClientBuilder.newClient();
+    assertTrue(client != null, "could not create Client instance");
+  }
+
+  /*
+   * @testName: newClientWithConfigurationTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1020;
+   * 
+   * @test_Strategy: Create new configured client instance using the default
+   * client builder factory provided by the JAX-RS implementation provider.
+   */
+  @Test
+  public void newClientWithConfigurationTest() throws Fault {
+    String property = "JAXRSTCK";
+    Client client = ClientBuilder.newClient();
+    client.property(property, property);
+    Configuration config = client.getConfiguration();
+    client = ClientBuilder.newClient(config);
+    assertNotNull(client, "could not create Client instance");
+    assertEquals(property, client.getConfiguration().getProperty(property),
+        "client does not contain given config");
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/clientrequestcontext/ContextProvider.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/clientrequestcontext/ContextProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,11 +18,10 @@ package jakarta.ws.rs.tck.api.client.clientrequestcontext;
 
 import java.io.IOException;
 
-import jakarta.ws.rs.tck.common.JAXRSCommonClient.Fault;
-
 import jakarta.ws.rs.client.ClientRequestContext;
 import jakarta.ws.rs.client.ClientRequestFilter;
 import jakarta.ws.rs.ext.Provider;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient.Fault;
 
 @Provider
 public class ContextProvider implements ClientRequestFilter {

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/clientrequestcontext/GetPropertyNamesIsImmutableProvider.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/clientrequestcontext/GetPropertyNamesIsImmutableProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,11 +19,10 @@ package jakarta.ws.rs.tck.api.client.clientrequestcontext;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import jakarta.ws.rs.tck.common.JAXRSCommonClient.Fault;
-
 import jakarta.ws.rs.client.ClientRequestContext;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.Provider;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient.Fault;
 
 @Provider
 /**

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/clientrequestcontext/GetPropertyNamesProvider.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/clientrequestcontext/GetPropertyNamesProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,11 +19,10 @@ package jakarta.ws.rs.tck.api.client.clientrequestcontext;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import jakarta.ws.rs.tck.common.JAXRSCommonClient.Fault;
-import jakarta.ws.rs.tck.common.util.JaxrsUtil;
-
 import jakarta.ws.rs.client.ClientRequestContext;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient.Fault;
+import jakarta.ws.rs.tck.common.util.JaxrsUtil;
 
 public class GetPropertyNamesProvider extends ContextProvider {
   private AtomicInteger counter;

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/clientrequestcontext/GetSetPropertyProvider.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/clientrequestcontext/GetSetPropertyProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,10 +18,9 @@ package jakarta.ws.rs.tck.api.client.clientrequestcontext;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-import jakarta.ws.rs.tck.common.JAXRSCommonClient.Fault;
-
 import jakarta.ws.rs.client.ClientRequestContext;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient.Fault;
 
 public class GetSetPropertyProvider extends ContextProvider {
   private AtomicInteger counter;

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/clientrequestcontext/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/clientrequestcontext/JAXRSClientIT.java
@@ -1,0 +1,1529 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.client.clientrequestcontext;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Configuration;
+import jakarta.ws.rs.core.Cookie;
+import jakarta.ws.rs.core.GenericEntity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.core.Variant;
+import jakarta.ws.rs.ext.RuntimeDelegate;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.common.provider.StringBean;
+import jakarta.ws.rs.tck.common.provider.StringBeanEntityProvider;
+import jakarta.ws.rs.tck.common.provider.StringBeanRuntimeDelegate;
+import jakarta.ws.rs.tck.common.provider.StringBeanWithAnnotation;
+import jakarta.ws.rs.tck.common.util.JaxrsUtil;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = 8883841555516513076L;
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  /*
+   * @testName: abortWithTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:427; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85;
+   * 
+   * @test_Strategy: Abort the filter chain with a response. This method breaks
+   * the filter chain processing and returns the provided response back to the
+   * client. The provided response goes through the chain of applicable response
+   * filters.
+   * 
+   * ClientRequestFilter.filter ClientRequestFilter.abortWith
+   */
+  @Test
+  public void abortWithTest() throws Fault {
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext context)
+          throws Fault {
+        Response r = Response.status(Status.CREATED).build();
+        context.abortWith(r);
+      }
+    };
+    Invocation i = buildInvocation(provider);
+    Response r = invoke(i);
+    assertStatus(r, Status.CREATED);
+  }
+
+  /*
+   * @testName: getAcceptableLanguagesTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:428; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: Get a list of languages that are acceptable for the
+   * response. Returns: a read-only list of acceptable languages sorted
+   * according to their q-value, with highest preference first.
+   * 
+   * ClientRequestFilter.filter ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getAcceptableLanguagesTest() throws Fault {
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext context)
+          throws Fault {
+        List<Locale> locales = context.getAcceptableLanguages();
+        String languages = JaxrsUtil.iterableToString(";", locales);
+        Response r = Response.ok(languages).build();
+        context.abortWith(r);
+      }
+    };
+    Invocation.Builder builder = buildBuilder(provider);
+    Invocation invocation;
+    invocation = builder.acceptLanguage(Locale.CANADA_FRENCH)
+        .acceptLanguage(Locale.PRC).buildGet();
+    Response response = invoke(invocation);
+    String entity = response.readEntity(String.class);
+    assertContains(entity, Locale.CANADA_FRENCH.toString());
+    assertContains(entity, Locale.PRC.toString());
+  }
+
+  /*
+   * @testName: getAcceptableLanguagesByWeightsTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:428; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: a read-only list of requested response media types sorted
+   * according to their q-value, with highest preference first.
+   * 
+   * ClientRequestFilter.filter ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getAcceptableLanguagesByWeightsTest() throws Fault {
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext context)
+          throws Fault {
+        List<Locale> locales = context.getAcceptableLanguages();
+        String languages = JaxrsUtil.iterableToString(";", locales);
+        Response r = Response.ok(languages).build();
+        context.abortWith(r);
+      }
+    };
+    Invocation.Builder builder = buildBuilder(provider);
+    Invocation invocation;
+    invocation = builder.acceptLanguage("da, en-gb;q=0.6, en-us;q=0.7")
+        .buildGet();
+    Response response = invoke(invocation);
+    String entity = response.readEntity(String.class).toLowerCase();
+    assertContains(entity, "da");
+    assertContains(entity, "gb");
+    assertContains(entity, "us");
+    int indexDa = entity.indexOf("da");
+    int indexUs = entity.indexOf("us");
+    int indexGb = entity.indexOf("gb");
+
+    assertTrue(indexDa < indexUs && indexUs < indexGb,
+        "List of acceptable languages " + entity + " is not sorted by q values");
+  }
+
+  /*
+   * @testName: getAcceptableLanguagesIsImmutableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:428; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: a read-only list of requested response media types sorted
+   * according to their q-value, with highest preference first.
+   * 
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getAcceptableLanguagesIsImmutableTest() throws Fault {
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext context)
+          throws Fault {
+        List<Locale> locales = context.getAcceptableLanguages();
+        try {
+          locales.add(Locale.JAPAN);
+        } catch (Exception e) {
+          // either exception is thrown, or add does nothing
+        }
+        locales = context.getAcceptableLanguages();
+        boolean b = locales.contains(Locale.JAPAN);
+        assertTrue(!b, "getAcceptableLanguages is not read-only");
+        Response r = Response.ok().build();
+        context.abortWith(r);
+      }
+    };
+    WebTarget target = buildTarget(provider);
+    Invocation.Builder builder = target.request();
+    Invocation invocation;
+    invocation = builder
+        .header("Accept-Language", "da, en-gb;q=0.6, en-us;q=0.7").buildGet();
+    Response response = invoke(invocation);
+    assertStatus(response, Status.OK);
+  }
+
+  /*
+   * @testName: getAcceptableMediaTypesTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:429; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: Get a list of media types that are acceptable for the
+   * response. Returns a read-only list of requested response media types sorted
+   * according to their q-value, with highest preference first.
+   * 
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getAcceptableMediaTypesTest() throws Fault {
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext context)
+          throws Fault {
+        List<MediaType> types = context.getAcceptableMediaTypes();
+        String medias = JaxrsUtil.iterableToString(";", types);
+        Response r = Response.ok(medias).build();
+        context.abortWith(r);
+      }
+    };
+    String media = "text/*;q=0.3, text/html;q=0.7, text/html;level=1, text/html;level=2;q=0.4, */*;q=0.5";
+    Invocation.Builder builder = buildBuilder(provider);
+    Invocation invocation = builder.header("Accept", media).buildGet();
+    Response response = invoke(invocation);
+
+    String entity = response.readEntity(String.class);
+    assertContains(entity, "text/*");
+    assertContains(entity, "text/html");
+    assertContains(entity, "*/*");
+  }
+
+  /*
+   * @testName: getAcceptableMediaTypesIsSortedTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:429; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: Get a list of media types that are acceptable for the
+   * response. Returns a read-only list of requested response media types sorted
+   * according to their q-value, with highest preference first.
+   * 
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getAcceptableMediaTypesIsSortedTest() throws Fault {
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext context)
+          throws Fault {
+        List<MediaType> types = context.getAcceptableMediaTypes();
+        String medias = JaxrsUtil.iterableToString(";", types);
+        Response r = Response.ok(medias).build();
+        context.abortWith(r);
+      }
+    };
+    String media = "text/plain;q=0.3, text/html;q=0.7, text/xml;level=1, text/java;level=2;q=0.4, */*;q=0.5";
+    Invocation.Builder builder = buildBuilder(provider);
+    Invocation invocation = builder.header("Accept", media).buildGet();
+    Response response = invoke(invocation);
+
+    String entity = response.readEntity(String.class).toLowerCase();
+    int indexXml = entity.indexOf(MediaType.TEXT_XML);
+    int indexHtml = entity.indexOf(MediaType.TEXT_HTML);
+    int indexAny = entity.indexOf(MediaType.WILDCARD);
+    int indexJava = entity.indexOf("text/java");
+    int indexPlain = entity.indexOf(MediaType.TEXT_PLAIN);
+
+    assertTrue(indexXml < indexHtml && indexHtml < indexAny
+        && indexAny < indexJava && indexJava < indexPlain, "Media Types " +
+        entity + " are not sorted");
+  }
+
+  /*
+   * @testName: getAcceptableMediaTypesIsImmutableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:429; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: Get a list of media types that are acceptable for the
+   * response. Returns a read-only list of requested response media types sorted
+   * according to their q-value, with highest preference first.
+   * 
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getAcceptableMediaTypesIsImmutableTest() throws Fault {
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext context)
+          throws Fault {
+        List<MediaType> types = context.getAcceptableMediaTypes();
+        try {
+          types.add(MediaType.APPLICATION_JSON_TYPE);
+        } catch (Exception e) {
+          // either exception is thrown or add does nothing
+        }
+        types = context.getAcceptableMediaTypes();
+        boolean b = types.contains(MediaType.APPLICATION_JSON_TYPE);
+        assertTrue(!b, "getAcceptableMediaTypes is not read only");
+        Response r = Response.ok().build();
+        context.abortWith(r);
+      }
+    };
+    String media = "text/*;q=0.3, text/html;q=0.7, text/html;level=1, text/html;level=2;q=0.4, */*;q=0.5";
+    Invocation.Builder builder = buildBuilder(provider);
+    Invocation invocation = builder.header("Accept", media).buildGet();
+    Response response = invoke(invocation);
+    assertStatus(response, Status.OK);
+  }
+
+  /*
+   * @testName: getClientTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:430; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: Get the client instance associated with the request.
+   * 
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getClientTest() throws Fault {
+    final Client client = ClientBuilder.newClient();
+
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext context)
+          throws Fault {
+        Client contextClient = context.getClient();
+        assertTrue(client == contextClient,
+            "the client instance is different from the context one");
+        Response r = Response.ok().build();
+        context.abortWith(r);
+      }
+    };
+    client.register(provider);
+    WebTarget target = client.target(getUrl());
+    Invocation invocation = target.request().buildGet();
+    Response response = invoke(invocation);
+    assertStatus(response, Status.OK);
+  }
+
+  /*
+   * @testName: getConfigurationTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:977; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: Get the immutable configuration of the request.
+   * 
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getConfigurationTest() throws Fault {
+    final Client client = ClientBuilder.newClient();
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext context)
+          throws Fault {
+        Client contextClient = context.getClient();
+        assertEquals(contextClient, client,
+            "the client instance is different from the context one");
+        Configuration contextConfig = context.getConfiguration();
+        assertNotNull(contextConfig,
+            "context.getConfiguration() returned null");
+        Response r = Response.ok().build();
+        context.abortWith(r);
+      }
+    };
+    client.register(provider);
+    WebTarget target = client.target(getUrl());
+    Invocation invocation = target.request().buildGet();
+    Response response = invoke(invocation);
+    assertStatus(response, Status.OK);
+  }
+
+  /*
+   * @testName: getCookiesTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:432; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: Get any cookies that accompanied the request. Returns a
+   * read-only map of cookie name (String) to Cookie.
+   * 
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getCookiesTest() throws Fault {
+    Cookie cts = new Cookie("cts", "cts");
+    Cookie tck = new Cookie("tck", "tck");
+    Cookie jee = new Cookie("jee", "jee");
+
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext context)
+          throws Fault {
+        String cookies = JaxrsUtil.iterableToString(";",
+            context.getCookies().values());
+        Response r = Response.ok(cookies).build();
+        context.abortWith(r);
+      }
+    };
+    Invocation invocation = buildBuilder(provider).cookie(cts).cookie(tck)
+        .cookie(jee).buildGet();
+    Response response = invoke(invocation);
+
+    String entity = response.readEntity(String.class);
+    assertContains(entity, "cts");
+    assertContains(entity, "tck");
+    assertContains(entity, "jee");
+  }
+
+  /*
+   * @testName: getCookiesIsImmutableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:432; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: Get any cookies that accompanied the request. Returns a
+   * read-only map of cookie name (String) to Cookie.
+   * 
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getCookiesIsImmutableTest() throws Fault {
+    final Cookie cts = new Cookie("cts", "cts");
+
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext context)
+          throws Fault {
+        Map<String, Cookie> cookies = context.getCookies();
+        try {
+          cookies.put("test", cts);
+        } catch (Exception e) {
+          // either exception is thrown or put does nothing
+        }
+        cookies = context.getCookies();
+        Cookie cookie = cookies.get("test");
+        assertTrue(cookie == null, "getCookies is not read-only");
+        Response r = Response.ok().build();
+        context.abortWith(r);
+      }
+    };
+    Invocation invocation = buildBuilder(provider).cookie(cts).buildGet();
+    Response response = invoke(invocation);
+    assertStatus(response, Status.OK);
+  }
+
+  /*
+   * @testName: getDateNullTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:433; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: Get message date. Returns: the message date, otherwise null
+   * if not present.
+   *
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getDateNullTest() throws Fault {
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext context)
+          throws Fault {
+        Date date = context.getDate();
+        Response r = Response.ok(date == null ? "NULL" : date.toString())
+            .build();
+        context.abortWith(r);
+      }
+    };
+    Invocation invocation = buildInvocation(provider);
+    Response response = invoke(invocation);
+
+    String entity = response.readEntity(String.class);
+    assertContains(entity, "NULL");
+  }
+
+  /*
+   * @testName: getDateTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:433; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: Get message date. Returns: the message date, otherwise null
+   * if not present.
+   *
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getDateTest() throws Fault {
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext context)
+          throws Fault {
+        Date date = context.getDate();
+        Response r = Response.ok(date.toString()).build();
+        context.abortWith(r);
+      }
+    };
+    Invocation invocation = buildBuilder(provider)
+        .header("Date", "Tue, 15 Nov 1994 08:12:31 GMT").buildGet();
+    Response response = invoke(invocation);
+
+    String entity = response.readEntity(String.class);
+    assertContains(entity, "Nov");
+    assertContains(entity, "1994");
+    assertContains(entity, "31");
+  }
+
+  /*
+   * @testName: getEntityNullTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:434; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: Get the message entity Java instance. Returns null if the
+   * message does not contain an entity.
+   * 
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getEntityNullTest() throws Fault {
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext context)
+          throws Fault {
+        Object entity = context.getEntity();
+        Response r = Response.ok(entity == null ? "NULL" : entity.toString())
+            .build();
+        context.abortWith(r);
+      }
+    };
+    Invocation invocation = buildInvocation(provider);
+    Response response = invoke(invocation);
+
+    String entity = response.readEntity(String.class);
+    assertContains(entity, "NULL");
+  }
+
+  /*
+   * @testName: getEntityTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:434; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85;
+   * 
+   * @test_Strategy: Get the message entity Java instance. Returns null if the
+   * message does not contain an entity.
+   * 
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getEntityTest() throws Fault {
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext context)
+          throws Fault {
+        Object entity = context.getEntity();
+        Response r = Response.ok(entity.toString()).build();
+        context.abortWith(r);
+      }
+    };
+    Entity<String> post = createEntity("test");
+    Invocation invocation = buildBuilder(provider).buildPost(post);
+    Response response = invoke(invocation);
+
+    String entity = response.readEntity(String.class);
+    assertContains(entity, "test");
+  }
+
+  /*
+   * @testName: getEntityAnnotationsTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:435; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: Get the annotations attached to the entity. Note that the
+   * returned annotations array contains only those annotations explicitly
+   * attached to entity instance (such as the ones attached using
+   * Entity.Entity(Object, jakarta.ws.rs.core.MediaType,
+   * java.lang.annotation.Annotation[]) method).
+   * 
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getEntityAnnotationsTest() throws Fault {
+    Annotation[] annotations = ContextProvider.class.getAnnotations();
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext context)
+          throws Fault {
+        Annotation[] annotations = context.getEntityAnnotations();
+        String first = annotations == null ? "NULL"
+            : annotations.length == 0 ? "0"
+                : annotations[0].annotationType().getName();
+        Response r = Response.ok(first).build();
+        context.abortWith(r);
+      }
+    };
+    Entity<String> post = Entity.entity("test", MediaType.WILDCARD_TYPE,
+        annotations);
+    Invocation invocation = buildBuilder(provider).buildPost(post);
+    Response response = invoke(invocation);
+
+    String entity = response.readEntity(String.class);
+    assertContains(entity, annotations[0].annotationType().getName());
+  }
+
+  /*
+   * @testName: getEntityAnnotationsIsNotTakenFromEntityClassTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:435; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: Get the annotations attached to the entity. Note that the
+   * returned annotations array contains only those annotations explicitly
+   * attached to entity instance (such as the ones attached using
+   * Entity.Entity(Object, jakarta.ws.rs.core.MediaType,
+   * java.lang.annotation.Annotation[]) method). The entity instance annotations
+   * array does not include annotations declared on the entity implementation
+   * class or its ancestors.
+   * 
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getEntityAnnotationsIsNotTakenFromEntityClassTest() throws Fault {
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext context)
+          throws Fault {
+        Annotation[] annotations = context.getEntityAnnotations();
+        String first = annotations == null ? "0"
+            : String.valueOf(annotations.length);
+        Response r = Response.ok(first).build();
+        context.abortWith(r);
+      }
+    };
+    Entity<StringBeanWithAnnotation> post = createEntity(
+        new StringBeanWithAnnotation("test"));
+    Invocation invocation = buildTarget(provider)
+        .register(StringBeanEntityProvider.class).request().buildPost(post);
+    Response response = invoke(invocation);
+
+    String entity = response.readEntity(String.class);
+    assertContains(entity, "0");
+  }
+
+  /*
+   * @testName: getEntityAnnotationsNullTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:435; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: Get the annotations attached to the entity.
+   * 
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getEntityAnnotationsNullTest() throws Fault {
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext context)
+          throws Fault {
+        Annotation[] annotations = context.getEntityAnnotations();
+        String len = annotations == null ? "0"
+            : String.valueOf(annotations.length);
+        Response r = Response.ok(len).build();
+        context.abortWith(r);
+      }
+    };
+    Entity<String> post = createEntity("test");
+    Invocation invocation = buildBuilder(provider).buildPost(post);
+    Response response = invoke(invocation);
+
+    String entity = response.readEntity(String.class);
+    assertContains(entity, "0");
+  }
+
+  /*
+   * @testName: getEntityClassTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:436; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: Get the raw entity type information.
+   * 
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getEntityClassTest() throws Fault {
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext context)
+          throws Fault {
+        Class<?> clazz = context.getEntityClass();
+        Response r = Response.ok(clazz.getName()).build();
+        context.abortWith(r);
+      }
+    };
+    Entity<ByteArrayInputStream> post = createEntity(
+        new ByteArrayInputStream("test".getBytes()));
+    Invocation invocation = buildBuilder(provider).buildPost(post);
+    Response response = invoke(invocation);
+
+    String entity = response.readEntity(String.class);
+    assertContains(entity, ByteArrayInputStream.class.getName());
+  }
+
+  /*
+   * @testName: getEntityClassListStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:436; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: Get the raw entity type information.
+   * 
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getEntityClassListStringTest() throws Fault {
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext context)
+          throws Fault {
+        Class<?> clazz = context.getEntityClass();
+        Response r = Response.ok(clazz.getName()).build();
+        context.abortWith(r);
+      }
+    };
+    List<String> list = new ArrayList<String>();
+    Entity<List<String>> post = createEntity(list);
+    Invocation invocation = buildBuilder(provider).buildPost(post);
+    Response response = invoke(invocation);
+
+    String entity = response.readEntity(String.class);
+    assertContains(entity, ArrayList.class.getName());
+  }
+
+  /*
+   * @testName: getEntityTypeListStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:438; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: Get the generic entity type information.
+   * 
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getEntityTypeListStringTest() throws Fault {
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext context)
+          throws Fault {
+        Type type = context.getEntityType();
+        String entity = type.toString();
+        Response r = Response.ok(entity).build();
+        context.abortWith(r);
+      }
+    };
+    List<String> list = new ArrayList<String>();
+    GenericEntity<List<String>> generic = new GenericEntity<List<String>>(
+        list) {
+    };
+    Entity<GenericEntity<List<String>>> post = createEntity(generic);
+    Invocation invocation = buildBuilder(provider).buildPost(post);
+    Response response = invoke(invocation);
+
+    String entity = response.readEntity(String.class);
+    assertContains(entity, String.class.getName());
+  }
+
+  /*
+   * @testName: getHeadersTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:439; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: Get the mutable request headers multivalued map.
+   * 
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getHeadersTest() throws Fault {
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext context)
+          throws Fault {
+        MultivaluedMap<String, Object> headers = context.getHeaders();
+        String entity = JaxrsUtil.iterableToString(";", headers.keySet());
+        Response r = Response.ok(entity).build();
+        context.abortWith(r);
+      }
+    };
+    Invocation invocation = buildBuilder(provider)
+        .header("Accept", MediaType.TEXT_HTML).header("tck", "cts")
+        .header("Date", "Tue, 15 Nov 1994 08:12:31 GMT").buildGet();
+    Response response = invoke(invocation);
+
+    String entity = response.readEntity(String.class);
+    assertContains(entity, "Accept");
+    assertContains(entity, "Date");
+    assertContains(entity, "tck");
+  }
+
+  /*
+   * @testName: getHeadersIsMutableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:440; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: Get the mutable request headers multivalued map.
+   * 
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getHeadersIsMutableTest() throws Fault {
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext context)
+          throws Fault {
+        MultivaluedMap<String, Object> headers = context.getHeaders();
+        headers.add("Accept", MediaType.APPLICATION_JSON);
+
+        headers = context.getHeaders();
+        String entity = JaxrsUtil.iterableToString(";", headers.keySet());
+        Response r = Response.ok(entity).build();
+        context.abortWith(r);
+      }
+    };
+    Invocation invocation = buildBuilder(provider).buildGet();
+    Response response = invoke(invocation);
+
+    String entity = response.readEntity(String.class);
+    assertContains(entity, "Accept");
+  }
+
+  /*
+   * @testName: getHeaderStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:440; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: Get a message header as a single string value.
+   * 
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getHeaderStringTest() throws Fault {
+    final String TCK = "cts";
+    final String DATE = "Tue, 15 Nov 1994 08:12:31 GMT";
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext context)
+          throws Fault {
+        String value;
+        value = context.getHeaderString("tck");
+        assertContainsIgnoreCase(value, TCK, "The expected value", TCK,
+            "was not found, found", value, "instead");
+        value = context.getHeaderString("accept");
+        assertContainsIgnoreCase(value, MediaType.TEXT_HTML,
+            "The expected value", MediaType.TEXT_HTML, "was not found, found",
+            value, "instead");
+        value = context.getHeaderString("date");
+        assertContainsIgnoreCase(value, DATE, "The expected value", DATE,
+            "was not found, found", value, "instead");
+        Response r = Response.ok().build();
+        context.abortWith(r);
+      }
+    };
+    Invocation invocation = buildBuilder(provider)
+        .header("Accept", MediaType.TEXT_HTML)
+        .header("tck", new StringBuffer().append(TCK)) // toString()
+        .header("Date", DATE).buildGet();
+    Response response = invoke(invocation);
+    assertStatus(response, Status.OK);
+  }
+
+  /*
+   * @testName: getHeaderStringUsingHeaderDelegateTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:440; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: Get a message header as a single string value. Each single
+   * header value is converted to String using a RuntimeDelegate.HeaderDelegate.
+   * 
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getHeaderStringUsingHeaderDelegateTest() throws Fault {
+    final String name = "BEAN";
+    final StringBean bean = new StringBean(name);
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext context)
+          throws Fault {
+        String value = context.getHeaderString(name);
+        Response r = Response.ok(value).build();
+        context.abortWith(r);
+      }
+    };
+    RuntimeDelegate original = RuntimeDelegate.getInstance();
+    RuntimeDelegate.setInstance(new StringBeanRuntimeDelegate(original));
+    try {
+      Invocation invocation = buildBuilder(provider).header(name, bean)
+          .buildGet();
+      Response response = invoke(invocation);
+      String body = response.readEntity(String.class);
+      assertContains(name.toLowerCase(), body.toLowerCase());
+    } finally {
+      RuntimeDelegate.setInstance(original);
+      StringBeanRuntimeDelegate.assertNotStringBeanRuntimeDelegate();
+    }
+  }
+
+  /*
+   * @testName: getLanguageIsNullTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:441; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: Get the language of the entity. Returns: the language of
+   * the entity or null if not specified
+   * 
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getLanguageIsNullTest() throws Fault {
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext context)
+          throws Fault {
+        Locale lang = context.getLanguage();
+        String entity = lang == null ? "NULL" : lang.toString();
+        Response r = Response.ok(entity).build();
+        context.abortWith(r);
+      }
+    };
+    Entity<String> entity = createEntity("TEST");
+    Invocation invocation = buildBuilder(provider).buildPost(entity);
+    Response response = invoke(invocation);
+
+    String body = response.readEntity(String.class);
+    assertContains(body, "NULL");
+  }
+
+  /*
+   * @testName: getLanguageTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:441; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: Get the language of the entity. Returns: the language of
+   * the entity or null if not specified
+   * 
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getLanguageTest() throws Fault {
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext context)
+          throws Fault {
+        Locale lang = context.getLanguage();
+        String entity = lang == null ? "NULL" : lang.toString();
+        Response r = Response.ok(entity).build();
+        context.abortWith(r);
+      }
+    };
+    Locale locale = Locale.TRADITIONAL_CHINESE;
+    Variant variant = new Variant(MediaType.TEXT_XML_TYPE, locale, null);
+    Entity<String> entity = Entity.entity("TEST", variant);
+    Invocation invocation = buildBuilder(provider).buildPost(entity);
+    Response response = invoke(invocation);
+
+    String body = response.readEntity(String.class).toLowerCase().replace('-',
+        '_');
+    assertContains(body, locale.toString().toLowerCase());
+  }
+
+  /*
+   * @testName: getMediaTypeIsNullTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:442; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: Get the media type of the entity. Returns: the media type
+   * or null if not specified (e.g. there's no request entity).
+   * 
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getMediaTypeIsNullTest() throws Fault {
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext context)
+          throws Fault {
+        MediaType media = context.getMediaType();
+        String entity = media == null ? "NULL" : media.toString();
+        Response r = Response.ok(entity).build();
+        context.abortWith(r);
+      }
+    };
+    Invocation invocation = buildBuilder(provider).buildGet();
+    Response response = invoke(invocation);
+
+    String body = response.readEntity(String.class);
+    assertContains(body, "NULL");
+  }
+
+  /*
+   * @testName: getMediaTypeTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:442; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: Get the media type of the entity. Returns: the media type
+   * or null if not specified (e.g. there's no request entity).
+   * 
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getMediaTypeTest() throws Fault {
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext context)
+          throws Fault {
+        MediaType media = context.getMediaType();
+        String entity = media == null ? "NULL" : media.toString();
+        Response r = Response.ok(entity).build();
+        context.abortWith(r);
+      }
+    };
+    Entity<String> entity = Entity.entity("TEST",
+        MediaType.APPLICATION_FORM_URLENCODED);
+    Invocation invocation = buildBuilder(provider).buildPost(entity);
+    Response response = invoke(invocation);
+
+    String body = response.readEntity(String.class);
+    assertContains(body, MediaType.APPLICATION_FORM_URLENCODED);
+  }
+
+  /*
+   * @testName: getMethodTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:443; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: Get the request method.
+   * 
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getMethodTest() throws Fault {
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext context)
+          throws Fault {
+        String method = context.getMethod();
+        Response r = Response.ok(method).build();
+        context.abortWith(r);
+      }
+    };
+    Entity<String> entity = createEntity("TEST");
+    Invocation invocation;
+    Response response;
+
+    for (String method : new String[] { "OPTIONS", "DELETE", "GET", "TRACE" }) {
+      invocation = buildBuilder(provider).build(method);
+      response = invoke(invocation);
+      String body = response.readEntity(String.class).toUpperCase();
+      assertContains(body, method);
+    }
+
+    for (String method : new String[] { "PUT", "POST" }) {
+      invocation = buildBuilder(provider).build(method, entity);
+      response = invoke(invocation);
+      String body = response.readEntity(String.class).toUpperCase();
+      assertContains(body, method);
+    }
+  }
+
+  /*
+   * @testName: getPropertyIsNullTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:444; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: Returns the property with the given name registered in the
+   * current request/response exchange context, or null if there is no property
+   * by that name.
+   * 
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getPropertyIsNullTest() throws Fault {
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext context)
+          throws Fault {
+        Object property = context.getProperty("PROPERTY");
+        String entity = property == null ? "NULL" : property.toString();
+        Response r = Response.ok(entity).build();
+        context.abortWith(r);
+      }
+    };
+    Invocation invocation = buildBuilder(provider).buildGet();
+    Response response = invoke(invocation);
+
+    String body = response.readEntity(String.class);
+    assertContains(body, "NULL");
+  }
+
+  /*
+   * @testName: getSetPropertyTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:444; JAXRS:JAVADOC:453; JAXRS:JAVADOC:455;
+   * JAXRS:JAVADOC:456; JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: Returns the property with the given name registered in the
+   * current request/response exchange context, or null if there is no property
+   * by that name.
+   * 
+   * Binds an object to a given property name in the current request/response
+   * exchange context.
+   * 
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getSetPropertyTest() throws Fault {
+    final AtomicInteger counter = new AtomicInteger(0);
+    ContextProvider provider = new GetSetPropertyProvider(counter);
+    ContextProvider provider2 = new GetSetPropertyProvider(counter) {
+    };
+
+    Invocation invocation = buildInvocation(provider, provider2);
+    Response response = invoke(invocation);
+
+    String body = response.readEntity(String.class);
+    assertContains(body, "value");
+  }
+
+  /*
+   * @testName: getPropertyNamesTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:978; JAXRS:JAVADOC:453; JAXRS:JAVADOC:455;
+   * JAXRS:JAVADOC:456; JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: Returns an immutable collection containing the property
+   * names available within the context of the current request/response exchange
+   * context.
+   * 
+   * Binds an object to a given property name in the current request/response
+   * exchange context.
+   * 
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getPropertyNamesTest() throws Fault {
+    final AtomicInteger counter = new AtomicInteger(0);
+    ContextProvider provider = new GetPropertyNamesProvider(counter);
+    ContextProvider provider2 = new GetPropertyNamesProvider(counter) {
+    };
+
+    Invocation invocation = buildInvocation(provider, provider2);
+    Response response = invoke(invocation);
+
+    String body = response.readEntity(String.class);
+    assertContains(body, "PROPERTY1");
+    assertContains(body, "PROPERTY2");
+  }
+
+  /*
+   * @testName: getPropertyNamesIsImmutableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:978; JAXRS:JAVADOC:453; JAXRS:JAVADOC:455;
+   * JAXRS:JAVADOC:456; JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: Returns an immutable collection containing the property
+   * names available within the context of the current request/response exchange
+   * context.
+   * 
+   * Binds an object to a given property name in the current request/response
+   * exchange context.
+   * 
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getPropertyNamesIsImmutableTest() throws Fault {
+    final AtomicInteger counter = new AtomicInteger(0);
+    ContextProvider provider = new GetPropertyNamesIsImmutableProvider(counter);
+
+    Invocation invocation = buildInvocation(provider);
+    Response response = invoke(invocation);
+    String body = response.readEntity(String.class);
+    assertEqualsInt(0, counter.get(),
+        "getPropertyNames collection is not immutable");
+    assertEquals("0", body, "getPropertyNames collection is not immutable");
+    logMsg("getPropertyNames is immutable as expected");
+  }
+
+  /*
+   * @testName: getStringHeadersTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:446; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: Get a string view of header values associated with the
+   * message.
+   * 
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getStringHeadersTest() throws Fault {
+    final String TCK = "cts";
+    final String DATE = "Tue, 15 Nov 1994 08:12:31 GMT";
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext context)
+          throws Fault {
+        MultivaluedMap<String, String> map;
+        map = context.getStringHeaders();
+        StringBuilder value = new StringBuilder();
+        value.append(map.getFirst("Accept")).append(" ");
+        value.append(map.getFirst("tck")).append(" ");
+        value.append(map.getFirst("Date"));
+        Response r = Response.ok(value.toString()).build();
+        context.abortWith(r);
+      }
+    };
+    Invocation invocation = buildBuilder(provider)
+        .header("Accept", MediaType.TEXT_HTML).header("tck", TCK)
+        .header("Date", DATE).buildGet();
+    Response response = invoke(invocation);
+    String body = response.readEntity(String.class);
+    assertContains(body, MediaType.TEXT_HTML);
+    assertContains(body, TCK);
+    assertContains(body, DATE);
+  }
+
+  /*
+   * @testName: getStringHeadersReflectsTheUnderlayingMapTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:446; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: Get a string view of header values associated with the
+   * message. Changes in the underlying headers map are reflected in this view.
+   * 
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getStringHeadersReflectsTheUnderlayingMapTest() throws Fault {
+    final String TCK = "cts";
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext context)
+          throws Fault {
+        context.getHeaders().add(TCK, TCK);
+        MultivaluedMap<String, String> map;
+        map = context.getStringHeaders();
+        String value = map.getFirst(TCK);
+        Response r = Response.ok(value).build();
+        context.abortWith(r);
+      }
+    };
+    Invocation invocation = buildBuilder(provider).buildGet();
+    Response response = invoke(invocation);
+    String body = response.readEntity(String.class);
+    assertContains(body, TCK);
+  }
+
+  /*
+   * @testName: getStringHeadersUsingHeaderDelegateTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:446; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: Get a string view of header values associated with the
+   * message. The method converts the non-string header values to strings using
+   * a RuntimeDelegate.HeaderDelegate
+   * 
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getStringHeadersUsingHeaderDelegateTest() throws Fault {
+    final String TCK = "cts";
+    final StringBean bean = new StringBean(TCK);
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext context)
+          throws Fault {
+        MultivaluedMap<String, String> map;
+        map = context.getStringHeaders();
+        StringBuilder value = new StringBuilder();
+        value.append(map.getFirst(TCK));
+        Response r = Response.ok(value.toString()).build();
+        context.abortWith(r);
+      }
+    };
+    RuntimeDelegate delegate = RuntimeDelegate.getInstance();
+    RuntimeDelegate.setInstance(new StringBeanRuntimeDelegate(delegate));
+    try {
+      Invocation invocation = buildBuilder(provider).header(TCK, bean)
+          .buildGet();
+      Response response = invoke(invocation);
+      String body = response.readEntity(String.class);
+      assertContains(body, TCK);
+    } finally {
+      RuntimeDelegate.setInstance(delegate);
+      StringBeanRuntimeDelegate.assertNotStringBeanRuntimeDelegate();
+    }
+  }
+
+  /*
+   * @testName: getUriTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:447; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: Get the request URI.
+   * 
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void getUriTest() throws Fault {
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext context)
+          throws Fault {
+        URI uri = context.getUri();
+        String entity = uri.toASCIIString();
+        Response r = Response.ok(entity).build();
+        context.abortWith(r);
+      }
+    };
+
+    Invocation invocation = buildInvocation(provider);
+    Response response = invoke(invocation);
+
+    String body = response.readEntity(String.class);
+    assertContains(body, getUrl());
+  }
+
+  /*
+   * @testName: hasEntityTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:448; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy: Check if there is an entity available in the request. The
+   * method returns true if the entity is present, returns false otherwise.
+   * 
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void hasEntityTest() throws Fault {
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext context)
+          throws Fault {
+        boolean has = context.hasEntity();
+        String entity = String.valueOf(has);
+        Response r = Response.ok(entity).build();
+        context.abortWith(r);
+      }
+    };
+
+    Invocation invocation = buildInvocation(provider);
+    Response response = invoke(invocation);
+    String body = response.readEntity(String.class);
+    assertContains(body, "false");
+
+    Entity<String> entity = createEntity("TEST");
+    WebTarget target = buildTarget(provider);
+    invocation = target.request().buildPost(entity);
+    response = invoke(invocation);
+    body = response.readEntity(String.class);
+    assertContains(body, "true");
+  }
+
+  /*
+   * @testName: removePropertyTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:449; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456;
+   * JAXRS:SPEC:85; JAXRS:JAVADOC:427;
+   * 
+   * @test_Strategy:Removes a property with the given name from the current
+   * request/response exchange context. After removal, subsequent calls to
+   * getProperty(java.lang.String) to retrieve the property value will return
+   * null.
+   *
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void removePropertyTest() throws Fault {
+    final AtomicInteger counter = new AtomicInteger(0);
+    ContextProvider provider = new RemovePropertyProvider(counter);
+    ContextProvider provider2 = new RemovePropertyProvider(counter) {
+    };
+    ContextProvider provider3 = new RemovePropertyProvider(counter) {
+    };
+
+    Invocation invocation = buildInvocation(provider, provider2, provider3);
+    Response response = invoke(invocation);
+
+    String body = response.readEntity(String.class);
+    assertContains(body, "NULL");
+  }
+
+  /*
+   * @testName: setEntityTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:450; JAXRS:JAVADOC:434; JAXRS:JAVADOC:435;
+   * JAXRS:JAVADOC:438; JAXRS:JAVADOC:455; JAXRS:JAVADOC:456; JAXRS:SPEC:85;
+   * 
+   * @test_Strategy: Set a new response message entity. It is the callers
+   * responsibility to wrap the actual entity with
+   * jakarta.ws.rs.core.GenericEntity if preservation of its generic type is
+   * required.
+   * 
+   * ClientRequestFilter.abortWith
+   */
+  @Test
+  public void setEntityTest() throws Fault {
+    final AtomicInteger counter = new AtomicInteger(0);
+
+    ContextProvider provider = new SetEntityProvider(counter);
+    ContextProvider provider2 = new SetEntityProvider(counter) {
+    };
+
+    Entity<ByteArrayInputStream> entity = createEntity(
+        new ByteArrayInputStream("test".getBytes()));
+
+    WebTarget target = buildTarget(provider, provider2);
+    Invocation invocation = target.request().buildPost(entity);
+    Response response = invoke(invocation);
+
+    assertStatus(response, Status.OK);
+  }
+
+  // ///////////////////////////////////////////////////////////////////////
+  /**
+   * Call given provider CheckContextFilter method
+   */
+  protected static Response invoke(Invocation i) throws Fault {
+    Response r = null;
+    try {
+      r = i.invoke();
+    } catch (Exception e) {
+      Object cause = e.getCause();
+      if (cause instanceof Fault)
+        throw (Fault) cause;
+      else
+        throw new Fault(e);
+    }
+    return r;
+  }
+
+  protected static Invocation buildInvocation(ContextProvider... provider) {
+    WebTarget target = buildTarget(provider);
+    Invocation i = target.request().buildGet();
+    return i;
+  }
+
+  protected static WebTarget buildTarget(ContextProvider... providers) {
+    Client client = ClientBuilder.newClient();
+    for (ContextProvider provider : providers)
+      client.register(provider);
+    WebTarget target = client.target(getUrl());
+    return target;
+  }
+
+  protected static Invocation.Builder buildBuilder(
+      ContextProvider... provider) {
+    Invocation.Builder builder = buildTarget(provider).request();
+    return builder;
+  }
+
+  protected static void assertStatus(Response r, Status status) throws Fault {
+    assertTrue(r.getStatus() == status.getStatusCode(), "Expected " +
+        status.getStatusCode() + " got " + r.getStatus());
+    TestUtil.logMsg("Found expected status: " + status.getStatusCode());
+  }
+
+  protected static void assertContains(String string, String substring)
+      throws Fault {
+    assertTrue(string.contains(substring), string + " does NOT contain " +
+        substring + ", it is: " + string);
+    TestUtil.logMsg("Found expected substring: " + substring);
+  }
+
+  /**
+   * @return any possible url
+   */
+  protected static String getUrl() {
+    return "http://localhost:8080/404URL/";
+  }
+
+  protected <T> Entity<T> createEntity(T entity) {
+    return Entity.entity(entity, MediaType.WILDCARD_TYPE);
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/clientrequestcontext/RemovePropertyProvider.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/clientrequestcontext/RemovePropertyProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,12 +16,13 @@
 
 package jakarta.ws.rs.tck.api.client.clientrequestcontext;
 
-import java.util.concurrent.atomic.AtomicInteger;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import jakarta.ws.rs.tck.common.JAXRSCommonClient.Fault;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import jakarta.ws.rs.client.ClientRequestContext;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient.Fault;
 
 public class RemovePropertyProvider extends ContextProvider {
   private AtomicInteger counter;
@@ -37,36 +38,20 @@ public class RemovePropertyProvider extends ContextProvider {
     switch (counter.incrementAndGet()) {
     case 1:
       Object property = context.getProperty(propName);
-      assertFault(property == null, "property already exist");
+      assertTrue(property == null, "property already exist");
       context.setProperty(propName, propName);
       break;
     case 2:
       property = context.getProperty(propName);
-      assertFault(property != null, "property not exist");
+      assertTrue(property != null, "property not exist");
       context.removeProperty(propName);
       break;
     case 3:
       property = context.getProperty(propName);
-      assertFault(property == null, "property already exist");
+      assertTrue(property == null, "property already exist");
       Response response = Response.ok("NULL").build();
       context.abortWith(response);
       break;
-    }
-  }
-
-  /**
-   * @param conditionTrue
-   * @param message
-   * @throws Fault
-   *           when conditionTrue is not met with message provided
-   */
-  protected static void //
-      assertFault(boolean conditionTrue, Object... message) throws Fault {
-    if (!conditionTrue) {
-      StringBuilder sb = new StringBuilder();
-      for (Object msg : message)
-        sb.append(msg).append(" ");
-      throw new Fault(sb.toString());
     }
   }
 

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/clientrequestcontext/SetEntityProvider.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/clientrequestcontext/SetEntityProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,18 +16,19 @@
 
 package jakarta.ws.rs.tck.api.client.clientrequestcontext;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import jakarta.ws.rs.tck.common.JAXRSCommonClient.Fault;
-import jakarta.ws.rs.tck.lib.util.TestUtil;
 
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.client.ClientRequestContext;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient.Fault;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
 
 public class SetEntityProvider extends ContextProvider {
   private AtomicInteger counter;
@@ -76,13 +77,13 @@ public class SetEntityProvider extends ContextProvider {
       annotations = context.getEntityAnnotations();
       clz = context.getEntityType();
       // check
-      assertFault(entity != null, "there is no entity, yet");
-      assertFault(!entity.toString().equals(entityName),
+      assertTrue(entity != null, "there is no entity, yet");
+      assertTrue(!entity.toString().equals(entityName),
           "the fake entity was already set");
-      assertFault(annotations == null || annotations.length == 0,
+      assertTrue(annotations == null || annotations.length == 0,
           "there are already annotations!");
-      assertFault(!mtype.equals(type), "fake MediaType is already set");
-      assertFault(clz != String.class, "String entity is already set");
+      assertTrue(!mtype.equals(type), "fake MediaType is already set");
+      assertTrue(clz != String.class, "String entity is already set");
       // set
       context.setEntity(entityName, annos, type);
       break;
@@ -94,31 +95,18 @@ public class SetEntityProvider extends ContextProvider {
       annotations = context.getEntityAnnotations();
       clz = context.getEntityType();
       // check
-      assertFault(entity != null, "there is no entity set");
-      assertFault(entity.toString().equals(entityName),
+      assertTrue(entity != null, "there is no entity set");
+      assertTrue(entity.toString().equals(entityName),
           "there is no fake entity set, yet");
-      assertFault(annotations.length == 2,
+      assertTrue(annotations.length == 2,
           "the fake annotations were not set, yet");
-      assertFault(mtype.equals(type), "fake MediaType was not set, yet");
-      assertFault(clz == String.class, "String entity not set, yet");
+      assertTrue(mtype.equals(type), "fake MediaType was not set, yet");
+      assertTrue(clz == String.class, "String entity not set, yet");
       // set
       context.setEntity(entityName, annos, type);
       Response response = Response.ok().build();
       context.abortWith(response);
       break;
-    }
-  }
-
-  /**
-   * @param conditionTrue
-   * @param message
-   * @throws Fault
-   *           when conditionTrue is not met with message provided
-   */
-  protected static void //
-      assertFault(boolean conditionTrue, Object message) throws Fault {
-    if (!conditionTrue) {
-      throw new Fault(message.toString());
     }
   }
 }

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/clientresponsecontext/ContextProvider.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/clientresponsecontext/ContextProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.client.clientresponsecontext;
+
+import java.io.IOException;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientResponseContext;
+import jakarta.ws.rs.client.ClientResponseFilter;
+import jakarta.ws.rs.ext.Provider;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient.Fault;
+
+@Provider
+@Priority(Integer.MIN_VALUE)
+public class ContextProvider implements ClientResponseFilter {
+
+  protected void checkFilterContext(ClientRequestContext requestContext,
+      ClientResponseContext responseContext) throws Fault {
+    throw new Fault("this TCK method is not implemented yet");
+  }
+
+  @Override
+  public void filter(ClientRequestContext requestContext,
+      ClientResponseContext responseContext) throws IOException {
+    try {
+      checkFilterContext(requestContext, responseContext);
+    } catch (Fault e) {
+      throw new IOException(e);
+    }
+
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/clientresponsecontext/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/clientresponsecontext/JAXRSClientIT.java
@@ -1,0 +1,986 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.client.clientresponsecontext;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientRequestFilter;
+import jakarta.ws.rs.client.ClientResponseContext;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.EntityTag;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Link;
+import jakarta.ws.rs.core.Link.Builder;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.NewCookie;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.core.Response.Status.Family;
+import jakarta.ws.rs.core.Response.StatusType;
+import jakarta.ws.rs.ext.RuntimeDelegate;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.common.provider.StringBean;
+import jakarta.ws.rs.tck.common.provider.StringBeanRuntimeDelegate;
+import jakarta.ws.rs.tck.common.util.JaxrsUtil;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = -9134505693194656037L;
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  /*
+   * @testName: getAllowedMethodsTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:457; JAXRS:JAVADOC:479; JAXRS:JAVADOC:480;
+   * 
+   * @test_Strategy: Get the allowed HTTP methods from the Allow HTTP header.
+   * All methods will returned as upper case strings.
+   * 
+   * ClientResponseFilter.filter
+   */
+  @Test
+  public void getAllowedMethodsTest() throws Fault {
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext requestContext,
+          ClientResponseContext responseContext) throws Fault {
+        Set<String> map = responseContext.getAllowedMethods();
+        logMsg("found methods:", JaxrsUtil.iterableToString(" ", map));
+        assertTrue(map.size() == 2, "Allowed mthods were not set");
+        assertTrue(map.contains("OPTIONS"),
+            "OPTIONS allowed method were not found");
+        assertTrue(map.contains("GET"), "GET allowed method was not found");
+      }
+    };
+    Response response = Response.ok().header(HttpHeaders.ALLOW, "get")
+        .header(HttpHeaders.ALLOW, "options").build();
+    invokeWithResponseAndAssertStatus(response, Status.OK, provider);
+  }
+
+  /*
+   * @testName: getCookiesTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:458; JAXRS:JAVADOC:479; JAXRS:JAVADOC:480;
+   * 
+   * @test_Strategy: Get any new cookies set on the response message.
+   * 
+   * ClientResponseFilter.filter
+   */
+  @Test
+  public void getCookiesTest() throws Fault {
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext requestContext,
+          ClientResponseContext responseContext) throws Fault {
+        Map<String, NewCookie> map = responseContext.getCookies();
+        assertTrue(map.size() == 2, "Cookies were not set");
+      }
+    };
+    NewCookie cookie1 = new NewCookie("cookie1", "cookie1");
+    NewCookie cookie2 = new NewCookie("cookie2", "cookie2");
+    Response response = Response.ok().cookie(cookie1).cookie(cookie2).build();
+    invokeWithResponseAndAssertStatus(response, Status.OK, provider);
+  }
+
+  /*
+   * @testName: getDateTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:459; JAXRS:JAVADOC:479; JAXRS:JAVADOC:480;
+   * 
+   * @test_Strategy: Get message date.
+   * 
+   * ClientResponseFilter.filter
+   */
+  @Test
+  public void getDateTest() throws Fault {
+    final Date date = getNewDate();
+    ContextProvider in = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext requestContext,
+          ClientResponseContext responseContext) throws Fault {
+        assertTrue(date.equals(responseContext.getDate()), "The #getDate " +
+            responseContext.getDate() +
+            " is not equal to what is inserted to the response " + date);
+        logMsg("Found #getDate()=", responseContext.getDate());
+      }
+    };
+    Response response = Response.ok().header("Date", date).build();
+    invokeWithResponseAndAssertStatus(response, Status.OK, in);
+  }
+
+  /*
+   * @testName: getEntityStreamTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:460; JAXRS:JAVADOC:479; JAXRS:JAVADOC:480;
+   * 
+   * @test_Strategy: Get the entity input stream
+   * 
+   * ClientResponseFilter.filter
+   */
+  @Test
+  public void getEntityStreamTest() throws Fault {
+    final String entity = "ENTITY";
+    ContextProvider in = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext requestContext,
+          ClientResponseContext responseContext) throws Fault {
+        InputStream stream = responseContext.getEntityStream();
+        assertTrue(stream != null, "the #getEntityStream is null");
+        InputStreamReader isr = new InputStreamReader(stream);
+        BufferedReader br = new BufferedReader(isr);
+        String line = null;
+        try {
+          line = br.readLine();
+        } catch (IOException e) {
+          throw new Fault(e);
+        } finally {
+          try {
+            br.close();
+          } catch (IOException e) {
+          }
+        }
+        assertTrue(entity.equals(line), "The #getEntityStream " + line +
+            " is not equal to what is inserted to the response: " + entity);
+        logMsg("Found #getEntityStream()=", line);
+        // for next reading
+        responseContext
+            .setEntityStream(new ByteArrayInputStream(entity.getBytes()));
+      }
+    };
+    Response response = Response.ok(entity).build();
+    invokeWithResponseAndAssertStatus(response, Status.OK, in);
+  }
+
+  /*
+   * @testName: getEntityTagTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:461; JAXRS:JAVADOC:479; JAXRS:JAVADOC:480;
+   * 
+   * @test_Strategy: Get the entity tag.
+   * 
+   * ClientResponseFilter.filter
+   */
+  @Test
+  public void getEntityTagTest() throws Fault {
+    final String value = "EntityTagValue";
+    final EntityTag tag = new EntityTag(value);
+    ContextProvider in = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext requestContext,
+          ClientResponseContext responseContext) throws Fault {
+        EntityTag etag = responseContext.getEntityTag();
+        assertTrue(etag != null, "the #getEntityTag is null");
+        assertTrue(value.equals(etag.getValue()), "The #getEntityTag " +
+            etag.getValue() +
+            " is not equal to what is inserted to the response: " + value);
+        logMsg("Found #getEntityTag()=", value);
+      }
+    };
+    Response response = Response.ok().tag(tag).build();
+    invokeWithResponseAndAssertStatus(response, Status.OK, in);
+  }
+
+  /*
+   * @testName: getHeadersTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:462; JAXRS:JAVADOC:479; JAXRS:JAVADOC:480;
+   * 
+   * @test_Strategy: Get the mutable response headers multivalued map.
+   *
+   * ClientResponseFilter.filter
+   */
+  @Test
+  public void getHeadersTest() throws Fault {
+    final String header1 = "header1";
+    final String value1 = "value1";
+    final String header2 = "header2";
+    final String value2 = "value2";
+    ContextProvider in = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext requestContext,
+          ClientResponseContext responseContext) throws Fault {
+        MultivaluedMap<String, String> headers = responseContext.getHeaders();
+        assertTrue(headers != null, "the #getHeaders is null");
+        assertTrue(headers.size() == 2, "the #getHeaders size is " +
+            headers.size() + " expected 2");
+        assertTrue(value1.equals(headers.getFirst(header1)),
+            "#getHeaders was supposed to contain" + header1 + ":" + value1 +
+            " header, but " + header1 + " is " + headers.getFirst(header1));
+        logMsg("Found #getHeaders()={", header1, ":", value1, "}");
+      }
+    };
+    Response response = Response.ok().header(header1, value1)
+        .header(header2, value2).build();
+    invokeWithResponseAndAssertStatus(response, Status.OK, in);
+  }
+
+  /*
+   * @testName: getHeadersIsMutableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:462; JAXRS:JAVADOC:479; JAXRS:JAVADOC:480;
+   * 
+   * @test_Strategy: Get the mutable response headers multivalued map.
+   * 
+   * ClientResponseFilter.filter
+   */
+  @Test
+  public void getHeadersIsMutableTest() throws Fault {
+    final String header1 = "header1";
+    final String value1 = "value1";
+    ContextProvider in = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext requestContext,
+          ClientResponseContext responseContext) throws Fault {
+        MultivaluedMap<String, String> headers = responseContext.getHeaders();
+        headers.add(header1, value1);
+        headers = responseContext.getHeaders();
+        assertTrue(headers != null, "the #getHeaders is null");
+        assertTrue(headers.size() == 1, "the #getHeaders size is " +
+            headers.size() + " expected 1");
+        assertTrue(value1.equals(headers.getFirst(header1)),
+            "#getHeaders was supposed to contain " + header1 + ":" + value1 +
+            " header, but " + header1 + " is " + headers.getFirst(header1));
+        logMsg("#getHeaders is mutable as expected");
+      }
+    };
+    Response response = Response.ok().build();
+    invokeWithResponseAndAssertStatus(response, Status.OK, in);
+  }
+
+  /*
+   * @testName: getHeaderStringIsNullTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:463; JAXRS:JAVADOC:479; JAXRS:JAVADOC:480;
+   * 
+   * @test_Strategy: the message header value. If the message header is not
+   * present then null is returned.
+   * 
+   * ClientResponseFilter.filter
+   */
+  @Test
+  public void getHeaderStringIsNullTest() throws Fault {
+    final String header1 = "header1";
+    ContextProvider in = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext requestContext,
+          ClientResponseContext responseContext) throws Fault {
+        String header = responseContext.getHeaderString(header1);
+        assertTrue(header == null, "the #getHeaderString is NOT null");
+        logMsg("#getHeaderString is null as expected");
+      }
+    };
+    Response response = Response.ok().build();
+    invokeWithResponseAndAssertStatus(response, Status.OK, in);
+  }
+
+  /*
+   * @testName: getHeaderStringIsEmptyTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:463; JAXRS:JAVADOC:479; JAXRS:JAVADOC:480;
+   * 
+   * @test_Strategy: the message header value. If the message header is present
+   * but has no value then the empty string is returned.
+   * 
+   * ClientResponseFilter.filter
+   */
+  @Test
+  public <T> void getHeaderStringIsEmptyTest() throws Fault {
+    final String header1 = "header1";
+    RuntimeDelegate original = RuntimeDelegate.getInstance();
+    RuntimeDelegate.setInstance(new NullStringBeanRuntimeDelegate(original));
+    ContextProvider in = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext requestContext,
+          ClientResponseContext responseContext) throws Fault {
+        String header = responseContext.getHeaderString(header1);
+        assertTrue(header != null, "the #getHeaderString is null");
+        assertTrue(header.equals(""), "the #getHeaderString is NOT empty, but " +
+            header);
+        logMsg("#getHeaderString is empty string as expected");
+      }
+    };
+    Response response = Response.ok().header(header1, new StringBean("aa"))
+        .build();
+    try {
+      invokeWithResponseAndAssertStatus(response, Status.OK, in);
+    } finally {
+      RuntimeDelegate.setInstance(original);
+      StringBeanRuntimeDelegate.assertNotStringBeanRuntimeDelegate();
+    }
+  }
+
+  /*
+   * @testName: getHeaderStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:463; JAXRS:JAVADOC:479; JAXRS:JAVADOC:480;
+   * 
+   * @test_Strategy: the message header value.
+   * 
+   * ClientResponseFilter.filter
+   */
+  @Test
+  public void getHeaderStringTest() throws Fault {
+    final String header1 = "header1";
+    final String value1 = "value1";
+    ContextProvider in = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext requestContext,
+          ClientResponseContext responseContext) throws Fault {
+        String header = responseContext.getHeaderString(header1);
+        assertTrue(header != null, "the #getHeaderString is null");
+        assertTrue(header.equals(value1), "the #getHeaderString=" + header +
+            " differs from expected " + value1);
+        logMsg("#getHeaderString is", value1, "as expected");
+      }
+    };
+    Response response = Response.ok().header(header1, value1).build();
+    invokeWithResponseAndAssertStatus(response, Status.OK, in);
+  }
+
+  /*
+   * @testName: getHeaderStringIsCommaSeparatedTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:463; JAXRS:JAVADOC:479; JAXRS:JAVADOC:480;
+   * 
+   * @test_Strategy: the message header value. If the message header is present
+   * more than once then the values of joined together and separated by a ','
+   * character.
+   * 
+   * ClientResponseFilter.filter
+   */
+  @Test
+  public void getHeaderStringIsCommaSeparatedTest() throws Fault {
+    final String header1 = "header1";
+    final String value1 = "value1";
+    final String value2 = "value2";
+    ContextProvider in = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext requestContext,
+          ClientResponseContext responseContext) throws Fault {
+        String header = responseContext.getHeaderString(header1);
+        String value3 = value1 + "," + value2;
+        String value4 = value2 + "," + value1;
+        assertTrue(header != null, "the #getHeaderString is null");
+        assertTrue(header.equals(value3) || header.equals(value4),
+            "the #getHeaderString=" + header +
+            " differs from expected comma separated combination of " + value1 +
+            " and " + value2);
+        logMsg("#getHeaderString is comma separated combination of", value1,
+            "and", value2, "as expected");
+      }
+    };
+    Response response = Response.ok().header(header1, value1)
+        .header(header1, value2).build();
+    invokeWithResponseAndAssertStatus(response, Status.OK, in);
+  }
+
+  /*
+   * @testName: getLanguageTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:464; JAXRS:JAVADOC:479; JAXRS:JAVADOC:480;
+   * 
+   * @test_Strategy: Get the language of the entity.
+   * 
+   * ClientResponseFilter.filter
+   */
+  @Test
+  public void getLanguageTest() throws Fault {
+    final Locale language = Locale.CANADA_FRENCH;
+    ContextProvider in = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext requestContext,
+          ClientResponseContext responseContext) throws Fault {
+        Locale responseLanguage = responseContext.getLanguage();
+        assertTrue(responseLanguage != null, "the #getLanguage is null");
+        assertTrue(language.equals(responseLanguage),
+            "#getLanguage was supposed to be " + language + " but was " +
+            responseLanguage);
+        logMsg("Found #getLanguage()=", responseLanguage);
+      }
+    };
+    Response response = Response.ok("entity").language(language).build();
+    invokeWithResponseAndAssertStatus(response, Status.OK, in);
+  }
+
+  /*
+   * @testName: getLastModifiedTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:465; JAXRS:JAVADOC:479; JAXRS:JAVADOC:480;
+   * 
+   * @test_Strategy: Get the last modified date.
+   * 
+   * ClientResponseFilter.filter
+   */
+  @Test
+  public void getLastModifiedTest() throws Fault {
+    final Date lastModified = getNewDate();
+    ContextProvider in = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext requestContext,
+          ClientResponseContext responseContext) throws Fault {
+        Date date = responseContext.getLastModified();
+        assertTrue(date != null, "the #getLastModified is null");
+        assertTrue(lastModified.equals(date),
+            "#getLastModified was supposed to be " + lastModified + " but was " +
+            date);
+        logMsg("Found #getLastModified()=", date);
+      }
+    };
+    Response response = Response.ok().lastModified(lastModified).build();
+    invokeWithResponseAndAssertStatus(response, Status.OK, in);
+  }
+
+  /*
+   * @testName: getLengthTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:466; JAXRS:JAVADOC:479; JAXRS:JAVADOC:480;
+   * 
+   * @test_Strategy: Get Content-Length value.
+   * 
+   * ClientResponseFilter.filter
+   */
+  @Test
+  public void getLengthTest() throws Fault {
+    final String entity = "ENTITY";
+    ContextProvider in = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext requestContext,
+          ClientResponseContext responseContext) throws Fault {
+        int len = responseContext.getLength();
+        assertTrue(len == entity.length(), "#getLength was supposed to be " +
+            entity.length() + " but was " + len);
+        logMsg("Found #getLength()=", len);
+      }
+    };
+    Response response = Response.ok()
+        .header(HttpHeaders.CONTENT_LENGTH, entity.length()).build();
+    invokeWithResponseAndAssertStatus(response, Status.OK, in);
+  }
+
+  /*
+   * @testName: getLinkTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:467; JAXRS:JAVADOC:479; JAXRS:JAVADOC:480;
+   * 
+   * @test_Strategy: Get the link for the relation.
+   * 
+   * ClientResponseFilter.filter
+   */
+  @Test
+  public void getLinkTest() throws Fault {
+    final String rel = "RELATION";
+    ContextProvider in = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext requestContext,
+          ClientResponseContext responseContext) throws Fault {
+        Link link = responseContext.getLink(rel);
+        assertTrue(link != null, "the #getLink is null");
+        assertTrue(link.getUri() != null, "the #getLink.getUri is null");
+        assertTrue(link.getUri().toASCIIString().contains(getUrl()),
+            "#getLink was supposed to contain " + getUrl() + " but was " +
+            link.getUri().toASCIIString());
+        logMsg("Found #getLink()=", link.getUri().toASCIIString());
+      }
+    };
+    Response response = Response.ok().link(getUrl(), rel).build();
+    invokeWithResponseAndAssertStatus(response, Status.OK, in);
+  }
+
+  /*
+   * @testName: getLinkBuilderTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:468; JAXRS:JAVADOC:479; JAXRS:JAVADOC:480;
+   * 
+   * @test_Strategy: Convenience method that returns a
+   * jakarta.ws.rs.core.Link.Builder for the relation. ClientResponseFilter.filter
+   */
+  @Test
+  public void getLinkBuilderTest() throws Fault {
+    final String rel = "RELATION";
+    ContextProvider in = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext requestContext,
+          ClientResponseContext responseContext) throws Fault {
+        Builder builder = responseContext.getLinkBuilder(rel);
+        assertTrue(builder != null, "the #getLinkBuilder is null");
+        assertTrue(builder.build().getUri().toASCIIString().contains(getUrl()),
+            "#getLinkBuilder.build was supposed to contain " + getUrl() +
+            " but was " + builder.build().getUri().toASCIIString());
+        logMsg("Found #getLinkBuilder()=",
+            builder.build().getUri().toASCIIString());
+      }
+    };
+    Response response = Response.ok().link(getUrl(), rel).build();
+    invokeWithResponseAndAssertStatus(response, Status.OK, in);
+  }
+
+  /*
+   * @testName: getLinksTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:469; JAXRS:JAVADOC:479; JAXRS:JAVADOC:480;
+   * 
+   * @test_Strategy: Get the links attached to the message as header.
+   * 
+   * ClientResponseFilter.filter
+   */
+  @Test
+  public void getLinksTest() throws Fault {
+    final Link link = Link.fromUri(getUrl()).build();
+    ContextProvider in = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext requestContext,
+          ClientResponseContext responseContext) throws Fault {
+        Set<Link> links = responseContext.getLinks();
+        assertTrue(links != null, "the #getLinks is null");
+        assertTrue(links.size() == 1,
+            "the links was supposed to be of size 1, was " + links.size());
+        assertTrue(links.contains(link), "#getLinks was supposed to contain " +
+            link.getUri().toASCIIString());
+        logMsg("Found #getLinks()={", link.getUri().toASCIIString(), "}");
+      }
+    };
+    Response response = Response.ok().links(link).build();
+    invokeWithResponseAndAssertStatus(response, Status.OK, in);
+  }
+
+  /*
+   * @testName: getLocationTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:470; JAXRS:JAVADOC:479; JAXRS:JAVADOC:480;
+   * 
+   * @test_Strategy: Get the location. ClientResponseFilter.filter
+   */
+  @Test
+  public void getLocationTest() throws Fault {
+    URI uri = null;
+    try {
+      uri = new URI(getUrl());
+    } catch (URISyntaxException e) {
+      throw new Fault(e);
+    }
+    final URI location = uri;
+    ContextProvider in = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext requestContext,
+          ClientResponseContext responseContext) throws Fault {
+        URI responseLocation = responseContext.getLocation();
+        assertTrue(responseLocation != null, "the #getLinks is null");
+        assertTrue(location.equals(responseLocation),
+            "#getLocation was supposed to be " + location + " but was " +
+            responseLocation);
+        logMsg("Found #getLocation=", location.toASCIIString());
+      }
+    };
+    Response response = Response.ok().location(location).build();
+    invokeWithResponseAndAssertStatus(response, Status.OK, in);
+  }
+
+  /*
+   * @testName: getMediaTypeTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:471; JAXRS:JAVADOC:479; JAXRS:JAVADOC:480;
+   * 
+   * @test_Strategy: Get the media type of the entity.
+   * 
+   * ClientResponseFilter.filter
+   */
+  @Test
+  public void getMediaTypeTest() throws Fault {
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext requestContext,
+          ClientResponseContext responseContext) throws Fault {
+        MediaType type = responseContext.getMediaType();
+        assertTrue(MediaType.APPLICATION_SVG_XML_TYPE.equals(type),
+            "Unexpected mediatype found " + type);
+        TestUtil.logMsg("Found expected MediaType.APPLICATION_SVG_XML_TYPE");
+      }
+    };
+    Response response = Response.ok("TEST", MediaType.APPLICATION_SVG_XML)
+        .build();
+    invokeWithResponseAndAssertStatus(response, Status.OK, provider);
+  }
+
+  /*
+   * @testName: getStatusTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:472; JAXRS:JAVADOC:479; JAXRS:JAVADOC:480;
+   * 
+   * @test_Strategy: Get the status code associated with the response.
+   * ClientResponseFilter.filter
+   */
+  @Test
+  public void getStatusTest() throws Fault {
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext requestContext,
+          ClientResponseContext responseContext) throws Fault {
+        assertTrue(responseContext.getStatus() == 222, "unexpected status " +
+            responseContext.getStatus());
+        TestUtil.logMsg("Found expected response status 222");
+      }
+    };
+    Response response = Response.status(222).build();
+    ClientRequestFilter filter = createRequestFilter(response);
+    Invocation i = buildInvocation(filter, provider);
+    Response r = invoke(i);
+    assertTrue(r.getStatus() == 222, "unexpected status " + r.getStatus());
+  }
+
+  /*
+   * @testName: getStatusInfoTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:473; JAXRS:JAVADOC:479; JAXRS:JAVADOC:480;
+   * 
+   * @test_Strategy: Get the status code associated with the response.
+   * 
+   * ClientResponseFilter.filter
+   */
+  @Test
+  public void getStatusInfoTest() throws Fault {
+    ContextProvider provider = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext requestContext,
+          ClientResponseContext responseContext) throws Fault {
+        assertTrue(responseContext.getStatusInfo().getStatusCode() == 222,
+            "unexpected status " +
+            responseContext.getStatusInfo().getStatusCode());
+        TestUtil.logMsg("Found expected response status 222");
+      }
+    };
+    Response response = Response.status(222).build();
+    ClientRequestFilter filter = createRequestFilter(response);
+    Invocation i = buildInvocation(filter, provider);
+    Response r = invoke(i);
+    assertTrue(r.getStatus() == 222, "unexpected status " + r.getStatus());
+  }
+
+  /*
+   * @testName: hasEntityWhenEntityTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:474; JAXRS:JAVADOC:479; JAXRS:JAVADOC:480;
+   * 
+   * @test_Strategy: Check if there is a non-empty entity input stream is
+   * available in the response message. ClientResponseFilter.filter
+   */
+  @Test
+  public void hasEntityWhenEntityTest() throws Fault {
+    final String entity = "eNtitY";
+    ContextProvider in = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext requestContext,
+          ClientResponseContext responseContext) throws Fault {
+        boolean has = responseContext.hasEntity();
+        assertTrue(has, "the #hasEntity did not found the given entity");
+        logMsg("Found #hasEntity()=true");
+      }
+    };
+    Response response = Response.ok(entity).build();
+    invokeWithResponseAndAssertStatus(response, Status.OK, in);
+  }
+
+  /*
+   * @testName: hasEntityWhenNoEntityTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:474; JAXRS:JAVADOC:479; JAXRS:JAVADOC:480;
+   * 
+   * @test_Strategy: Check if there is a non-empty entity input stream is
+   * available in the response message.
+   * 
+   * ClientResponseFilter.filter
+   */
+  @Test
+  public void hasEntityWhenNoEntityTest() throws Fault {
+    ContextProvider in = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext requestContext,
+          ClientResponseContext responseContext) throws Fault {
+        boolean has = responseContext.hasEntity();
+        assertTrue(!has, "the #hasEntity found some entity");
+        logMsg("Found #hasEntity()=false");
+      }
+    };
+    Response response = Response.ok().build();
+    invokeWithResponseAndAssertStatus(response, Status.OK, in);
+  }
+
+  /*
+   * @testName: hasLinkWhenLinkTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:475; JAXRS:JAVADOC:479; JAXRS:JAVADOC:480;
+   * 
+   * @test_Strategy: Check if link for relation exists.
+   * ClientResponseFilter.filter
+   */
+  @Test
+  public void hasLinkWhenLinkTest() throws Fault {
+    final String rel = "RelatiOn";
+    ContextProvider in = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext requestContext,
+          ClientResponseContext responseContext) throws Fault {
+        boolean has = responseContext.hasLink(rel);
+        assertTrue(has, "the #hasLink did not found the given link");
+        logMsg("#hasLink has found the given link");
+      }
+    };
+    Response response = Response.ok().link(getUrl(), rel).build();
+    invokeWithResponseAndAssertStatus(response, Status.OK, in);
+  }
+
+  /*
+   * @testName: hasLinkWhenNoLinkTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:475; JAXRS:JAVADOC:479; JAXRS:JAVADOC:480;
+   * 
+   * @test_Strategy: Check if link for relation exists.
+   * 
+   * ClientResponseFilter.filter
+   */
+  @Test
+  public void hasLinkWhenNoLinkTest() throws Fault {
+    ContextProvider in = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext requestContext,
+          ClientResponseContext responseContext) throws Fault {
+        boolean has = responseContext.hasLink("rel");
+        assertTrue(!has, "the #hasLink did found some link");
+        logMsg("#hasLink has not found any link as expected");
+      }
+    };
+    Response response = Response.ok().link(getUrl(), "ANY").build();
+    invokeWithResponseAndAssertStatus(response, Status.OK, in);
+  }
+
+  /*
+   * @testName: setEntityStreamTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:476; JAXRS:JAVADOC:479; JAXRS:JAVADOC:480;
+   * 
+   * @test_Strategy: Set a new entity input stream. ClientResponseFilter.filter
+   */
+  @Test
+  public void setEntityStreamTest() throws Fault {
+    final String entity = "ENTITY";
+    ContextProvider in = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext requestContext,
+          ClientResponseContext responseContext) throws Fault {
+        responseContext
+            .setEntityStream(new ByteArrayInputStream(entity.getBytes()));
+        InputStream stream = responseContext.getEntityStream();
+        assertTrue(stream != null, "the #getEntityStream is null");
+        InputStreamReader isr = new InputStreamReader(stream);
+        BufferedReader br = new BufferedReader(isr);
+        String line = null;
+        try {
+          line = br.readLine();
+        } catch (IOException e) {
+          throw new Fault(e);
+        } finally {
+          try {
+            br.close();
+          } catch (IOException e) {
+          }
+        }
+        assertTrue(entity.equals(line), "The #getEntityStream " + line +
+            " is not equal to what is inserted to the response: " + entity);
+        logMsg("#setEntityStream(", entity, ") set entity", line);
+      }
+    };
+    Response response = Response.ok().build();
+    invokeWithResponseAndAssertStatus(response, Status.OK, in);
+  }
+
+  /*
+   * @testName: setStatusTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:477; JAXRS:JAVADOC:479; JAXRS:JAVADOC:480;
+   * 
+   * @test_Strategy: Set a new response status code. ClientResponseFilter.filter
+   */
+  @Test
+  public void setStatusTest() throws Fault {
+    ContextProvider in = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext requestContext,
+          ClientResponseContext responseContext) throws Fault {
+        responseContext.setStatus(Status.FORBIDDEN.getStatusCode());
+      }
+    };
+    Response response = Response.ok().build();
+    invokeWithResponseAndAssertStatus(response, Status.FORBIDDEN, in);
+  }
+
+  /*
+   * @testName: setStatusInfoTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:478; JAXRS:JAVADOC:479; JAXRS:JAVADOC:480;
+   * 
+   * @test_Strategy: Set the complete status information associated with the
+   * response.
+   * 
+   * ClientResponseFilter.filter
+   */
+  @Test
+  public void setStatusInfoTest() throws Fault {
+    ContextProvider in = new ContextProvider() {
+      @Override
+      protected void checkFilterContext(ClientRequestContext requestContext,
+          ClientResponseContext responseContext) throws Fault {
+        StatusType info = new StatusType() {
+          @Override
+          public int getStatusCode() {
+            return Status.FOUND.getStatusCode();
+          }
+
+          @Override
+          public String getReasonPhrase() {
+            return null;
+          }
+
+          @Override
+          public Family getFamily() {
+            return null;
+          }
+        };
+        responseContext.setStatusInfo(info);
+      }
+    };
+    Response response = Response.ok().build();
+    invokeWithResponseAndAssertStatus(response, Status.FOUND, in);
+  }
+
+  // ///////////////////////////////////////////////////////////////////////
+  protected static ClientRequestFilter createRequestFilter(
+      final Response response) {
+    ClientRequestFilter outFilter = new ClientRequestFilter() {
+
+      @Override
+      public void filter(ClientRequestContext context) throws IOException {
+        // logMsg(" -- OUT FILTER --");
+        Response r;
+        if (response == null)
+          r = Response.ok().build();
+        else
+          r = response;
+        context.abortWith(r);
+      }
+    };
+    return outFilter;
+  }
+
+  /**
+   * Call given provider CheckContextFilter method
+   */
+  protected static Response invoke(Invocation i) throws Fault {
+    Response r = null;
+    try {
+      r = i.invoke();
+    } catch (Exception e) {
+      Object cause = e.getCause();
+      if (cause instanceof Fault)
+        throw (Fault) cause;
+      else
+        throw new Fault(e);
+    }
+    return r;
+  }
+
+  protected static Invocation buildInvocation(ClientRequestFilter requestFilter,
+      ContextProvider... provider) {
+    WebTarget target = buildTarget(requestFilter, provider);
+    Invocation i = target.request().buildGet();
+    return i;
+  }
+
+  protected static WebTarget buildTarget(ClientRequestFilter requestFilter,
+      ContextProvider... providers) {
+    Client client = ClientBuilder.newClient();
+    client.register(requestFilter);
+    for (ContextProvider provider : providers)
+      client.register(provider);
+    WebTarget target = client.target(getUrl());
+    return target;
+  }
+
+  protected static void assertStatus(Response r, Status status) throws Fault {
+    assertTrue(r.getStatus() == status.getStatusCode(), "Expected " +
+        status.getStatusCode() + " got " + r.getStatus());
+    TestUtil.logMsg("Found expected status: " + status.getStatusCode());
+  }
+
+  protected static void invokeWithResponseAndAssertStatus(Response response,
+      Status status, ContextProvider provider) throws Fault {
+    ClientRequestFilter filter = createRequestFilter(response);
+    Invocation i = buildInvocation(filter, provider);
+    Response r = invoke(i);
+    assertStatus(r, status);
+  }
+
+  /**
+   * @return any nonexistent URL
+   */
+  protected static String getUrl() {
+    return "http://localhost:8080/404URL/";
+  }
+
+  protected static Date getNewDate() {
+    Calendar calendar = Calendar.getInstance();
+    calendar.set(Calendar.MILLISECOND, 0);
+    Date date = calendar.getTime();
+    return date;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/clientresponsecontext/NullStringBeanHeaderDelegate.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/clientresponsecontext/NullStringBeanHeaderDelegate.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.client.clientresponsecontext;
+
+import jakarta.ws.rs.ext.RuntimeDelegate.HeaderDelegate;
+import jakarta.ws.rs.tck.common.provider.StringBean;
+
+/**
+ * Header Delegate for getHeaderStringIsEmptyTest
+ */
+public class NullStringBeanHeaderDelegate
+    implements HeaderDelegate<StringBean> {
+
+  @Override
+  public StringBean fromString(String arg0) throws IllegalArgumentException {
+    return new StringBean(arg0);
+  }
+
+  @Override
+  public String toString(StringBean arg0) throws IllegalArgumentException {
+    // By design. We need to set header as a no value
+    // so that then the ClientResponseContext.getHeaderString should return
+    // an empty string
+    return null;
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/clientresponsecontext/NullStringBeanRuntimeDelegate.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/clientresponsecontext/NullStringBeanRuntimeDelegate.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.client.clientresponsecontext;
+
+import jakarta.ws.rs.ext.RuntimeDelegate;
+import jakarta.ws.rs.tck.common.provider.StringBean;
+import jakarta.ws.rs.tck.common.provider.StringBeanRuntimeDelegate;
+
+/**
+ * Runtime Delegate for getHeaderStringIsEmptyTest
+ */
+public class NullStringBeanRuntimeDelegate extends StringBeanRuntimeDelegate {
+
+  public NullStringBeanRuntimeDelegate(RuntimeDelegate orig) {
+    super(orig);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T> HeaderDelegate<T> createHeaderDelegate(Class<T> arg0)
+      throws IllegalArgumentException {
+    if (arg0 == StringBean.class)
+      return (HeaderDelegate<T>) new NullStringBeanHeaderDelegate();
+    else
+      return super.createHeaderDelegate(arg0);
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/entity/AnnotatedClass.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/entity/AnnotatedClass.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.client.entity;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.ext.Provider;
+
+@Provider
+@Priority(Integer.MAX_VALUE)
+@Produces
+@Consumes
+public abstract class AnnotatedClass {
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/entity/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/entity/JAXRSClientIT.java
@@ -1,0 +1,535 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.client.entity;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Form;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.Variant;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient.Fault;
+import jakarta.ws.rs.tck.common.util.JaxrsUtil;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = 3872631127958907381L;
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  /*
+   * @testName: entityMediaTypeTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:492; JAXRS:JAVADOC:504;
+   * 
+   * @test_Strategy: Create an entity using a supplied content media type.
+   *
+   * Get entity media type.
+   */
+  @Test
+  public void entityMediaTypeTest() throws Fault {
+    Entity<String> entity;
+    MediaType[] mTypes = getMediaTypes(MediaType.class);
+    for (MediaType type : mTypes) {
+      entity = Entity.entity("entity", type);
+      assertEntity(entity, "entity");
+      assertMediaType(entity, type.toString());
+    }
+  }
+
+  /*
+   * @testName: entityMediaTypeGetEntityTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:492; JAXRS:JAVADOC:502;
+   * 
+   * @test_Strategy: Create an entity using a supplied content media type.
+   * 
+   * Get entity data.
+   */
+  @Test
+  public void entityMediaTypeGetEntityTest() throws Fault {
+    Entity<?> entity;
+    Object[] entities = getEntities();
+    for (int i = 0; i != ENTITY_VALUES.length; i++) {
+      entity = Entity.entity(entities[i], MediaType.WILDCARD_TYPE);
+      assertEntity(entity, ENTITY_VALUES[i]);
+    }
+  }
+
+  /*
+   * @testName: entityMediaTypeAnnotationsTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:493; JAXRS:JAVADOC:504; JAXRS:JAVADOC:500;
+   * 
+   * @test_Strategy: Create an entity using a supplied content media type.
+   *
+   * Get entity media type. Get the entity annotations.
+   */
+  @Test
+  public void entityMediaTypeAnnotationsTest() throws Fault {
+    Entity<String> entity;
+    MediaType[] mTypes = getMediaTypes(MediaType.class);
+    Annotation[] annotations = AnnotatedClass.class.getAnnotations();
+    for (MediaType type : mTypes) {
+      entity = Entity.entity("entity", type, annotations);
+      assertEntity(entity, "entity");
+      assertMediaType(entity, type.toString());
+      assertAnnotations(entity, annotations);
+    }
+  }
+
+  /*
+   * @testName: entityMediaTypeAnnotationsDifferentEntitiesTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:493; JAXRS:JAVADOC:504; JAXRS:JAVADOC:500;
+   * 
+   * @test_Strategy: Create an entity using a supplied content media type.
+   *
+   * Get entity media type. Get the entity annotations.
+   */
+  @Test
+  public void entityMediaTypeAnnotationsDifferentEntitiesTest() throws Fault {
+    Entity<Object> entity;
+    Annotation[] annotations = AnnotatedClass.class.getAnnotations();
+    Object[] entities = getEntities();
+    for (int i = 0; i != ENTITY_VALUES.length; i++) {
+      entity = Entity.entity(entities[i], MediaType.WILDCARD_TYPE, annotations);
+      assertEntity(entity, ENTITY_VALUES[i]);
+      assertMediaType(entity, MediaType.WILDCARD);
+      assertAnnotations(entity, annotations);
+    }
+  }
+
+  /*
+   * @testName: entityStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:494; JAXRS:JAVADOC:504;
+   * 
+   * @test_Strategy: Create an entity using a supplied content media type.
+   *
+   * Get entity media type.
+   */
+  @Test
+  public void entityStringTest() throws Fault {
+    Entity<String> entity;
+    String[] mTypes = getMediaTypes(String.class);
+    for (String type : mTypes) {
+      entity = Entity.entity("entity", type);
+      assertEntity(entity, "entity");
+      assertMediaType(entity, type);
+    }
+  }
+
+  /*
+   * @testName: entityStringGetEntityTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:494; JAXRS:JAVADOC:502;
+   * 
+   * @test_Strategy: Create an entity using a supplied content media type.
+   * 
+   * Get entity data.
+   */
+  @Test
+  public void entityStringGetEntityTest() throws Fault {
+    Entity<?> entity;
+    Object[] entities = getEntities();
+    for (int i = 0; i != ENTITY_VALUES.length; i++) {
+      entity = Entity.entity(entities[i], MediaType.WILDCARD);
+      assertEntity(entity, ENTITY_VALUES[i]);
+    }
+  }
+
+  /*
+   * @testName: entityStringThrowsExceptionWhenNullTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:494;
+   * 
+   * @test_Strategy: Create an entity using a supplied content media type.
+   * throws IllegalArgumentException - if the supplied string cannot be parsed
+   * or is null.
+   */
+  @Test
+  public void entityStringThrowsExceptionWhenNullTest() throws Fault {
+    try {
+      Entity.entity("entity", (String) null);
+      throw new Fault("IllegalArgumentException has not been thrown");
+    } catch (IllegalArgumentException e) {
+      logMsg("IllegalArgumentException has been thrown as expected");
+    }
+  }
+
+  /*
+   * @testName: entityStringThrowsExceptionWhenUnparsableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:494;
+   * 
+   * @test_Strategy: Create an entity using a supplied content media type.
+   * throws IllegalArgumentException - if the supplied string cannot be parsed
+   * or is null.
+   */
+  @Test
+  public void entityStringThrowsExceptionWhenUnparsableTest() throws Fault {
+    try {
+      Entity.entity("entity", "\\//\\");
+      throw new Fault("IllegalArgumentException has not been thrown");
+    } catch (IllegalArgumentException e) {
+      logMsg("IllegalArgumentException has been thrown as expected");
+    }
+  }
+
+  /*
+   * @testName: entityVariantTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:496; JAXRS:JAVADOC:501; JAXRS:JAVADOC:502;
+   * JAXRS:JAVADOC:503; JAXRS:JAVADOC:504; JAXRS:JAVADOC:505;
+   * 
+   * @test_Strategy: Create an entity using a supplied content media type.
+   */
+  @Test
+  public void entityVariantTest() throws Fault {
+    Entity<?> entity;
+    Object[] pairs = getEntities();
+    MediaType[] media = getMediaTypes(MediaType.class);
+    for (int i = 0; i != pairs.length; i++)
+      for (int j = 0; j != media.length; j++)
+        for (int k = 0; k != LANGUAGES.length; k++)
+          for (int l = 0; l != ENCODINGS.length; l++) {
+            Variant variant = new Variant(media[j], LANGUAGES[k], ENCODINGS[l]);
+            entity = Entity.entity(pairs[i], variant);
+            assertEntity(entity, ENTITY_VALUES[i]);
+            assertMediaType(entity, media[j].toString());
+            assertLanguages(entity, LANGUAGES[k]);
+            assertEncoding(entity, ENCODINGS[l]);
+            assertVariant(entity, variant);
+          }
+  }
+
+  /*
+   * @testName: entityVariantAnnotationsTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:497; JAXRS:JAVADOC:500; JAXRS:JAVADOC:501;
+   * JAXRS:JAVADOC:502; JAXRS:JAVADOC:503; JAXRS:JAVADOC:504; JAXRS:JAVADOC:505;
+   * 
+   * @test_Strategy: Create an entity using a supplied content media type.
+   */
+  @Test
+  public void entityVariantAnnotationsTest() throws Fault {
+    Entity<?> entity;
+    Object[] pairs = getEntities();
+    MediaType[] media = getMediaTypes(MediaType.class);
+    Annotation[] annotations = AnnotatedClass.class.getAnnotations();
+    for (int i = 0; i != pairs.length; i++)
+      for (int j = 0; j != media.length; j++)
+        for (int k = 0; k != LANGUAGES.length; k++)
+          for (int l = 0; l != ENCODINGS.length; l++) {
+            Variant variant = new Variant(media[j], LANGUAGES[k], ENCODINGS[l]);
+            entity = Entity.entity(pairs[i], variant, annotations);
+            logMsg(pairs[i], media[j], LANGUAGES[k], ENCODINGS[l]);
+            assertEntity(entity, ENTITY_VALUES[i]);
+            assertMediaType(entity, media[j].toString());
+            assertLanguages(entity, LANGUAGES[k]);
+            assertEncoding(entity, ENCODINGS[l]);
+            assertVariant(entity, variant);
+            assertAnnotations(entity, annotations);
+          }
+  }
+
+  /*
+   * @testName: formFormTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:498;
+   * 
+   * @test_Strategy: Create an form entity.
+   * rs.MediaType#APPLICATION_FORM_URLENCODED form entity.
+   */
+  @Test
+  public void formFormTest() throws Fault {
+    Entity<?> entity;
+    entity = Entity.form(new Form());
+    assertMediaType(entity, MediaType.APPLICATION_FORM_URLENCODED);
+  }
+
+  /*
+   * @testName: formMultivaluedMapTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:499;
+   * 
+   * @test_Strategy: Create an form entity.
+   * rs.MediaType#APPLICATION_FORM_URLENCODED form entity.
+   */
+  @Test
+  public void formMultivaluedMapTest() throws Fault {
+    Entity<?> entity;
+    entity = Entity.form(new MultivaluedHashMap<String, String>());
+    assertMediaType(entity, MediaType.APPLICATION_FORM_URLENCODED);
+  }
+
+  /*
+   * @testName: htmlTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:506;
+   * 
+   * @test_Strategy: Create an form entity. .rs.core.MediaType#TEXT_HTML entity
+   */
+  @Test
+  public void htmlTest() throws Fault {
+    Entity<?> entity;
+    Object[] entities = getEntities();
+    for (int i = 0; i != entities.length; i++) {
+      entity = Entity.html(entities[i]);
+      assertMediaType(entity, MediaType.TEXT_HTML);
+      assertEntity(entity, ENTITY_VALUES[i]);
+    }
+  }
+
+  /*
+   * @testName: jsonTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:507;
+   * 
+   * @test_Strategy: Create an form entity. .rs.core.MediaType#APPLICATION_JSON
+   * entity
+   */
+  @Test
+  public void jsonTest() throws Fault {
+    Entity<?> entity;
+    Object[] entities = getEntities();
+    for (int i = 0; i != entities.length; i++) {
+      entity = Entity.json(entities[i]);
+      assertMediaType(entity, MediaType.APPLICATION_JSON);
+      assertEntity(entity, ENTITY_VALUES[i]);
+    }
+  }
+
+  /*
+   * @testName: textTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:508;
+   * 
+   * @test_Strategy: Create an form entity. .rs.core.MediaType#TEXT_PLAIN
+   * entity.
+   */
+  @Test
+  public void textTest() throws Fault {
+    Entity<?> entity;
+    Object[] entities = getEntities();
+    for (int i = 0; i != entities.length; i++) {
+      entity = Entity.text(entities[i]);
+      assertMediaType(entity, MediaType.TEXT_PLAIN);
+      assertEntity(entity, ENTITY_VALUES[i]);
+    }
+  }
+
+  /*
+   * @testName: xhtmlTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:509;
+   * 
+   * @test_Strategy: Create an form entity.
+   * .rs.core.MediaType#APPLICATION_XHTML_XML entity
+   */
+  @Test
+  public void xhtmlTest() throws Fault {
+    Entity<?> entity;
+    Object[] entities = getEntities();
+    for (int i = 0; i != entities.length; i++) {
+      entity = Entity.xhtml(entities[i]);
+      assertMediaType(entity, MediaType.APPLICATION_XHTML_XML);
+      assertEntity(entity, ENTITY_VALUES[i]);
+    }
+  }
+
+  /*
+   * @testName: xmlTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:510;
+   * 
+   * @test_Strategy: Create an form entity. .rs.core.MediaType#APPLICATION_XML
+   * entity
+   */
+  @Test
+  public void xmlTest() throws Fault {
+    Entity<?> entity;
+    Object[] entities = getEntities();
+    for (int i = 0; i != entities.length; i++) {
+      entity = Entity.xml(entities[i]);
+      assertMediaType(entity, MediaType.APPLICATION_XML);
+      assertEntity(entity, ENTITY_VALUES[i]);
+    }
+  }
+
+  // ///////////////////////////////////////////////////////////////////////
+
+  protected <T> void assertEntity(Entity<T> entity, String original)
+      throws Fault {
+    assertTrue(entity.getEntity().toString().contains(original),
+        entity.getEntity().toString() + " does not contain expected " + original);
+    logMsg("Found expected", original);
+  }
+
+  protected <T> void assertMediaType(Entity<T> entity, String original)
+      throws Fault {
+    assertTrue(entity.getMediaType().toString().equals(original),
+        "MediaType retrieved from entity " + entity.getMediaType() +
+        " differes from " + original);
+    logMsg("Sucessfully retrieved MediaType", original);
+  }
+
+  protected <T> void assertAnnotation(Entity<T> entity, Annotation original)
+      throws Fault {
+    Comparator<Annotation> comparator = new Comparator<Annotation>() {
+      @Override
+      public int compare(Annotation o1, Annotation o2) {
+        return o1.toString().compareTo(o2.toString());
+      }
+    };
+    Annotation[] annotations = entity.getAnnotations();
+    Arrays.sort(annotations, comparator);
+    int index = Arrays.binarySearch(annotations, original, comparator);
+    assertTrue(index != -1, "Annotation " + original + " not found");
+    logMsg("Sucessfully retrieved Annotation", original);
+  }
+
+  protected <T> void assertAnnotations(Entity<T> entity, Annotation[] original)
+      throws Fault {
+    for (Annotation annotation : original)
+      assertAnnotation(entity, annotation);
+  }
+
+  protected <T> void assertLanguages(Entity<T> entity, Locale original)
+      throws Fault {
+    assertTrue(entity.getLanguage().equals(original),
+        "Language retrieved from entity " + entity.getLanguage() + " differes from " +
+        original);
+    logMsg("Sucessfully retrieved Language", original);
+  }
+
+  protected <T> void assertEncoding(Entity<T> entity, String original)
+      throws Fault {
+    assertTrue(entity.getEncoding().equals(original),
+        "Encoding retrieved from entity " + entity.getEncoding() + " differes from " +
+        original);
+    logMsg("Sucessfully retrieved Encoding", original);
+  }
+
+  protected <T> void assertVariant(Entity<T> entity, Variant original)
+      throws Fault {
+    assertTrue(entity.getVariant() == original,
+        "Variant retrieved from entity " + entity.getVariant() + " differes from " +
+        original);
+    logMsg("Sucessfully retrieved Variant", original);
+  }
+
+  /**
+   * MediaType should either be an enum or have the values method It's neither
+   * so this method uses reflection to acquire public static fields of given
+   * class, either MediaType or String.
+   * 
+   * @param clazz
+   *          Class of the public static Field
+   * @return array of the Fields of a given class
+   * @throws Fault
+   */
+  @SuppressWarnings("unchecked")
+  protected <T> T[] getMediaTypes(Class<T> clazz) throws Fault {
+    MediaType type = MediaType.WILDCARD_TYPE;
+    List<T> list = new LinkedList<T>();
+    for (Field field : MediaType.class.getFields())
+      if (Modifier.isStatic(field.getModifiers())
+          && Modifier.isPublic(field.getModifiers())
+          && field.getType().equals(clazz))
+        try {
+          T value = (T) field.get(type);
+          if (value.toString().contains("/"))
+            list.add(value);
+        } catch (Exception e) {
+          throw new Fault(e);
+        }
+    T[] array = (T[]) Array.newInstance(clazz, 0);
+    return list.toArray(array);
+  }
+
+  /** Get different objects and their class for entities to be created */
+  protected Object[] getEntities() {
+    String sEntity = ENTITY_VALUES[0];
+    InputStream isEntity = new ByteArrayInputStream(
+        ENTITY_VALUES[1].getBytes()) {
+      @Override
+      public String toString() {
+        String line = null;
+        try {
+          line = JaxrsUtil.readFromStream(this);
+          reset();
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+        return line;
+      }
+    };
+    // Cannot have serializable inner class - findbugs
+    Serializable serEntity = new SerializableClass();
+    StringBuilder builderEntity = new StringBuilder().append(ENTITY_VALUES[3]);
+    StringBuffer bufferEntity = new StringBuffer().append(ENTITY_VALUES[4]);
+
+    Object[] array = new Object[] { sEntity, isEntity, serEntity, builderEntity,
+        bufferEntity };
+    return array;
+  }
+
+  static final String[] ENTITY_VALUES = { "string", "inputstream",
+      "serializable", "stringbuilder", "stringbuffer" };
+
+  static final Locale[] LANGUAGES = { Locale.FRENCH, Locale.GERMAN };
+
+  static final String[] ENCODINGS = { "UTF-16", "ISO-8859-2", "CP1250" };
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/entity/SerializableClass.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/entity/SerializableClass.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.client.entity;
+
+import java.io.Serializable;
+
+public class SerializableClass implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  @Override
+  public String toString() {
+    return "serializable";
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/invocation/GenericTypeResponse.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/invocation/GenericTypeResponse.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.client.invocation;
+
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
+
+public class GenericTypeResponse extends GenericType<Response> {
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/invocation/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/invocation/JAXRSClientIT.java
@@ -1,0 +1,792 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.client.invocation;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.ProcessingException;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientRequestFilter;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.client.InvocationCallback;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+/*
+ * The misuse of GenericType<Response> is on purpose to check the behavior 
+ * corresponding to javadoc  
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = -7647322937577043460L;
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  /*
+   * @testName: invokePlainTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:512;
+   * 
+   * @test_Strategy: Synchronously invoke the request and receive a response
+   * back.
+   */
+  @Test
+  public void invokePlainTest() throws Fault {
+    Invocation.Builder builder = createInvocationBuilder();
+    Invocation invocation = builder.buildGet();
+    Response r = invocation.invoke();
+    assertContains(r, Request.GET.name());
+  }
+
+  /*
+   * @testName: invokeThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:512;
+   * 
+   * @test_Strategy: throws ProcessingException in case the invocation failed.
+   * 
+   */
+  @Test
+  public void invokeThrowsExceptionTest() throws Fault {
+    Invocation.Builder builder = createInvocationBuilder(null);
+    Invocation invocation = builder.buildGet();
+    try {
+      invocation.invoke();
+    } catch (ProcessingException ie) {
+      // everything is fine
+      logMsg("ProcessingException has been thrown");
+      return;
+    }
+    throw new Fault("ProcessingException has NOT been thrown");
+  }
+
+  /*
+   * @testName: invokeClassTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:514;
+   * 
+   * @test_Strategy: Synchronously invoke the request and receive a response of
+   * the specified type back.
+   */
+  @Test
+  public void invokeClassTest() throws Fault {
+    Entity<String> entity = createEntity("invokeClassTest");
+    Invocation.Builder builder = createInvocationBuilder();
+    Invocation invocation = builder.buildPost(entity);
+    String r = invocation.invoke(String.class);
+    assertContains(r, Request.POST.name());
+    assertContains(r, "invokeClassTest");
+  }
+
+  /*
+   * @testName: invokeClassThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:514;
+   * 
+   * @test_Strategy: throws ProcessingException in case the invocation failed.
+   * 
+   */
+  @Test
+  public void invokeClassThrowsExceptionTest() throws Fault {
+    Invocation.Builder builder = createInvocationBuilder(null);
+    Invocation invocation = builder.buildGet();
+    try {
+      invocation.invoke(String.class);
+    } catch (ProcessingException ie) {
+      // everything is fine
+      logMsg("ProcessingException has been thrown");
+      return;
+    }
+    throw new Fault("ProcessingException has NOT been thrown");
+  }
+
+  /*
+   * @testName: invokeStringThrowsWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:514;
+   * 
+   * @test_Strategy: in case the response status code of the response returned
+   * by the server is not SUCCESSFUL
+   */
+  @Test
+  public void invokeStringThrowsWebApplicationExceptionTest() throws Fault {
+    Invocation.Builder builder = createInvocationBuilder(
+        createBadResponseFilter());
+    Invocation invocation = builder.buildGet();
+    try {
+      invocation.invoke(String.class);
+    } catch (WebApplicationException ie) {
+      // everything is fine
+      logMsg("WebApplicationException has been thrown");
+      return;
+    }
+    throw new Fault("WebApplicationException has NOT been thrown");
+  }
+
+  /*
+   * @testName: invokeResponseThrowsNoWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:514;
+   * 
+   * @test_Strategy: in case the response status code of the response returned
+   * by the server is not SUCCESSFUL and the response type is not Response
+   */
+  @Test
+  public void invokeResponseThrowsNoWebApplicationExceptionTest() throws Fault {
+    Invocation.Builder builder = createInvocationBuilder(
+        createBadResponseFilter());
+    Invocation invocation = builder.buildGet();
+    Response r = invocation.invoke(Response.class);
+    assertStatus(r, Status.NOT_ACCEPTABLE);
+    logMsg("Returned unexpected response with status code", r.getStatus());
+  }
+
+  /*
+   * @testName: invokeGenericTypeTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:517;
+   * 
+   * @test_Strategy: Synchronously invoke the request and receive a response of
+   * the specified generic type back.
+   */
+  @Test
+  public void invokeGenericTypeTest() throws Fault {
+    GenericType<String> entity = new GenericType<String>() {
+    };
+    Invocation.Builder builder = createInvocationBuilder();
+    Invocation invocation = builder.buildGet();
+    String r = invocation.invoke(entity);
+    assertContains(r, Request.GET.name());
+  }
+
+  /*
+   * @testName: invokeGenericTypeThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:517;
+   * 
+   * @test_Strategy: throws ProcessingException in case the invocation failed.
+   * 
+   */
+  @Test
+  public void invokeGenericTypeThrowsExceptionTest() throws Fault {
+    Invocation.Builder builder = createInvocationBuilder(null);
+    Invocation invocation = builder.buildGet();
+    try {
+      invocation.invoke(new GenericType<String>() {
+      });
+    } catch (ProcessingException ie) {
+      // everything is fine
+      logMsg("ProcessingException has been thrown");
+      return;
+    }
+    throw new Fault("ProcessingException has NOT been thrown");
+  }
+
+  /*
+   * @testName: invokeGenericTypeStringThrowsWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:517;
+   * 
+   * @test_Strategy: in case the response status code of the response returned
+   * by the server is not SUCCESSFUL
+   */
+  @Test
+  public void invokeGenericTypeStringThrowsWebApplicationExceptionTest()
+      throws Fault {
+    Invocation.Builder builder = createInvocationBuilder(
+        createBadResponseFilter());
+    Invocation invocation = builder.buildGet();
+    try {
+      invocation.invoke(new GenericType<String>() {
+      });
+    } catch (WebApplicationException e) {
+      // everything is fine
+      logMsg("WebApplicationException has been thrown");
+      return;
+    }
+    throw new Fault("WebApplicationException has NOT been thrown");
+  }
+
+  /*
+   * @testName:
+   * invokeAnnonymousGenericTypeResponseThrowsNoWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:517;
+   * 
+   * @test_Strategy: in case the response status code of the response returned
+   * by the server is not SUCCESSFUL and response type is not Response
+   */
+  @Test
+  public void invokeAnnonymousGenericTypeResponseThrowsNoWebApplicationExceptionTest()
+      throws Fault {
+    Invocation.Builder builder = createInvocationBuilder(
+        createBadResponseFilter());
+    Invocation invocation = builder.buildGet();
+    Response response = invocation.invoke(new GenericType<Response>() {
+    });
+    assertStatus(response, Status.NOT_ACCEPTABLE);
+    logMsg("Response return code is", response.getStatus(), "as expected");
+  }
+
+  /*
+   * @testName:
+   * invokeExtendedGenericTypeResponseThrowsNoWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:517;
+   * 
+   * @test_Strategy: in case the response status code of the response returned
+   * by the server is not SUCCESSFUL and response type is not Response
+   */
+  @Test
+  public void invokeExtendedGenericTypeResponseThrowsNoWebApplicationExceptionTest()
+      throws Fault {
+    Invocation.Builder builder = createInvocationBuilder(
+        createBadResponseFilter());
+    Invocation invocation = builder.buildGet();
+    Response response = invocation.invoke(new GenericTypeResponse());
+    assertStatus(response, Status.NOT_ACCEPTABLE);
+    logMsg("Response return code is", response.getStatus(), "as expected");
+  }
+
+  /*
+   * @testName: submitPlainTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:520;
+   * 
+   * @test_Strategy: Submit the request for an asynchronous invocation and
+   * receive a future response back.
+   */
+  @Test
+  public void submitPlainTest() throws Fault {
+    Invocation.Builder builder = createInvocationBuilder();
+    Invocation invocation = builder.buildGet();
+    Future<Response> future = invocation.submit();
+    Response response;
+    try {
+      response = future.get();
+      assertContains(response, Request.GET.name());
+    } catch (Exception e) {
+      throw new Fault(e);
+    }
+  }
+
+  /*
+   * @testName: submitPlainThrowsProcessingExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:520;
+   * 
+   * @test_Strategy: Note that calling the Future.get() method on the returned
+   * Future instance may throw an ExecutionException that wraps a
+   * ProcessingException thrown in case of an invocation processing failure
+   */
+  @Test
+  public void submitPlainThrowsProcessingExceptionTest() throws Fault {
+    Invocation.Builder builder = createInvocationBuilder(null);
+    Invocation invocation = builder.buildGet();
+    Future<Response> future = invocation.submit();
+    assertExceptionWithProcessingExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName: submitClassTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:521;
+   * 
+   * @test_Strategy: Submit the request for an asynchronous invocation and
+   * receive a future response of the specified type back.
+   */
+  @Test
+  public void submitClassTest() throws Fault {
+    Invocation.Builder builder = createInvocationBuilder();
+    Entity<String> entity = createEntity("submitClassTest");
+    Invocation invocation = builder.buildPost(entity);
+    Future<String> future = invocation.submit(String.class);
+    String response;
+    try {
+      response = future.get();
+      assertContains(response, Request.POST.name());
+      assertContains(response, "submitClassTest");
+    } catch (Exception e) {
+      throw new Fault(e);
+    }
+  }
+
+  /*
+   * @testName: submitStringThrowsProcessingExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:521;
+   * 
+   * @test_Strategy: Note that calling the Future.get() method on the returned
+   * Future instance may throw an ExecutionException that wraps a
+   * ProcessingException thrown in case of an invocation processing failure
+   */
+  @Test
+  public void submitStringThrowsProcessingExceptionTest() throws Fault {
+    Invocation.Builder builder = createInvocationBuilder(null);
+    Invocation invocation = builder.buildGet();
+    Future<String> future = invocation.submit(String.class);
+    assertExceptionWithProcessingExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName: submitStringThrowsWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:521;
+   * 
+   * @test_Strategy:Note that calling the Future.get() method on the returned
+   * Future instance may throw a WebApplicationException or one of its
+   * subclasses thrown in case the received response status code is not
+   * successful and the specified response type is not Response.
+   */
+  @Test
+  public void submitStringThrowsWebApplicationExceptionTest() throws Fault {
+    Invocation.Builder builder = createInvocationBuilder(
+        createBadResponseFilter());
+    Invocation invocation = builder.buildGet();
+    Future<String> future = invocation.submit(String.class);
+    assertExceptionWithWebApplicationExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName: submitResponseThrowsNoWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:521;
+   * 
+   * @test_Strategy: Note that calling the Future.get() method on the returned
+   * Future instance may throw a WebApplicationException or one of its
+   * subclasses thrown in case the received response status code is not
+   * successful and the specified response type is not Response.
+   */
+  @Test
+  public void submitResponseThrowsNoWebApplicationExceptionTest() throws Fault {
+    Invocation.Builder builder = createInvocationBuilder(
+        createBadResponseFilter());
+    Invocation invocation = builder.buildGet();
+    Future<Response> future = invocation.submit(Response.class);
+    assertStatus(future, Status.NOT_ACCEPTABLE);
+  }
+
+  /*
+   * @testName: submitGenericTypeTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:522;
+   * 
+   * @test_Strategy: Submit the request for an asynchronous invocation and
+   * receive a future response of the specified generic type back.
+   */
+  @Test
+  public void submitGenericTypeTest() throws Fault {
+    Invocation.Builder builder = createInvocationBuilder();
+    Entity<String> entity = createEntity("submitGenericTypeTest");
+    Invocation invocation = builder.buildPost(entity);
+    Future<String> future = invocation.submit(new GenericType<String>() {
+    });
+    String response;
+    try {
+      response = future.get();
+      assertContains(response, Request.POST.name());
+      assertContains(response, "submitGenericTypeTest");
+    } catch (Exception e) {
+      throw new Fault(e);
+    }
+  }
+
+  /*
+   * @testName: submitGenericTypeThrowsProcessingExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:522;
+   * 
+   * @test_Strategy: Note that calling the Future.get() method on the returned
+   * Future instance may throw an ExecutionException that wraps a
+   * ProcessingException thrown in case of an invocation processing failure
+   */
+  @Test
+  public void submitGenericTypeThrowsProcessingExceptionTest() throws Fault {
+    Invocation.Builder builder = createInvocationBuilder(null);
+    Entity<String> entity = createEntity("submitGenericTypeTest");
+    Invocation invocation = builder.buildPost(entity);
+    Future<String> future = invocation.submit(new GenericType<String>() {
+    });
+    assertExceptionWithProcessingExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName: submitGenericTypeStringThrowsWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:522;
+   * 
+   * @test_Strategy: Note that calling the Future.get() method on the returned
+   * Future instance may throw a WebApplicationException or one of its
+   * subclasses thrown in case the received response status code is not
+   * successful and the specified response type is not Response.
+   */
+  @Test
+  public void submitGenericTypeStringThrowsWebApplicationExceptionTest()
+      throws Fault {
+    Invocation.Builder builder = createInvocationBuilder(
+        createBadResponseFilter());
+    Entity<String> entity = createEntity("submitGenericTypeTest");
+    Invocation invocation = builder.buildPost(entity);
+    Future<String> future = invocation.submit(new GenericType<String>() {
+    });
+    assertExceptionWithWebApplicationExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName:
+   * submitAnnonymousGenericTypeResponseThrowsNoWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:522;
+   * 
+   * @test_Strategy: Note that calling the Future.get() method on the returned
+   * Future instance may throw a WebApplicationException or one of its
+   * subclasses thrown in case the received response status code is not
+   * successful and the specified response type is not Response.
+   */
+  @Test
+  public void submitAnnonymousGenericTypeResponseThrowsNoWebApplicationExceptionTest()
+      throws Fault {
+    Invocation.Builder builder = createInvocationBuilder(
+        createBadResponseFilter());
+    Entity<String> entity = createEntity("submitGenericTypeTest");
+    Invocation invocation = builder.buildPost(entity);
+    Future<Response> future = invocation.submit(new GenericType<Response>() {
+    });
+    assertStatus(future, Status.NOT_ACCEPTABLE);
+  }
+
+  /*
+   * @testName:
+   * submitExtendedGenericTypeResponseThrowsNoWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:522;
+   * 
+   * @test_Strategy: Note that calling the Future.get() method on the returned
+   * Future instance may throw a WebApplicationException or one of its
+   * subclasses thrown in case the received response status code is not
+   * successful and the specified response type is not Response.
+   */
+  @Test
+  public void submitExtendedGenericTypeResponseThrowsNoWebApplicationExceptionTest()
+      throws Fault {
+    Invocation.Builder builder = createInvocationBuilder(
+        createBadResponseFilter());
+    Entity<String> entity = createEntity("submitGenericTypeTest");
+    Invocation invocation = builder.buildPost(entity);
+    Future<Response> future = invocation.submit(new GenericTypeResponse());
+    assertStatus(future, Status.NOT_ACCEPTABLE);
+  }
+
+  /*
+   * @testName: submitInvocationCallbackTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:523;
+   * 
+   * @test_Strategy: Submit the request for an asynchronous invocation and
+   * register an InvocationCallback to process the future result of the
+   * invocation.
+   */
+  @Test
+  public void submitInvocationCallbackTest() throws Fault {
+    InvocationCallback<String> callback = createCallback(String.class);
+    Invocation.Builder builder = createInvocationBuilder();
+    Invocation invocation = builder.buildGet();
+    Future<String> future = invocation.submit(callback);
+    String response;
+    try {
+      response = future.get();
+      assertContains(response, Request.GET.name());
+    } catch (Exception e) {
+      throw new Fault(e);
+    }
+  }
+
+  /*
+   * @testName: submitInvocationCallbackThrowsProcessingExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:523;
+   * 
+   * @test_Strategy: Note that calling the Future.get() method on the returned
+   * Future instance may throw an ExecutionException that wraps a
+   * ProcessingException thrown in case of an invocation processing failure
+   */
+  @Test
+  public void submitInvocationCallbackThrowsProcessingExceptionTest()
+      throws Fault {
+    InvocationCallback<String> callback = createCallback(String.class);
+    Invocation.Builder builder = createInvocationBuilder(null);
+    Invocation invocation = builder.buildGet();
+    Future<String> future = invocation.submit(callback);
+    assertExceptionWithProcessingExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName: submitInvocationCallbackStringThrowsWebAppExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:523;
+   * 
+   * @test_Strategy: Note that calling the Future.get() method on the returned
+   * Future instance may throw a WebApplicationException or one of its
+   * subclasses thrown in case the received response status code is not
+   * successful and the specified response type is not Response.
+   */
+  @Test
+  public void submitInvocationCallbackStringThrowsWebAppExceptionTest()
+      throws Fault {
+    InvocationCallback<String> callback = createCallback(String.class);
+    Invocation.Builder builder = createInvocationBuilder(
+        createBadResponseFilter());
+    Invocation invocation = builder.buildGet();
+    Future<String> future = invocation.submit(callback);
+    assertExceptionWithWebApplicationExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName: submitInvocationCallbackResponseThrowsNoWebAppExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:523;
+   * 
+   * @test_Strategy: Note that calling the Future.get() method on the returned
+   * Future instance may throw a WebApplicationException or one of its
+   * subclasses thrown in case the received response status code is not
+   * successful and the specified response type is not Response.
+   */
+  @Test
+  public void submitInvocationCallbackResponseThrowsNoWebAppExceptionTest()
+      throws Fault {
+    InvocationCallback<Response> callback = createCallback(Response.class);
+    Invocation.Builder builder = createInvocationBuilder(
+        createBadResponseFilter());
+    Invocation invocation = builder.buildGet();
+    Future<Response> future = invocation.submit(callback);
+    Response r = null;
+    try {
+      r = future.get();
+    } catch (Exception e) {
+      throw new Fault("Unexpected exception caught", e);
+    }
+    assertStatus(r, Status.NOT_ACCEPTABLE);
+    logMsg("Found expected status code", r.getStatus());
+  }
+
+  // ///////////////////////////////////////////////////////////////////////
+
+  /**
+   * Simulates server side
+   * 
+   * @return Response containing request method and entity
+   */
+  protected ClientRequestFilter createRequestFilter() {
+    ClientRequestFilter filter = new ClientRequestFilter() {
+      @Override
+      public void filter(ClientRequestContext ctx) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        sb.append(ctx.getMethod()).append(";");
+        if (ctx.hasEntity())
+          sb.append(ctx.getEntity()).append(";");
+        Response r = Response.ok(sb.toString()).build();
+        ctx.abortWith(r);
+      }
+    };
+    return filter;
+  }
+
+  protected Invocation.Builder createInvocationBuilder(
+      ClientRequestFilter filter) {
+    Client client = ClientBuilder.newClient();
+    if (filter != null)
+      client.register(filter);
+    WebTarget target = client.target("http://cts.tck:888");
+    Invocation.Builder builder = target.request();
+    return builder;
+  }
+
+  protected Invocation.Builder createInvocationBuilder() {
+    return createInvocationBuilder(createRequestFilter());
+  }
+
+  protected ClientRequestFilter createBadResponseFilter() {
+    ClientRequestFilter filter = new ClientRequestFilter() {
+      @Override
+      public void filter(ClientRequestContext arg0) throws IOException {
+        Response r = Response.status(Status.NOT_ACCEPTABLE).build();
+        arg0.abortWith(r);
+      }
+    };
+    return filter;
+  }
+
+  @SuppressWarnings("unchecked")
+  protected <T> InvocationCallback<T> createCallback(Class<T> clazz) {
+    InvocationCallback<T> callback = null;
+    if (clazz == String.class)
+      callback = (InvocationCallback<T>) new InvocationCallback<String>() {
+        @Override
+        public void completed(String arg0) {
+        }
+
+        @Override
+        public void failed(Throwable throwable) {
+        }
+      };
+    else if (clazz == Response.class)
+      callback = (InvocationCallback<T>) new InvocationCallback<Response>() {
+        @Override
+        public void completed(Response arg0) {
+        }
+
+        @Override
+        public void failed(Throwable throwable) {
+        }
+      };
+    return callback;
+  }
+
+  /*
+   * readEntity vs. getEntity (from response) is set here
+   */
+  protected String getEntity(Response r) {
+    String entity = r.readEntity(String.class);
+    return entity.toLowerCase();
+  }
+
+  /**
+   * Create entity instance
+   */
+  protected <T> Entity<T> createEntity(T t) {
+    return Entity.entity(t, MediaType.WILDCARD_TYPE);
+  }
+
+  protected void assertStatus(Response response, Status status) throws Fault {
+    assertTrue(response.getStatus() == status.getStatusCode(),
+        "Returned unexpected " + response.getStatus() + " status code");
+  }
+
+  protected void assertContains(Response response, String what) throws Fault {
+    assertStatus(response, Status.OK);
+    String entity = getEntity(response);
+    assertContains(entity, what);
+  }
+
+  protected void assertContains(String responseEntity, String what)
+      throws Fault {
+    assertTrue(responseEntity.toLowerCase().contains(what.toLowerCase()),
+        responseEntity + " does not contain expected " + what);
+    logMsg("Found expected", what);
+  }
+
+  // for submit ------------------------------------------------------------
+
+  protected void assertStatus(Future<Response> future, Status status)
+      throws Fault {
+    Response response;
+    try {
+      response = future.get();
+    } catch (Exception e) {
+      throw new Fault(e);
+    }
+    assertStatus(response, status);
+    logMsg("Response cotains expected status", status);
+  }
+
+  protected void //
+      assertExceptionWithWebApplicationExceptionIsThrownAndLog(Future<?> future)
+          throws Fault {
+    try {
+      future.get();
+      throw new Fault("ExecutionException has not been thrown");
+    } catch (ExecutionException e) {
+      assertWebApplicationExceptionIsCauseAndLog(e);
+    } catch (InterruptedException e) {
+      throw new Fault("Unexpected exception thrown", e);
+    }
+  }
+
+  protected void assertExceptionWithProcessingExceptionIsThrownAndLog(
+      Future<?> future) throws Fault {
+    try {
+      future.get();
+      throw new Fault("ExecutionException has not been thrown");
+    } catch (ExecutionException e) {
+      assertProcessingExceptionIsCauseAndLog(e);
+    } catch (InterruptedException e) {
+      throw new Fault("Unexpected exception thrown", e);
+    }
+  }
+
+  protected void //
+      assertProcessingExceptionIsCauseAndLog(ExecutionException e)
+          throws Fault {
+    logMsg("ExecutionException has been thrown as expected", e);
+    assertTrue(hasWrapped(e, ProcessingException.class),
+        "ExecutionException wrapped " + e.getCause() +
+        " rather then ProcessingException");
+    logMsg("ExecutionException.getCause is ProcessingException as expected");
+  }
+
+  protected void //
+      assertWebApplicationExceptionIsCauseAndLog(ExecutionException e)
+          throws Fault {
+    logMsg("ExecutionException has been thrown as expected", e);
+    assertTrue(hasWrapped(e, WebApplicationException.class),
+        "ExecutionException wrapped " + e.getCause() +
+        " rather then WebApplicationException");
+    logMsg(
+        "ExecutionException.getCause is WebApplicationException as expected");
+  }
+
+  static boolean //
+      hasWrapped(Throwable parent, Class<? extends Throwable> wrapped) {
+    while (parent.getCause() != null) {
+      if (wrapped.isInstance(parent.getCause()))
+        return true;
+      parent = parent.getCause();
+    }
+    return false;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/invocationcallback/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/invocationcallback/JAXRSClientIT.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.client.invocationcallback;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.ProcessingException;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientRequestFilter;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.client.InvocationCallback;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = 8164327856558890177L;
+
+  private static final int WAIT_SECONDS = 5;
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  /*
+   * @testName: completedTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:539;
+   * 
+   * @test_Strategy: Called when the invocation was successfully completed.
+   */
+  @Test
+  public void completedTest() throws Fault {
+    AtomicInteger ai = new AtomicInteger(0);
+    CountDownLatch countDownLatch = new CountDownLatch(1);
+    InvocationCallback<String> callback = createCallback(ai, countDownLatch);
+    Invocation.Builder builder = createInvocationBuilder();
+    Invocation invocation = builder.buildGet();
+    Future<String> future = invocation.submit(callback);
+    try {
+      countDownLatch.await(WAIT_SECONDS, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      fault(e);
+    }
+    assertContains(future, "get");
+    assertEqualsInt(10, ai.get(), "Unexpected result from InvocationCallback",
+        ai.get(), "expected was 10");
+    logMsg("InvocationCallback#completed has been called as expected");
+  }
+
+  /*
+   * @testName: failedTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:979;
+   * 
+   * @test_Strategy: Called when the invocation has failed for any reason.
+   */
+  @Test
+  public void failedTest() throws Fault {
+    AtomicInteger ai = new AtomicInteger(0);
+    CountDownLatch countDownLatch = new CountDownLatch(1);
+    InvocationCallback<String> callback = createCallback(ai, countDownLatch);
+    Invocation.Builder builder = createInvocationBuilder(null);
+    Invocation invocation = builder.buildGet();
+    Future<String> future = invocation.submit(callback);
+    try {
+      countDownLatch.await(WAIT_SECONDS, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      fault(e);
+    }
+    assertExceptionWithProcessingExceptionIsThrownAndLog(future);
+    assertEqualsInt(100, ai.get(), "Unexpected result from InvocationCallback",
+        ai.get(), "expected was 100");
+    logMsg("InvocationCallback#failed has been called as expected");
+  }
+
+  // ///////////////////////////////////////////////////////////////////////
+
+  /**
+   * Simulates server side
+   * 
+   * @return Response containing request method and entity
+   */
+  private static ClientRequestFilter createRequestFilter() {
+    ClientRequestFilter filter = new ClientRequestFilter() {
+      @Override
+      public void filter(ClientRequestContext ctx) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        sb.append(ctx.getMethod()).append(";");
+        if (ctx.hasEntity())
+          sb.append(ctx.getEntity()).append(";");
+        Response r = Response.ok(sb.toString()).build();
+        ctx.abortWith(r);
+      }
+    };
+    return filter;
+  }
+
+  private static Invocation.Builder createInvocationBuilder(
+      ClientRequestFilter filter) {
+    Client client = ClientBuilder.newClient();
+    if (filter != null)
+      client.register(filter);
+    WebTarget target = client.target("http://cts.tck:888");
+    Invocation.Builder builder = target.request();
+    return builder;
+  }
+
+  private static Invocation.Builder createInvocationBuilder() {
+    return createInvocationBuilder(createRequestFilter());
+  }
+
+  private static InvocationCallback<String> createCallback(
+      final AtomicInteger ai, final CountDownLatch latch) {
+    InvocationCallback<String> callback = null;
+    callback = new InvocationCallback<String>() {
+      @Override
+      public void completed(String arg0) {
+        ai.set(ai.get() + 10);
+        latch.countDown();
+      }
+
+      @Override
+      public void failed(Throwable throwable) {
+        ai.set(ai.get() + 100);
+        latch.countDown();
+      }
+    };
+    return callback;
+  }
+
+  private static void assertContains(String responseEntity, String what)
+      throws Fault {
+    assertTrue(responseEntity.toLowerCase().contains(what.toLowerCase()),
+        responseEntity + " does not contain expected " + what);
+    logMsg("Found expected", what);
+  }
+
+  private static void assertContains(Future<String> future, String what)
+      throws Fault {
+    String responseEntity = null;
+    try {
+      responseEntity = future.get();
+    } catch (Exception e) {
+      throw new Fault(e);
+    }
+    assertContains(responseEntity, what);
+  }
+
+  private void assertExceptionWithProcessingExceptionIsThrownAndLog(
+      Future<?> future) throws Fault {
+    try {
+      future.get();
+      throw new Fault("ExecutionException has not been thrown");
+    } catch (ExecutionException e) {
+      assertProcessingExceptionIsCauseAndLog(e);
+    } catch (InterruptedException e) {
+      throw new Fault("Unexpected exception thrown", e);
+    }
+  }
+
+  private void //
+      assertProcessingExceptionIsCauseAndLog(ExecutionException e)
+          throws Fault {
+    logMsg("ExecutionException has been thrown as expected", e);
+    assertTrue(hasWrapped(e, ProcessingException.class),
+        "ExecutionException wrapped " + e.getCause() +
+        " rather then ProcessingException");
+    logMsg("ExecutionException.getCause is ProcessingException as expected");
+  }
+
+  private static boolean //
+      hasWrapped(Throwable parent, Class<? extends Throwable> wrapped) {
+    while (parent.getCause() != null) {
+      if (wrapped.isInstance(parent.getCause()))
+        return true;
+      parent = parent.getCause();
+    }
+    return false;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/responseprocessingexception/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/responseprocessingexception/JAXRSClientIT.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright (c) 2014, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.client.responseprocessingexception;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.client.ResponseProcessingException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = 4199815250447993450L;
+
+  static final Status STATUS = Status.EXPECTATION_FAILED;
+
+  static final String MESSAGE = "Exception thrown by TCK";
+
+  public JAXRSClientIT() {
+    setContextRoot("/jaxrs_api_rs_processingexception_web");
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  /*
+   * @testName: constructorWithRuntimeExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1027; JAXRS:JAVADOC:1026;
+   * 
+   * @test_Strategy:Constructs a new JAX-RS runtime response processing
+   * exception for a specific response with the specified cause and a detail
+   * message of (cause==null ? null : cause.toString())
+   * 
+   * ResponseProcessingException.getResponse
+   */
+  @Test
+  public void constructorWithRuntimeExceptionTest() throws Fault {
+    Response response = buildResponse(STATUS);
+    IllegalStateException ile = new IllegalStateException("TCK exception");
+    ResponseProcessingException mpe = new ResponseProcessingException(response,
+        ile);
+    assertCause(mpe, ile);
+    assertMessage(mpe, ile.getMessage());
+    assertResponse(mpe);
+  }
+
+  /*
+   * @testName: constructorWithCheckedExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1027; JAXRS:JAVADOC:1026;
+   * 
+   * @test_Strategy:Constructs a new JAX-RS runtime response processing
+   * exception for a specific response with the specified cause and a detail
+   * message of (cause==null ? null : cause.toString())
+   * 
+   * ResponseProcessingException.getResponse
+   */
+  @Test
+  public void constructorWithCheckedExceptionTest() throws Fault {
+    Response response = buildResponse(STATUS);
+    IOException ioe = new IOException("TCK exception");
+    ResponseProcessingException mpe = new ResponseProcessingException(response,
+        ioe);
+    assertCause(mpe, ioe);
+    assertMessage(mpe, ioe.getMessage());
+    assertResponse(mpe);
+  }
+
+  /*
+   * @testName: constructorWithNullThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1027; JAXRS:JAVADOC:1026;
+   * 
+   * @test_Strategy: Constructs a new JAX-RS runtime processing exception with
+   * the specified cause and a detail message of (cause==null ? null :
+   * cause.toString())
+   * 
+   * ResponseProcessingException.getResponse
+   */
+  @Test
+  public void constructorWithNullThrowableTest() throws Fault {
+    Response response = buildResponse(STATUS);
+    ResponseProcessingException mpe = new ResponseProcessingException(response,
+        (Throwable) null);
+    assertResponse(mpe);
+    assertNull(mpe.getCause(),
+        "getCause does not work for ResponseProcessingException and null cause");
+    assertNull(mpe.getMessage(),
+        "getMessage does not work for ResponseProcessingException and null cause");
+  }
+
+  /*
+   * @testName: constructorWithNullThrowableNullMessageTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1028; JAXRS:JAVADOC:1026;
+   * 
+   * @test_Strategy: Constructs a new JAX-RS runtime response processing
+   * exception with the specified detail message and cause.
+   * 
+   * ResponseProcessingException.getResponse
+   */
+  @Test
+  public void constructorWithNullThrowableNullMessageTest() throws Fault {
+    Response response = buildResponse(STATUS);
+    ResponseProcessingException mpe = new ResponseProcessingException(response,
+        (String) null, (Throwable) null);
+    assertResponse(mpe);
+    assertNull(mpe.getCause(),
+        "getCause does not work for ResponseProcessingException and null cause");
+    assertNull(mpe.getMessage(),
+        "getMessage does not work for ResponseProcessingException and null cause");
+  }
+
+  /*
+   * @testName: constructorWithNullThrowableNotNullMessageTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1028; JAXRS:JAVADOC:1026;
+   * 
+   * @test_Strategy: Constructs a new JAX-RS runtime response processing
+   * exception with the specified detail message and cause.
+   * 
+   * ResponseProcessingException.getResponse
+   */
+  @Test
+  public void constructorWithNullThrowableNotNullMessageTest() throws Fault {
+    Response response = buildResponse(STATUS);
+    ResponseProcessingException mpe = new ResponseProcessingException(response,
+        MESSAGE, (Throwable) null);
+    assertResponse(mpe);
+    assertNull(mpe.getCause(),
+        "getCause does not work for ResponseProcessingException and null cause and not null message");
+    assertMessage(mpe, MESSAGE);
+  }
+
+  /*
+   * @testName: constructorWithRuntimeExceptionNullMessageTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1028; JAXRS:JAVADOC:1026;
+   * 
+   * @test_Strategy: Constructs a new JAX-RS runtime response processing
+   * exception with the specified detail message and cause.
+   * 
+   * ResponseProcessingException.getResponse
+   */
+  @Test
+  public void constructorWithRuntimeExceptionNullMessageTest() throws Fault {
+    Response response = buildResponse(STATUS);
+    IllegalStateException ise = new IllegalStateException(
+        "JAXRS TCK exception");
+    ResponseProcessingException mpe = new ResponseProcessingException(response,
+        (String) null, ise);
+    assertResponse(mpe);
+    assertCause(mpe, ise);
+    assertNull(mpe.getMessage(), "getMessage does not work for",
+        "ResponseProcessingException and RuntimeException and null message");
+  }
+
+  /*
+   * @testName: constructorWithCheckedExceptionNullMessageTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1028; JAXRS:JAVADOC:1026;
+   * 
+   * @test_Strategy: Constructs a new JAX-RS runtime response processing
+   * exception with the specified detail message and cause.
+   * 
+   * ResponseProcessingException.getResponse
+   */
+  @Test
+  public void constructorWithCheckedExceptionNullMessageTest() throws Fault {
+    Response response = buildResponse(STATUS);
+    IOException ioe = new IOException("JAXRS TCK exception");
+    ResponseProcessingException mpe = new ResponseProcessingException(response,
+        (String) null, ioe);
+    assertResponse(mpe);
+    assertCause(mpe, ioe);
+    assertNull(mpe.getMessage(), "getMessage does not work for",
+        "ResponseProcessingException and CheckedException and null message");
+  }
+
+  /*
+   * @testName: constructorWithRuntimeExceptionAndNotNullMessageTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1028; JAXRS:JAVADOC:1026;
+   * 
+   * @test_Strategy: Constructs a new JAX-RS runtime response processing
+   * exception with the specified detail message and cause.
+   * 
+   * ResponseProcessingException.getResponse
+   */
+  @Test
+  public void constructorWithRuntimeExceptionAndNotNullMessageTest()
+      throws Fault {
+    Response response = buildResponse(STATUS);
+    IllegalStateException ise = new IllegalStateException(
+        "JAXRS TCK exception");
+    ResponseProcessingException mpe = new ResponseProcessingException(response,
+        MESSAGE, ise);
+    assertResponse(mpe);
+    assertCause(mpe, ise);
+    assertMessage(mpe, MESSAGE);
+  }
+
+  /*
+   * @testName: constructorWithCheckedExceptionAndNotNullMessageTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1028; JAXRS:JAVADOC:1026;
+   * 
+   * @test_Strategy: Constructs a new JAX-RS runtime response processing
+   * exception with the specified detail message and cause.
+   * 
+   * ResponseProcessingException.getResponse
+   */
+  @Test
+  public void constructorWithCheckedExceptionAndNotNullMessageTest()
+      throws Fault {
+    Response response = buildResponse(STATUS);
+    IOException ioe = new IOException("JAXRS TCK exception");
+    ResponseProcessingException mpe = new ResponseProcessingException(response,
+        MESSAGE, ioe);
+    assertResponse(mpe);
+    assertCause(mpe, ioe);
+    assertMessage(mpe, MESSAGE);
+  }
+
+  /*
+   * @testName: constructorWithNotNullMessageTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1029; JAXRS:JAVADOC:1026;
+   * 
+   * @test_Strategy: Constructs a new JAX-RS runtime response processing
+   * exception with the specified detail message. The cause is not initialized
+   * 
+   * ResponseProcessingException.getResponse
+   */
+  @Test
+  public void constructorWithNotNullMessageTest() throws Fault {
+    Response response = buildResponse(STATUS);
+    ResponseProcessingException mpe = new ResponseProcessingException(response,
+        MESSAGE);
+    assertNull(mpe.getCause(),
+        "getCause does not work for ResponseProcessingException and not null message");
+    assertResponse(mpe);
+    assertMessage(mpe, MESSAGE);
+  }
+
+  /*
+   * @testName: constructorWithNullMessageTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1029; JAXRS:JAVADOC:1026;
+   * 
+   * @test_Strategy: Constructs a new JAX-RS runtime response processing
+   * exception with the specified detail message. The cause is not initialized
+   * 
+   * ResponseProcessingException.getResponse
+   */
+  @Test
+  public void constructorWithNullMessageTest() throws Fault {
+    Response response = buildResponse(STATUS);
+    ResponseProcessingException mpe = new ResponseProcessingException(response,
+        (String) null);
+    assertResponse(mpe);
+    assertNull(mpe.getCause(),
+        "getCause does not work for ResponseProcessingException and null message");
+    assertNull(mpe.getMessage(),
+        "getMessage does not work for ResponseProcessingException and null message");
+  }
+
+  // /////////////////////////////////////////////////////////////
+  protected Response buildResponse(Status status) {
+    return Response.status(status).build();
+  }
+
+  protected void assertResponse(ResponseProcessingException e) throws Fault {
+    assertNotNull(e.getResponse(), "#getResponse is null");
+    Response response = e.getResponse();
+    assertEqualsInt(response.getStatus(), STATUS.getStatusCode(),
+        "response contains unexpected status", response.getStatus());
+    logMsg("response contains expected", STATUS, "status");
+  }
+
+  protected void assertCause(ResponseProcessingException e, Throwable expected)
+      throws Fault {
+    assertEquals(e.getCause(), expected, "#getCause does not contain expected",
+        expected, "but", e.getCause());
+    logMsg("getCause contains expected", expected);
+  }
+
+  protected void assertMessage(ResponseProcessingException e, String message)
+      throws Fault {
+    assertNotNull(e.getMessage(), "#getMessage is null");
+    assertContains(e.getMessage(), message,
+        "ResponseProcessingException#getMessage()",
+        "does not contain expected message", message, "but", e.getMessage());
+    logMsg("ResponseProcessingException#getMesaage contains expected message",
+        message);
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/webtarget/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/client/webtarget/JAXRSClientIT.java
@@ -1,0 +1,1179 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.client.webtarget;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientRequestFilter;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriBuilder;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = 5527613586671403135L;
+
+  private static final String ENCODED = "%42%5A%61%7a%2F%%21";
+
+  private static final String SLASHED = "%42%5A%61%7a/%%21";
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  /*
+   * @testName: getUriTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:608;
+   * 
+   * @test_Strategy: Get the URI identifying the resource.
+   */
+  @Test
+  public void getUriTest() throws Fault {
+    WebTarget target = createWebTarget();
+    URI uri = target.getUri();
+    assertContains(uri.toASCIIString(), URL);
+    logMsg("URI", uri, "contains", URL);
+  }
+
+  /*
+   * @testName: getUriBuilderTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:609;
+   * 
+   * @test_Strategy: Get the URI builder initialized with the URI of the current
+   * resource target. The returned URI builder is detached from the target, i.e.
+   * any updates in the URI builder MUST NOT have any effects on the URI of the
+   * originating target.
+   */
+  @Test
+  public void getUriBuilderTest() throws Fault {
+    WebTarget target = createWebTarget();
+    URI uri = target.getUriBuilder().build();
+    assertContains(uri.toASCIIString(), URL);
+    logMsg("URI", uri, "contains", URL);
+  }
+
+  /*
+   * @testName: getUriBuilderIsDetachedTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:609;
+   * 
+   * @test_Strategy: Get the URI builder initialized with the URI of the current
+   * resource target. The returned URI builder is detached from the target, i.e.
+   * any updates in the URI builder MUST NOT have any effects on the URI of the
+   * originating target.
+   */
+  @Test
+  public void getUriBuilderIsDetachedTest() throws Fault {
+    Client client = ClientBuilder.newClient();
+    WebTarget target = client.target(URL);
+    UriBuilder builder = target.getUriBuilder();
+    client.close(); // The way to affect original target
+    URI uri = builder.build();
+    assertContains(uri.toASCIIString(), URL);
+    logMsg("URI", uri, "contains", URL);
+  }
+
+  /*
+   * @testName: matrixParamTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:610;
+   * 
+   * @test_Strategy: Create a new instance by appending a matrix parameter to
+   * the existing set of matrix parameters of the current final segment of the
+   * URI of the current target instance. If multiple values are supplied the
+   * parameter will be added once per value.
+   */
+  @Test
+  public void matrixParamTest() throws Fault {
+    WebTarget target = createWebTarget();
+    target = target.matrixParam("matrix", "arg1", "arg2", "arg3");
+    assertConfigurationSnapshot(target);
+    URI uri = target.getUri();
+    assertContains(uri.toASCIIString(), ";matrix=arg1");
+    assertContains(uri.toASCIIString(), ";matrix=arg2");
+    assertContains(uri.toASCIIString(), ";matrix=arg3");
+    logMsg("URI", uri, "contains given matrix params");
+  }
+
+  /*
+   * @testName: matrixParamOnTwoSegmentsTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:610; JAXRS:JAVADOC:612;
+   * 
+   * @test_Strategy: Create a new instance by appending a matrix parameter to
+   * the existing set of matrix parameters of the current final segment of the
+   * URI of the current target instance. Note that the matrix parameters are
+   * tied to a particular path segment; appending a value to an existing matrix
+   * parameter name will not affect the position of the matrix parameter in the
+   * URI path.
+   * 
+   * Create a new instance by appending path to the URI of the current target
+   * instance.
+   */
+  @Test
+  public void matrixParamOnTwoSegmentsTest() throws Fault {
+    WebTarget target = createWebTarget();
+    target = target.matrixParam("matrix1", "segment1");
+    assertConfigurationSnapshot(target);
+    target = target.path("path");
+    assertConfigurationSnapshot(target);
+    target = target.matrixParam("matrix2", "segment2");
+    assertConfigurationSnapshot(target);
+    URI uri = target.getUri();
+    assertUriContains(uri, ";matrix1=segment1/path;matrix2=segment2");
+    logMsg("URI", uri, "contains given matrix params");
+  }
+
+  /*
+   * @testName:
+   * matrixParamWithNullValueRemovesParamsWithTheNameOnMoreSegmentsTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:610; JAXRS:JAVADOC:612;
+   * 
+   * @test_Strategy: Create a new instance by appending a matrix parameter to
+   * the existing set of matrix parameters of the current final segment of the
+   * URI of the current target instance.
+   *
+   * In case a single null value is entered, all parameters with that name in
+   * the current final path segment are removed (if present) from the collection
+   * of last segment matrix parameters inherited from the current target.
+   * 
+   * Note that the matrix parameters are tied to a particular path segment;
+   * appending a value to an existing matrix parameter name will not affect the
+   * position of the matrix parameter in the URI path.
+   * 
+   * Create a new instance by appending path to the URI of the current target
+   * instance.
+   */
+  @Test
+  public void matrixParamWithNullValueRemovesParamsWithTheNameOnMoreSegmentsTest()
+      throws Fault {
+    WebTarget target = createWebTarget();
+    target = target.matrixParam("matrix1", "segment1");
+    assertConfigurationSnapshot(target);
+    target = target.path("path1");
+    assertConfigurationSnapshot(target);
+    target = target.matrixParam("matrix2", "segment1");
+    target = target.matrixParam("matrix2", new Object[] { null });
+    assertConfigurationSnapshot(target);
+    target = target.path("path2");
+    assertConfigurationSnapshot(target);
+    target = target.matrixParam("matrix1", "segment1");
+    target = target.matrixParam("matrix1", new Object[] { null });
+    assertConfigurationSnapshot(target);
+    target = target.path("path3");
+    URI uri = target.getUri();
+    assertUriContains(uri, ";matrix1=segment1/path1/path2/path3");
+    logMsg("URI", uri, "contains given matrix params");
+  }
+
+  /*
+   * @testName: matrixParamThrowsNPEOnNameTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:610;
+   * 
+   * @test_Strategy: throws NullPointerException if the name or any of the
+   * values is null.
+   */
+  @Test
+  public void matrixParamThrowsNPEOnNameTest() throws Fault {
+    WebTarget target = createWebTarget();
+    try {
+      target.matrixParam(null, "segment1");
+      throw new Fault("NullPointerException has not been thrown");
+    } catch (NullPointerException npe) {
+      logMsg("NullPointerException has been thrown as expected", npe);
+    }
+  }
+
+  /*
+   * @testName: matrixParamThrowsNPEOnFirstArgIsNullTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:610;
+   * 
+   * @test_Strategy: throws NullPointerException - if there are multiple values
+   * present and any of those values is null.
+   */
+  @Test
+  public void matrixParamThrowsNPEOnFirstArgIsNullTest() throws Fault {
+    WebTarget target = createWebTarget();
+    try {
+      target.matrixParam("matrix", null, "segment1");
+      throw new Fault("NullPointerException has not been thrown");
+    } catch (NullPointerException npe) {
+      logMsg("NullPointerException has been thrown as expected", npe);
+    }
+  }
+
+  /*
+   * @testName: matrixParamThrowsNPEOnSecondArgIsNullTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:610;
+   * 
+   * @test_Strategy: throws NullPointerException - if there are multiple values
+   * present and any of those values is null.
+   */
+  @Test
+  public void matrixParamThrowsNPEOnSecondArgIsNullTest() throws Fault {
+    WebTarget target = createWebTarget();
+    try {
+      target.matrixParam("matrix", "segment1", null);
+      throw new Fault("NullPointerException has not been thrown");
+    } catch (NullPointerException npe) {
+      logMsg("NullPointerException has been thrown as expected", npe);
+    }
+  }
+
+  /*
+   * @testName: pathTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:612;
+   * 
+   * @test_Strategy: Create a new instance by appending path to the URI of the
+   * current target instance. When constructing the final path, a '/' separator
+   * will be inserted between the existing path and the supplied path if
+   * necessary. Existing '/' characters are preserved thus a single value can
+   * represent multiple URI path segments.
+   */
+  @Test
+  public void pathTest() throws Fault {
+    WebTarget target = createWebTarget();
+    target = target.path("a/").path("/b/").path("/c/").path("d").path("e");
+    assertConfigurationSnapshot(target);
+    URI uri = target.getUri();
+    assertUriContains(uri, "/a/b/c/d/e");
+    logMsg("URI", uri, "contains given path");
+  }
+
+  /*
+   * @testName: pathThrowsNPEOnNullTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:612;
+   * 
+   * @test_Strategy: throws NullPointerException if path is null.
+   */
+  @Test
+  public void pathThrowsNPEOnNullTest() throws Fault {
+    WebTarget target = createWebTarget();
+    try {
+      target.path(null);
+      throw new Fault("NullPointerException has not been thrown");
+    } catch (NullPointerException npe) {
+      logMsg("NullPointerException has been thrown as expected", npe);
+    }
+  }
+
+  /*
+   * @testName: queryParamTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:618;
+   * 
+   * @test_Strategy: Create a new instance by adding a query parameter to the
+   * URI of the current target instance. If multiple values are supplied the
+   * parameter will be added once per value.
+   */
+  @Test
+  public void queryParamTest() throws Fault {
+    WebTarget target = createWebTarget();
+    target = target.queryParam("paramName", new StringBuffer().append("value1"),
+        new StringBuilder().append("value2"), "value3");
+    assertConfigurationSnapshot(target);
+    URI uri = target.getUri();
+    assertUriContains(uri,
+        "?paramName=value1&paramName=value2&paramName=value3");
+    logMsg("URI", uri, "contains given query parameter");
+  }
+
+  /*
+   * @testName: queryParamNullValueTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:618;
+   * 
+   * @test_Strategy: In case a single null value is entered, all parameters with
+   * that name are removed (if present) from the collection of query parameters
+   * inherited from the current target.
+   */
+  @Test
+  public void queryParamNullValueTest() throws Fault {
+    WebTarget target = createWebTarget();
+    target = target.path("path").queryParam("paramName",
+        new StringBuffer().append("value1"),
+        new StringBuilder().append("value2"), "value3");
+    assertConfigurationSnapshot(target);
+    target = target.queryParam("param", (Object[]) null).path("path2");
+    URI uri = target.getUri();
+    assertUriContains(uri, "/path/path2");
+    logMsg("#paramName(name, null) removed values as expected");
+  }
+
+  /*
+   * @testName: queryParamThrowsNPEOnNullNameTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:618;
+   * 
+   * @test_Strategy: throws NullPointerException if the parameter name is null
+   * or if there are multiple values present and any of those values is null.
+   */
+  @Test
+  public void queryParamThrowsNPEOnNullNameTest() throws Fault {
+    WebTarget target = createWebTarget();
+    try {
+      target.queryParam(null, "lane");
+      throw new Fault("NullPointerException has not been thrown");
+    } catch (NullPointerException npe) {
+      logMsg("NullPointerException has been thrown as expected", npe);
+    }
+  }
+
+  /*
+   * @testName: queryParamThrowsNPEOnNullValueTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:618;
+   * 
+   * @test_Strategy: throws NullPointerException if the parameter name is null
+   * or if there are multiple values present and any of those values is null.
+   */
+  @Test
+  public void queryParamThrowsNPEOnNullValueTest() throws Fault {
+    WebTarget target = createWebTarget();
+    try {
+      target.queryParam("param", new Object[] { null, "" });
+      throw new Fault("NullPointerException has not been thrown");
+    } catch (NullPointerException npe) {
+      logMsg("NullPointerException has been thrown as expected", npe);
+    }
+  }
+
+  /*
+   * @testName: requestNoArgTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:622;
+   * 
+   * @test_Strategy: Start building a request to the targeted web resource.
+   */
+  @Test
+  public void requestNoArgTest() throws Fault {
+    WebTarget target = createWebTarget();
+    Response response = target.request().buildGet().invoke();
+    String body = response.readEntity(String.class);
+    assertContains(body, URL);
+    assertContains(body, MediaType.WILDCARD);
+  }
+
+  /*
+   * @testName: requestStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:623;
+   * 
+   * @test_Strategy: Start building a request to the targeted web resource and
+   * define the accepted response media types.
+   */
+  @Test
+  public void requestStringTest() throws Fault {
+    WebTarget target = createWebTarget();
+    Response response = target.request(MediaType.APPLICATION_ATOM_XML,
+        MediaType.APPLICATION_JSON, MediaType.TEXT_XML).buildGet().invoke();
+    String body = response.readEntity(String.class);
+    assertContains(body, URL);
+    assertContains(body, MediaType.APPLICATION_ATOM_XML);
+    assertContains(body, MediaType.APPLICATION_JSON);
+    assertContains(body, MediaType.TEXT_XML);
+  }
+
+  /*
+   * @testName: requestMediaTypeTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:624;
+   * 
+   * @test_Strategy: Start building a request to the targeted web resource and
+   * define the accepted response media types.
+   */
+  @Test
+  public void requestMediaTypeTest() throws Fault {
+    WebTarget target = createWebTarget();
+    Response response = target
+        .request(MediaType.APPLICATION_ATOM_XML_TYPE,
+            MediaType.APPLICATION_JSON_TYPE, MediaType.TEXT_XML_TYPE)
+        .buildGet().invoke();
+    String body = response.readEntity(String.class);
+    assertContains(body, URL);
+    assertContains(body, MediaType.APPLICATION_ATOM_XML);
+    assertContains(body, MediaType.APPLICATION_JSON);
+    assertContains(body, MediaType.TEXT_XML);
+  }
+
+  /*
+   * @testName: resolveTemplateTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:940;
+   * 
+   * @test_Strategy: Create a new instance by resolving a URI template with a
+   * given name in the URI of the current target instance using a supplied
+   * value. In case a template name or value is entered a NullPointerException
+   * is thrown. A snapshot of the present configuration of the current (parent)
+   * target instance is taken and is inherited by the newly constructed (child)
+   * target instance.
+   */
+  @Test
+  public void resolveTemplateTest() throws Fault {
+    WebTarget target = createWebTarget();
+    target = target.path("{path}").resolveTemplate("path", "lane");
+    assertConfigurationSnapshot(target);
+    URI uri = target.getUri();
+    assertUriContains(uri, "/lane");
+    logMsg("URI", uri, "contains given path parameter");
+  }
+
+  /*
+   * @testName: resolveTemplateThrowsNPEOnNullNameTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:940;
+   * 
+   * @test_Strategy: Create a new instance by resolving a URI template with a
+   * given name in the URI of the current target instance using a supplied
+   * value. In case a template name or value is entered a NullPointerException
+   * is thrown. A snapshot of the present configuration of the current (parent)
+   * target instance is taken and is inherited by the newly constructed (child)
+   * target instance.
+   */
+  @Test
+  public void resolveTemplateThrowsNPEOnNullNameTest() throws Fault {
+    WebTarget target = createWebTarget();
+    try {
+      target.path("{path}").resolveTemplate(null, "lane");
+      throw new Fault("NullPointerException has not been thrown");
+    } catch (NullPointerException npe) {
+      logMsg("NullPointerException has been thrown as expected", npe);
+    }
+  }
+
+  /*
+   * @testName: resolveTemplateThrowsNPEOnNullValueTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:940;
+   * 
+   * @test_Strategy: Create a new instance by resolving a URI template with a
+   * given name in the URI of the current target instance using a supplied
+   * value. In case a template name or value is entered a NullPointerException
+   * is thrown. A snapshot of the present configuration of the current (parent)
+   * target instance is taken and is inherited by the newly constructed (child)
+   * target instance.
+   */
+  @Test
+  public void resolveTemplateThrowsNPEOnNullValueTest() throws Fault {
+    WebTarget target = createWebTarget();
+    try {
+      target.path("{path}").resolveTemplate("path", null);
+      throw new Fault("NullPointerException has not been thrown");
+    } catch (NullPointerException npe) {
+      logMsg("NullPointerException has been thrown as expected", npe);
+    }
+  }
+
+  /*
+   * @testName: resolveTemplateWithBooleanFalseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:942;
+   * 
+   * @test_Strategy: Create a new instance by resolving a URI template with a
+   * given name in the URI of the current target instance using a supplied
+   * value. In case a template name or value is entered a NullPointerException
+   * is thrown. A snapshot of the present configuration of the current (parent)
+   * target instance is taken and is inherited by the newly constructed (child)
+   * target instance.
+   * 
+   * if true, the slash ('/') characters in template values will be encoded if
+   * the template is placed in the URI path component, otherwise the slash
+   * characters will not be encoded in path templates.
+   */
+  @Test
+  public void resolveTemplateWithBooleanFalseTest() throws Fault {
+    WebTarget target = createWebTarget();
+    target = target.path("{path}").resolveTemplate("path", ENCODED, false);
+    assertConfigurationSnapshot(target);
+    URI uri = target.getUri();
+    assertUriContains(uri, "/" + ENCODED.replace("%", "%25"));
+    logMsg("URI", uri, "contains given path parameter");
+  }
+
+  /*
+   * @testName: resolveTemplateWithBooleanTrueTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:942;
+   * 
+   * @test_Strategy: Create a new instance by resolving a URI template with a
+   * given name in the URI of the current target instance using a supplied
+   * value. In case a template name or value is entered a NullPointerException
+   * is thrown. A snapshot of the present configuration of the current (parent)
+   * target instance is taken and is inherited by the newly constructed (child)
+   * target instance.
+   * 
+   * if true, the slash ('/') characters in template values will be encoded if
+   * the template is placed in the URI path component, otherwise the slash
+   * characters will not be encoded in path templates.
+   */
+  @Test
+  public void resolveTemplateWithBooleanTrueTest() throws Fault {
+    WebTarget target = createWebTarget();
+    target = target.path("{path}").resolveTemplate("path", SLASHED, true);
+    assertConfigurationSnapshot(target);
+    URI uri = target.getUri();
+    assertUriContains(uri,
+        "/" + SLASHED.replace("%", "%25").replace("/", "%2F"));
+    logMsg("URI", uri, "contains given path parameter");
+  }
+
+  /*
+   * @testName: resolveTemplateWithBooleanTrueThrowsNPEOnNullNameTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:942;
+   * 
+   * @test_Strategy: Create a new instance by resolving a URI template with a
+   * given name in the URI of the current target instance using a supplied
+   * value. In case a template name or value is entered a NullPointerException
+   * is thrown. A snapshot of the present configuration of the current (parent)
+   * target instance is taken and is inherited by the newly constructed (child)
+   * target instance.
+   */
+  @Test
+  public void resolveTemplateWithBooleanTrueThrowsNPEOnNullNameTest()
+      throws Fault {
+    WebTarget target = createWebTarget();
+    try {
+      target.path("{path}").resolveTemplate(null, "lane", true);
+      throw new Fault("NullPointerException has not been thrown");
+    } catch (NullPointerException npe) {
+      logMsg("NullPointerException has been thrown as expected", npe);
+    }
+  }
+
+  /*
+   * @testName: resolveTemplateWithBooleanTrueThrowsNPEOnNullValueTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:942;
+   * 
+   * @test_Strategy: Create a new instance by resolving a URI template with a
+   * given name in the URI of the current target instance using a supplied
+   * value. In case a template name or value is entered a NullPointerException
+   * is thrown. A snapshot of the present configuration of the current (parent)
+   * target instance is taken and is inherited by the newly constructed (child)
+   * target instance.
+   */
+  @Test
+  public void resolveTemplateWithBooleanTrueThrowsNPEOnNullValueTest()
+      throws Fault {
+    WebTarget target = createWebTarget();
+    try {
+      target.path("{path}").resolveTemplate("path", null, true);
+      throw new Fault("NullPointerException has not been thrown");
+    } catch (NullPointerException npe) {
+      logMsg("NullPointerException has been thrown as expected", npe);
+    }
+  }
+
+  /*
+   * @testName: resolveTemplateWithBooleanFalseThrowsNPEOnNullNameTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:942;
+   * 
+   * @test_Strategy: Create a new instance by resolving a URI template with a
+   * given name in the URI of the current target instance using a supplied
+   * value. In case a template name or value is entered a NullPointerException
+   * is thrown. A snapshot of the present configuration of the current (parent)
+   * target instance is taken and is inherited by the newly constructed (child)
+   * target instance.
+   */
+  @Test
+  public void resolveTemplateWithBooleanFalseThrowsNPEOnNullNameTest()
+      throws Fault {
+    WebTarget target = createWebTarget();
+    try {
+      target.path("{path}").resolveTemplate(null, "lane", false);
+      throw new Fault("NullPointerException has not been thrown");
+    } catch (NullPointerException npe) {
+      logMsg("NullPointerException has been thrown as expected", npe);
+    }
+  }
+
+  /*
+   * @testName: resolveTemplateWithBooleanFalseThrowsNPEOnNullValueTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:942;
+   * 
+   * @test_Strategy: Create a new instance by resolving a URI template with a
+   * given name in the URI of the current target instance using a supplied
+   * value. In case a template name or value is entered a NullPointerException
+   * is thrown. A snapshot of the present configuration of the current (parent)
+   * target instance is taken and is inherited by the newly constructed (child)
+   * target instance.
+   */
+  @Test
+  public void resolveTemplateWithBooleanFalseThrowsNPEOnNullValueTest()
+      throws Fault {
+    WebTarget target = createWebTarget();
+    try {
+      target.path("{path}").resolveTemplate("path", null, false);
+      throw new Fault("NullPointerException has not been thrown");
+    } catch (NullPointerException npe) {
+      logMsg("NullPointerException has been thrown as expected", npe);
+    }
+  }
+
+  /*
+   * @testName: resolveTemplateFromEncodedTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:944;
+   * 
+   * @test_Strategy: Create a new WebTarget instance by resolving a URI template
+   * with a given name in the URI of the current target instance using a
+   * supplied encoded value. A template with a matching name will be replaced by
+   * the supplied value. Value is converted to String using its toString()
+   * method and is then encoded to match the rules of the URI component to which
+   * they pertain. All % characters in the stringified values that are not
+   * followed by two hexadecimal numbers will be encoded.
+   */
+  @Test
+  public void resolveTemplateFromEncodedTest() throws Fault {
+    WebTarget target = createWebTarget();
+    StringBuilder sb = new StringBuilder();
+    sb.append(ENCODED);
+    target = target.path("{path}").resolveTemplateFromEncoded("path", sb);
+    assertConfigurationSnapshot(target);
+    URI uri = target.getUri();
+    assertUriContains(uri, "/" + ENCODED.replace("%%", "%25%"));
+    logMsg("URI", uri, "contains given path parameter");
+  }
+
+  /*
+   * @testName: resolveTemplateFromEncodedThrowsNPEForNullNameTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:944;
+   * 
+   * @test_Strategy: NullPointerException - if the resolved template name or
+   * value is null.
+   */
+  @Test
+  public void resolveTemplateFromEncodedThrowsNPEForNullNameTest()
+      throws Fault {
+    WebTarget target = createWebTarget();
+    try {
+      target.path("{path}").resolveTemplateFromEncoded(null, "xyz");
+      throw new Fault("NullPointerException has not been thrown");
+    } catch (NullPointerException npe) {
+      logMsg("NullPointerException has been thrown as expected", npe);
+    }
+  }
+
+  /*
+   * @testName: resolveTemplateFromEncodedThrowsNPEForNullValueTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:944;
+   * 
+   * @test_Strategy: NullPointerException - if the resolved template name or
+   * value is null.
+   */
+  @Test
+  public void resolveTemplateFromEncodedThrowsNPEForNullValueTest()
+      throws Fault {
+    WebTarget target = createWebTarget();
+    try {
+      target.path("{path}").resolveTemplateFromEncoded("path", null);
+      throw new Fault("NullPointerException has not been thrown");
+    } catch (NullPointerException npe) {
+      logMsg("NullPointerException has been thrown as expected", npe);
+    }
+  }
+
+  /*
+   * @testName: resolveTemplatesTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:946;
+   * 
+   * @test_Strategy: Create a new WebTarget instance by resolving one or more
+   * URI templates in the URI of the current target instance using supplied
+   * name-value pairs. A call to the method with an empty parameter map is
+   * ignored, i.e. same WebTarget instance is returned. A snapshot of the
+   * present configuration of the current (parent) target instance is taken and
+   * is inherited by the newly constructed (child) target instance.
+   */
+  @Test
+  public void resolveTemplatesTest() throws Fault {
+    Map<String, Object> map = new TreeMap<String, Object>();
+    map.put("path", new StringBuilder().append("lane"));
+    map.put("highway", new StringBuffer().append("route66"));
+    map.put("sidewalk", "pavement");
+
+    WebTarget target = createWebTarget();
+    target = target.path("{path}").path("{highway}").path("{sidewalk}");
+    target = target.resolveTemplates(map);
+
+    assertConfigurationSnapshot(target);
+    URI uri = target.getUri();
+    assertUriContains(uri, "/lane/route66/pavement");
+    logMsg("URI", uri, "contains given path parameters");
+  }
+
+  /*
+   * @testName: resolveTemplatesReturnsTheSameTargetTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:946;
+   * 
+   * @test_Strategy: A call to the method with an empty parameter map is
+   * ignored, i.e. same WebTarget instance is returned.
+   */
+  @Test
+  public void resolveTemplatesReturnsTheSameTargetTest() throws Fault {
+    WebTarget target = createWebTarget();
+    target = target.path("{path}");
+    WebTarget other = target.resolveTemplates(new TreeMap<String, Object>());
+    assertEquals(target, other,
+        "#pathParams did not return the same target when the input map is empty");
+    logMsg("#pathParams returned the same traget wehn empty as expected");
+  }
+
+  /*
+   * @testName: resolveTemplatesNullValueTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:946;
+   * 
+   * @test_Strategy: NullPointerException - if the name-value map or any of the
+   * names or values in the map is null.
+   */
+  @Test
+  public void resolveTemplatesNullValueTest() throws Fault {
+    Map<String, Object> map = new HashMap<String, Object>();
+    map.put("path", null);
+    WebTarget target = createWebTarget();
+    try {
+      target.path("{path}").resolveTemplates(map);
+      throw new Fault("NullPointerException has not been thrown");
+    } catch (NullPointerException npe) {
+      logMsg("NullPointerException has been thrown as expected", npe);
+    }
+  }
+
+  /*
+   * @testName: resolveTemplatesNullNameTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:946;
+   * 
+   * @test_Strategy: NullPointerException - if the name-value map or any of the
+   * names or values in the map is null.
+   */
+  @Test
+  public void resolveTemplatesNullNameTest() throws Fault {
+    Map<String, Object> map = new HashMap<String, Object>();
+    map.put(null, "xyz");
+    WebTarget target = createWebTarget();
+    try {
+      target.path("{path}").resolveTemplates(map);
+      throw new Fault("NullPointerException has not been thrown");
+    } catch (NullPointerException npe) {
+      logMsg("NullPointerException has been thrown as expected", npe);
+    }
+  }
+
+  /*
+   * @testName: resolveTemplatesNullMapTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:946;
+   * 
+   * @test_Strategy: NullPointerException - if the name-value map or any of the
+   * names or values in the map is null.
+   */
+  @Test
+  public void resolveTemplatesNullMapTest() throws Fault {
+    WebTarget target = createWebTarget();
+    try {
+      target.path("{path}").resolveTemplates((Map<String, Object>) null);
+      throw new Fault("NullPointerException has not been thrown");
+    } catch (NullPointerException npe) {
+      logMsg("NullPointerException has been thrown as expected", npe);
+    }
+  }
+
+  /*
+   * @testName: resolveTemplatesWithBooleanTrueTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:948;
+   * 
+   * @test_Strategy: Create a new WebTarget instance by resolving one or more
+   * URI templates in the URI of the current target instance using supplied
+   * name-value pairs. A call to the method with an empty parameter map is
+   * ignored, i.e. same WebTarget instance is returned. A snapshot of the
+   * present configuration of the current (parent) target instance is taken and
+   * is inherited by the newly constructed (child) target instance.
+   */
+  @Test
+  public void resolveTemplatesWithBooleanTrueTest() throws Fault {
+    Map<String, Object> map = new TreeMap<String, Object>();
+    map.put("path", new StringBuilder().append("lane"));
+    map.put("highway", new StringBuffer().append("route66"));
+    map.put("sidewalk", SLASHED);
+
+    WebTarget target = createWebTarget();
+    target = target.path("{path}").path("{highway}").path("{sidewalk}");
+    target = target.resolveTemplates(map, true);
+
+    assertConfigurationSnapshot(target);
+    URI uri = target.getUri();
+    assertUriContains(uri,
+        "/lane/route66/" + SLASHED.replace("%", "%25").replace("/", "%2F"));
+    logMsg("URI", uri, "contains given path parameters");
+  }
+
+  /*
+   * @testName: resolveTemplatesWithBooleanFalseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:948;
+   * 
+   * @test_Strategy: Create a new WebTarget instance by resolving one or more
+   * URI templates in the URI of the current target instance using supplied
+   * name-value pairs. A call to the method with an empty parameter map is
+   * ignored, i.e. same WebTarget instance is returned. A snapshot of the
+   * present configuration of the current (parent) target instance is taken and
+   * is inherited by the newly constructed (child) target instance.
+   */
+  @Test
+  public void resolveTemplatesWithBooleanFalseTest() throws Fault {
+    Map<String, Object> map = new TreeMap<String, Object>();
+    map.put("path", new StringBuilder().append("lane"));
+    map.put("highway", new StringBuffer().append("route66"));
+    map.put("sidewalk", "pavement");
+
+    WebTarget target = createWebTarget();
+    target = target.path("{path}").path("{highway}").path("{sidewalk}");
+    target = target.resolveTemplates(map, false);
+
+    assertConfigurationSnapshot(target);
+    URI uri = target.getUri();
+    assertUriContains(uri, "/lane/route66/pavement");
+    logMsg("URI", uri, "contains given path parameters");
+  }
+
+  /*
+   * @testName: resolveTemplatesWithBooleanTrueReturnsTheSameTargetTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:948;
+   * 
+   * @test_Strategy: A call to the method with an empty parameter map is
+   * ignored, i.e. same WebTarget instance is returned.
+   */
+  @Test
+  public void resolveTemplatesWithBooleanTrueReturnsTheSameTargetTest()
+      throws Fault {
+    WebTarget target = createWebTarget();
+    target = target.path("{path}");
+    WebTarget other = target.resolveTemplates(new TreeMap<String, Object>(),
+        true);
+    assertEquals(target, other,
+        "#pathParams did not return the same target when the input map is empty");
+    logMsg("#pathParams returned the same traget wehn empty as expected");
+  }
+
+  /*
+   * @testName: resolveTemplatesWithBooleanFalseReturnsTheSameTargetTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:948;
+   * 
+   * @test_Strategy: A call to the method with an empty parameter map is
+   * ignored, i.e. same WebTarget instance is returned.
+   */
+  @Test
+  public void resolveTemplatesWithBooleanFalseReturnsTheSameTargetTest()
+      throws Fault {
+    WebTarget target = createWebTarget();
+    target = target.path("{path}");
+    WebTarget other = target.resolveTemplates(new TreeMap<String, Object>(),
+        false);
+    assertEquals(target, other,
+        "#pathParams did not return the same target when the input map is empty");
+    logMsg("#pathParams returned the same traget wehn empty as expected");
+  }
+
+  /*
+   * @testName: resolveTemplatesWithBooleanNullValueTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:948;
+   * 
+   * @test_Strategy: NullPointerException - if the name-value map or any of the
+   * names or values in the map is null.
+   */
+  @Test
+  public void resolveTemplatesWithBooleanNullValueTest() throws Fault {
+    Map<String, Object> map = new HashMap<String, Object>();
+    map.put("path", null);
+    WebTarget target = createWebTarget();
+    try {
+      target.path("{path}").resolveTemplates(map, true);
+      throw new Fault("NullPointerException has not been thrown");
+    } catch (NullPointerException npe) {
+      logMsg("NullPointerException has been thrown as expected", npe);
+    }
+  }
+
+  /*
+   * @testName: resolveTemplatesWithBooleanNullNameTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:948;
+   * 
+   * @test_Strategy: NullPointerException - if the name-value map or any of the
+   * names or values in the map is null.
+   */
+  @Test
+  public void resolveTemplatesWithBooleanNullNameTest() throws Fault {
+    Map<String, Object> map = new HashMap<String, Object>();
+    map.put(null, "xyz");
+    WebTarget target = createWebTarget();
+    try {
+      target.path("{path}").resolveTemplates(map, false);
+      throw new Fault("NullPointerException has not been thrown");
+    } catch (NullPointerException npe) {
+      logMsg("NullPointerException has been thrown as expected", npe);
+    }
+  }
+
+  /*
+   * @testName: resolveTemplatesWithBooleanNullMapTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:948;
+   * 
+   * @test_Strategy: NullPointerException - if the name-value map or any of the
+   * names or values in the map is null.
+   */
+  @Test
+  public void resolveTemplatesWithBooleanNullMapTest() throws Fault {
+    WebTarget target = createWebTarget();
+    try {
+      target.path("{path}").resolveTemplates((Map<String, Object>) null, false);
+      throw new Fault("NullPointerException has not been thrown");
+    } catch (NullPointerException npe) {
+      logMsg("NullPointerException has been thrown as expected", npe);
+    }
+  }
+
+  /*
+   * @testName: resolveTemplatesFromEncodedTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:950;
+   * 
+   * @test_Strategy: Create a new WebTarget instance by resolving a URI template
+   * with a given name in the URI of the current target instance using a
+   * supplied encoded value. A template with a matching name will be replaced by
+   * the supplied value. Value is converted to String using its toString()
+   * method and is then encoded to match the rules of the URI component to which
+   * they pertain. All % characters in the stringified values that are not
+   * followed by two hexadecimal numbers will be encoded.
+   */
+  @Test
+  public void resolveTemplatesFromEncodedTest() throws Fault {
+    WebTarget target = createWebTarget();
+    StringBuilder sb = new StringBuilder();
+    sb.append(ENCODED);
+    HashMap<String, Object> map = new HashMap<String, Object>();
+    map.put("path", sb);
+    target = target.path("{path}").resolveTemplatesFromEncoded(map);
+    assertConfigurationSnapshot(target);
+    URI uri = target.getUri();
+    assertUriContains(uri, "/" + ENCODED.replace("%%", "%25%"));
+    logMsg("URI", uri, "contains given path parameter");
+  }
+
+  /*
+   * @testName: resolveTemplatesFromEncodedReturnsTheSameTargetTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:950;
+   * 
+   * @test_Strategy: A call to the method with an empty parameter map is
+   * ignored, i.e. same WebTarget instance is returned.
+   */
+  @Test
+  public void resolveTemplatesFromEncodedReturnsTheSameTargetTest()
+      throws Fault {
+    WebTarget target = createWebTarget();
+    target = target.path("{path}");
+    WebTarget other = target
+        .resolveTemplatesFromEncoded(new TreeMap<String, Object>());
+    assertEquals(target, other,
+        "#pathParams did not return the same target when the input map is empty");
+    logMsg("#pathParams returned the same traget wehn empty as expected");
+  }
+
+  /*
+   * @testName: resolveTemplatesFromEncodedThrowsNPEForNullNameTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:950;
+   * 
+   * @test_Strategy: NullPointerException - if the name-value map or any of the
+   * names or encoded values in the map is null.
+   */
+  @Test
+  public void resolveTemplatesFromEncodedThrowsNPEForNullNameTest()
+      throws Fault {
+    WebTarget target = createWebTarget();
+    HashMap<String, Object> map = new HashMap<String, Object>();
+    map.put(null, "xyz");
+    try {
+      target.path("{path}").resolveTemplatesFromEncoded(map);
+      throw new Fault("NullPointerException has not been thrown");
+    } catch (NullPointerException npe) {
+      logMsg("NullPointerException has been thrown as expected", npe);
+    }
+  }
+
+  /*
+   * @testName: resolveTemplatesFromEncodedThrowsNPEForNullValueTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:950;
+   * 
+   * @test_Strategy: NullPointerException - if the name-value map or any of the
+   * names or encoded values in the map is null.
+   */
+  @Test
+  public void resolveTemplatesFromEncodedThrowsNPEForNullValueTest()
+      throws Fault {
+    WebTarget target = createWebTarget();
+    HashMap<String, Object> map = new HashMap<String, Object>();
+    map.put("path", null);
+    try {
+      target.path("{path}").resolveTemplatesFromEncoded(map);
+      throw new Fault("NullPointerException has not been thrown");
+    } catch (NullPointerException npe) {
+      logMsg("NullPointerException has been thrown as expected", npe);
+    }
+  }
+
+  /*
+   * @testName: resolveTemplatesFromEncodedThrowsNPEForNullMapTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:950;
+   * 
+   * @test_Strategy: NullPointerException - if the name-value map or any of the
+   * names or encoded values in the map is null.
+   */
+  @Test
+  public void resolveTemplatesFromEncodedThrowsNPEForNullMapTest()
+      throws Fault {
+    WebTarget target = createWebTarget();
+    try {
+      target.path("{path}")
+          .resolveTemplatesFromEncoded((TreeMap<String, Object>) null);
+      throw new Fault("NullPointerException has not been thrown");
+    } catch (NullPointerException npe) {
+      logMsg("NullPointerException has been thrown as expected", npe);
+    }
+  }
+
+  // ///////////////////////////////////////////////////////////////////////
+
+  /**
+   * Simulates server side
+   * 
+   * @return Response containing request method and entity
+   */
+  protected static ClientRequestFilter createRequestFilter() {
+    ClientRequestFilter filter = new ClientRequestFilter() {
+      @Override
+      public void filter(ClientRequestContext ctx) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        sb.append(ctx.getMethod()).append(";");
+        sb.append(ctx.getUri().toASCIIString()).append(";");
+        if (ctx.hasEntity())
+          sb.append(ctx.getEntity()).append(";");
+        List<MediaType> list = ctx.getAcceptableMediaTypes();
+        for (MediaType type : list)
+          sb.append(type).append(";");
+        Response r = Response.ok(sb.toString()).build();
+        ctx.abortWith(r);
+      }
+    };
+    return filter;
+  }
+
+  protected WebTarget createWebTarget() throws Fault {
+    Client client = ClientBuilder.newClient();
+    client.register(FILTER);
+    WebTarget target = client.target(URL);
+    assertConfigurationSnapshot(target);
+    return target;
+  }
+
+  protected static void assertContains(String string, String substring)
+      throws Fault {
+    assertTrue(string.toLowerCase().contains(substring.toLowerCase()), string +
+        " does not contain expected " + substring);
+    logMsg("Found expected", substring);
+  }
+
+  protected static//
+  void assertUriContains(URI uri, String suffix) throws Fault {
+    String normalizedUri = uri.toASCIIString().replace(" ", "").replace("%2f",
+        "%2F");
+    assertContains(normalizedUri, URL + suffix);
+  }
+
+  /**
+   * Whenever a new instance of WebTarget is created, one should check the
+   * Configuration is inherited, i.e. it contains FILTER instance.
+   * 
+   * This is because javadoc says: A snapshot of the present configuration of
+   * the current (parent) target instance is taken and is inherited by the newly
+   * constructed (child) target instance.
+   */
+  protected static void assertConfigurationSnapshot(WebTarget target)
+      throws Fault {
+    Collection<Object> filters = target.getConfiguration().getInstances();
+    assertTrue(filters.contains(FILTER),
+        "The snapshot of configuration has not been taken");
+  }
+
+  protected static final String URL = "http://cts.tck:888/resource";
+
+  protected static final ClientRequestFilter FILTER = createRequestFilter();
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/badrequestexception/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/badrequestexception/JAXRSClientIT.java
@@ -1,0 +1,348 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.badrequestexception;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = -7606579523483319730L;
+
+  private static final Status STATUS = Status.BAD_REQUEST;
+
+  protected static final String MESSAGE = "TCK BadRequestException description";
+
+  protected static final String HOST = "www.jcp.org";
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  /*
+   * @testName: constructorTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:305; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new bad client request exception.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorTest() throws Fault {
+    BadRequestException e = new BadRequestException();
+    assertResponse(e);
+
+  }
+
+  /*
+   * @testName: constructorResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:306; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new bad client request exception. throws -
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 400.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorResponseTest() throws Fault {
+    Response response = buildResponse();
+    BadRequestException e = new BadRequestException(response);
+    assertResponse(e, HOST);
+  }
+
+  /*
+   * @testName: constructorResponseThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:306;
+   * 
+   * @test_Strategy: Construct a new bad client request exception. throws -
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 400.
+   */
+  @Test
+  public void constructorResponseThrowsExceptionTest() throws Fault {
+    for (Status status : Status.values())
+      if (status != STATUS)
+        try {
+          Response response = Response.status(status).build();
+          BadRequestException e = new BadRequestException(response);
+          fault("Exception has been not been thrown for response with status",
+              status, "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg("IllegalArgumentException has been thrown for status", status,
+              "as expected");
+        }
+  }
+
+  /*
+   * @testName: constructorThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:307; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new bad client request exception. cause - the
+   * underlying cause of the exception.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable throwable : throwables) {
+      BadRequestException e = new BadRequestException(throwable);
+      assertResponse(e);
+      assertCause(e, throwable);
+    }
+  }
+
+  /*
+   * @testName: constructorResponseThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:308; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new bad client request exception. throws -
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 400.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorResponseThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    Response response = buildResponse();
+    for (Throwable throwable : throwables) {
+      BadRequestException e = new BadRequestException(response, throwable);
+      assertResponse(e, HOST);
+      assertCause(e, throwable);
+    }
+  }
+
+  /*
+   * @testName: constructorResponseThrowableThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:308;
+   * 
+   * @test_Strategy: Construct a new bad client request exception. throws -
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 400.
+   */
+  @Test
+  public void constructorResponseThrowableThrowsExceptionTest() throws Fault {
+    for (Status status : Status.values())
+      if (status != STATUS)
+        try {
+          Response response = Response.status(status).build();
+          BadRequestException e = new BadRequestException(response,
+              new Throwable());
+          fault("Exception has been not been thrown for response with status",
+              status, "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg("IllegalArgumentException has been thrown for status", status,
+              "as expected");
+        }
+  }
+
+  /*
+   * @testName: constructorStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1056;
+   * 
+   * @test_Strategy: message - the detail message (which is saved for later
+   * retrieval by the Throwable.getMessage() method).
+   */
+  @Test
+  public void constructorStringTest() throws Fault {
+    BadRequestException e = new BadRequestException(MESSAGE);
+    assertMessage(e);
+    assertResponse(e);
+  }
+
+  /*
+   * @testName: constructorStringResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1057;
+   * 
+   * @test_Strategy: message - the detail message (which is saved for later
+   * retrieval by the Throwable.getMessage() method).
+   */
+  @Test
+  public void constructorStringResponseTest() throws Fault {
+    Response response = buildResponse();
+    BadRequestException e = new BadRequestException(MESSAGE, response);
+    assertResponse(e, HOST);
+    assertMessage(e);
+  }
+
+  /*
+   * @testName: constructorStringResponseThrowsIEATest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1057;
+   * 
+   * @test_Strategy: Construct a new bad client request exception. throws -
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 400.
+   */
+  @Test
+  public void constructorStringResponseThrowsIEATest() throws Fault {
+    for (Status status : Status.values())
+      if (status != STATUS)
+        try {
+          Response response = Response.status(status).build();
+          BadRequestException e = new BadRequestException(MESSAGE, response);
+          fault("Exception has been not been thrown for response with status",
+              status, "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg("IllegalArgumentException has been thrown for status", status,
+              "as expected");
+        }
+  }
+
+  /*
+   * @testName: constructorStringThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1058;
+   * 
+   * @test_Strategy: Construct a new bad client request exception.
+   */
+  @Test
+  public void constructorStringThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable throwable : throwables) {
+      BadRequestException e = new BadRequestException(MESSAGE, throwable);
+      assertMessage(e);
+      assertCause(e, throwable);
+      assertResponse(e);
+    }
+  }
+
+  /*
+   * @testName: constructorStringRequestThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1059;
+   * 
+   * @test_Strategy: Construct a new bad client request exception.
+   */
+  @Test
+  public void constructorStringRequestThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    Response response = buildResponse();
+    for (Throwable throwable : throwables) {
+      BadRequestException e = new BadRequestException(MESSAGE, response,
+          throwable);
+      assertMessage(e);
+      assertCause(e, throwable);
+      assertResponse(e, HOST);
+    }
+  }
+
+  /*
+   * @testName: constructorStringRequestThrowableThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1059;
+   * 
+   * @test_Strategy: Construct a new bad client request exception. throws -
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 400.
+   */
+  @Test
+  public void constructorStringRequestThrowableThrowsIAETest() throws Fault {
+    for (Status status : Status.values())
+      if (status != STATUS)
+        try {
+          Response response = Response.status(status).build();
+          BadRequestException e = new BadRequestException(MESSAGE, response,
+              new Throwable());
+          fault("Exception has been not been thrown for response with status",
+              status, "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg("IllegalArgumentException has been thrown for status", status,
+              "as expected");
+        }
+  }
+
+  // /////////////////////////////////////////////////////////////
+  protected Response buildResponse() {
+    Response r = Response.status(STATUS).header(HttpHeaders.HOST, HOST).build();
+    return r;
+  }
+
+  protected void assertResponse(BadRequestException e) throws Fault {
+    assertNotNull(e.getResponse(), "#getResponse is null");
+    Response response = e.getResponse();
+    assertEqualsInt(response.getStatus(), STATUS.getStatusCode(),
+        "response contains unexpected status", response.getStatus());
+    logMsg("response contains expected", STATUS, "status");
+  }
+
+  /**
+   * Check the given exception contains a prebuilt response containing the http
+   * header HOST
+   */
+  protected void assertResponse(BadRequestException e, String host)
+      throws Fault {
+    assertResponse(e);
+    String header = e.getResponse().getHeaderString(HttpHeaders.HOST);
+    assertNotNull(header, "http header", HttpHeaders.HOST,
+        " of response is null");
+    assertEquals(host, header, "Found unexpected http", HttpHeaders.HOST,
+        "header", header);
+    logMsg("Found expected http", HttpHeaders.HOST, "header");
+  }
+
+  protected void assertMessage(BadRequestException e) throws Fault {
+    assertNotNull(e.getMessage(), "getMessage() is null");
+    assertContains(e.getMessage(), MESSAGE, "Unexpected getMessage()",
+        e.getMessage());
+    logMsg("found expected getMessage()=", e.getMessage());
+  }
+
+  protected void assertCause(WebApplicationException e, Throwable expected)
+      throws Fault {
+    assertEquals(e.getCause(), expected, "#getCause does not contain expected",
+        expected, "but", e.getCause());
+    logMsg("getCause contains expected", expected);
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/bindingpriority/ContextProvider.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/bindingpriority/ContextProvider.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.bindingpriority;
+
+import java.io.IOException;
+
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientRequestFilter;
+import jakarta.ws.rs.ext.Provider;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient.Fault;
+
+@Provider
+public class ContextProvider implements ClientRequestFilter {
+
+  protected void checkFilterContext(ClientRequestContext context) throws Fault {
+    throw new Fault("this TCK method is not implemented yet");
+  }
+
+  @Override
+  public void filter(ClientRequestContext context) throws IOException {
+    try {
+      checkFilterContext(context);
+    } catch (Fault e) {
+      throw new IOException(e);
+    }
+  }
+
+  /**
+   * @param conditionTrue
+   * @param message
+   * @throws Fault
+   *           when conditionTrue is not met with message provided
+   */
+  protected static void //
+      assertFault(boolean conditionTrue, Object... message) throws Fault {
+    if (!conditionTrue) {
+      StringBuilder sb = new StringBuilder();
+      for (Object msg : message)
+        sb.append(msg).append(" ");
+      throw new Fault(sb.toString());
+    }
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/bindingpriority/HigherPriorityProvider.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/bindingpriority/HigherPriorityProvider.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.bindingpriority;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient.Fault;
+
+@Priority(Integer.MIN_VALUE)
+// the lower the number the higher the priority
+public class HigherPriorityProvider extends ContextProvider {
+  private AtomicInteger counter;
+
+  public HigherPriorityProvider(AtomicInteger counter) {
+    super();
+    this.counter = counter;
+  }
+
+  @Override
+  protected void checkFilterContext(ClientRequestContext context) throws Fault {
+    assertFault(counter.incrementAndGet() == 1,
+        "Lower provider priority has been called as ", counter.get(), "nd");
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/bindingpriority/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/bindingpriority/JAXRSClientIT.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.bindingpriority;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.ClientRequestFilter;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = 1501029701397272718L;
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  /*
+   * @testName: checkBindingPriorityHigherRegisteredFirstTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:92;
+   * 
+   * @test_Strategy: Priority defined for a filter or interceptor.
+   */
+  @Test
+  public void checkBindingPriorityHigherRegisteredFirstTest() throws Fault {
+    AtomicInteger ai = new AtomicInteger(0);
+    ContextProvider lowerProiority = new LowerPriorityProvider(ai);
+    ContextProvider higherPriority = new HigherPriorityProvider(ai);
+    Response response = invokeWithClientRequestFilters(higherPriority,
+        lowerProiority);
+    assertTrue(response.getStatus() == Status.OK.getStatusCode(),
+        "returned status " + response.getStatus());
+  }
+
+  /*
+   * @testName: checkBindingPriorityLowerRegisteredFirstTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:92;
+   * 
+   * @test_Strategy: Priority defined for a filter or interceptor.
+   */
+  @Test
+  public void checkBindingPriorityLowerRegisteredFirstTest() throws Fault {
+    AtomicInteger ai = new AtomicInteger(0);
+    ContextProvider lowerProiority = new LowerPriorityProvider(ai);
+    ContextProvider higherPriority = new HigherPriorityProvider(ai);
+    Response response = invokeWithClientRequestFilters(lowerProiority,
+        higherPriority);
+    assertTrue(response.getStatus() == Status.OK.getStatusCode(),
+        "returned status " + response.getStatus());
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  protected Response invokeWithClientRequestFilters(
+      ClientRequestFilter... filters) {
+    Client client = ClientBuilder.newClient();
+    for (ClientRequestFilter filter : filters)
+      client.register(filter);
+    WebTarget target = client.target("http://nourl/");
+    Response response = target.request().buildGet().invoke();
+    return response;
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/bindingpriority/LowerPriorityProvider.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/bindingpriority/LowerPriorityProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.bindingpriority;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient.Fault;
+
+@Priority(Integer.MAX_VALUE)
+// the lower the number the higher the priority
+public class LowerPriorityProvider extends ContextProvider {
+  private AtomicInteger counter;
+
+  public LowerPriorityProvider(AtomicInteger counter) {
+    super();
+    this.counter = counter;
+  }
+
+  @Override
+  protected void checkFilterContext(ClientRequestContext context) throws Fault {
+    assertFault(counter.incrementAndGet() == 2,
+        "Lower provider priority has been called as ", counter.get(), "st");
+    Response response = Response.ok().build();
+    context.abortWith(response);
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/clienterrorexception/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/clienterrorexception/JAXRSClientIT.java
@@ -1,0 +1,902 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.clienterrorexception;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.ClientErrorException;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = 6441920735149224053L;
+
+  protected static final String MESSAGE = "TCK ClientErrorException description";
+
+  protected static final String HOST = "www.jcp.org";
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  /*
+   * @testName: constructorStatusTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:310; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new client error exception.
+   * java.lang.IllegalArgumentException - in case the status code is null or if
+   * it is not from the Response.Status.Family.CLIENT_ERROR status code family.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStatusTest() throws Fault {
+    for (Status status : Status.values())
+      if (Status.Family
+          .familyOf(status.getStatusCode()) == Status.Family.CLIENT_ERROR) {
+        ClientErrorException e = new ClientErrorException(status);
+        assertResponse(e, status);
+      }
+  }
+
+  /*
+   * @testName: constructorStatusThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:310;
+   * 
+   * @test_Strategy: Construct a new client error exception.
+   * java.lang.IllegalArgumentException - in case the status code is null or if
+   * it is not from the Response.Status.Family.CLIENT_ERROR status code family.
+   */
+  @Test
+  public void constructorStatusThrowsExceptionTest() throws Fault {
+    for (Status status : Status.values())
+      if (Status.Family
+          .familyOf(status.getStatusCode()) != Status.Family.CLIENT_ERROR)
+        try {
+          ClientErrorException e = new ClientErrorException(status);
+          fault("IllegalArgumentException has not been thrown for status",
+              status, "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been thrown as expected for status",
+              status);
+        }
+  }
+
+  /*
+   * @testName: constructorStatusNullThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:310;
+   * 
+   * @test_Strategy: Construct a new client error exception.
+   * java.lang.IllegalArgumentException - in case the status code is null or if
+   * it is not from the Response.Status.Family.CLIENT_ERROR status code family.
+   */
+  @Test
+  public void constructorStatusNullThrowsExceptionTest() throws Fault {
+    try {
+      ClientErrorException e = new ClientErrorException((Status) null);
+      fault(
+          "IllegalArgumentException has not been thrown for null status; exception",
+          e);
+    } catch (IllegalArgumentException e) {
+      logMsg(
+          "IllegalArgumentException has been thrown as expected for null status");
+    }
+  }
+
+  /*
+   * @testName: constructorIntTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:311; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new client error exception.
+   * java.lang.IllegalArgumentException - in case the status code is not a valid
+   * HTTP status code or if it is not from the
+   * Response.Status.Family.CLIENT_ERROR status code family.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorIntTest() throws Fault {
+    for (Status status : Status.values())
+      if (Status.Family
+          .familyOf(status.getStatusCode()) == Status.Family.CLIENT_ERROR) {
+        ClientErrorException e = new ClientErrorException(
+            status.getStatusCode());
+        assertResponse(e, status);
+      }
+  }
+
+  /*
+   * @testName: constructorIntThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:311;
+   * 
+   * @test_Strategy: Construct a new client error exception.
+   * java.lang.IllegalArgumentException - in case the status code is not a valid
+   * HTTP status code or if it is not from the
+   * Response.Status.Family.CLIENT_ERROR status code family.
+   */
+  @Test
+  public void constructorIntThrowsExceptionTest() throws Fault {
+    for (Status status : Status.values())
+      if (Status.Family
+          .familyOf(status.getStatusCode()) != Status.Family.CLIENT_ERROR)
+        try {
+          ClientErrorException e = new ClientErrorException(
+              status.getStatusCode());
+          fault("IllegalArgumentException has not been thrown for status",
+              status, "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been thrown as expected for status",
+              status);
+        }
+  }
+
+  /*
+   * @testName: constructorIntNotValidStatusThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:311;
+   * 
+   * @test_Strategy: Construct a new client error exception.
+   * java.lang.IllegalArgumentException - in case the status code is not a valid
+   * HTTP status code or if it is not from the
+   * Response.Status.Family.CLIENT_ERROR status code family.
+   */
+  @Test
+  public void constructorIntNotValidStatusThrowsExceptionTest() throws Fault {
+    for (int status : new int[] { -1, 999, Integer.MIN_VALUE,
+        Integer.MAX_VALUE })
+      try {
+        ClientErrorException e = new ClientErrorException(status);
+        fault("IllegalArgumentException has not been thrown for status", status,
+            "; exception", e);
+      } catch (IllegalArgumentException e) {
+        logMsg(
+            "IllegalArgumentException has been thrown as expected for status",
+            status);
+      }
+  }
+
+  /*
+   * @testName: constructorResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:312; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new client error exception.
+   * java.lang.IllegalArgumentException - in case the response status code is
+   * not from the Response.Status.Family.CLIENT_ERROR status code family.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorResponseTest() throws Fault {
+    for (Status status : Status.values())
+      if (Status.Family
+          .familyOf(status.getStatusCode()) == Status.Family.CLIENT_ERROR) {
+        Response response = buildResponse(status);
+        ClientErrorException e = new ClientErrorException(response);
+        assertResponse(e, status, HOST);
+      }
+  }
+
+  /*
+   * @testName: constructorResponseThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:312;
+   * 
+   * @test_Strategy: Construct a new client error exception.
+   * java.lang.IllegalArgumentException - in case the response status code is
+   * not from the Response.Status.Family.CLIENT_ERROR status code family.
+   */
+  @Test
+  public void constructorResponseThrowsExceptionTest() throws Fault {
+    for (Status status : Status.values())
+      if (Status.Family
+          .familyOf(status.getStatusCode()) != Status.Family.CLIENT_ERROR)
+        try {
+          Response response = Response.status(status).build();
+          ClientErrorException e = new ClientErrorException(response);
+          fault("IllegalArgumentException has not been thrown for status",
+              status, "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been thrown as expected for status",
+              status);
+        }
+  }
+
+  /*
+   * @testName: constructorStatusThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:313; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new client error exception.
+   * java.lang.IllegalArgumentException - in case the status code is null or if
+   * it is not from the Response.Status.Family.CLIENT_ERROR status code family.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStatusThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Status status : Status.values())
+      if (Status.Family
+          .familyOf(status.getStatusCode()) == Status.Family.CLIENT_ERROR) {
+        for (Throwable throwable : throwables) {
+          ClientErrorException e = new ClientErrorException(status, throwable);
+          assertResponse(e, status);
+          assertCause(e, throwable);
+        }
+      }
+  }
+
+  /*
+   * @testName: constructorStatusThrowableThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:313;
+   * 
+   * @test_Strategy: Construct a new client error exception.
+   * java.lang.IllegalArgumentException - in case the status code is null or if
+   * it is not from the Response.Status.Family.CLIENT_ERROR status code family.
+   */
+  @Test
+  public void constructorStatusThrowableThrowsExceptionTest() throws Fault {
+    for (Status status : Status.values())
+      if (Status.Family
+          .familyOf(status.getStatusCode()) != Status.Family.CLIENT_ERROR)
+        try {
+          ClientErrorException e = new ClientErrorException(status,
+              new Throwable());
+          fault("IllegalArgumentException has not been thrown for status",
+              status, "exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been thrown as expected for status",
+              status);
+        }
+  }
+
+  /*
+   * @testName: constructorStatusNullThrowableThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:313;
+   * 
+   * @test_Strategy: Construct a new client error exception.
+   * java.lang.IllegalArgumentException - in case the status code is null or if
+   * it is not from the Response.Status.Family.CLIENT_ERROR status code family.
+   */
+  @Test
+  public void constructorStatusNullThrowableThrowsExceptionTest() throws Fault {
+    try {
+      ClientErrorException e = new ClientErrorException((Status) null,
+          new Throwable());
+      fault(
+          "IllegalArgumentException has not been thrown for null status; exception",
+          e);
+    } catch (IllegalArgumentException e) {
+      logMsg(
+          "IllegalArgumentException has been thrown as expected for null status");
+    }
+  }
+
+  /*
+   * @testName: constructorIntThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:314; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new client error exception.
+   * java.lang.IllegalArgumentException - in case the status code is not a valid
+   * HTTP status code or if it is not from the
+   * Response.Status.Family.CLIENT_ERROR status code family.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorIntThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Status status : Status.values())
+      if (Status.Family
+          .familyOf(status.getStatusCode()) == Status.Family.CLIENT_ERROR) {
+        for (Throwable throwable : throwables) {
+          ClientErrorException e = new ClientErrorException(
+              status.getStatusCode(), throwable);
+          assertResponse(e, status);
+          assertCause(e, throwable);
+        }
+      }
+  }
+
+  /*
+   * @testName: constructorIntThrowableThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:314;
+   * 
+   * @test_Strategy: Construct a new client error exception.
+   * java.lang.IllegalArgumentException - in case the status code is not a valid
+   * HTTP status code or if it is not from the
+   * Response.Status.Family.CLIENT_ERROR status code family.
+   */
+  @Test
+  public void constructorIntThrowableThrowsExceptionTest() throws Fault {
+    for (Status status : Status.values())
+      if (Status.Family
+          .familyOf(status.getStatusCode()) != Status.Family.CLIENT_ERROR)
+        try {
+          ClientErrorException e = new ClientErrorException(
+              status.getStatusCode(), new Throwable());
+          fault("IllegalArgumentException has not been thrown for status",
+              status, "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been thrown as expected for status",
+              status);
+        }
+  }
+
+  /*
+   * @testName: constructorIntNotValidStatusThrowableThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:314;
+   * 
+   * @test_Strategy: Construct a new client error exception.
+   * java.lang.IllegalArgumentException - in case the status code is not a valid
+   * HTTP status code or if it is not from the
+   * Response.Status.Family.CLIENT_ERROR status code family.
+   */
+  @Test
+  public void constructorIntNotValidStatusThrowableThrowsExceptionTest()
+      throws Fault {
+    for (int status : new int[] { -1, 999, Integer.MIN_VALUE,
+        Integer.MAX_VALUE })
+      try {
+        ClientErrorException e = new ClientErrorException(status,
+            new Throwable());
+        fault("IllegalArgumentException has not been thrown for status", status,
+            "; exception", e);
+      } catch (IllegalArgumentException e) {
+        logMsg(
+            "IllegalArgumentException has been thrown as expected for status",
+            status);
+      }
+  }
+
+  /*
+   * @testName: constructorResponseThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:315; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new client error exception.
+   * java.lang.IllegalArgumentException - in case the response status code is
+   * not from the Response.Status.Family.CLIENT_ERROR status code family.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorResponseThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Status status : Status.values())
+      if (Status.Family
+          .familyOf(status.getStatusCode()) == Status.Family.CLIENT_ERROR) {
+        for (Throwable throwable : throwables) {
+          Response response = buildResponse(status);
+          ClientErrorException e = new ClientErrorException(response,
+              throwable);
+          assertResponse(e, status, HOST);
+          assertCause(e, throwable);
+        }
+      }
+  }
+
+  /*
+   * @testName: constructorResponseThrowableThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:315;
+   * 
+   * @test_Strategy: Construct a new client error exception.
+   * java.lang.IllegalArgumentException - in case the response status code is
+   * not from the Response.Status.Family.CLIENT_ERROR status code family.
+   */
+  @Test
+  public void constructorResponseThrowableThrowsExceptionTest() throws Fault {
+    for (Status status : Status.values())
+      if (Status.Family
+          .familyOf(status.getStatusCode()) != Status.Family.CLIENT_ERROR)
+        try {
+          Response response = Response.status(status).build();
+          ClientErrorException e = new ClientErrorException(response,
+              new Throwable());
+          fault("IllegalArgumentException has not been thrown for status",
+              status, "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been thrown as expected for status",
+              status);
+        }
+  }
+
+  /*
+   * @testName: constructorStringStatusTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1060; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new client error exception. getResponse
+   */
+  @Test
+  public void constructorStringStatusTest() throws Fault {
+    for (Status status : Status.values())
+      if (Status.Family
+          .familyOf(status.getStatusCode()) == Status.Family.CLIENT_ERROR) {
+        ClientErrorException e = new ClientErrorException(MESSAGE, status);
+        assertResponse(e, status);
+        assertMessage(e);
+      }
+  }
+
+  /*
+   * @testName: constructorStringStatusThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1060;
+   * 
+   * @test_Strategy: Construct a new client error exception.
+   * java.lang.IllegalArgumentException - in case the status code is null or if
+   * it is not from the Response.Status.Family.CLIENT_ERROR status code family.
+   */
+  @Test
+  public void constructorStringStatusThrowsIAETest() throws Fault {
+    for (Status status : Status.values())
+      if (Status.Family
+          .familyOf(status.getStatusCode()) != Status.Family.CLIENT_ERROR)
+        try {
+          ClientErrorException e = new ClientErrorException(MESSAGE, status);
+          fault("IllegalArgumentException has not been thrown for status",
+              status, "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been thrown as expected for status",
+              status);
+        }
+  }
+
+  /*
+   * @testName: constructorStringStatusNullThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1060;
+   * 
+   * @test_Strategy: Construct a new client error exception.
+   * java.lang.IllegalArgumentException - in case the status code is null or if
+   * it is not from the Response.Status.Family.CLIENT_ERROR status code family.
+   */
+  @Test
+  public void constructorStringStatusNullThrowsIAETest() throws Fault {
+    try {
+      ClientErrorException e = new ClientErrorException(MESSAGE, (Status) null);
+      fault(
+          "IllegalArgumentException has not been thrown for null status; exception",
+          e);
+    } catch (IllegalArgumentException e) {
+      logMsg(
+          "IllegalArgumentException has been thrown as expected for null status");
+    }
+  }
+
+  /*
+   * @testName: constructorStringIntTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1061; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new client error exception.
+   * java.lang.IllegalArgumentException - in case the status code is not a valid
+   * HTTP status code or if it is not from the
+   * Response.Status.Family.CLIENT_ERROR status code family.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringIntTest() throws Fault {
+    for (Status status : Status.values())
+      if (Status.Family
+          .familyOf(status.getStatusCode()) == Status.Family.CLIENT_ERROR) {
+        ClientErrorException e = new ClientErrorException(MESSAGE,
+            status.getStatusCode());
+        assertResponse(e, status);
+        assertMessage(e);
+      }
+  }
+
+  /*
+   * @testName: constructorStringIntThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1061;
+   * 
+   * @test_Strategy: Construct a new client error exception.
+   * java.lang.IllegalArgumentException - in case the status code is not a valid
+   * HTTP status code or if it is not from the
+   * Response.Status.Family.CLIENT_ERROR status code family.
+   */
+  @Test
+  public void constructorStringIntThrowsIAETest() throws Fault {
+    for (Status status : Status.values())
+      if (Status.Family
+          .familyOf(status.getStatusCode()) != Status.Family.CLIENT_ERROR)
+        try {
+          ClientErrorException e = new ClientErrorException(MESSAGE,
+              status.getStatusCode());
+          fault("IllegalArgumentException has not been thrown for status",
+              status, "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been thrown as expected for status",
+              status);
+        }
+  }
+
+  /*
+   * @testName: constructorStringIntNotValidStatusThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1061;
+   * 
+   * @test_Strategy: Construct a new client error exception.
+   * java.lang.IllegalArgumentException - in case the status code is not a valid
+   * HTTP status code or if it is not from the
+   * Response.Status.Family.CLIENT_ERROR status code family.
+   */
+  @Test
+  public void constructorStringIntNotValidStatusThrowsExceptionTest()
+      throws Fault {
+    for (int status : new int[] { -1, 999, Integer.MIN_VALUE,
+        Integer.MAX_VALUE })
+      try {
+        ClientErrorException e = new ClientErrorException(MESSAGE, status);
+        fault("IllegalArgumentException has not been thrown for status", status,
+            "; exception", e);
+      } catch (IllegalArgumentException e) {
+        logMsg(
+            "IllegalArgumentException has been thrown as expected for status",
+            status);
+      }
+  }
+
+  /*
+   * @testName: constructorStringResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1062; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new client error exception.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringResponseTest() throws Fault {
+    for (Status status : Status.values())
+      if (Status.Family
+          .familyOf(status.getStatusCode()) == Status.Family.CLIENT_ERROR) {
+        Response response = buildResponse(status);
+        ClientErrorException e = new ClientErrorException(MESSAGE, response);
+        assertResponse(e, status, HOST);
+        assertMessage(e);
+      }
+  }
+
+  /*
+   * @testName: constructorStringResponseThrowsIEATest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1062;
+   * 
+   * @test_Strategy: Construct a new client error exception.
+   * java.lang.IllegalArgumentException - in case the response status code is
+   * not from the Response.Status.Family.CLIENT_ERROR status code family.
+   */
+  @Test
+  public void constructorStringResponseThrowsIEATest() throws Fault {
+    for (Status status : Status.values())
+      if (Status.Family
+          .familyOf(status.getStatusCode()) != Status.Family.CLIENT_ERROR)
+        try {
+          Response response = Response.status(status).build();
+          ClientErrorException e = new ClientErrorException(MESSAGE, response);
+          fault("IllegalArgumentException has not been thrown for status",
+              status, "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been thrown as expected for status",
+              status);
+        }
+  }
+
+  /*
+   * @testName: constructorStringStatusThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1063; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new client error exception. getResponse
+   */
+  @Test
+  public void constructorStringStatusThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Status status : Status.values())
+      if (Status.Family
+          .familyOf(status.getStatusCode()) == Status.Family.CLIENT_ERROR) {
+        for (Throwable throwable : throwables) {
+          ClientErrorException e = new ClientErrorException(MESSAGE, status,
+              throwable);
+          assertResponse(e, status);
+          assertCause(e, throwable);
+          assertMessage(e);
+        }
+      }
+  }
+
+  /*
+   * @testName: constructorStringStatusThrowableThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1063;
+   * 
+   * @test_Strategy: Construct a new client error exception.
+   * java.lang.IllegalArgumentException - in case the status code is null or if
+   * it is not from the Response.Status.Family.CLIENT_ERROR status code family.
+   */
+  @Test
+  public void constructorStringStatusThrowableThrowsIAETest() throws Fault {
+    for (Status status : Status.values())
+      if (Status.Family
+          .familyOf(status.getStatusCode()) != Status.Family.CLIENT_ERROR)
+        try {
+          ClientErrorException e = new ClientErrorException(MESSAGE, status,
+              new Throwable());
+          fault("IllegalArgumentException has not been thrown for status",
+              status, "exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been thrown as expected for status",
+              status);
+        }
+  }
+
+  /*
+   * @testName: constructorStringStatusNullThrowableThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1063;
+   * 
+   * @test_Strategy: Construct a new client error exception.
+   * java.lang.IllegalArgumentException - in case the status code is null or if
+   * it is not from the Response.Status.Family.CLIENT_ERROR status code family.
+   */
+  @Test
+  public void constructorStringStatusNullThrowableThrowsIAETest() throws Fault {
+    try {
+      ClientErrorException e = new ClientErrorException(MESSAGE, (Status) null,
+          new Throwable());
+      fault(
+          "IllegalArgumentException has not been thrown for null status; exception",
+          e);
+    } catch (IllegalArgumentException e) {
+      logMsg(
+          "IllegalArgumentException has been thrown as expected for null status");
+    }
+  }
+
+  /*
+   * @testName: constructorStringIntThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1064; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new client error exception.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringIntThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Status status : Status.values())
+      if (Status.Family
+          .familyOf(status.getStatusCode()) == Status.Family.CLIENT_ERROR) {
+        for (Throwable throwable : throwables) {
+          ClientErrorException e = new ClientErrorException(MESSAGE,
+              status.getStatusCode(), throwable);
+          assertResponse(e, status);
+          assertCause(e, throwable);
+          assertMessage(e);
+        }
+      }
+  }
+
+  /*
+   * @testName: constructorStringIntThrowableThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1064;
+   * 
+   * @test_Strategy: Construct a new client error exception.
+   * java.lang.IllegalArgumentException - in case the status code is not a valid
+   * HTTP status code or if it is not from the
+   * Response.Status.Family.CLIENT_ERROR status code family.
+   */
+  @Test
+  public void constructorStringIntThrowableThrowsIAETest() throws Fault {
+    for (Status status : Status.values())
+      if (Status.Family
+          .familyOf(status.getStatusCode()) != Status.Family.CLIENT_ERROR)
+        try {
+          ClientErrorException e = new ClientErrorException(MESSAGE,
+              status.getStatusCode(), new Throwable());
+          fault("IllegalArgumentException has not been thrown for status",
+              status, "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been thrown as expected for status",
+              status);
+        }
+  }
+
+  /*
+   * @testName: constructorStringIntNotValidStatusThrowableThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1064;
+   * 
+   * @test_Strategy: Construct a new client error exception.
+   * java.lang.IllegalArgumentException - in case the status code is not a valid
+   * HTTP status code or if it is not from the
+   * Response.Status.Family.CLIENT_ERROR status code family.
+   */
+  @Test
+  public void constructorStringIntNotValidStatusThrowableThrowsIAETest()
+      throws Fault {
+    for (int status : new int[] { -1, 999, Integer.MIN_VALUE,
+        Integer.MAX_VALUE })
+      try {
+        ClientErrorException e = new ClientErrorException(MESSAGE, status,
+            new Throwable());
+        fault("IllegalArgumentException has not been thrown for status", status,
+            "; exception", e);
+      } catch (IllegalArgumentException e) {
+        logMsg(
+            "IllegalArgumentException has been thrown as expected for status",
+            status);
+      }
+  }
+
+  /*
+   * @testName: constructorStringResponseThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1065; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new client error exception.
+   * java.lang.IllegalArgumentException - in case the response status code is
+   * not from the Response.Status.Family.CLIENT_ERROR status code family.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringResponseThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Status status : Status.values())
+      if (Status.Family
+          .familyOf(status.getStatusCode()) == Status.Family.CLIENT_ERROR) {
+        for (Throwable throwable : throwables) {
+          Response response = buildResponse(status);
+          ClientErrorException e = new ClientErrorException(MESSAGE, response,
+              throwable);
+          assertResponse(e, status, HOST);
+          assertCause(e, throwable);
+          assertMessage(e);
+        }
+      }
+  }
+
+  /*
+   * @testName: constructorStringResponseThrowableThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1065;
+   * 
+   * @test_Strategy: Construct a new client error exception.
+   * java.lang.IllegalArgumentException - in case the response status code is
+   * not from the Response.Status.Family.CLIENT_ERROR status code family.
+   */
+  @Test
+  public void constructorStringResponseThrowableThrowsIAETest() throws Fault {
+    for (Status status : Status.values())
+      if (Status.Family
+          .familyOf(status.getStatusCode()) != Status.Family.CLIENT_ERROR)
+        try {
+          Response response = Response.status(status).build();
+          ClientErrorException e = new ClientErrorException(MESSAGE, response,
+              new Throwable());
+          fault("IllegalArgumentException has not been thrown for status",
+              status, "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been thrown as expected for status",
+              status);
+        }
+  }
+
+  // ////////////////////////////////////////////////////////////////////////
+  protected Response buildResponse(Status status) {
+    Response r = Response.status(status).header(HttpHeaders.HOST, HOST).build();
+    return r;
+  }
+
+  protected void assertResponse(ClientErrorException e, Status status)
+      throws Fault {
+    assertNotNull(e.getResponse(), "getResponse is null");
+    int got = e.getResponse().getStatus();
+    assertEqualsInt(got, status.getStatusCode(), "Status set in Response", got,
+        "differes from expected", status);
+    logMsg("Response of the exception contains expected status", status);
+  }
+
+  /**
+   * Check the given exception contains a prebuilt response containing the http
+   * header HOST
+   */
+  protected void assertResponse(ClientErrorException e, Status status,
+      String host) throws Fault {
+    assertResponse(e, status);
+    String header = e.getResponse().getHeaderString(HttpHeaders.HOST);
+    assertNotNull(header, "http header", HttpHeaders.HOST,
+        " of response is null");
+    assertEquals(host, header, "Found unexpected http", HttpHeaders.HOST,
+        "header", header);
+    logMsg("Found expected http", HttpHeaders.HOST, "header");
+  }
+
+  protected void assertCause(WebApplicationException e, Throwable expected)
+      throws Fault {
+    assertEquals(e.getCause(), expected, "#getCause does not contain expected",
+        expected, "but", e.getCause());
+    logMsg("getCause contains expected", expected);
+  }
+
+  protected void assertMessage(ClientErrorException e) throws Fault {
+    assertNotNull(e.getMessage(), "getMessage() is null");
+    assertContains(e.getMessage(), MESSAGE, "Unexpected getMessage()",
+        e.getMessage());
+    logMsg("found expected getMessage()=", e.getMessage());
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/abstractmultivaluedmap/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/abstractmultivaluedmap/JAXRSClientIT.java
@@ -1,0 +1,714 @@
+/*
+ * Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.core.abstractmultivaluedmap;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.util.Set;
+
+import jakarta.ws.rs.core.AbstractMultivaluedMap;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+    private static final long serialVersionUID = -6248642901050437887L;
+
+    protected static final String KEY = "key";
+
+    @BeforeEach
+    void logStartTest(TestInfo testInfo) {
+        TestUtil.logMsg("STARTING TEST : " + testInfo.getDisplayName());
+    }
+
+    @AfterEach
+    void logFinishTest(TestInfo testInfo) {
+        TestUtil.logMsg("FINISHED TEST : " + testInfo.getDisplayName());
+    }
+
+    /*
+     * @testName: constructorTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:726;
+     * 
+     * @test_Strategy: Initialize the backing store in the abstract parent
+     * multivalued map implementation.
+     */
+    @Test
+    public void constructorTest() throws Fault {
+        AbstractMultivaluedMap<String, Object> map = createMap();
+        assertContainsDefaultValues(map);
+    }
+
+    /*
+     * @testName: addTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:727; JAXRS:JAVADOC:96;
+     * 
+     * @test_Strategy: Add a value to the current list of values for the supplied
+     * key. NOTE: This implementation ignores values; A supplied value of is ignored
+     * and not added to the value list. Overriding implementations may modify this
+     * behavior by redefining the #addNull method
+     */
+    @Test
+    public void addTest() throws Fault {
+        AbstractMultivaluedMap<String, Object> map = createMap();
+        map.add("key2", VALUES[3]);
+        map.add("key2", VALUES[4]);
+        assertContains(map, "key2", VALUES[3], VALUES[4]);
+    }
+
+    /*
+     * @testName: addNullKeyTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:727; JAXRS:JAVADOC:96;
+     * 
+     * @test_Strategy: Add a value to the current list of values for the supplied
+     * key. NOTE: This implementation ignores values; A supplied value of is ignored
+     * and not added to the value list. Overriding implementations may modify this
+     * behavior by redefining the #addNull method
+     */
+    @Test
+    public void addNullKeyTest() throws Fault {
+        AbstractMultivaluedMap<String, Object> map = createMap();
+        map.add(null, VALUES[3]);
+        assertContains(map, null, VALUES[3]);
+    }
+
+    /*
+     * @testName: addNullValuesTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:727; JAXRS:JAVADOC:96;
+     * 
+     * @test_Strategy: Add a value to the current list of values for the supplied
+     * key. NOTE: This implementation ignores values; A supplied value of is ignored
+     * and not added to the value list. Overriding implementations may modify this
+     * behavior by redefining the #addNull method
+     */
+    @Test
+    public void addNullValuesTest() throws Fault {
+        AbstractMultivaluedMap<String, Object> map = createMap();
+        map.add("key2", null);
+        map.add("key3", null);
+        assertNotContains(map, "key2", (Object) null);
+        assertNotContains(map, "key3", (Object) null);
+    }
+
+    /*
+     * @testName: addAllValuesTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:728; JAXRS:JAVADOC:832;
+     * 
+     * @test_Strategy: Add multiple values to the current list of values for the
+     * supplied key. If the supplied array of new values is empty, method returns
+     * immediately.
+     */
+    @Test
+    public void addAllValuesTest() throws Fault {
+        AbstractMultivaluedMap<String, Object> map = createMap();
+        map.addAll(KEY, VALUES[3], VALUES[4]);
+        assertContainsDefaultValues(map);
+        assertContains(map, KEY, VALUES[3], VALUES[4]);
+    }
+
+    /*
+     * @testName: addAllNullValuesTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:728; JAXRS:JAVADOC:832;
+     * 
+     * @test_Strategy: Add multiple values to the current list of values for the
+     * supplied key. If the supplied array of new values is empty, method returns
+     * immediately.
+     */
+    @Test
+    public void addAllNullValuesTest() throws Fault {
+        AbstractMultivaluedMap<String, Object> map = createMap();
+        map.addAll(KEY, VALUES[3], null);
+        assertContainsDefaultValues(map);
+        assertContains(map, KEY, VALUES[3]);
+        assertNotContains(map, KEY, (Object) null);
+    }
+
+    /*
+     * @testName: addAllEmptyValuesTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:728; JAXRS:JAVADOC:832;
+     * 
+     * @test_Strategy: Add multiple values to the current list of values for the
+     * supplied key. If the supplied array of new values is empty, method returns
+     * immediately.
+     */
+    @Test
+    public void addAllEmptyValuesTest() throws Fault {
+        AbstractMultivaluedMap<String, Object> map = createMap();
+        map.addAll("key2", new Object[] {});
+        assertContainsDefaultValues(map);
+        assertTrue(!map.containsKey("key2"), "The method didn't returned immediatelly when empty array");
+    }
+
+    /*
+     * @testName: addAllThrowsNPETest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:728; JAXRS:JAVADOC:832;
+     * 
+     * @test_Strategy: Method throws a NullPointerException if the supplied array of
+     * values is null.
+     */
+    @Test
+    public void addAllThrowsNPETest() throws Fault {
+        AbstractMultivaluedMap<String, Object> map = createMap();
+        try {
+            map.addAll("key2", (Object[]) null);
+            throw new Fault("NullPointerException has not been thrown");
+        } catch (NullPointerException e) {
+            logMsg("NullPointerException has been thrown as expected", e);
+        }
+    }
+
+    /*
+     * @testName: addAllListTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:729; JAXRS:JAVADOC:833;
+     * 
+     * @test_Strategy: Add all the values from the supplied value list to the
+     * current list of values for the supplied key. If the supplied value list is
+     * empty, method returns immediately.
+     */
+    @Test
+    public void addAllListTest() throws Fault {
+        AbstractMultivaluedMap<String, Object> map = createMap();
+        List<Object> list = new ArrayList<Object>();
+        list.add(VALUES[3]);
+        list.add(VALUES[4]);
+        map.addAll(KEY, list);
+        assertContainsDefaultValues(map);
+        assertContains(map, KEY, VALUES[3], VALUES[4]);
+    }
+
+    /*
+     * @testName: addAllListNullValuesTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:729; JAXRS:JAVADOC:833;
+     * 
+     * @test_Strategy: Add all the values from the supplied value list to the
+     * current list of values for the supplied key. If the supplied value list is
+     * empty, method returns immediately.
+     * 
+     */
+    @Test
+    public void addAllListNullValuesTest() throws Fault {
+        AbstractMultivaluedMap<String, Object> map = createMap();
+        List<Object> list = new ArrayList<Object>();
+        list.add(VALUES[3]);
+        list.add(null);
+        map.addAll(KEY, list);
+        assertContainsDefaultValues(map);
+        assertContains(map, KEY, VALUES[3]);
+        assertNotContains(map, KEY, (Object) null);
+    }
+
+    /*
+     * @testName: addAllListEmptyValuesTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:729; JAXRS:JAVADOC:833;
+     * 
+     * @test_Strategy: Add all the values from the supplied value list to the
+     * current list of values for the supplied key. If the supplied value list is
+     * empty, method returns immediately.
+     */
+    @Test
+    public void addAllListEmptyValuesTest() throws Fault {
+        AbstractMultivaluedMap<String, Object> map = createMap();
+        map.addAll("key2", new ArrayList<Object>());
+        assertContainsDefaultValues(map);
+        assertTrue(!map.containsKey("key2"), "The method didn't returned immediatelly when empty array");
+    }
+
+    /*
+     * @testName: addAllListThrowsNPETest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:729; JAXRS:JAVADOC:833;
+     * 
+     * @test_Strategy: Throws: NullPointerException - if the supplied value list is
+     * null.
+     * 
+     */
+    @Test
+    public void addAllListThrowsNPETest() throws Fault {
+        AbstractMultivaluedMap<String, Object> map = createMap();
+        try {
+            map.addAll("key2", (List<Object>) null);
+            throw new Fault("NullPointerException has not been thrown");
+        } catch (NullPointerException e) {
+            logMsg("NullPointerException has been thrown as expected", e);
+        }
+    }
+
+    /*
+     * @testName: addFirstTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:730; JAXRS:JAVADOC:738; JAXRS:JAVADOC:834;
+     * JAXRS:JAVADOC:97;
+     * 
+     * @test_Strategy: Add a value to the first position in the current list of
+     * values for the supplied key.
+     * 
+     * A shortcut to get the first value of the supplied key.
+     */
+    @Test
+    public void addFirstTest() throws Fault {
+        AbstractMultivaluedMap<String, Object> map = createMap();
+        map.addFirst(KEY, VALUES[3]);
+        Object first = map.getFirst(KEY);
+        assertTrue(first.equals(VALUES[3]), "First is unexpected item " + first);
+        logMsg("Found first item", first);
+    }
+
+    /*
+     * @testName: addFirstNullTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:730; JAXRS:JAVADOC:834;
+     * 
+     * @test_Strategy: Add a value to the first position in the current list of
+     * values for the supplied key.
+     * 
+     */
+    @Test
+    public void addFirstNullTest() throws Fault {
+        AbstractMultivaluedMap<String, Object> map = createMap();
+        map.addFirst(KEY, null);
+        assertContainsDefaultValues(map);
+        assertNotContains(map, KEY, (Object) null);
+    }
+
+    /*
+     * @testName: clearTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:731;
+     * 
+     * @test_Strategy: clears all items
+     */
+    @Test
+    public void clearTest() throws Fault {
+        AbstractMultivaluedMap<String, Object> map = createMap();
+        map.clear();
+        assertNotContains(map, KEY, VALUES[0], VALUES[1], VALUES[2]);
+    }
+
+    /*
+     * @testName: containsKeyTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:732;
+     * 
+     * @test_Strategy: informs about containing key
+     */
+    @Test
+    public void containsKeyTest() throws Fault {
+        AbstractMultivaluedMap<String, Object> map = createMap();
+        map.add(null, VALUES[3]);
+        assertTrue(map.containsKey(KEY), "#containsKey has not found given key");
+        assertTrue(map.containsKey(null), "#containsKey has not found NULL key");
+        logMsg("#containsKey found non-null key and also the null key");
+    }
+
+    /*
+     * @testName: containsValueTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:733;
+     * 
+     * @test_Strategy: informs about containing value
+     */
+    @Test
+    public void containsValueTest() throws Fault {
+        AbstractMultivaluedMap<String, Object> map = createMap();
+        List<Object> list = map.get(KEY);
+        assertTrue(map.containsValue(list), "#containsValue has not found " + list);
+        assertTrue(!map.containsValue(VALUES[3]), "#containsValue has found " + VALUES[3]);
+        assertTrue(!map.containsValue(KEY), "#containsValue has found key");
+        logMsg("#containsValue() found list of items as expected");
+    }
+
+    /*
+     * @testName: entrySetTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:734;
+     * 
+     * @test_Strategy: gets the entry Set
+     */
+    @Test
+    public void entrySetTest() throws Fault {
+        AbstractMultivaluedMap<String, Object> map = createMap();
+        Set<Entry<String, List<Object>>> set = map.entrySet();
+        for (Entry<String, List<Object>> entry : set) {
+            assertTrue(entry.getKey().equals(KEY), "no key has been found in #entrySet()");
+            List<Object> list = entry.getValue();
+            assertTrue(list.contains(VALUES[0]), VALUES[0] + " was not found in #entrySet()");
+            assertTrue(list.contains(VALUES[1]), VALUES[1] + " was not found in #entrySet()");
+            assertTrue(list.contains(VALUES[2]), VALUES[2] + " was not found in #entrySet()");
+        }
+        logMsg("#entrySet() has correct values");
+    }
+
+    /*
+     * @testName: equalsTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:735;
+     * 
+     * @test_Strategy: This implementation delegates the method call to to the the
+     * underlying [key, multi-value] store.
+     */
+    @Test
+    public void equalsTest() throws Fault {
+        ArrayList<Object> list = new ArrayList<Object>();
+        list.add(VALUES[0]);
+        Map<String, List<Object>> hashMap = new HashMap<String, List<Object>>();
+        hashMap.put(KEY, list);
+
+        AbstractMultivaluedMap<String, Object> map = new AbstractMultivaluedMap<String, Object>(hashMap) {
+        };
+        assertTrue(map.equals(hashMap), "delegation of #equals() not sucessfull");
+        hashMap.put("key2", list);
+        assertTrue(map.equals(hashMap), "delegation of #equals() not sucessfull");
+
+        logMsg("#equals() is delegated to underlaying map");
+    }
+
+    /*
+     * @testName: getTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:737;
+     * 
+     * @test_Strategy: get the list of items
+     */
+    @Test
+    public void getTest() throws Fault {
+        ArrayList<Object> list = new ArrayList<Object>();
+        list.add(VALUES[0]);
+        Map<String, List<Object>> hashMap = new HashMap<String, List<Object>>();
+        hashMap.put(KEY, list);
+
+        AbstractMultivaluedMap<String, Object> map = new AbstractMultivaluedMap<String, Object>(hashMap) {
+        };
+        assertTrue(map.get(KEY) == list, "#get() not sucessfull");
+        logMsg("#get() is sucessfull");
+    }
+
+    /*
+     * @testName: hashCodeTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:739;
+     * 
+     * @test_Strategy: This implementation delegates the method call to to the the
+     * underlying [key, multi-value] store.
+     */
+    @Test
+    public void hashCodeTest() throws Fault {
+        ArrayList<Object> list = new ArrayList<Object>();
+        list.add(VALUES[0]);
+        Map<String, List<Object>> hashMap = new HashMap<String, List<Object>>();
+        hashMap.put(KEY, list);
+
+        AbstractMultivaluedMap<String, Object> map = new AbstractMultivaluedMap<String, Object>(hashMap) {
+        };
+        assertTrue(map.hashCode() == map.hashCode(), "delegation of #hashCode() not sucessfull");
+        hashMap.put("key2", list);
+        assertTrue(map.hashCode() == map.hashCode(), "delegation of #hashCode() not sucessfull");
+
+        logMsg("#hashCode() is delegated to underlaying map");
+    }
+
+    /*
+     * @testName: isEmptyTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:740;
+     * 
+     * @test_Strategy: check whether it is empty
+     */
+    @Test
+    public void isEmptyTest() throws Fault {
+        AbstractMultivaluedMap<String, Object> map = createMap();
+        assertTrue(!map.isEmpty(), "#isEmpty returns true for one key and a list");
+        map.clear();
+        assertTrue(map.isEmpty(), "#isEmpty returns false after #clear call");
+        map.add(null, VALUES[0]);
+        assertTrue(!map.isEmpty(), "#isEmpty returns true for null key and a list");
+
+        logMsg("#isEmpty returns correct values");
+    }
+
+    /*
+     * @testName: keySetTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:741;
+     * 
+     * @test_Strategy: keySet test
+     */
+    @Test
+    public void keySetTest() throws Fault {
+        AbstractMultivaluedMap<String, Object> map = createMap();
+        assertTrue(map.keySet().size() == 1, "#keySet returns set of size " + map.keySet().size() + " for one key");
+        map.add("key2", VALUES[3]);
+        assertTrue(map.keySet().size() == 2, "#keySet returns set of size " + map.keySet().size() + " for two keys");
+        assertTrue(map.keySet().contains(KEY), "key was not found");
+        assertTrue(map.keySet().contains("key2"), "key2 was not found");
+
+        map.clear();
+        assertTrue(map.keySet().size() == 0, "#keySet returns set of size " + map.keySet().size() + " after #clear()");
+        map.add(null, VALUES[3]);
+        assertTrue(map.keySet().size() == 1, "#keySet returns set of size " + map.keySet().size() + " for null key");
+        logMsg("#keySet returns correct values");
+    }
+
+    /*
+     * @testName: putTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:742;
+     * 
+     * @test_Strategy: put
+     */
+    @Test
+    public void putTest() throws Fault {
+        ArrayList<Object> list = new ArrayList<Object>();
+        list.add(VALUES[0]);
+        list.add(VALUES[1]);
+        list.add(VALUES[2]);
+
+        Map<String, List<Object>> hashMap = new HashMap<String, List<Object>>();
+        AbstractMultivaluedMap<String, Object> map = new AbstractMultivaluedMap<String, Object>(hashMap) {
+        };
+        map.put(KEY, list);
+        assertContainsDefaultValues(map);
+
+        logMsg("#put() put the value");
+    }
+
+    /*
+     * @testName: putAllTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:743;
+     * 
+     * @test_Strategy: putAll
+     */
+    @Test
+    public void putAllTest() throws Fault {
+        ArrayList<Object> list = new ArrayList<Object>();
+        list.add(VALUES[0]);
+        list.add(VALUES[1]);
+        list.add(VALUES[2]);
+        Map<String, List<Object>> hashMap = new HashMap<String, List<Object>>();
+        hashMap.put(KEY, list);
+        hashMap.put("key2", list);
+
+        AbstractMultivaluedMap<String, Object> map = createMap();
+        map.clear();
+        assertTrue(map.isEmpty(), "#clear did not emptied map");
+        map.putAll(hashMap);
+        assertContainsDefaultValues(map);
+        assertContains(map, "key2", VALUES[0], VALUES[1], VALUES[2]);
+
+        logMsg("#putAll() put all the values of both keys");
+    }
+
+    /*
+     * @testName: putSingleTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:744; JAXRS:JAVADOC:98;
+     * 
+     * @test_Strategy: Set the value for the key to be a one item list consisting of
+     * the supplied value. Any existing values will be replaced. NOTE: This
+     * implementation ignores values; A supplied value of is ignored and not added
+     * to the purged value list. As a result of such operation, empty value list
+     * would be registered for the supplied key
+     */
+    @Test
+    public void putSingleTest() throws Fault {
+        AbstractMultivaluedMap<String, Object> map = createMap();
+        map.putSingle(KEY, VALUES[4]);
+        assertContains(map, KEY, VALUES[4]);
+        assertNotContains(map, KEY, VALUES[0], VALUES[1], VALUES[2]);
+
+        logMsg("#putSingle() sucessfully replaced the values by a new one");
+    }
+
+    /*
+     * @testName: putSingleNullValueTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:744; JAXRS:JAVADOC:98;
+     * 
+     * @test_Strategy: Set the value for the key to be a one item list consisting of
+     * the supplied value. Any existing values will be replaced. NOTE: This
+     * implementation ignores null values; A supplied value of is ignored and not
+     * added to the purged value list. As a result of such operation, empty value
+     * list would be registered for the supplied key
+     */
+    @Test
+    public void putSingleNullValueTest() throws Fault {
+        AbstractMultivaluedMap<String, Object> map = createMap();
+        map.putSingle(KEY, null);
+        assertNotContains(map, KEY, (Object) null);
+        logMsg("#putSingle(key, null) did replaced the values as expected");
+    }
+
+    /*
+     * @testName: removeTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:745;
+     * 
+     * @test_Strategy: remove the correct key
+     */
+    @Test
+    public void removeTest() throws Fault {
+        AbstractMultivaluedMap<String, Object> map = createMap();
+        map.add("key2", VALUES[3]);
+        List<Object> list = map.remove(KEY);
+        assertTrue(list.size() == 3, "removed a list of size " + list.size());
+        assertNotContains(map, KEY, VALUES[0], VALUES[1], VALUES[2]);
+        assertContains(map, "key2", VALUES[3]);
+        logMsg("#removeTest(key) removed the correct key and the value as expected");
+    }
+
+    /*
+     * @testName: sizeTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:746;
+     * 
+     * @test_Strategy: check correct size
+     */
+    @Test
+    public void sizeTest() throws Fault {
+        AbstractMultivaluedMap<String, Object> map = createMap();
+        map.add("key2", VALUES[3]);
+        assertTrue(map.size() == 2, "returned unexpected size " + map.size());
+        map.clear();
+        assertTrue(map.size() == 0, "returned unexpected size after clear " + map.size());
+        logMsg("#size() returns correct values");
+    }
+
+    /*
+     * @testName: toStringTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:747;
+     * 
+     * @test_Strategy: check toString does something
+     */
+    @Test
+    public void toStringTest() throws Fault {
+        AbstractMultivaluedMap<String, Object> map = createMap();
+        assertTrue(map.toString() != null, "#toString isNull");
+        logMsg("#toString returned", map.toString());
+    }
+
+    /*
+     * @testName: valuesTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:748;
+     * 
+     * @test_Strategy: check correct values
+     */
+    @Test
+    public void valuesTest() throws Fault {
+        AbstractMultivaluedMap<String, Object> map = createMap();
+        map.add("key2", VALUES[3]);
+        Collection<List<Object>> values = map.values();
+
+        for (List<Object> list : values)
+            assertTrue(list.size() == 1 || list.size() == 3, "Got unexpected values of size " + list.size());
+        assertTrue(values.size() == 2, "Unexpected #values of size " + values.size());
+        logMsg("#values returned", values.size(), "lists");
+    }
+
+    /*
+     * @testName: equalsIgnoreValueOrderTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:736;
+     * 
+     * @test_Strategy: Compare the specified map with this map for equality modulo
+     * the order of values for each key. Specifically, the values associated with
+     * each key are compared as if they were ordered lists.
+     */
+    @Test
+    public void equalsIgnoreValueOrderTest() throws Fault {
+        AbstractMultivaluedMap<String, Object> map = createMap();
+        MultivaluedHashMap<String, Object> map2 = new MultivaluedHashMap<String, Object>();
+        map2.addAll(KEY, VALUES[2], VALUES[0], VALUES[1]);
+
+        assertTrue(map.equalsIgnoreValueOrder(map2), map + " and " + map2 + " are not equalIgnoreValueOrder");
+        assertFalse(map.equals(map2), map + " and " + map2 + " are equal");
+        logMsg("#equalsIgnoreValueOrder compared maps", map, "and", map2, "as expected");
+    }
+
+    // ////////////////////////////////////////////////////////////////////////
+    static final String[] VALUES = { "value1", "value2", "value3", "value4", "value5" };
+
+    protected static AbstractMultivaluedMap<String, Object> createMap() {
+        return createMap(KEY, VALUES[0], VALUES[1], VALUES[2]);
+    }
+
+    protected static AbstractMultivaluedMap<String, Object> createMap(String key, Object... values) {
+        Map<String, List<Object>> hashMap = new HashMap<String, List<Object>>();
+        ArrayList<Object> list = new ArrayList<Object>();
+        list.addAll(Arrays.asList(values));
+        hashMap.put(key, list);
+        AbstractMultivaluedMap<String, Object> map = new AbstractMultivaluedMap<String, Object>(hashMap) {
+        };
+        return map;
+    }
+
+    protected static void assertContainsDefaultValues(AbstractMultivaluedMap<String, Object> map) throws Fault {
+        assertContains(map, KEY, VALUES[0], VALUES[1], VALUES[2]);
+    }
+
+    protected static void assertContains(AbstractMultivaluedMap<String, Object> map, String key, Object... values)
+            throws Fault {
+        List<Object> list = map.get(key);
+        for (Object item : values)
+            assertTrue(list.contains(item), "Given map does not contain value " + item);
+        logMsg("Found key", key, "with following values:");
+        logMsg(values);
+    }
+
+    protected static void assertNotContains(AbstractMultivaluedMap<String, Object> map, String key, Object... values)
+            throws Fault {
+        List<Object> list = map.get(key);
+        if (list != null)
+            for (Object item : values)
+                assertTrue(!list.contains(item), "Given map does contain value " + item);
+        logMsg("Given key", key, "does not contain following values as expected:");
+        logMsg(values);
+    }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/cachecontrol/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/cachecontrol/JAXRSClientIT.java
@@ -1,0 +1,838 @@
+/*
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.core.cachecontrol;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.core.CacheControl;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+    private static final long serialVersionUID = 1L;
+
+    static Object[] expected = { (boolean) true, (boolean) false, (boolean) false, (boolean) false, (boolean) true,
+            (boolean) false, (boolean) false, new ArrayList<String>(), new ArrayList<String>() };
+
+    static String _root = "/jaxrs_rs_core_cacheControlTest_web";
+
+    @BeforeEach
+    void logStartTest(TestInfo testInfo) {
+        TestUtil.logMsg("STARTING TEST : " + testInfo.getDisplayName());
+    }
+
+    @AfterEach
+    void logFinishTest(TestInfo testInfo) {
+        TestUtil.logMsg("FINISHED TEST : " + testInfo.getDisplayName());
+    }
+
+    /*
+     * @testName: emptyConstructorTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:24; JAXRS:JAVADOC:28; JAXRS:JAVADOC:29;
+     * JAXRS:JAVADOC:32; JAXRS:JAVADOC:33; JAXRS:JAVADOC:34; JAXRS:JAVADOC:35;
+     * JAXRS:JAVADOC:36; JAXRS:JAVADOC:37;
+     * 
+     * @test_Strategy: Client instantiate a CacheControl instance using Constructor
+     * CacheControl(). Verify all values are set correctly.
+     */
+    @Test
+    public void emptyConstructorTest() throws Fault {
+        boolean pass = true;
+        StringBuffer sb = new StringBuffer();
+
+        CacheControl ccl = new CacheControl();
+        pass = verifyList(expected, ccl, sb);
+        assertTrue(pass, "At least one assertion failed: " + sb);
+    }
+
+    /*
+     * @testName: maxAgeTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:24; JAXRS:JAVADOC:28; JAXRS:JAVADOC:29;
+     * JAXRS:JAVADOC:30; JAXRS:JAVADOC:32; JAXRS:JAVADOC:33; JAXRS:JAVADOC:34;
+     * JAXRS:JAVADOC:35; JAXRS:JAVADOC:36; JAXRS:JAVADOC:37; JAXRS:JAVADOC:38;
+     * 
+     * @test_Strategy: Client instantiate a CacheControl instance using Constructor
+     * CacheControl(). Verify all values are set correctly.
+     */
+    @Test
+    public void maxAgeTest() throws Fault {
+        boolean pass = true;
+        StringBuffer sb = new StringBuffer();
+
+        int maxAge = -1;
+
+        CacheControl ccl1 = new CacheControl();
+        ccl1.setMaxAge(maxAge);
+
+        pass = verifyList(expected, ccl1, sb);
+        pass &= verifyMaxAge(ccl1, maxAge, sb);
+
+        maxAge = 2000;
+        ccl1.setMaxAge(maxAge);
+        pass &= verifyList(expected, ccl1, sb);
+        pass &= verifyMaxAge(ccl1, maxAge, sb);
+
+        assertTrue(pass, "At least one assertion failed: " + sb);
+    }
+
+    /*
+     * @testName: sMaxAgeTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:24; JAXRS:JAVADOC:27; JAXRS:JAVADOC:28;
+     * JAXRS:JAVADOC:29; JAXRS:JAVADOC:32; JAXRS:JAVADOC:33; JAXRS:JAVADOC:34;
+     * JAXRS:JAVADOC:35; JAXRS:JAVADOC:36; JAXRS:JAVADOC:37; JAXRS:JAVADOC:45;
+     * 
+     * @test_Strategy: Client instantiate a CacheControl instance using Constructor
+     * CacheControl(). Verify all values are set correctly.
+     */
+    @Test
+    public void sMaxAgeTest() throws Fault {
+        boolean pass = true;
+        StringBuffer sb = new StringBuffer();
+
+        int sMaxAge = -1;
+
+        CacheControl ccl1 = new CacheControl();
+        ccl1.setSMaxAge(sMaxAge);
+
+        pass = verifyList(expected, ccl1, sb);
+        pass &= verifySMaxAge(ccl1, sMaxAge, sb);
+
+        sMaxAge = 2000;
+        ccl1.setSMaxAge(sMaxAge);
+        pass &= verifyList(expected, ccl1, sb);
+        pass &= verifySMaxAge(ccl1, sMaxAge, sb);
+
+        assertTrue(pass, "At least one assertion failed: " + sb);
+    }
+
+    /*
+     * @testName: revalidateTest
+     *
+     * @assertion_ids: JAXRS:JAVADOC:24; JAXRS:JAVADOC:28; JAXRS:JAVADOC:29;
+     * JAXRS:JAVADOC:32; JAXRS:JAVADOC:33; JAXRS:JAVADOC:34; JAXRS:JAVADOC:35;
+     * JAXRS:JAVADOC:36; JAXRS:JAVADOC:37; JAXRS:JAVADOC:39;
+     *
+     * @test_Strategy: Client instantiate a CacheControl instance using Constructor
+     * CacheControl(). Verify all values are set correctly.
+     */
+    @Test
+    public void revalidateTest() throws Fault {
+        boolean pass = true;
+        StringBuffer sb = new StringBuffer();
+
+        boolean revalidate = false;
+        expected[5] = revalidate;
+
+        CacheControl ccl2 = new CacheControl();
+        ccl2.setMustRevalidate(revalidate);
+
+        pass = verifyList(expected, ccl2, sb);
+        sb.append("Finished the first round");
+
+        revalidate = true;
+        expected[5] = revalidate;
+
+        ccl2.setMustRevalidate(revalidate);
+
+        pass &= verifyList(expected, ccl2, sb);
+
+        assertTrue(pass, "At least one assertion failed: " + sb);
+    }
+
+    /*
+     * @testName: noCacheTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:24; JAXRS:JAVADOC:28; JAXRS:JAVADOC:29;
+     * JAXRS:JAVADOC:32; JAXRS:JAVADOC:33; JAXRS:JAVADOC:34; JAXRS:JAVADOC:35;
+     * JAXRS:JAVADOC:36; JAXRS:JAVADOC:37; JAXRS:JAVADOC:40;
+     * 
+     * @test_Strategy: Client instantiate a CacheControl instance using Constructor
+     * CacheControl(). Verify all values are set correctly.
+     */
+    @Test
+    public void noCacheTest() throws Fault {
+        boolean pass = true;
+        StringBuffer sb = new StringBuffer();
+
+        boolean nocache = false;
+        expected[2] = nocache;
+
+        CacheControl ccl3 = new CacheControl();
+        ccl3.setNoCache(nocache);
+
+        pass = verifyList(expected, ccl3, sb);
+
+        nocache = true;
+        expected[2] = nocache;
+
+        ccl3.setNoCache(nocache);
+        pass &= verifyList(expected, ccl3, sb);
+
+        assertTrue(pass, "At least one assertion failed: " + sb);
+    }
+
+    /*
+     * @testName: noStoreTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:24; JAXRS:JAVADOC:28; JAXRS:JAVADOC:29;
+     * JAXRS:JAVADOC:32; JAXRS:JAVADOC:33; JAXRS:JAVADOC:34; JAXRS:JAVADOC:35;
+     * JAXRS:JAVADOC:36; JAXRS:JAVADOC:37; JAXRS:JAVADOC:41;
+     * 
+     * @test_Strategy: Client instantiate a CacheControl instance using Constructor
+     * CacheControl(). Verify all values are set correctly.
+     */
+    @Test
+    public void noStoreTest() throws Fault {
+        boolean pass = true;
+        StringBuffer sb = new StringBuffer();
+
+        boolean nostore = false;
+        expected[3] = nostore;
+
+        CacheControl ccl4 = new CacheControl();
+        ccl4.setNoStore(nostore);
+
+        pass = verifyList(expected, ccl4, sb);
+
+        nostore = true;
+        expected[3] = nostore;
+
+        ccl4.setNoStore(nostore);
+
+        pass &= verifyList(expected, ccl4, sb);
+        assertTrue(pass, "At least one assertion failed: " + sb);
+    }
+
+    /*
+     * @testName: noTransformTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:24; JAXRS:JAVADOC:28; JAXRS:JAVADOC:29;
+     * JAXRS:JAVADOC:32; JAXRS:JAVADOC:33; JAXRS:JAVADOC:34; JAXRS:JAVADOC:35;
+     * JAXRS:JAVADOC:36; JAXRS:JAVADOC:37; JAXRS:JAVADOC:42;
+     * 
+     * @test_Strategy: Client instantiate a CacheControl instance using Constructor
+     * CacheControl(). Verify all values are set correctly.
+     */
+    @Test
+    public void noTransformTest() throws Fault {
+        boolean pass = true;
+        StringBuffer sb = new StringBuffer();
+
+        boolean notransform = false;
+        expected[4] = notransform;
+
+        CacheControl ccl4 = new CacheControl();
+        ccl4.setNoTransform(notransform);
+
+        pass = verifyList(expected, ccl4, sb);
+
+        notransform = true;
+        expected[4] = notransform;
+
+        ccl4.setNoTransform(notransform);
+
+        pass &= verifyList(expected, ccl4, sb);
+        assertTrue(pass, "At least one assertion failed: " + sb);
+    }
+
+    /*
+     * @testName: privateTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:24; JAXRS:JAVADOC:28; JAXRS:JAVADOC:29;
+     * JAXRS:JAVADOC:32; JAXRS:JAVADOC:33; JAXRS:JAVADOC:34; JAXRS:JAVADOC:35;
+     * JAXRS:JAVADOC:36; JAXRS:JAVADOC:37; JAXRS:JAVADOC:43;
+     * 
+     * @test_Strategy: Client instantiate a CacheControl instance using Constructor
+     * CacheControl(). Verify all values are set correctly.
+     */
+    @Test
+    public void privateTest() throws Fault {
+        boolean pass = true;
+        StringBuffer sb = new StringBuffer();
+
+        boolean _private = false;
+        expected[1] = _private;
+
+        CacheControl ccl5 = new CacheControl();
+        ccl5.setPrivate(_private);
+
+        pass = verifyList(expected, ccl5, sb);
+
+        _private = true;
+        expected[1] = _private;
+
+        ccl5.setPrivate(_private);
+
+        pass &= verifyList(expected, ccl5, sb);
+        assertTrue(pass, "At least one assertion failed: " + sb);
+    }
+
+    /*
+     * @testName: proxyRevalidateTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:24; JAXRS:JAVADOC:28; JAXRS:JAVADOC:29;
+     * JAXRS:JAVADOC:32; JAXRS:JAVADOC:33; JAXRS:JAVADOC:34; JAXRS:JAVADOC:35;
+     * JAXRS:JAVADOC:36; JAXRS:JAVADOC:37; JAXRS:JAVADOC:44;
+     * 
+     * @test_Strategy: Client instantiate a CacheControl instance using Constructor
+     * CacheControl(). Verify all values are set correctly.
+     */
+    @Test
+    public void proxyRevalidateTest() throws Fault {
+        boolean pass = true;
+        StringBuffer sb = new StringBuffer();
+
+        boolean proxyRevalidate = false;
+        expected[6] = proxyRevalidate;
+
+        CacheControl ccl5 = new CacheControl();
+        ccl5.setProxyRevalidate(proxyRevalidate);
+
+        pass = verifyList(expected, ccl5, sb);
+
+        proxyRevalidate = true;
+        expected[6] = proxyRevalidate;
+
+        ccl5.setProxyRevalidate(proxyRevalidate);
+
+        pass &= verifyList(expected, ccl5, sb);
+        assertTrue(pass, "At least one assertion failed: " + sb);
+    }
+
+    /*
+     * @testName: equalsTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:24; JAXRS:JAVADOC:25; JAXRS:JAVADOC:31;
+     * JAXRS:JAVADOC:38; JAXRS:JAVADOC:39; JAXRS:JAVADOC:40; JAXRS:JAVADOC:41;
+     * JAXRS:JAVADOC:42; JAXRS:JAVADOC:43; JAXRS:JAVADOC:44; JAXRS:JAVADOC:45;
+     * 
+     * @test_Strategy: Client instantiate two CacheControl instance using
+     * Constructor CacheControl(). Setting all their properties one by one, verify
+     * hashCode and equals methods work correctly and accordingly.
+     */
+    @Test
+    public void equalsTest() throws Fault {
+        boolean pass = true;
+        StringBuffer sb = new StringBuffer();
+
+        CacheControl ccl6 = new CacheControl();
+        CacheControl ccl7 = new CacheControl();
+
+        ccl6.setProxyRevalidate(false);
+        ccl7.setProxyRevalidate(true);
+        if (ccl6.equals(ccl7)) {
+            pass = false;
+            sb.append("UnEqual Test setProxyRevalidate failed." + newline);
+        }
+
+        if (ccl6.hashCode() == ccl7.hashCode()) {
+            pass = false;
+            sb.append("HashCode UnEqual Test setProxyRevalidate failed." + newline);
+        }
+
+        ccl7.setProxyRevalidate(false);
+        if (!ccl6.equals(ccl7)) {
+            pass = false;
+            sb.append("Equal Test setProxyRevalidate failed." + newline);
+        }
+
+        if (ccl6.hashCode() != ccl7.hashCode()) {
+            pass = false;
+            sb.append("HashCode Equal Test setProxyRevalidate failed." + newline);
+        }
+
+        ccl6.setPrivate(true);
+        ccl7.setPrivate(false);
+        if (ccl6.equals(ccl7)) {
+            pass = false;
+            sb.append("UnEqual Test setPrivate failed." + newline);
+        }
+
+        if (ccl6.hashCode() == ccl7.hashCode()) {
+            pass = false;
+            sb.append("HashCode UnEqual Test setPrivate failed." + newline);
+        }
+
+        ccl7.setPrivate(true);
+        if (!ccl6.equals(ccl7)) {
+            pass = false;
+            sb.append("Equal Test setPrivate failed." + newline);
+        }
+
+        if (ccl6.hashCode() != ccl7.hashCode()) {
+            pass = false;
+            sb.append("HashCode Equal Test setPrivate failed." + newline);
+        }
+
+        ccl6.setNoTransform(true);
+        ccl7.setNoTransform(false);
+        if (ccl6.equals(ccl7)) {
+            pass = false;
+            sb.append("UnEqual Test setNoTransform failed." + newline);
+        }
+
+        if (ccl6.hashCode() == ccl7.hashCode()) {
+            pass = false;
+            sb.append("HashCode UnEqual Test setNoTransform failed." + newline);
+        }
+
+        ccl7.setNoTransform(true);
+        if (!ccl6.equals(ccl7)) {
+            pass = false;
+            sb.append("Equal Test setNoTransform failed." + newline);
+        }
+
+        if (ccl6.hashCode() != ccl7.hashCode()) {
+            pass = false;
+            sb.append("HashCode Equal Test setNoTransform failed." + newline);
+        }
+
+        ccl6.setNoStore(true);
+        ccl7.setNoStore(false);
+        if (ccl6.equals(ccl7)) {
+            pass = false;
+            sb.append("UnEqual Test setNoStore failed." + newline);
+        }
+
+        if (ccl6.hashCode() == ccl7.hashCode()) {
+            pass = false;
+            sb.append("HashCode UnEqual Test setNoStore failed." + newline);
+        }
+
+        ccl7.setNoStore(true);
+        if (!ccl6.equals(ccl7)) {
+            pass = false;
+            sb.append("Equal Test setNoStore failed." + newline);
+        }
+
+        if (ccl6.hashCode() != ccl7.hashCode()) {
+            pass = false;
+            sb.append("HashCode Equal Test setNoStore failed." + newline);
+        }
+
+        ccl6.setNoCache(true);
+        ccl7.setNoCache(false);
+        if (ccl6.equals(ccl7)) {
+            pass = false;
+            sb.append("UnEqual Test setNoCache failed." + newline);
+        }
+
+        if (ccl6.hashCode() == ccl7.hashCode()) {
+            pass = false;
+            sb.append("HashCode UnEqual Test setNoCache failed." + newline);
+        }
+
+        ccl7.setNoCache(true);
+        if (!ccl6.equals(ccl7)) {
+            pass = false;
+            sb.append("Equal Test setNoCache failed." + newline);
+        }
+
+        if (ccl6.hashCode() != ccl7.hashCode()) {
+            pass = false;
+            sb.append("HashCode Equal Test setNoCache failed." + newline);
+        }
+
+        ccl6.setMustRevalidate(true);
+        ccl7.setMustRevalidate(false);
+        if (ccl6.equals(ccl7)) {
+            pass = false;
+            sb.append("UnEqual Test setMustRevalidate failed." + newline);
+        }
+
+        if (ccl6.hashCode() == ccl7.hashCode()) {
+            pass = false;
+            sb.append("HashCode UnEqual Test setMustRevalidate failed." + newline);
+        }
+
+        ccl7.setMustRevalidate(true);
+        if (!ccl6.equals(ccl7)) {
+            pass = false;
+            sb.append("Equal Test setMustRevalidate failed." + newline);
+        }
+
+        if (ccl6.hashCode() != ccl7.hashCode()) {
+            pass = false;
+            sb.append("HashCode Equal Test setMustRevalidate failed." + newline);
+        }
+
+        ccl6.setSMaxAge(-1);
+        ccl7.setSMaxAge(200);
+        if (ccl6.equals(ccl7)) {
+            pass = false;
+            sb.append("UnEqual Test setSMaxAge failed." + newline);
+        }
+
+        if (ccl6.hashCode() == ccl7.hashCode()) {
+            pass = false;
+            sb.append("HashCode UnEqual Test setSMaxAge failed." + newline);
+        }
+
+        ccl7.setSMaxAge(-1);
+        if (!ccl6.equals(ccl7)) {
+            pass = false;
+            sb.append("Equal Test setSMaxAge failed." + newline);
+        }
+
+        if (ccl6.hashCode() != ccl7.hashCode()) {
+            pass = false;
+            sb.append("HashCode UnEqual Test setSMaxAge failed." + newline);
+        }
+
+        ccl6.setMaxAge(-1);
+        ccl7.setMaxAge(200);
+        if (ccl6.equals(ccl7)) {
+            pass = false;
+            sb.append("UnEqual Test setMaxAge failed." + newline);
+        }
+
+        if (ccl6.hashCode() == ccl7.hashCode()) {
+            pass = false;
+            sb.append("HashCode UnEqual Test setMaxAge failed." + newline);
+        }
+
+        ccl7.setMaxAge(-1);
+        if (!ccl6.equals(ccl7)) {
+            pass = false;
+            sb.append("Equal Test setMaxAge failed." + newline);
+        }
+
+        if (ccl6.hashCode() != ccl7.hashCode()) {
+            pass = false;
+            sb.append("HashCode UnEqual Test setMaxAge failed." + newline);
+        }
+
+        assertTrue(pass, "At least one assertion failed: " + sb);
+    }
+
+    /*
+     * @testName: toStringTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:24; JAXRS:JAVADOC:38; JAXRS:JAVADOC:39;
+     * JAXRS:JAVADOC:40; JAXRS:JAVADOC:41; JAXRS:JAVADOC:42; JAXRS:JAVADOC:43;
+     * JAXRS:JAVADOC:44; JAXRS:JAVADOC:45; JAXRS:JAVADOC:46;
+     * 
+     * @test_Strategy: Client instantiate a CacheControl instance using Constructor
+     * CacheControl(). Setting all their properties verify toString method work
+     * correctly and accordingly.
+     */
+    @Test
+    public void toStringTest() throws Fault {
+        boolean pass = true;
+        StringBuffer sb = new StringBuffer();
+
+        CacheControl ccl8 = new CacheControl();
+
+        ccl8.setProxyRevalidate(true);
+        ccl8.setPrivate(true);
+        ccl8.setNoTransform(true);
+        ccl8.setNoStore(true);
+        ccl8.setNoCache(true);
+        ccl8.setMustRevalidate(false);
+        ccl8.setSMaxAge(-1);
+        ccl8.setMaxAge(200);
+
+        String value = ccl8.toString().toLowerCase();
+        sb.append(value + newline);
+
+        if (!value.contains("private")) {
+            pass = false;
+            sb.append("ToString test failed in Private" + newline);
+        }
+
+        if (!value.contains("no-cache")) {
+            pass = false;
+            sb.append("ToString test failed in no-cache" + newline);
+        }
+
+        if (!value.contains("no-store")) {
+            pass = false;
+            sb.append("ToString test failed in no-store" + newline);
+        }
+
+        if (!value.contains("no-transform")) {
+            pass = false;
+            sb.append("ToString test failed in no-transform" + newline);
+        }
+
+        if (!value.contains("proxy-revalidate")) {
+            pass = false;
+            sb.append("ToString test failed in proxy-revalidate" + newline);
+        }
+
+        if (!value.contains("max-age=200")) {
+            pass = false;
+            sb.append("ToString test failed in max-age=200" + newline);
+        }
+
+        if (value.contains("s-maxage")) {
+            pass = false;
+            sb.append("ToString test failed in s-maxage" + newline);
+        }
+
+        if (value.contains("must-revalidate")) {
+            pass = false;
+            sb.append("ToString test failed in must-revalidate" + newline);
+        }
+
+        assertTrue(pass, "At least one assertion failed: " + sb);
+    }
+
+    /*
+     * @testName: getExtensionTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:26;
+     * 
+     * @test_Strategy: Client instantiate one CacheControl instance using
+     * Constructor CacheControl(). verify getCacheExtension method work correctly.
+     */
+    @Test
+    public void getExtensionTest() throws Fault {
+        boolean pass = true;
+        StringBuffer sb = new StringBuffer();
+
+        Map<String, String> map_exp = new HashMap<String, String>();
+        map_exp.put("community", "\"UCI\"");
+
+        CacheControl ccl8 = new CacheControl();
+
+        ccl8.setProxyRevalidate(true);
+        ccl8.setPrivate(true);
+        ccl8.setNoTransform(true);
+        ccl8.setNoStore(true);
+        ccl8.setNoCache(true);
+        ccl8.setMustRevalidate(false);
+        ccl8.setSMaxAge(-1);
+        ccl8.setMaxAge(200);
+
+        Map<String, String> map_actual = ccl8.getCacheExtension();
+
+        if (map_actual.size() != 0) {
+            pass = false;
+            sb.append("Expected map size 0, got" + map_actual.size() + newline);
+        }
+
+        map_actual.put("community", "\"UCI\"");
+        map_actual = ccl8.getCacheExtension();
+
+        if (!map_exp.equals(map_actual)) {
+            pass = false;
+            sb.append("Map comparison failed" + newline);
+        }
+
+        sb.append("Expected Map: ");
+
+        for (Entry<String, String> entry : map_exp.entrySet()) {
+            sb.append("key=" + entry.getKey() + "; value=" + entry.getValue() + ";" + newline);
+        }
+
+        if (!pass) {
+            for (Entry<String, String> entry : map_actual.entrySet()) {
+                sb.append("key= " + entry.getKey() + "; value=" + entry.getValue() + ";");
+                sb.append(newline);
+            }
+            throw new Fault("At least one assertion failed: " + sb.toString());
+        }
+
+        TestUtil.logTrace(sb.toString());
+    }
+
+    /*
+     * @testName: valueOfTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:47;
+     * 
+     * @test_Strategy: Client instantiate one CacheControl instance using
+     * Constructor CacheControl.valueOf(String). verify valueOf method work
+     * correctly.
+     */
+    @Test
+    public void valueOfTest() throws Fault {
+        boolean pass = true;
+        StringBuffer sb = new StringBuffer();
+
+        String value_to_parse = "private, no-cache, no-store, no-transform, proxy-revalidate, max-age=200";
+
+        CacheControl ccl8 = CacheControl.valueOf(value_to_parse);
+
+        String value = ccl8.toString().toLowerCase();
+        sb.append(value + newline);
+
+        if (!value.contains("private")) {
+            pass = false;
+            sb.append("ToString test failed in Private" + newline);
+        }
+
+        if (!value.contains("no-cache")) {
+            pass = false;
+            sb.append("ToString test failed in no-cache" + newline);
+        }
+
+        if (!value.contains("no-store")) {
+            pass = false;
+            sb.append("ToString test failed in no-store" + newline);
+        }
+
+        if (!value.contains("no-transform")) {
+            pass = false;
+            sb.append("ToString test failed in no-transform" + newline);
+        }
+
+        if (!value.contains("proxy-revalidate")) {
+            pass = false;
+            sb.append("ToString test failed in proxy-revalidate" + newline);
+        }
+
+        if (!value.contains("max-age=200")) {
+            pass = false;
+            sb.append("ToString test failed in max-age=200" + newline);
+        }
+
+        if (value.contains("s-maxage")) {
+            pass = false;
+            sb.append("ToString test failed in s-maxage" + newline);
+        }
+
+        if (value.contains("must-revalidate")) {
+            pass = false;
+            sb.append("ToString test failed in must-revalidate" + newline);
+        }
+
+        assertTrue(pass, "At least one assertion failed: " + sb);
+
+        TestUtil.logTrace("Test passed. " + sb.toString());
+    }
+
+    /*
+     * @testName: valueOfTest1
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:47;
+     * 
+     * @test_Strategy: Client instantiate one CacheControl instance using
+     * Constructor CacheControl.valueOf(null). verify IllegalArgumentException is
+     * thrown.
+     */
+    @Test
+    public void valueOfTest1() throws Fault {
+        boolean pass = true;
+        StringBuffer sb = new StringBuffer();
+
+        try {
+            CacheControl.valueOf(null);
+            pass = false;
+            sb.append("Expected IllegalArgumentException not thrown" + newline);
+        } catch (IllegalArgumentException iex) {
+            sb.append("Expected IllegalArgumentException thrown" + newline);
+        } catch (Throwable any) {
+            sb.append("Wrong type of Exception thrown" + any.fillInStackTrace());
+            pass = false;
+
+        }
+
+        assertTrue(pass, "At least one assertion failed: " + sb);
+
+        TestUtil.logTrace("Test passed. " + sb.toString());
+    }
+
+    @Override
+    @BeforeEach
+    public void cleanup() {
+        expected[0] = true;
+        expected[1] = false; // Private
+        expected[2] = false; // No-cache
+        expected[3] = false; // No-Store
+        expected[4] = true; // No-Transform
+        expected[5] = false; // Must-Revalidate
+        expected[6] = false; // ProxyRevalidate
+    }
+
+    private static boolean verifyMaxAge(CacheControl ccl, int maxAge, StringBuffer sb) {
+        boolean pass = true;
+        if (ccl.getMaxAge() != maxAge) {
+            pass = false;
+            sb.append("set/getMaxAge test failed.  Expecting " + maxAge + ", got " + ccl.getMaxAge() + ".");
+        }
+        return pass;
+    }
+
+    private static boolean verifySMaxAge(CacheControl ccl, int maxAge, StringBuffer sb) {
+        boolean pass = true;
+        if (ccl.getSMaxAge() != maxAge) {
+            pass = false;
+            sb.append("set/getMaxAge test failed.  Expecting " + maxAge + ", got " + ccl.getMaxAge() + ".");
+        }
+        return pass;
+    }
+
+    private static boolean verifyList(Object[] expected, CacheControl ccl, StringBuffer sb) {
+        boolean pass = true;
+
+        if (ccl.isPrivate() != (Boolean) expected[1]) {
+            pass = false;
+            sb.append("isPrivate test failed.  Expecting =" + expected[1] + "; Got =" + ccl.isPrivate());
+        }
+        if (ccl.isNoCache() != (Boolean) expected[2]) {
+            pass = false;
+            sb.append("isNoCache test failed.  Expecting =" + expected[2] + "; Got =" + ccl.isNoCache());
+        }
+        if (ccl.isNoStore() != (Boolean) expected[3]) {
+            pass = false;
+            sb.append("isNoStore test failed.  Expecting =" + expected[3] + "; Got =" + ccl.isNoStore());
+        }
+        if (ccl.isNoTransform() != (Boolean) expected[4]) {
+            pass = false;
+            sb.append("isNoTransform test failed.  Expecting =" + expected[4] + "; Got =" + ccl.isNoTransform());
+        }
+        if (ccl.isMustRevalidate() != (Boolean) expected[5]) {
+            pass = false;
+            sb.append("isMustRevalidate test failed.  Expecting =" + expected[5] + "; Got =" + ccl.isMustRevalidate());
+        }
+        if (ccl.isProxyRevalidate() != (Boolean) expected[6]) {
+            pass = false;
+            sb.append(
+                    "isProxyRevalidate test failed.  Expecting =" + expected[6] + "; Got =" + ccl.isProxyRevalidate());
+        }
+        if (!ccl.getPrivateFields().equals(expected[7])) {
+            pass = false;
+            sb.append("getPrivateFields test failed.  Expecting =" + expected[7] + "; Got =" + ccl.getPrivateFields());
+        }
+        if (!ccl.getNoCacheFields().equals(expected[8])) {
+            pass = false;
+            sb.append("getNoCacheFields test failed.  Expecting =" + expected[8] + "; Got =" + ccl.getNoCacheFields());
+        }
+        return pass;
+
+    }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/configurable/Assertable.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/configurable/Assertable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,37 +16,33 @@
 
 package jakarta.ws.rs.tck.api.rs.core.configurable;
 
-import jakarta.ws.rs.tck.common.JAXRSCommonClient.Fault;
-
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient.Fault;
 
 public abstract class Assertable {
-  final static String[] LOCATION = { "Client", "WebTarget",
-      "Invocation.Builder", "Invocation" };
+    final static String[] LOCATION = { "Client", "WebTarget", "Invocation.Builder", "Invocation" };
 
-  private int locationIndex = 0;
+    private int locationIndex = 0;
 
-  public abstract void check1OnClient(Client client) throws Fault;
+    public abstract void check1OnClient(Client client) throws Fault;
 
-  public abstract void check2OnTarget(WebTarget target) throws Fault;
+    public abstract void check2OnTarget(WebTarget target) throws Fault;
 
-  public void incrementLocation() {
-    locationIndex = (locationIndex + 1 == LOCATION.length) ? 0
-        : locationIndex + 1;
-  }
+    public void incrementLocation() {
+        locationIndex = (locationIndex + 1 == LOCATION.length) ? 0 : locationIndex + 1;
+    }
 
-  public String getLocation() {
-    return new StringBuilder().append("on ").append(LOCATION[locationIndex])
-        .append(" configuration").toString();
-  }
+    public String getLocation() {
+        return new StringBuilder().append("on ").append(LOCATION[locationIndex]).append(" configuration").toString();
+    }
 
-  public static String getLocation(int index) {
-    return LOCATION[index];
-  }
+    public static String getLocation(int index) {
+        return LOCATION[index];
+    }
 
-  public int getLocationIndex() {
-    return locationIndex;
-  }
+    public int getLocationIndex() {
+        return locationIndex;
+    }
 
 }

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/configurable/CallableProvider.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/configurable/CallableProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,14 +23,13 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.concurrent.Callable;
 
-import jakarta.ws.rs.tck.common.util.JaxrsUtil;
-
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.ext.MessageBodyReader;
 import jakarta.ws.rs.ext.MessageBodyWriter;
 import jakarta.ws.rs.ext.Provider;
+import jakarta.ws.rs.tck.common.util.JaxrsUtil;
 
 @Provider
 public class CallableProvider

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/configurable/ConfigurableObject.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/configurable/ConfigurableObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -24,6 +24,6 @@ import jakarta.ws.rs.core.Configurable;
  */
 public interface ConfigurableObject {
 
-  void config(Configurable<?> config);
+    void config(Configurable<?> config);
 
 }

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/configurable/FeatureReturningFalse.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/configurable/FeatureReturningFalse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,9 +20,9 @@ import jakarta.ws.rs.core.Feature;
 import jakarta.ws.rs.core.FeatureContext;
 
 public class FeatureReturningFalse implements Feature {
-  @Override
-  public boolean configure(FeatureContext context) {
-    // false returning feature is not to be registered
-    return false;
-  }
+    @Override
+    public boolean configure(FeatureContext context) {
+        // false returning feature is not to be registered
+        return false;
+    }
 }

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/configurable/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/configurable/JAXRSClientIT.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.core.configurable;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Configurable;
+import jakarta.ws.rs.core.Configuration;
+import jakarta.ws.rs.core.Feature;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+    private static final long serialVersionUID = -6880902064949040518L;
+
+    private int registeredClassesCnt = -1;
+
+    private int registeredInstancesCnt = -1;
+
+    @BeforeEach
+    void logStartTest(TestInfo testInfo) {
+        TestUtil.logMsg("STARTING TEST : " + testInfo.getDisplayName());
+    }
+
+    @AfterEach
+    void logFinishTest(TestInfo testInfo) {
+        TestUtil.logMsg("FINISHED TEST : " + testInfo.getDisplayName());
+    }
+
+    /*
+     * @testName: registerFeatureClassReturningFalseTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:754;
+     * 
+     * @test_Strategy: Register a feature meta-provider to be instantiated and used
+     * in the scope of this configurable context.
+     * 
+     * Any subsequent registration attempts for a component type, for which a class
+     * or instance-based registration already exists in the system MUST be rejected
+     * by the JAX-RS implementation and a warning SHOULD be raised to inform the
+     * user about the rejected registration.
+     */
+    @Test
+    public void registerFeatureClassReturningFalseTest() throws Fault {
+        Assertable assertable = new SingleCheckAssertable() {
+            @Override
+            protected void check(Configurable<?> configurable) throws Fault {
+                assertSizeAndLog(configurable);
+            }
+
+            void assertSizeAndLog(Configurable<?> config) throws Fault {
+                int cnt = config.getConfiguration().getClasses().size();
+                assertEqualsInt(cnt, 1 + registeredClassesCnt, "unexpected number of registered classes found:", cnt,
+                        getLocation());
+                logMsg("Found", cnt, "features");
+            }
+
+        };
+        Class<?>[] classes = new Class<?>[] { FeatureReturningFalse.class, FeatureReturningFalse.class };
+        checkConfig(assertable, classes);
+    }
+
+    /*
+     * @testName: registerFeatureClassReturningFalseWithPriorityTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:755;
+     * 
+     * @test_Strategy: Register a feature meta-provider to be instantiated and used
+     * in the scope of this configurable context.
+     * 
+     * Any subsequent registration attempts for a component type, for which a class
+     * or instance-based registration already exists in the system MUST be rejected
+     * by the JAX-RS implementation and a warning SHOULD be raised to inform the
+     * user about the rejected registration.
+     */
+    @Test
+    public void registerFeatureClassReturningFalseWithPriorityTest() throws Fault {
+        Assertable assertable = new SingleCheckAssertable() {
+            @Override
+            protected void check(Configurable<?> configurable) throws Fault {
+                assertSizeAndLog(configurable);
+            }
+
+            void assertSizeAndLog(Configurable<?> config) throws Fault {
+                int cnt = config.getConfiguration().getClasses().size();
+                assertEqualsInt(cnt, 1 + registeredClassesCnt, "unexpected number of registered classes found:", cnt,
+                        getLocation());
+                logMsg("Found", cnt, "features");
+            }
+
+        };
+
+        Registrar registrar = new Registrar() {
+            int priority = 0;
+
+            @Override
+            public void register(Configurable<?> config, Object registerable) {
+                config.register((Class<?>) registerable, ++priority);
+            }
+        };
+
+        Class<?>[] classes = new Class<?>[] { FeatureReturningFalse.class, FeatureReturningFalse.class };
+        checkConfig(registrar, assertable, classes);
+    }
+
+    /*
+     * @testName: registerFeatureInstanceReturningFalseTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:758;
+     * 
+     * @test_Strategy: Register a feature. In case the registered provider is a
+     * client-side Feature feature, this object instantiates the feature and invokes
+     * the Feature#configure(FeatureContext) method and lets the feature update it's
+     * internal configuration state.
+     */
+    @Test
+    public void registerFeatureInstanceReturningFalseTest() throws Fault {
+        final Feature feature = new FeatureReturningFalse();
+        Assertable assertable = new SingleCheckAssertable() {
+            @Override
+            protected void check(Configurable<?> configurable) throws Fault {
+                assertSizeAndLog(configurable);
+            }
+
+            void assertSizeAndLog(Configurable<?> config) throws Fault {
+                int cnt = config.getConfiguration().getInstances().size();
+                assertEqualsInt(cnt, 1 + registeredInstancesCnt, "unexpected number of registered instances found:",
+                        cnt, getLocation());
+                logMsg("Found", cnt, "features");
+            }
+
+        };
+        Object[] features = new Object[] { feature, feature };
+        checkConfig(assertable, features);
+    }
+
+    /*
+     * @testName: registerClassContractsTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:756;
+     * 
+     * @test_Strategy: Register a feature meta-provider to be instantiated and used
+     * in the scope of this configurable context.
+     * 
+     * Any subsequent registration attempts for a component type, for which a class
+     * or instance-based registration already exists in the system MUST be rejected
+     * by the JAX-RS implementation and a warning SHOULD be raised to inform the
+     * user about the rejected registration.
+     */
+    @Test
+    public void registerClassContractsTest() throws Fault {
+        Assertable assertable = new SingleCheckAssertable() {
+            @Override
+            protected void check(Configurable<?> configurable) throws Fault {
+                assertSizeAndLog(configurable);
+            }
+
+            void assertSizeAndLog(Configurable<?> config) throws Fault {
+                int cnt = config.getConfiguration().getClasses().size();
+                assertEqualsInt(cnt, 1 + registeredClassesCnt, "unexpected number of registered classes found:", cnt,
+                        getLocation());
+                logMsg("Found", cnt, "features");
+            }
+
+        };
+
+        Registrar registrar = new Registrar() {
+            int priority = 0;
+
+            @Override
+            public void register(Configurable<?> config, Object registerable) {
+                config.register((Class<?>) registerable, ++priority);
+            }
+        };
+
+        Class<?>[] classes = new Class<?>[] { FeatureReturningFalse.class, FeatureReturningFalse.class };
+        checkConfig(registrar, assertable, classes);
+    }
+
+    // ///////////////////////////////////////////////////////////////////////
+    /**
+     * Check on every possible setting of configuration by a Feature or a singleton
+     * 
+     */
+    protected void checkConfig(Assertable assertable, Object[] registerables) throws Fault {
+        checkConfig(new Registrar(), assertable, registerables);
+    }
+
+    protected void checkConfig(Registrar registrar, Assertable assertable, Object[] registerables) throws Fault {
+        Client client = ClientBuilder.newClient();
+        Configuration config = client.getConfiguration();
+        registeredClassesCnt = config.getClasses().size();
+        registeredInstancesCnt = config.getInstances().size();
+        logMsg("Already registered", registeredClassesCnt, "classes");
+        logMsg("Already registered", registeredInstancesCnt, "instances");
+
+        register(registrar, client, registerables[0]);
+        assertable.check1OnClient(client);
+        assertable.incrementLocation();
+
+        WebTarget target = client.target("http://tck.cts:888");
+        register(registrar, target, registerables[1]);
+        assertable.check2OnTarget(target);
+        assertable.incrementLocation();
+    }
+
+    protected void register(Registrar registrar, Configurable<?> config, Object registerable) {
+        registrar.register(config, registerable);
+    }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/configurable/Registrar.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/configurable/Registrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,13 +23,13 @@ import jakarta.ws.rs.core.Configurable;
  * The default behavior is for single argument register method
  */
 public class Registrar {
-  public void register(Configurable<?> config, Object registerable) {
-    if (registerable instanceof Class) // register(Class)
-      config.register((Class<?>) registerable);
-    else if (registerable instanceof String) // setProperty()
-      config.property((String) registerable, registerable);
-    else
-      // register(Object)
-      config.register(registerable);
-  }
+    public void register(Configurable<?> config, Object registerable) {
+        if (registerable instanceof Class) // register(Class)
+            config.register((Class<?>) registerable);
+        else if (registerable instanceof String) // setProperty()
+            config.property((String) registerable, registerable);
+        else
+            // register(Object)
+            config.register(registerable);
+    }
 }

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/configurable/SingleCheckAssertable.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/configurable/SingleCheckAssertable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,11 +16,10 @@
 
 package jakarta.ws.rs.tck.api.rs.core.configurable;
 
-import jakarta.ws.rs.tck.common.JAXRSCommonClient.Fault;
-
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Configurable;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient.Fault;
 
 public abstract class SingleCheckAssertable extends Assertable {
 

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/configuration/CallableProvider1.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/configuration/CallableProvider1.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.core.configuration;
+
+import jakarta.ws.rs.tck.api.rs.core.configurable.CallableProvider;
+
+public class CallableProvider1 extends CallableProvider {
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/configuration/CallableProvider2.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/configuration/CallableProvider2.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.core.configuration;
+
+import jakarta.ws.rs.tck.api.rs.core.configurable.CallableProvider;
+
+public class CallableProvider2 extends CallableProvider {
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/configuration/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/configuration/JAXRSClientIT.java
@@ -1,0 +1,770 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.core.configuration;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.RuntimeType;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Configurable;
+import jakarta.ws.rs.core.Configuration;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.tck.api.rs.core.configurable.Assertable;
+import jakarta.ws.rs.tck.api.rs.core.configurable.CallableProvider;
+import jakarta.ws.rs.tck.api.rs.core.configurable.Registrar;
+import jakarta.ws.rs.tck.api.rs.core.configurable.SingleCheckAssertable;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+    private static final long serialVersionUID = -6325966971451285868L;
+
+    private int registeredPropertiesCnt = -1;
+
+    private int registeredClassesCnt = -1;
+
+    private int registeredInstancesCnt = -1;
+
+    @BeforeEach
+    void logStartTest(TestInfo testInfo) {
+        TestUtil.logMsg("STARTING TEST : " + testInfo.getDisplayName());
+    }
+
+    @AfterEach
+    void logFinishTest(TestInfo testInfo) {
+        TestUtil.logMsg("FINISHED TEST : " + testInfo.getDisplayName());
+    }
+
+    /*
+     * @testName: getPropertiesTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:995; JAXRS:JAVADOC:758;
+     * 
+     * @test_Strategy: Get the immutable bag of configuration properties. Set the
+     * new configuration property
+     */
+    @Test
+    public void getPropertiesTest() throws Fault {
+        Assertable assertable = new Assertable() {
+
+            @Override
+            public void check1OnClient(Client client) throws Fault {
+                assertSizeAndLog(client.getConfiguration(), 1);
+            }
+
+            @Override
+            public void check2OnTarget(WebTarget target) throws Fault {
+                assertSizeAndLog(target.getConfiguration(), 2);
+            }
+
+            void assertSizeAndLog(Configuration config, int size) throws Fault {
+                int pSize = config.getProperties().size();
+                assertEqualsInt(pSize, size + registeredPropertiesCnt,
+                        "getConfiguration().getProperties() is not unexpected", getLocation(), "got", pSize,
+                        "properties");
+                logMsg("Found", pSize, "properties");
+            }
+
+        };
+        checkConfigWithProperties(assertable);
+    }
+
+    /*
+     * @testName: getPropertiesIsImmutableTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:995; JAXRS:JAVADOC:758;
+     * 
+     * @test_Strategy: Get the immutable bag of configuration properties. Set the
+     * new configuration property
+     */
+    @Test
+    public void getPropertiesIsImmutableTest() throws Fault {
+        Assertable assertable = new Assertable() {
+
+            @Override
+            public void check1OnClient(Client client) throws Fault {
+                setNewProperty(client.getConfiguration());
+                assertSizeAndLog(client.getConfiguration(), 1);
+            }
+
+            @Override
+            public void check2OnTarget(WebTarget target) throws Fault {
+                setNewProperty(target.getConfiguration());
+                assertSizeAndLog(target.getConfiguration(), 2);
+            }
+
+            void setNewProperty(Configuration config) {
+                try {
+                    config.getProperties().put("property88", "property88");
+                } catch (Exception e) {
+                    // can throw an exception or do nothing
+                    // or getProperties can be hard copy
+                }
+            }
+
+            void assertSizeAndLog(Configuration config, int size) throws Fault {
+                assertTrue(config.getProperties().size() == size + registeredPropertiesCnt,
+                        "getConfiguration().getProperties() is NOT immutable " + getLocation() + " got "
+                                + config.getProperties().size());
+                logMsg("Found", config.getProperties().size(), " properties");
+            }
+
+        };
+        checkConfigWithProperties(assertable);
+    }
+
+    /*
+     * @testName: getPropertyTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:996; JAXRS:JAVADOC:758;
+     * 
+     * @test_Strategy: Get the value for the property with a given name. Set the new
+     * configuration property
+     */
+    @Test
+    public void getPropertyTest() throws Fault {
+        Assertable assertable = new Assertable() {
+
+            @Override
+            public void check1OnClient(Client client) throws Fault {
+                assertPropertyIsSet(client.getConfiguration(), "property0");
+                logMsg("Found", client.getConfiguration().getProperty("property0"));
+            }
+
+            @Override
+            public void check2OnTarget(WebTarget target) throws Fault {
+                assertPropertyIsSet(target.getConfiguration(), "property0");
+                assertPropertyIsSet(target.getConfiguration(), "property1");
+                logMsg("Found", target.getConfiguration().getProperty("property1"));
+            }
+
+            void assertPropertyIsSet(Configuration config, String property) throws Fault {
+                assertTrue(config.getProperty(property).equals(property),
+                        "config.setProperty() did not set anything: " + getLocation());
+            }
+
+        };
+        checkConfigWithProperties(assertable);
+    }
+
+    /*
+     * @testName: getPropertyIsNullTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:996; JAXRS:JAVADOC:758;
+     * 
+     * @test_Strategy: null if the property with such name is not configured.
+     */
+    @Test
+    public void getPropertyIsNullTest() throws Fault {
+        Assertable assertable = new SingleCheckAssertable() {
+            void assertPropertyIsNull(Configurable<?> config) throws Fault {
+                assertTrue(config.getConfiguration().getProperty("property88") == null,
+                        "#getProperty('nonexisting') != null " + getLocation());
+                logMsg("#getProperty('nonexisting') is null as expected");
+            }
+
+            @Override
+            protected void check(Configurable<?> configurable) throws Fault {
+                assertPropertyIsNull(configurable);
+            }
+
+        };
+        checkConfigWithProperties(assertable);
+    }
+
+    /*
+     * @testName: getClassesTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:992; JAXRS:JAVADOC:758;
+     * 
+     * @test_Strategy: Get the immutable set of registered provider classes to be
+     * instantiated, injected and utilized in the scope of the configured instance.
+     * A provider class is a Java class with a jakarta.ws.rs.ext.Provider annotation
+     * declared on the class that implements a specific service interface.
+     * 
+     * Register a provider class to be instantiated
+     */
+    @Test
+    public void getClassesTest() throws Fault {
+        Assertable assertable = new Assertable() {
+
+            @Override
+            public void check1OnClient(Client client) throws Fault {
+                assertSizeAndLog(client.getConfiguration(), 1);
+            }
+
+            @Override
+            public void check2OnTarget(WebTarget target) throws Fault {
+                assertSizeAndLog(target.getConfiguration(), 2);
+            }
+
+            void assertSizeAndLog(Configuration config, int count) throws Fault {
+                assertTrue(config.getClasses().size() == count + registeredClassesCnt,
+                        "config.getClasses() return unexcepted size " + getLocation() + " : "
+                                + config.getClasses().size());
+                logMsg("Found", config.getClasses().size(), "providers");
+            }
+
+        };
+        Class<?>[] providerClasses = new Class[] { CallableProvider1.class, CallableProvider2.class };
+        checkConfig(assertable, providerClasses);
+    }
+
+    /*
+     * @testName: getClassesIsImmutableTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:992; JAXRS:JAVADOC:758;
+     * 
+     * @test_Strategy: Get the immutable set of registered provider classes to be
+     * instantiated, injected and utilized in the scope of the configured instance.
+     * A provider class is a Java class with a jakarta.ws.rs.ext.Provider annotation
+     * declared on the class that implements a specific service interface.
+     *
+     * Register a provider class to be instantiated
+     */
+    @Test
+    public void getClassesIsImmutableTest() throws Fault {
+        Assertable assertable = new Assertable() {
+
+            @Override
+            public void check1OnClient(Client client) throws Fault {
+                assertSizeAndLog(client.getConfiguration(), 0);
+                registerNewProviderInstance(client.getConfiguration());
+                assertSizeAndLog(client.getConfiguration(), 0);
+            }
+
+            @Override
+            public void check2OnTarget(WebTarget target) throws Fault {
+                registerNewProviderInstance(target.getConfiguration());
+                assertSizeAndLog(target.getConfiguration(), 0);
+            }
+
+            void assertSizeAndLog(Configuration config, int count) throws Fault {
+                if (config.getClasses().size() == 1)
+                    logMsg("Found", config.getClasses().iterator().next());
+                assertTrue(config.getClasses().size() == count + registeredClassesCnt,
+                        "config.getClasses() return unexcepted size " + getLocation() + " : "
+                                + config.getClasses().size());
+                logMsg("Found", config.getClasses().size(), "providers");
+            }
+
+            void registerNewProviderInstance(Configuration config) {
+                Class<?> clz = CallableProvider.class;
+                try {
+                    config.getClasses().add(clz);
+                } catch (Exception e) {
+                    // can throw exception or do nothing
+                    // when adding to this immutable set
+                    // or it can be a new hard copied set
+                }
+            }
+
+        };
+        checkConfigWithProperties(assertable);
+    }
+
+    /*
+     * @testName: getClassesIsNeverNullTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:992; JAXRS:JAVADOC:758;
+     * 
+     * @test_Strategy: The returned value shall never be null.
+     *
+     * Register a provider ("singleton") instance
+     */
+    @Test
+    public void getClassesIsNeverNullTest() throws Fault {
+        Assertable assertable = new SingleCheckAssertable() {
+
+            @Override
+            protected void check(Configurable<?> configurable) throws Fault {
+                assertNotNullAndLog(configurable);
+            }
+
+            void assertNotNullAndLog(Configurable<?> config) throws Fault {
+                assertNotNull(config.getConfiguration().getClasses(), "#getClasses shall never be null", getLocation());
+                logMsg("#getClasses() is not null as expected", getLocation());
+            }
+        };
+        checkConfigWithProperties(assertable);
+    }
+
+    /*
+     * @testName: getInstancesTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:994; JAXRS:JAVADOC:758;
+     * 
+     * @test_Strategy: Get the immutable set of registered provider instances to be
+     * utilized by the configurable instance.
+     * 
+     * Register a provider ("singleton") instance
+     */
+    @Test
+    public void getInstancesTest() throws Fault {
+        Assertable assertable = new Assertable() {
+
+            @Override
+            public void check1OnClient(Client client) throws Fault {
+                assertSizeAndLog(client.getConfiguration(), 1);
+            }
+
+            @Override
+            public void check2OnTarget(WebTarget target) throws Fault {
+                assertSizeAndLog(target.getConfiguration(), 2);
+            }
+
+            void assertSizeAndLog(Configuration config, int count) throws Fault {
+                assertTrue(config.getInstances().size() == count + registeredInstancesCnt,
+                        "config.getClasses() return unexcepted size " + getLocation() + " : "
+                                + config.getInstances().size());
+                logMsg("Found", config.getInstances().size(), "providers");
+            }
+
+        };
+        Object[] providerObjects = createProviderInstances();
+        checkConfig(assertable, providerObjects);
+    }
+
+    /*
+     * @testName: getInstancesIsImmutableTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:994; JAXRS:JAVADOC:758;
+     * 
+     * @test_Strategy: Get the immutable set of registered provider instances to be
+     * utilized by the configurable instance.
+     * 
+     * Register a provider ("singleton") instance
+     */
+    @Test
+    public void getInstancesIsImmutableTest() throws Fault {
+        Assertable assertable = new SingleCheckAssertable() {
+            @Override
+            protected void check(Configurable<?> configurable) throws Fault {
+                registerNewProviderInstance(configurable.getConfiguration());
+                assertSizeAndLog(configurable.getConfiguration(), 0);
+            }
+
+            void assertSizeAndLog(Configuration config, int count) throws Fault {
+                assertTrue(config.getClasses().size() == count + registeredClassesCnt,
+                        "config.getClasses() return unexcepted size " + getLocation() + " : "
+                                + config.getClasses().size());
+                logMsg("Found", config.getClasses().size(), "providers");
+            }
+
+            void registerNewProviderInstance(Configuration config) {
+                try {
+                    config.getInstances().add(new CallableProvider());
+                } catch (Exception e) {
+                    // can throw exception or do nothing
+                    // when adding to this immutable set
+                    // or it can be a new hard copied set
+                }
+            }
+        };
+        checkConfigWithProperties(assertable);
+    }
+
+    /*
+     * @testName: getContractsTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:993;
+     * 
+     * @test_Strategy: Get the extension contract registration information for a
+     * component of a given class.
+     */
+    @Test
+    public void getContractsTest() throws Fault {
+        final int priority = 124;
+        Assertable assertable = new SingleCheckAssertable() {
+
+            void assertNotNullAndLog(Configurable<?> config) throws Fault {
+                Map<Class<?>, Integer> map = config.getConfiguration().getContracts(CallableProvider.class);
+                assertEqualsInt(1, map.size(), "Unexpected contract size", map.size());
+                Class<?> contract = map.entrySet().iterator().next().getKey();
+                assertEquals(MessageBodyReader.class, contract, "Unexpected contract", contract, getLocation());
+                logMsg("#getContracts() is", contract, "as expected", getLocation());
+                int p = map.get(contract);
+                assertEqualsInt(priority, p, "Unexpected priority", p);
+                logMsg("Found expected priority", p);
+            }
+
+            @Override
+            protected void check(Configurable<?> configurable) throws Fault {
+                assertNotNullAndLog(configurable);
+            }
+        };
+
+        Registrar registrar = new Registrar() {
+            @Override
+            public void register(Configurable<?> config, Object registerable) {
+                Map<Class<?>, Integer> map = new HashMap<Class<?>, Integer>();
+                map.put(MessageBodyReader.class, priority);
+                config.register(CallableProvider.class, map);
+            }
+        };
+        checkConfigWithProperties(registrar, assertable);
+    }
+
+    /*
+     * @testName: getContractsIsNeverNullTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:993;
+     * 
+     * @test_Strategy: Get the extension contract registration information for a
+     * component of a given class. Method does not return null.
+     */
+    @Test
+    public void getContractsIsNeverNullTest() throws Fault {
+        Assertable assertable = new SingleCheckAssertable() {
+
+            void assertNotNullAndLog(Configurable<?> config) throws Fault {
+                Map<Class<?>, Integer> map = config.getConfiguration().getContracts(MessageBodyReader.class);
+                assertNotNull(map, "getContracts is null", getLocation());
+                logMsg("#getContracts() is not null as expected", getLocation());
+            }
+
+            @Override
+            protected void check(Configurable<?> configurable) throws Fault {
+                assertNotNullAndLog(configurable);
+            }
+        };
+
+        checkConfigWithProperties(assertable);
+    }
+
+    /*
+     * @testName: getInstancesIsNeverNullTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:994; JAXRS:JAVADOC:758;
+     * 
+     * @test_Strategy: The returned value shall never be null.
+     *
+     * Register a provider ("singleton") instance
+     */
+    @Test
+    public void getInstancesIsNeverNullTest() throws Fault {
+        Assertable assertable = new SingleCheckAssertable() {
+
+            void assertNotNullAndLog(Configurable<?> config) throws Fault {
+                assertNotNull(config.getConfiguration().getInstances(), "config.getInstances() shall never be null",
+                        getLocation());
+                logMsg("#getInstances() is not null as expected", getLocation());
+            }
+
+            @Override
+            protected void check(Configurable<?> configurable) throws Fault {
+                assertNotNullAndLog(configurable);
+            }
+        };
+        checkConfigWithProperties(assertable);
+    }
+
+    /*
+     * @testName: getPropertyNamesTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:997;
+     * 
+     * @test_Strategy: Returns an immutable collection containing the property names
+     * available within the context of the current configuration instance.
+     */
+    @Test
+    public void getPropertyNamesTest() throws Fault {
+        Assertable assertable = new Assertable() {
+
+            @Override
+            public void check1OnClient(Client client) throws Fault {
+                assertSizeAndLog(client.getConfiguration(), 1);
+            }
+
+            @Override
+            public void check2OnTarget(WebTarget target) throws Fault {
+                assertSizeAndLog(target.getConfiguration(), 2);
+            }
+
+            void assertSizeAndLog(Configuration config, int size) throws Fault {
+                int names = config.getPropertyNames().size();
+                assertEqualsInt(names, size + registeredPropertiesCnt, "getPropertyNames() is unexpected",
+                        getLocation(), "got", names, "properties");
+                logMsg("Found", names, "properties");
+            }
+        };
+
+        checkConfigWithProperties(assertable);
+    }
+
+    /*
+     * @testName: getPropertyNamesIsImmutableTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:997; JAXRS:JAVADOC:758;
+     * 
+     * @test_Strategy: Returns an immutable collection containing the property names
+     * available within the context of the current configuration instance. Set the
+     * new configuration property
+     */
+    @Test
+    public void getPropertyNamesIsImmutableTest() throws Fault {
+        Assertable assertable = new Assertable() {
+
+            @Override
+            public void check1OnClient(Client client) throws Fault {
+                setNewProperty(client.getConfiguration());
+                assertSizeAndLog(client.getConfiguration(), 1);
+            }
+
+            @Override
+            public void check2OnTarget(WebTarget target) throws Fault {
+                setNewProperty(target.getConfiguration());
+                assertSizeAndLog(target.getConfiguration(), 2);
+            }
+
+            void setNewProperty(Configuration config) {
+                try {
+                    config.getPropertyNames().add("property88");
+                } catch (Exception e) {
+                    // can throw an exception or do nothing
+                    // or getPropertyNames can be hard copy
+                }
+            }
+
+            void assertSizeAndLog(Configuration config, int size) throws Fault {
+                int pSize = config.getPropertyNames().size();
+                assertEqualsInt(pSize, size + registeredPropertiesCnt, "getPropertyNames() is NOT immutable",
+                        getLocation(), "got", pSize, "properties");
+                logMsg("Found", pSize, " properties");
+            }
+
+        };
+        checkConfigWithProperties(assertable);
+    }
+
+    /*
+     * @testName: getRuntimeTypeTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:998;
+     * 
+     * @test_Strategy: Get the runtime type of this configuration context.
+     */
+    @Test
+    public void getRuntimeTypeTest() throws Fault {
+        Assertable assertable = new SingleCheckAssertable() {
+
+            void assertNotNullAndLog(Configurable<?> config) throws Fault {
+                assertEquals(RuntimeType.CLIENT, config.getConfiguration().getRuntimeType(),
+                        "getRuntimeType() is unexpected", config.getConfiguration().getRuntimeType(), getLocation());
+                logMsg("#getRuntimeType() is", RuntimeType.CLIENT, "as expected", getLocation());
+            }
+
+            @Override
+            protected void check(Configurable<?> configurable) throws Fault {
+                assertNotNullAndLog(configurable);
+            }
+        };
+        checkConfigWithProperties(assertable);
+    }
+
+    /*
+     * @testName: isRegisteredProviderRegisteredInstanceTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:1001; JAXRS:JAVADOC:1002;
+     * 
+     * @test_Strategy: Check if a particular JAX-RS component instance (such as
+     * providers or features) has been previously registered in the runtime
+     * configuration context.
+     * 
+     * Method returns true only in case an instance equal to the component instance
+     * is already present among the components previously registered in the
+     * configuration context.
+     */
+    @Test
+    public void isRegisteredProviderRegisteredInstanceTest() throws Fault {
+        Assertable assertable = new Assertable() {
+            CallableProvider1 p1 = new CallableProvider1();
+
+            CallableProvider2 p2 = new CallableProvider2();
+
+            @Override
+            public void check1OnClient(Client client) throws Fault {
+                client.register(p1);
+                assertSizeAndLog(client.getConfiguration(), 1);
+            }
+
+            @Override
+            public void check2OnTarget(WebTarget target) throws Fault {
+                target.register(p2);
+                assertSizeAndLog(target.getConfiguration(), 2);
+            }
+
+            void assertSizeAndLog(Configuration config, int size) throws Fault {
+                assertFalse(config.isRegistered(CallableProvider.class), "CallableProvider is unexpectedly registered");
+                switch (size) {
+                    case 2:
+                        assertFalse(config.isRegistered(new CallableProvider2()),
+                                "CallableProvider2 is registered " + getLocation());
+                        assertTrue(config.isRegistered(p2),
+                                "CallableProvider2.class is NOT registered " + getLocation());
+                        assertTrue(config.isRegistered(CallableProvider2.class),
+                                "CallableProvider2.class is NOT registered " + getLocation());
+                        logMsg("Found registered CallableProvider2 as expected", getLocation());
+                    case 1:
+                        assertFalse(config.isRegistered(new CallableProvider1()),
+                                "CallableProvider1 is registered " + getLocation());
+                        assertTrue(config.isRegistered(p1),
+                                "CallableProvider1.class is NOT registered " + getLocation());
+                        assertTrue(config.isRegistered(CallableProvider1.class),
+                                "CallableProvider1.class is NOT registered " + getLocation());
+                        logMsg("Found registered CallableProvider1 as expected", getLocation());
+                }
+            }
+
+        };
+        checkConfigWithProperties(assertable);
+    }
+
+    /*
+     * @testName: isRegisteredProviderRegisteredClassTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:1001; JAXRS:JAVADOC:1002;
+     * 
+     * @test_Strategy: Check if a particular JAX-RS component instance (such as
+     * providers or features) has been previously registered in the runtime
+     * configuration context.
+     */
+    @Test
+    public void isRegisteredProviderRegisteredClassTest() throws Fault {
+        Assertable assertable = new Assertable() {
+
+            @Override
+            public void check1OnClient(Client client) throws Fault {
+                client.register(CallableProvider1.class);
+                assertSizeAndLog(client.getConfiguration(), 1);
+            }
+
+            @Override
+            public void check2OnTarget(WebTarget target) throws Fault {
+                target.register(CallableProvider2.class);
+                assertSizeAndLog(target.getConfiguration(), 2);
+            }
+
+            void assertSizeAndLog(Configuration config, int size) throws Fault {
+                assertFalse(config.isRegistered(new CallableProvider()), "CallableProvider is unexpectedly registered");
+                assertFalse(config.isRegistered(CallableProvider.class), "CallableProvider is unexpectedly registered");
+                switch (size) {
+                    case 2:
+                        assertFalse(config.isRegistered(new CallableProvider2()),
+                                "CallableProvider2 is registered " + getLocation());
+                        assertTrue(config.isRegistered(CallableProvider2.class),
+                                "CallableProvider2.class is NOT registered " + getLocation());
+                        logMsg("Found registered CallableProvider2 as expected", getLocation());
+                    case 1:
+                        assertFalse(config.isRegistered(new CallableProvider1()),
+                                "CallableProvider1 is registered " + getLocation());
+                        assertTrue(config.isRegistered(CallableProvider1.class),
+                                "CallableProvider1.class is NOT registered " + getLocation());
+                        logMsg("Found registered CallableProvider1 as expected", getLocation());
+                }
+            }
+
+        };
+        checkConfigWithProperties(assertable);
+    }
+
+    // ///////////////////////////////////////////////////////////////////////
+
+    /**
+     * the same as createFetureInstances but with properties
+     */
+    private static String[] createPropertyInstances() {
+        String[] properties = new String[] { "property0", "property1" };
+        return properties;
+    }
+
+    /**
+     * Provider has to not be anonymous class, because we need @Provider annotation
+     * there
+     */
+    private static Object[] createProviderInstances() {
+        Object[] instances = new CallableProvider[] { new CallableProvider() {
+        }, new CallableProvider() {
+        } };
+        return instances;
+    }
+
+    /**
+     * Check on every possible setting of configuration by a String property
+     */
+    private void checkConfigWithProperties(Assertable assertable) throws Fault {
+        String[] properties = createPropertyInstances();
+        checkConfig(assertable, properties);
+    }
+
+    /**
+     * Check on every possible setting of configuration by a String property
+     */
+    private void checkConfigWithProperties(Registrar registrar, Assertable assertable) throws Fault {
+        String[] properties = createPropertyInstances();
+        checkConfig(registrar, assertable, properties);
+    }
+
+    /**
+     * Check on every possible setting of configuration by a Feature or a singleton
+     * 
+     */
+    private void checkConfig(Assertable assertable, Object[] registerables) throws Fault {
+        checkConfig(new Registrar(), assertable, registerables);
+    }
+
+    protected void checkConfig(Registrar registrar, Assertable assertable, Object[] registerables) throws Fault {
+        Client client = ClientBuilder.newClient();
+        Configuration config = client.getConfiguration();
+        registeredPropertiesCnt = config.getProperties().size();
+        registeredClassesCnt = config.getClasses().size();
+        registeredInstancesCnt = config.getInstances().size();
+        logMsg("Already registered", registeredClassesCnt, "classes");
+        logMsg("Already registered", registeredInstancesCnt, "instances");
+        logMsg("Already registered", registeredPropertiesCnt, "properties");
+
+        register(registrar, client, registerables[0]);
+        assertable.check1OnClient(client);
+        assertable.incrementLocation();
+
+        WebTarget target = client.target("http://tck.cts:888");
+        register(registrar, target, registerables[1]);
+        assertable.check2OnTarget(target);
+        assertable.incrementLocation();
+    }
+
+    protected void register(Registrar registrar, Configurable<?> config, Object registerable) {
+        registrar.register(config, registerable);
+    }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/cookie/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/cookie/JAXRSClientIT.java
@@ -1,0 +1,413 @@
+/*
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.core.cookie;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.core.Cookie;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+    private static final long serialVersionUID = 724842945840527973L;
+
+    @BeforeEach
+    void logStartTest(TestInfo testInfo) {
+        TestUtil.logMsg("STARTING TEST : " + testInfo.getDisplayName());
+    }
+
+    @AfterEach
+    void logFinishTest(TestInfo testInfo) {
+        TestUtil.logMsg("FINISHED TEST : " + testInfo.getDisplayName());
+    }
+
+    /*
+     * @testName: constructorTest1
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:51; JAXRS:JAVADOC:53; JAXRS:JAVADOC:54;
+     * JAXRS:JAVADOC:55; JAXRS:JAVADOC:56; JAXRS:JAVADOC:57;
+     * 
+     * @test_Strategy: Create a Cookie instance using Constructor Cookie(String,
+     * String)
+     */
+    @Test
+    public void constructorTest1() throws Fault {
+        String name = "name_1";
+        String value = "value_1";
+        int version = 1;
+        String domain = "";
+        String path = "";
+
+        Cookie ck1 = new Cookie(name, value);
+        verifyCookie(ck1, name, value, path, domain, version);
+    }
+
+    /*
+     * @testName: constructorTest2
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:50; JAXRS:JAVADOC:53; JAXRS:JAVADOC:54;
+     * JAXRS:JAVADOC:55; JAXRS:JAVADOC:56; JAXRS:JAVADOC:57;
+     * 
+     * @test_Strategy: Create a Cookie instance using Constructor Cookie(String,
+     * String, String, String)
+     */
+    @Test
+    public void constructorTest2() throws Fault {
+        String name = "name_1";
+        String value = "value_1";
+        String path = "/acme";
+        String domain = "";
+        int version = 1;
+
+        Cookie ck2 = new Cookie(name, value, path, domain);
+
+        verifyCookie(ck2, name, value, path, domain, version);
+    }
+
+    /*
+     * @testName: constructorTest3
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:50; JAXRS:JAVADOC:53; JAXRS:JAVADOC:54;
+     * JAXRS:JAVADOC:55; JAXRS:JAVADOC:56; JAXRS:JAVADOC:57;
+     * 
+     * @test_Strategy: Create a Cookie instance using Constructor Cookie(String,
+     * String, String, String)
+     */
+    @Test
+    public void constructorTest3() throws Fault {
+        String name = "name_1";
+        String value = "value_1";
+        String path = "";
+        String domain = "y.x.foo.com";
+        int version = 1;
+
+        Cookie ck3 = new Cookie(name, value, path, domain);
+        verifyCookie(ck3, name, value, path, domain, version);
+    }
+
+    /*
+     * @testName: constructorTest4
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:51; JAXRS:JAVADOC:53; JAXRS:JAVADOC:54;
+     * JAXRS:JAVADOC:55; JAXRS:JAVADOC:56; JAXRS:JAVADOC:57;
+     * 
+     * @test_Strategy: Create a version 1 Cookie instance using Constructor
+     * Cookie(String, String, String, String, int)
+     */
+    @Test
+    public void constructorTest4() throws Fault {
+        String name = "name_1";
+        String value = "value_1";
+        String path = "/acme";
+        String domain = "y.x.foo.com";
+        int version = 1;
+
+        Cookie ck4 = new Cookie(name, value, path, domain, version);
+        verifyCookie(ck4, name, value, path, domain, version);
+    }
+
+    /*
+     * @testName: constructorTest5
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:49; JAXRS:JAVADOC:53; JAXRS:JAVADOC:54;
+     * JAXRS:JAVADOC:55; JAXRS:JAVADOC:56; JAXRS:JAVADOC:57;
+     * 
+     * @test_Strategy: Create a version 0 Cookie instance using Constructor
+     * Cookie(String, String, String, String, int)
+     */
+    @Test
+    public void constructorTest5() throws Fault {
+        String name = "name_1";
+        String value = "value_1";
+        String path = "/acme";
+        String domain = "y.x.foo.com";
+        int version = 0;
+
+        Cookie ck5 = new Cookie(name, value, path, domain, version);
+        verifyCookie(ck5, name, value, path, domain, version);
+    }
+
+    /*
+     * @testName: parseTest1
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:60; JAXRS:JAVADOC:53; JAXRS:JAVADOC:54;
+     * JAXRS:JAVADOC:55; JAXRS:JAVADOC:56; JAXRS:JAVADOC:57;
+     * 
+     * @test_Strategy: Create a version 0 Cookie instance by Parsing a String
+     */
+    @Test
+    public void parseTest1() throws Fault {
+        String cookie_toParse = "NAME_1=Value_1;";
+        String name = "name_1";
+        String value = "value_1";
+        String path = "";
+        String domain = "";
+        int version = 0;
+
+        Cookie ck6 = jakarta.ws.rs.core.Cookie.valueOf(cookie_toParse);
+        verifyCookie(ck6, name, value, path, domain, version);
+    }
+
+    /*
+     * @testName: parseTest2
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:60; JAXRS:JAVADOC:53; JAXRS:JAVADOC:54;
+     * JAXRS:JAVADOC:55; JAXRS:JAVADOC:56; JAXRS:JAVADOC:57;
+     * 
+     * @test_Strategy: Create a version 0 Cookie instance by Parsing a String
+     */
+    @Test
+    public void parseTest2() throws Fault {
+        String cookie_toParse = "$Version=\"1\"; Customer=\"WILE_E_COYOTE\"; $Path=\"/acme\"";
+
+        String name = "customer";
+        String value = "wile_e_coyote";
+        String path = "/acme";
+        String domain = "";
+        int version = 1;
+
+        Cookie ck7 = jakarta.ws.rs.core.Cookie.valueOf(cookie_toParse);
+
+        verifyCookie(ck7, name, value, path, domain, version);
+    }
+
+    /*
+     * @testName: parseTest3
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:60;
+     * 
+     * @test_Strategy: Testing Correcting exception thrown when calling
+     * Cookie.valueOf(null)
+     */
+    @Test
+    public void parseTest3() throws Fault {
+        try {
+            jakarta.ws.rs.core.Cookie.valueOf(null);
+            throw new Fault("Expectecd IllegalArgumentException not thrown.  Test Failed");
+        } catch (java.lang.IllegalArgumentException ilex) {
+            logMsg("IllegalArgumentException has been thrown as expected");
+        }
+    }
+
+    /*
+     * @testName: equalsTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:49; JAXRS:JAVADOC:52; JAXRS:JAVADOC:58;
+     * 
+     * @test_Strategy: Create two Cookie instances using Constructor Cookie(String,
+     * String, String, String, int). Change the parameters one by one, make sure
+     * hashCode() and equals method work.
+     */
+    @Test
+    public void equalsTest() throws Fault {
+        boolean pass = true;
+        StringBuffer sb = new StringBuffer();
+
+        String name = "name_1";
+        String value = "value_1";
+        String path = "/acme";
+        String domain = "y.x.foo.com";
+        int version = 0;
+
+        Cookie ck9 = new Cookie(name, value, path, domain, version);
+        Cookie ck10 = new Cookie(name, value, path, domain, version);
+
+        if (ck9.hashCode() != ck10.hashCode()) {
+            pass = false;
+            sb.append("First hashCode test failed" + newline);
+        }
+
+        if (!ck9.equals(ck10)) {
+            pass = false;
+            sb.append("First Equal test failed" + newline);
+        }
+
+        version = 1;
+        ck10 = new Cookie(name, value, path, domain, version);
+        if (ck9.hashCode() == ck10.hashCode()) {
+            pass = false;
+            sb.append("hashCode test failed at version" + newline);
+        }
+
+        if (ck9.equals(ck10)) {
+            pass = false;
+            sb.append("UnEqual test failed at version" + newline);
+        }
+
+        name = "name_2";
+        ck9 = new Cookie(name, value, path, domain, version);
+        if (ck9.hashCode() == ck10.hashCode()) {
+            pass = false;
+            sb.append("hashCode test failed at name" + newline);
+        }
+
+        if (ck9.equals(ck10)) {
+            pass = false;
+            sb.append("UnEqual test failed at name" + newline);
+        }
+
+        value = "value_2";
+        ck10 = new Cookie(name, value, path, domain, version);
+        if (ck9.hashCode() == ck10.hashCode()) {
+            pass = false;
+            sb.append("hashCode test failed at value" + newline);
+        }
+
+        if (ck9.equals(ck10)) {
+            pass = false;
+            sb.append("UnEqual test failed at value" + newline);
+        }
+
+        path = "/test";
+        ck9 = new Cookie(name, value, path, domain, version);
+        if (ck9.hashCode() == ck10.hashCode()) {
+            pass = false;
+            sb.append("hashCode test failed at path" + newline);
+        }
+
+        if (ck9.equals(ck10)) {
+            pass = false;
+            sb.append("UnEqual test failed at path" + newline);
+        }
+
+        domain = "sun.com";
+        ck9 = new Cookie(name, value, path, domain, version);
+        if (ck9.hashCode() == ck10.hashCode()) {
+            pass = false;
+            sb.append("hashCode test failed at domain" + newline);
+        }
+
+        if (ck9.equals(ck10)) {
+            pass = false;
+            sb.append("UnEqual test failed at domain" + newline);
+        }
+
+        assertTrue(pass, "At least one assertion failed: " + sb.toString());
+    }
+
+    /*
+     * @testName: toStringTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:49; JAXRS:JAVADOC:59;
+     * 
+     * @test_Strategy: Create two Cookie instances using Constructor Cookie(String,
+     * String, String, String, int). Change the parameters one by one, make sure
+     * hashCode() and equals method work.
+     */
+    @Test
+    public void toStringTest() throws Fault {
+        boolean pass = true;
+        StringBuffer sb = new StringBuffer();
+
+        String name = "name_1";
+        String value = "value_1";
+        String path = "/acme";
+        String domain = "y.x.foo.com";
+        int version = 0;
+
+        Cookie ck11 = new Cookie(name, value, path, domain, version);
+
+        String cookie = ck11.toString().toLowerCase();
+        if (!cookie.contains("name_1")) {
+            pass = false;
+            sb.append("Name test failed" + newline);
+        }
+
+        if (!cookie.contains("value_1")) {
+            pass = false;
+            sb.append("Value test failed" + newline);
+        }
+
+        if (!cookie.contains("acme")) {
+            pass = false;
+            sb.append("path test failed" + newline);
+        }
+
+        if (!cookie.contains("y.x.foo.com")) {
+            pass = false;
+            sb.append("domain test failed" + newline);
+        }
+
+        assertTrue(pass, "At least one assertion failed: " + sb.toString());
+    }
+
+    private static boolean verifyCookie(Cookie ck, String name, String value, String path, String domain, int version)
+            throws Fault {
+
+        StringBuffer sb = new StringBuffer();
+        boolean pass = true;
+
+        if (name == "" || name == null) {
+            pass = false;
+            sb.append("Cookie's name is empty");
+        } else if (!ck.getName().toLowerCase().equals(name)) {
+            pass = false;
+            sb.append("Failed name test.  Expect " + name + " got " + ck.getName());
+        }
+
+        if (value == "" || value == null) {
+            pass = false;
+            sb.append("Cookie's value is empty");
+        } else if (!ck.getValue().toLowerCase().equals(value)) {
+            pass = false;
+            sb.append("Failed value test.  Expect " + value + " got " + ck.getValue());
+        }
+
+        if (ck.getVersion() != version) {
+            pass = false;
+            sb.append("Failed version test.  Expect " + version + " got " + ck.getVersion());
+        }
+
+        if (path == "" || path == null) {
+            if (ck.getPath() != "" && ck.getPath() != null) {
+                pass = false;
+                sb.append("Failed path test.  Expect null String, got " + ck.getPath());
+            }
+        } else if (ck.getPath() == null || ck.getPath() == "") {
+            pass = false;
+            sb.append("Failed path test.  Got null, expecting " + path);
+        } else if (!ck.getPath().toLowerCase().equals(path)) {
+            pass = false;
+            sb.append("Failed path test.  Expect " + path + " got " + ck.getPath());
+        }
+
+        if (domain == "" || domain == null) {
+            if (ck.getDomain() != "" && ck.getDomain() != null) {
+                pass = false;
+                sb.append("Failed path test.  Expect " + domain + " got " + ck.getDomain());
+            }
+        } else if (!ck.getDomain().toLowerCase().equals(domain)) {
+            pass = false;
+            sb.append("Failed domain test.  Expect " + domain + " got " + ck.getDomain());
+        }
+
+        assertTrue(pass, "At least one assertion falied: " + sb.toString());
+
+        return pass;
+    }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/entitytag/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/entitytag/JAXRSClientIT.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.core.entitytag;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.core.EntityTag;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+    private static final long serialVersionUID = -5886257224223478590L;
+
+    @BeforeEach
+    void logStartTest(TestInfo testInfo) {
+        TestUtil.logMsg("STARTING TEST : " + testInfo.getDisplayName());
+    }
+
+    @AfterEach
+    void logFinishTest(TestInfo testInfo) {
+        TestUtil.logMsg("FINISHED TEST : " + testInfo.getDisplayName());
+    }
+
+    /*
+     * @testName: constructorTest1
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:62; JAXRS:JAVADOC:65; JAXRS:JAVADOC:67;
+     * 
+     * @test_Strategy: Create an EntityTag instance using entityTag(String)
+     */
+    @Test
+    public void constructorTest1() throws Fault {
+        String value = "cts test entity tag test";
+        boolean strong = true;
+
+        EntityTag et1 = new EntityTag(value);
+        verifyEntityTag(et1, value, strong);
+    }
+
+    /*
+     * @testName: constructorTest2
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:63; JAXRS:JAVADOC:65; JAXRS:JAVADOC:67;
+     * 
+     * @test_Strategy: Create an EntityTag instance using entityTag(String, boolean)
+     */
+    @Test
+    public void constructorTest2() throws Fault {
+        String value = "cts test entity tag test weak";
+        boolean strong = false;
+
+        EntityTag et2 = new EntityTag(value, true);
+
+        verifyEntityTag(et2, value, strong);
+
+        strong = true;
+
+        EntityTag et3 = new EntityTag(value, false);
+
+        verifyEntityTag(et3, value, strong);
+    }
+
+    /*
+     * @testName: equalsTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:62; JAXRS:JAVADOC:63; JAXRS:JAVADOC:64;
+     * JAXRS:JAVADOC:66;
+     * 
+     * @test_Strategy: Create two EntityTag instances using either entityTag(String,
+     * boolean) and entityTag(String). Verify EntityTag.equals(Object) and
+     * hashCode() work
+     */
+    @Test
+    public void equalsTest() throws Fault {
+        boolean pass = true;
+        StringBuffer sb = new StringBuffer();
+
+        String value = "cts test entity tag test";
+
+        EntityTag et4 = new EntityTag(value);
+        EntityTag et5 = new EntityTag(value, false);
+
+        if (!et4.equals(et5)) {
+            pass = false;
+            sb.append("Strong entity Tag equals test failed. " + et4.toString() + ";" + et5.toString() + ";");
+        }
+
+        if (et4.hashCode() != et5.hashCode()) {
+            pass = false;
+            sb.append("Strong entity Tag hashCode test failed. " + et4.toString() + ";" + et5.toString() + ";");
+        }
+
+        value = "cts test entity tag test weak";
+        EntityTag et6 = new EntityTag(value, true);
+        EntityTag et7 = new EntityTag(value, false);
+
+        if (et6.equals(et7)) {
+            pass = false;
+            sb.append("Weak entity Tag equals test failed. " + et6.toString() + ";" + et7.toString() + ";");
+        }
+
+        if (et6.hashCode() == et7.hashCode()) {
+            pass = false;
+            sb.append("Weak entity Tag hashCode test failed. " + et6.toString() + ";" + et7.toString() + ";");
+        }
+
+        assertTrue(pass, "At least one assertion failed: " + sb.toString());
+    }
+
+    /*
+     * @testName: toStringTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:62; JAXRS:JAVADOC:63; JAXRS:JAVADOC:68;
+     * 
+     * @test_Strategy: Create two EntityTag instances using either entityTag(String,
+     * boolean) and entityTag(String). Verify EntityTag.toString() works
+     */
+    @Test
+    public void toStringTest() throws Fault {
+        boolean pass = true;
+        StringBuffer sb = new StringBuffer();
+
+        String value = "cts test Strong EntityTag test";
+
+        EntityTag et8 = new EntityTag(value);
+        String header = et8.toString();
+        sb.append(header + "." + newline);
+
+        if (!header.contains(value)) {
+            pass = false;
+            sb.append("Strong EnttyTag ToString Test failed: " + header + " does not contain " + value);
+        }
+
+        value = "cts test Weak EntityTag test";
+
+        EntityTag et9 = new EntityTag(value, true);
+
+        header = et9.toString();
+        sb.append(header + "." + newline);
+
+        if (!header.contains(value)) {
+            pass = false;
+            sb.append("Weak EnttyTag ToString Test failed: " + header + " does not contain " + value);
+        }
+
+        assertTrue(pass, "At least one assertion failed: " + sb.toString());
+        System.out.println(sb.toString());
+    }
+
+    /*
+     * @testName: valueOfTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:69;
+     * 
+     * @test_Strategy: Create an EntityTag instances using EntityTag.valueOf(null)
+     * Verify IllegalArgumentException thrown
+     */
+    @Test
+    public void valueOfTest() throws Fault {
+        try {
+            EntityTag.valueOf(null);
+            throw new Fault("Expected IllegalArgumentException not thrown.  Test failed.");
+        } catch (java.lang.IllegalArgumentException ilex) {
+            logMsg("IllegalArgumentException has been thrown as expected");
+        }
+    }
+
+    /*
+     * @testName: valueOfTest1
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:69;
+     * 
+     * @test_Strategy: EntityTag.valueOf(value) does not throw Exception
+     */
+    @Test
+    public void valueOfTest1() throws Fault {
+        String value = "\"cts test Strong EntityTag test\"";
+        try {
+            EntityTag et10 = EntityTag.valueOf(value);
+            verifyEntityTag(et10, value, true);
+        } catch (Exception ilex) {
+            throw new Fault("Unexpected exception throw: " + ilex.getMessage());
+        }
+    }
+
+    private static void verifyEntityTag(EntityTag et, String value, boolean strong) throws Fault {
+        StringBuffer sb = new StringBuffer();
+        boolean pass = true;
+
+        if (!et.getValue().toLowerCase().replace("\"", "").equals(value.replace("\"", "").toLowerCase())) {
+            pass = false;
+            sb.append("Failed value test.  Expect " + value + " got " + et.getValue() + ".");
+        }
+
+        if (et.isWeak() == strong) {
+            pass = false;
+            sb.append("Failed isWeak test.  Expect " + !strong + " got " + et.isWeak());
+        }
+
+        assertTrue(pass, "at least one assertion failed: " + sb.toString());
+    }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/form/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/form/JAXRSClientIT.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.core.form;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.core.Form;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+    private static final long serialVersionUID = 1L;
+
+    protected static final String tck = "tck";
+
+    protected static final String cts = "cts";
+
+    @BeforeEach
+    void logStartTest(TestInfo testInfo) {
+        TestUtil.logMsg("STARTING TEST : " + testInfo.getDisplayName());
+    }
+
+    @AfterEach
+    void logFinishTest(TestInfo testInfo) {
+        TestUtil.logMsg("FINISHED TEST : " + testInfo.getDisplayName());
+    }
+
+    /*
+     * @testName: constructorNoArgTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:765; JAXRS:JAVADOC:766;
+     * 
+     * @test_Strategy: Returns multivalued map representation of the form.
+     * 
+     * Create a new form data instance.
+     */
+    @Test
+    public Form constructorNoArgTest() throws Fault {
+        Form form = new Form();
+        assertTrue(form != null, "No Form created");
+
+        MultivaluedMap<String, String> map = form.asMap();
+        assertTrue(map.isEmpty(), "Created From instance is not empty");
+        logMsg("Form instance created");
+        return form;
+    }
+
+    /*
+     * @testName: constructorStringArgsTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:767; JAXRS:JAVADOC:765;
+     * 
+     * @test_Strategy: Create a new form data instance with a single parameter
+     * entry.
+     */
+    @Test
+    public void constructorStringArgsTest() throws Fault {
+        Form form = new Form(tck, cts);
+        assertTrue(form != null, "No Form created");
+
+        MultivaluedMap<String, String> map = form.asMap();
+        assertTrue(map.containsKey(tck), "No given key " + tck + " exists in form instance");
+        assertTrue(map.getFirst(tck).equals(cts),
+                "Different value has been given from map for key " + tck + ": " + map.getFirst(tck));
+        logMsg("Form instance with String arguments sucessfully created");
+    }
+
+    /*
+     * @testName: constructorMultivaluedMapArgTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:768; JAXRS:JAVADOC:765;
+     * 
+     * @test_Strategy: Create a new form data instance with a single parameter
+     * entry.
+     */
+    @Test
+    public void constructorMultivaluedMapArgTest() throws Fault {
+        MultivaluedHashMap<String, String> init = new MultivaluedHashMap<String, String>();
+        init.add(tck, cts);
+        init.add(cts, cts);
+        Form form = new Form(init);
+        assertTrue(form != null, "No Form created");
+
+        MultivaluedMap<String, String> map = form.asMap();
+        assertTrue(map.containsKey(tck), "No given key " + tck + " exists in form instance");
+        assertTrue(map.getFirst(tck).equals(cts),
+                "Different value has been given from map for key " + tck + ": " + map.getFirst(tck));
+        assertTrue(map.containsKey(cts), "No given key " + cts + " exists in form instance");
+        assertTrue(map.getFirst(cts).equals(cts),
+                "Different value has been given from map for key " + cts + ": " + map.getFirst(cts));
+        logMsg("Form instance with MultivaluedMap argument sucessfully created");
+    }
+
+    /*
+     * @testName: paramTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:765; JAXRS:JAVADOC:769;
+     * 
+     * @test_Strategy: Returns multivalued map representation of the form.
+     * 
+     * Adds a new value to the specified form parameter.
+     */
+    @Test
+    public void paramTest() throws Fault {
+        Form form = constructorNoArgTest();
+        form.param(tck, tck);
+        form.param(cts, cts);
+
+        MultivaluedMap<String, String> map = form.asMap();
+        assertTrue(map.containsKey(tck), "No given key " + tck + "exists in form instance");
+        assertTrue(map.getFirst(tck).equals(tck),
+                "Different value has been given from map for key " + tck + ": " + map.getFirst(tck));
+        assertTrue(map.containsKey(cts), "No given key " + cts + " exists in form instance");
+        assertTrue(map.getFirst(cts).equals(cts),
+                "Different value has been given from map for key " + cts + ": " + map.getFirst(cts));
+    }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/genericentity/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/genericentity/JAXRSClientIT.java
@@ -1,0 +1,378 @@
+/*
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.core.genericentity;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.core.GenericEntity;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+* @class.setup_props: webServerHost; webServerPort; ts_home;
+*/
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+    private static final long serialVersionUID = 1L;
+
+    @BeforeEach
+    void logStartTest(TestInfo testInfo) {
+        TestUtil.logMsg("STARTING TEST : " + testInfo.getDisplayName());
+    }
+
+    @AfterEach
+    void logFinishTest(TestInfo testInfo) {
+        TestUtil.logMsg("FINISHED TEST : " + testInfo.getDisplayName());
+    }
+
+    /*
+     * @testName: constructorTest1
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:71;
+     * 
+     * @test_Strategy: Create a GenericEntity instance using GenericEntity(T entity,
+     * null) Verify the expected IllegalArgumentException is thrown.
+     */
+    @Test
+    public void constructorTest1() throws Fault {
+        List<String> list = new ArrayList<String>();
+        try {
+            new GenericEntity<List<String>>(list, null);
+            throw new Fault("Test failed; expected exception not thrown.");
+        } catch (IllegalArgumentException ilex) {
+            logMsg("Expected IllegalArgumentException thrown:", ilex.getMessage());
+        }
+    }
+
+    /*
+     * @testName: constructorTest2
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:71;
+     * 
+     * @test_Strategy: Create a GenericEntity instance using GenericEntity(null,
+     * Type) Verify the expected IllegalArgumentException is thrown.
+     */
+    @Test
+    public void constructorTest2() throws Fault {
+        try {
+            new GenericEntity<List<String>>(null, String.class.getGenericSuperclass());
+            throw new Fault("Test failed; expected exception not thrown.");
+        } catch (IllegalArgumentException ilex) {
+            logMsg("Expected IllegalArgumentException thrown:", ilex.getMessage());
+        }
+    }
+
+    /*
+     * @testName: singleArgumentConstructorTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:71;
+     * 
+     * @test_Strategy: Create a GenericEntity instance using GenericEntity(T entity)
+     * Verify the expected IllegalArgumentException is thrown for null and not for
+     * legal argument
+     */
+    @Test
+    public void singleArgumentConstructorTest() throws Fault {
+        try {
+            new GenericEntity<Map<String, List<Long>>>(null) {
+            };
+            throw new Fault("Test failed; expected exception not thrown.");
+        } catch (IllegalArgumentException ilex) {
+            logMsg("Expected IllegalArgumentException thrown:", ilex.getMessage());
+        }
+        GenericEntity<Map<String, List<Long>>> generic;
+        generic = new GenericEntity<Map<String, List<Long>>>(new java.util.HashMap<String, List<Long>>()) {
+        };
+        assertTrue(generic.getRawType().isAssignableFrom(HashMap.class), generic.getRawType() + " != " + Map.class);
+        logMsg("GenericEntity<Map<String, List<Long>>> instance created");
+    }
+
+    /*
+     * @testName: constructorWith2ArgsTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:71;
+     * 
+     * @test_Strategy: Create a GenericEntity instance using GenericEntity(T entity,
+     * not null)
+     */
+    @Test
+    public void constructorWith2ArgsTest() throws Fault {
+        List<String> list = new ArrayList<String>();
+        GenericEntity<List<String>> generic;
+        Method method = null;
+        try {
+            // obtain the correct return type
+            method = getClass().getMethod("dummyMethod");
+        } catch (Exception e) {
+            throw new Fault(e);
+        }
+        generic = new GenericEntity<List<String>>(list, method.getGenericReturnType());
+        String str = String.class.getSimpleName();
+        assertTrue(generic.getRawType().isAssignableFrom(ArrayList.class), generic.getRawType() + " != " + List.class);
+        assertTrue(generic.getType().toString().contains(str), generic.getType() + ".contains(" + str + ") != true");
+        logMsg("GenericEntity<List<String>>(List, Type) instance created");
+    }
+
+    /*
+     * @testName: constructorWith1ArgTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:71;
+     * 
+     * @test_Strategy: Create a GenericEntity instance using GenericEntity(T entity)
+     */
+    @Test
+    public void constructorWith1ArgTest() throws Fault {
+        List<String> list = new ArrayList<String>();
+        GenericEntity<List<String>> generic;
+        generic = new GenericEntity<List<String>>(list) {
+        };
+        String str = String.class.getSimpleName();
+        assertTrue(generic.getRawType() == ArrayList.class, generic.getRawType() + " != " + List.class);
+        assertTrue(generic.getType().toString().contains(str), generic.getType() + ".contains(" + str + ") != true");
+        logMsg("GenericEntity<List<String>>(List) instance created");
+    }
+
+    // * NEED for reflection in constructorWith2ArgsTest */
+    public List<String> dummyMethod() {
+        return null;
+    }
+
+    /*
+     * @testName: getEntityTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:72;
+     * 
+     * @test_Strategy: Create GenericEntity with a map, retrieve and validate
+     */
+    @Test
+    public void getEntityTest() throws Fault {
+        String testName = "EntityTest";
+        Map<String, List<Long>> map = new java.util.HashMap<String, List<Long>>();
+        map.put(testName, new java.util.LinkedList<Long>());
+
+        GenericEntity<Map<String, List<Long>>> ge = new GenericEntity<Map<String, List<Long>>>(map) {
+        };
+
+        if (ge.getEntity() != map || !ge.getEntity().keySet().iterator().next().equals(testName))
+            throw new Fault("Entity has not been retrieved");
+        logMsg("Entity has been retrieved");
+    }
+
+    /*
+     * @testName: getTypeTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:74;
+     * 
+     * @test_Strategy: Create a GenericEntity instance; Verify that
+     * GenericEntity.getType() works.
+     */
+    @Test
+    public void getTypeTest() throws Fault {
+        Boolean pass = true;
+        StringBuffer sb = new StringBuffer();
+
+        List<String> lists = new ArrayList<String>();
+        GenericEntity<List<String>> entitys = new GenericEntity<List<String>>(lists) {
+        };
+
+        String types = entitys.getType().toString();
+        if (types.equals("java.util.List<java.lang.String>")) {
+            sb.append("getType return correctly: ").append(types).append(newline);
+        } else {
+            pass = false;
+            sb.append("getType return incorrectly: ").append(types).append(newline)
+                    .append("Expecting java.util.List<java.lang.String>.").append(newline);
+        }
+
+        List<Integer> listi = new ArrayList<Integer>();
+        GenericEntity<List<Integer>> entityi = new GenericEntity<List<Integer>>(listi) {
+        };
+
+        String typei = entityi.getType().toString();
+        if (typei.equals("java.util.List<java.lang.Integer>")) {
+            sb.append("getType return correctly: ").append(types).append(newline);
+        } else {
+            pass = false;
+            sb.append("getType return incorrectly: ").append(typei).append(newline)
+                    .append("Expecting java.util.List<java.lang.Integer>.").append(newline);
+        }
+
+        if (pass) {
+            logMsg("Test passed. ", sb.toString());
+        } else {
+            throw new Fault("At least one assertion falied. " + sb.toString());
+        }
+    }
+
+    /*
+     * @testName: getRawTypeTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:73;
+     * 
+     * @test_Strategy: Create a GenericEntity instance; Verify that
+     * GenericEntity.getRawType() works.
+     */
+    @Test
+    public void getRawTypeTest() throws Fault {
+        Boolean pass = true;
+        StringBuffer sb = new StringBuffer();
+
+        List<String> lists = new ArrayList<String>();
+        GenericEntity<List<String>> entitys = new GenericEntity<List<String>>(lists) {
+        };
+
+        String types = entitys.getRawType().toString();
+        if (types.indexOf("java.util.ArrayList") > -1) {
+            sb.append("getType return correctly: ").append(types).append(newline);
+        } else {
+            pass = false;
+            sb.append("getType return incorrectly: ").append(types).append(newline);
+            sb.append("Expecting java.util.ArrayList.").append(newline);
+        }
+
+        List<Integer> listi = new ArrayList<Integer>();
+        GenericEntity<List<Integer>> entityi = new GenericEntity<List<Integer>>(listi) {
+        };
+
+        String typei = entityi.getRawType().toString();
+        if (typei.indexOf("java.util.ArrayList") > -1) {
+            sb.append("getType return correctly: ").append(types).append(newline);
+        } else {
+            pass = false;
+            sb.append("getType return incorrectly: ").append(typei).append(newline);
+            sb.append("Expecting java.util.ArrayList.").append(newline);
+        }
+
+        if (pass) {
+            logMsg("Test passed.", sb.toString());
+        } else {
+            throw new Fault("At least one assertion falied. " + sb.toString());
+        }
+    }
+
+    /*
+     * @testName: equalsTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:770;
+     * 
+     * @test_Strategy: Two GenericEntity<TreeSet<String>> must be the equal
+     */
+    @Test
+    public void equalsTest() throws Fault {
+        TreeSet<String> set = new TreeSet<String>();
+
+        GenericEntity<TreeSet<String>> type1 = new GenericEntity<TreeSet<String>>(set) {
+        };
+        GenericEntity<TreeSet<String>> type2 = new GenericEntity<TreeSet<String>>(set) {
+        };
+        GenericEntity<Set<String>> type3 = new GenericEntity<Set<String>>(set) {
+        };
+        GenericEntity<TreeSet<String>> type4 = new GenericEntity<TreeSet<String>>(new TreeSet<String>() {
+            private static final long serialVersionUID = 1L;
+        }) {
+        };
+
+        assertTrue(type1.equals(type1), "GenericEntity<TreeSet<String>> is not equal itself");
+        assertTrue(type2.equals(type2), "GenericEntity<TreeSet<String>> is not equal itself");
+        assertTrue(type1.equals(type2), "GenericEntity<TreeSet<String>> is not equal GenericEntity<TreeSet<String>>");
+        assertTrue(type2.equals(type1), "GenericEntity<TreeSet<String>> is not equal GenericEntity<TreeSet<String>>");
+        assertTrue(!type3.equals(type1), "GenericEntity<Set<String>> is equal GenericEntity<TreeSet<String>>");
+        assertTrue(type4.equals(type1),
+                "GenericEntity<TreeSet<String>>(set) is not equal GenericEntity<TreeSet<String>>(otherSet)");
+        logMsg("The tested GenericEntity<TreeSet<String>> instances are equal");
+    }
+
+    /*
+     * @testName: hashCodeTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:771;
+     * 
+     * @test_Strategy: HashCode of two GenericEntity<TreeSet<String>> must be the
+     * same
+     */
+    @Test
+    public void hashCodeTest() throws Fault {
+        TreeSet<String> set = new TreeSet<String>();
+        GenericEntity<TreeSet<String>> type1 = new GenericEntity<TreeSet<String>>(set) {
+        };
+        GenericEntity<TreeSet<String>> type2 = new GenericEntity<TreeSet<String>>(set) {
+        };
+        GenericEntity<Set<String>> type3 = new GenericEntity<Set<String>>(set) {
+        };
+        GenericEntity<TreeSet<String>> type4 = new GenericEntity<TreeSet<String>>(new TreeSet<String>() {
+            private static final long serialVersionUID = 1L;
+        }) {
+        };
+
+        assertTrue(type1.hashCode() == type1.hashCode(), "HashCode of itself is random");
+        assertTrue(type2.hashCode() == type2.hashCode(), "HashCode of itself is random");
+        assertTrue(type1.hashCode() == type2.hashCode(), "Both GenericEntity instances should have the same hashCode");
+        assertTrue(type1.hashCode() != type3.hashCode(),
+                "GenericEntity<Set<String>>.hashCode()==GenericEntity<TreeSet<String>>.hashCode()");
+        assertTrue(type4.hashCode() == type1.hashCode(),
+                "GenericEntity<Set<String>>(set).hashCode()!=GenericEntity<TreeSet<String>>(otherSet).hashCode()");
+
+        logMsg("Both GenericEntity instances have the same hashCode()");
+    }
+
+    /*
+     * @testName: toStringTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:772;
+     * 
+     * @test_Strategy: toString() of two GenericEntity<TreeSet<String>> must be the
+     * same
+     */
+    @Test
+    public void toStringTest() throws Fault {
+        TreeSet<String> set = new TreeSet<String>();
+        GenericEntity<TreeSet<String>> type1 = new GenericEntity<TreeSet<String>>(set) {
+        };
+        GenericEntity<TreeSet<String>> type2 = new GenericEntity<TreeSet<String>>(set) {
+        };
+        GenericEntity<Set<String>> type3 = new GenericEntity<Set<String>>(set) {
+        };
+        GenericEntity<TreeSet<String>> type4 = new GenericEntity<TreeSet<String>>(new TreeSet<String>() {
+            private static final long serialVersionUID = 1L;
+        }) {
+        };
+
+        assertTrue(type1.toString().equals(type1.toString()), "toString() of itself is random");
+        assertTrue(type2.toString().equals(type2.toString()), "toString() of itself is random");
+        assertTrue(type1.toString().equals(type2.toString()),
+                "Both GenericEntity instances should have the same toString()");
+        assertTrue(!type1.toString().equals(type3.toString()),
+                "GenericEntity<Set<String>>.toString()==GenericEntity<TreeSet<String>>.toString()");
+        assertTrue(type4.toString().equals(type1.toString()),
+                "GenericEntity<Set<String>>(set).toString()!=GenericEntity<TreeSet<String>>(otherSet).toString()");
+
+        logMsg("Both GenericEntity instances have the same toString()", type4);
+    }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/generictype/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/generictype/JAXRSClientIT.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.core.generictype;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+    private static final long serialVersionUID = 1L;
+
+    @BeforeEach
+    void logStartTest(TestInfo testInfo) {
+        TestUtil.logMsg("STARTING TEST : " + testInfo.getDisplayName());
+    }
+
+    @AfterEach
+    void logFinishTest(TestInfo testInfo) {
+        TestUtil.logMsg("FINISHED TEST : " + testInfo.getDisplayName());
+    }
+
+    /*
+     * @testName: constructorWithTypeTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:774; JAXRS:JAVADOC:775; JAXRS:JAVADOC:776;
+     * 
+     * @test_Strategy: Constructs a new generic type, supplying the generic type
+     * information and deriving the class.
+     */
+    @Test
+    public void constructorWithTypeTest() throws Fault {
+        Method method = null;
+        try {
+            // obtain the correct return type
+            method = getClass().getMethod("dummyMethod");
+        } catch (Exception e) {
+            throw new Fault(e);
+        }
+
+        GenericType<List<String>> type = new GenericType<List<String>>(method.getReturnType());
+        assertTrue(type != null, "Could not create a GenericType instance");
+        assertTrue(type.getRawType().isAssignableFrom(ArrayList.class), type.getRawType() + " != " + List.class);
+        assertTrue(type.getType().toString().contains(ArrayList.class.getName()),
+                type.getType() + " != " + ArrayList.class);
+        logMsg("Succesfully created GenericType<ArrayList<String>>(Type) instance");
+    }
+
+    // * NEED for reflection in constructorWith2ArgsTest */
+    public ArrayList<String> dummyMethod() {
+        return null;
+    }
+
+    /*
+     * @testName: constructorProtectedTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:774; JAXRS:JAVADOC:775; JAXRS:JAVADOC:776;
+     * 
+     * @test_Strategy: Constructs a new generic type, deriving the generic type and
+     * class from type parameter.
+     */
+    @Test
+    public void constructorProtectedTest() throws Fault {
+        GenericType<TreeSet<String>> type = new GenericType<TreeSet<String>>() {
+        };
+        assertTrue(type != null, "Could not create a GenericType instance");
+        assertTrue(type.getRawType().isAssignableFrom(TreeSet.class), type.getRawType() + " != " + Set.class);
+        assertTrue(type.getType().toString().contains(TreeSet.class.getName()),
+                type.getType() + " != " + TreeSet.class);
+        logMsg("Succesfully created GenericType<TreeSet<String>>(){} instance");
+    }
+
+    /*
+     * @testName: equalsTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:773;
+     * 
+     * @test_Strategy: Two GenericType<TreeSet<String>> must be the equal
+     */
+    @Test
+    public void equalsTest() throws Fault {
+        GenericType<TreeSet<String>> type1 = new GenericType<TreeSet<String>>() {
+        };
+        GenericType<TreeSet<String>> type2 = new GenericType<TreeSet<String>>() {
+        };
+        GenericType<Set<String>> type3 = new GenericType<Set<String>>() {
+        };
+
+        assertTrue(type1.equals(type1), "GenericType<TreeSet<String>> is not equal itself");
+        assertTrue(type2.equals(type2), "GenericType<TreeSet<String>> is not equal itself");
+        assertTrue(type1.equals(type2), "GenericType<TreeSet<String>> is not equal GenericType<TreeSet<String>>");
+        assertTrue(type2.equals(type1), "GenericType<TreeSet<String>> is not equal GenericType<TreeSet<String>>");
+        assertTrue(!type3.equals(type1), "GenericType<Set<String>> is equal GenericType<TreeSet<String>>");
+        logMsg("The tested GenericType<TreeSet<String>> instances are equal");
+    }
+
+    /*
+     * @testName: hashCodeTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:777;
+     * 
+     * @test_Strategy: hashCode of two GenericType<TreeSet<String>> must be the same
+     */
+    @Test
+    public void hashCodeTest() throws Fault {
+        GenericType<TreeSet<String>> type1 = new GenericType<TreeSet<String>>() {
+        };
+        GenericType<TreeSet<String>> type2 = new GenericType<TreeSet<String>>() {
+        };
+        GenericType<Set<String>> type3 = new GenericType<Set<String>>() {
+        };
+
+        assertTrue(type1.hashCode() == type1.hashCode(), "HashCode of itself is random");
+        assertTrue(type2.hashCode() == type2.hashCode(), "HashCode of itself is random");
+        assertTrue(type1.hashCode() == type2.hashCode(), "Both GenericType instances should have the same hashCode");
+        assertTrue(type1.hashCode() != type3.hashCode(),
+                "GenericType<Set<String>>.hashCode()==GenericType<TreeSet<String>>.hashCode()");
+
+        logMsg("Both GenericType instances have the same hashCode()");
+    }
+
+    /*
+     * @testName: toStringTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:778;
+     * 
+     * @test_Strategy: toString of two GenericType<TreeSet<String>> must be the same
+     */
+    @Test
+    public void toStringTest() throws Fault {
+        GenericType<TreeSet<String>> type1 = new GenericType<TreeSet<String>>() {
+        };
+        GenericType<TreeSet<String>> type2 = new GenericType<TreeSet<String>>() {
+        };
+        GenericType<Set<String>> type3 = new GenericType<Set<String>>() {
+        };
+
+        assertTrue(type1.toString().equals(type1.toString()), "toString() of itself is random");
+        assertTrue(type2.toString().equals(type2.toString()), "toString() of itself is random");
+        assertTrue(type1.toString().equals(type2.toString()),
+                "Both GenericType instances should have the same toString()");
+        assertTrue(!type1.toString().equals(type3.toString()),
+                "GenericType<Set<String>>.toString()==GenericType<TreeSet<String>>.toString()");
+
+        logMsg("Both GenericType instances have the same toString()", type1);
+    }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/link/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/link/JAXRSClientIT.java
@@ -1,0 +1,766 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.core.link;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientRequestFilter;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Link;
+import jakarta.ws.rs.core.Link.Builder;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriBuilder;
+import jakarta.ws.rs.ext.RuntimeDelegate;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.common.util.JaxrsUtil;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+    private static final long serialVersionUID = -373684847397542733L;
+
+    @BeforeEach
+    void logStartTest(TestInfo testInfo) {
+        TestUtil.logMsg("STARTING TEST : " + testInfo.getDisplayName());
+    }
+
+    @AfterEach
+    void logFinishTest(TestInfo testInfo) {
+        TestUtil.logMsg("FINISHED TEST : " + testInfo.getDisplayName());
+    }
+
+    /* Run test */
+
+    /*
+     * @testName: constructorTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:799;
+     * 
+     * @test_Strategy: see what happens when new Link() is used.
+     */
+    @Test
+    public void constructorTest() throws Fault {
+        Link link = new Link() {
+
+            @Override
+            public URI getUri() {
+                return null;
+            }
+
+            @Override
+            public UriBuilder getUriBuilder() {
+                return null;
+            }
+
+            @Override
+            public String getRel() {
+                return null;
+            }
+
+            @Override
+            public List<String> getRels() {
+                return null;
+            }
+
+            @Override
+            public String getTitle() {
+                return null;
+            }
+
+            @Override
+            public String getType() {
+                return null;
+            }
+
+            @Override
+            public Map<String, String> getParams() {
+                return null;
+            }
+
+            @Override
+            public String toString() {
+                return "";
+            }
+        };
+        // check no Exception is thrown
+        assertTrue(link != null, "new Link() is null");
+        logMsg("new Link() call iss successfull", link.toString());
+    }
+
+    /*
+     * @testName: fromMethodTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:1037;
+     * 
+     * @test_Strategy: Convenience method to build a link from a resource method.
+     * Note that path created from resource is relative to the application's root
+     * resource.
+     */
+    @Test
+    public void fromMethodTest() throws Fault {
+        Link link = linkFromResource("consumesAppJson");
+        String resource = link.toString();
+        assertContains(resource, "<consumesappjson>");
+        logMsg("Link", resource, "has been created");
+    }
+
+    /*
+     * @testName: fromResourceMethodLinkUsedInInvocationTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:787;
+     * 
+     * @test_Strategy: Generate a link by introspecting a resource method.
+     */
+    @Test
+    public void fromResourceMethodLinkUsedInInvocationTest() throws Fault {
+        final String linkName = "link";
+        Client client = ClientBuilder.newClient();
+        client.register(new ClientRequestFilter() {
+            @Override
+            public void filter(ClientRequestContext ctx) throws IOException {
+                String uri = ctx.getUri().toASCIIString();
+                Link.Builder builder = Link.fromMethod(Resource.class, "consumesAppJson").rel(linkName);
+                Link link = builder.build();
+                Response response = Response.ok(uri).links(link).build();
+                ctx.abortWith(response);
+            }
+        });
+        // Phase 1, ask for a link;
+        WebTarget target = client.target(url() + "resource/get");
+        Response response = target.request().get();
+        String entity = response.readEntity(String.class);
+        assertTrue(response.hasLink(linkName), "No link received");
+        assertContains(url() + "resource/get", entity);
+
+        // Phase 2, use the link, check the correctness
+        assertTrue(response.hasLink(linkName), "No link received");
+        Link link = response.getLink(linkName);
+        response = client.invocation(link).post(null);
+        entity = response.readEntity(String.class);
+        assertTrue(response.hasLink(linkName), "No link received");
+        assertContains(url() + "resource/consumesappjson", entity);
+        logMsg("Opaque Link has been used in Client.invocation() sucessfully");
+    }
+
+    /*
+     * @testName: fromResourceMethodThrowsIllegalArgumentExceptionNoMethodTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:1037
+     * 
+     * @test_Strategy: IllegalArgumentException if any argument is null or no method
+     * is found
+     */
+    @Test
+    public void fromResourceMethodThrowsIllegalArgumentExceptionNoMethodTest() throws Fault {
+        try {
+            linkFromResource("nonexistingMethod");
+            throw new Fault("IllegalArgumentException has not been thrown");
+        } catch (IllegalArgumentException iae) {
+            logMsg("IllegalArgumentException has been successfully thrown");
+        }
+    }
+
+    /*
+     * @testName: fromResourceMethodThrowsIllegalArgumentExceptionNullMethodTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:1037;
+     * 
+     * @test_Strategy: IllegalArgumentException if any argument is null or no method
+     * is found
+     */
+    @Test
+    public void fromResourceMethodThrowsIllegalArgumentExceptionNullMethodTest() throws Fault {
+        try {
+            linkFromResource(null);
+            throw new Fault("IllegalArgumentException has not been thrown");
+        } catch (IllegalArgumentException iae) {
+            logMsg("IllegalArgumentException has been successfully thrown");
+        }
+    }
+
+    /*
+     * @testName: fromResourceMethodThrowsIllegalArgumentExceptionNullClassTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:1037;
+     * 
+     * @test_Strategy: IllegalArgumentException if any argument is null or no method
+     * is found
+     */
+    @Test
+    public void fromResourceMethodThrowsIllegalArgumentExceptionNullClassTest() throws Fault {
+        try {
+            Link.fromMethod(null, "anymethod");
+            throw new Fault("IllegalArgumentException has not been thrown");
+        } catch (IllegalArgumentException iae) {
+            logMsg("IllegalArgumentException has been successfully thrown");
+        }
+    }
+
+    /*
+     * @testName: fromUriTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:788;
+     * 
+     * @test_Strategy: Create a new instance initialized from an existing URI.
+     */
+    @Test
+    public void fromUriTest() throws Fault {
+        URI uri = uri(Request.GET.name());
+        Builder builder = Link.fromUri(uri);
+        Link link = builder.build();
+        assertContains(link.toString(), url());
+        assertContains(link.toString(), "resource");
+        assertContains(link.toString(), "get");
+        logMsg("Link", link, "has been created from URI", uri);
+    }
+
+    /*
+     * @testName: fromUriThrowsIllegalArgumentExceptionTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:788;
+     * 
+     * @test_Strategy: throws IllegalArgumentException is uri is null
+     */
+    @Test
+    public void fromUriThrowsIllegalArgumentExceptionTest() throws Fault {
+        try {
+            Link.fromUri((URI) null);
+        } catch (IllegalArgumentException e) {
+            logMsg("IllegalArgument has been thrown as expected:", e);
+            return;
+        }
+        throw new Fault("IllegalArgumentException has not been thrown");
+    }
+
+    /*
+     * @testName: fromUriStringTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:790;
+     * 
+     * @test_Strategy: Create a new instance initialized from an existing URI.
+     */
+    @Test
+    public void fromUriStringTest() throws Fault {
+        URI uri = uri(Request.GET.name());
+        Builder builder = Link.fromUri(uri.toASCIIString());
+        Link link = builder.build();
+        assertContains(link.toString(), url());
+        assertContains(link.toString(), "resource");
+        assertContains(link.toString(), "get");
+        logMsg("Link", link, "has been created from URI", uri.toASCIIString());
+    }
+
+    /*
+     * @testName: fromUriStringThrowsIllegalArgumentExceptionTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:790;
+     * 
+     * @test_Strategy: throws IllegalArgumentException is uri is null
+     */
+    @Test
+    public void fromUriStringThrowsIllegalArgumentExceptionTest() throws Fault {
+        try {
+            Link.fromUri((String) null);
+        } catch (IllegalArgumentException e) {
+            logMsg("IllegalArgument has been thrown as expected:", e);
+            return;
+        }
+        throw new Fault("IllegalArgumentException has not been thrown");
+    }
+
+    /*
+     * @testName: getParamsFromResourceTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:792;
+     * 
+     * @test_Strategy: Returns an immutable map that includes all the link
+     * parameters defined on this link. If defined, this map will include entries
+     * for "rel", "title" and "type".
+     */
+    @Test
+    public void getParamsFromResourceTest() throws Fault {
+        String title = "Title";
+        String value;
+        Link link = Link.fromMethod(Resource.class, "producesSvgXml").title(title).build();
+        Map<String, String> params = link.getParams();
+        System.out.println(params);
+        value = params.get("type");
+        assertNull(value, "Unexpected media type in link found", value);
+        value = params.get("title");
+        assertContains(value, title);
+        logMsg(params, "found as expected");
+    }
+
+    /*
+     * @testName: getParamsFromBuilderTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:792;
+     * 
+     * @test_Strategy: Returns an immutable map that includes all the link
+     * parameters defined on this link. If defined, this map will include entries
+     * for "rel", "title" and "type".
+     */
+    @Test
+    public void getParamsFromBuilderTest() throws Fault {
+        Builder builder = Link.fromUri(uri("get"));
+        builder.rel("RELREL").title("TITLETITLE").type("TYPETYPE").param("NEWPARAM", "NEWPARAMVALUE");
+        Link link = builder.build();
+
+        String value;
+        Map<String, String> params = link.getParams();
+        value = params.get("title");
+        assertContains(value, "titletitle");
+        value = params.get("rel");
+        assertContains(value, "RELREL");
+        value = params.get("type");
+        assertContains(value, "typetype");
+        value = params.get("NEWPARAM");
+        assertContains(value, "newparamvalue");
+
+        logMsg(params, "found as expected");
+    }
+
+    /*
+     * @testName: getRelTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:793;
+     * 
+     * @test_Strategy: Returns the value associated with the link "rel" param, or
+     * null if this param is not specified.
+     */
+    @Test
+    public void getRelTest() throws Fault {
+        Builder builder = Link.fromUri(uri("get"));
+        builder.rel("RELREL").title("TITLETITLE").type("TYPETYPE").param("NEWPARAM", "NEWPARAMVALUE");
+        Link link = builder.build();
+        String rel = link.getRel();
+        assertTrue(rel.contains("RELREL"), "#getRel did NOT return expected RELREL");
+        logMsg("#getRel() return expected rel");
+    }
+
+    /*
+     * @testName: getRelIsEmptyListTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:793;
+     * 
+     * @test_Strategy: Returns the value associated with the link "rel" param, or
+     * null if this param is not specified.
+     */
+    @Test
+    public void getRelIsEmptyListTest() throws Fault {
+        Builder builder = Link.fromUri(uri("get"));
+        Link link = builder.build();
+        String rel = link.getRel();
+        assertTrue(rel == null, "#getRel is NOT null");
+        logMsg("#getRel() returns expected null");
+    }
+
+    /*
+     * @testName: getTitleTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:794;
+     * 
+     * @test_Strategy: Returns the value associated with the link "title" param, or
+     * null if this param is not specified.
+     */
+    @Test
+    public void getTitleTest() throws Fault {
+        Builder builder = Link.fromUri(uri("get"));
+        builder.rel("RELREL").title("TITLETITLE").type("TYPETYPE");
+        Link link = builder.build();
+        String title = link.getTitle();
+
+        assertTrue(title != null, "#getTitle did NOT return expected title");
+        assertContains(title, "TITLETITLE");
+    }
+
+    /*
+     * @testName: getTitleIsNullTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:794;
+     * 
+     * @test_Strategy: Returns the value associated with the link "title" param, or
+     * null if this param is not specified.
+     */
+    @Test
+    public void getTitleIsNullTest() throws Fault {
+        Link link = linkFromResource("get");
+        String title = link.getTitle();
+        assertTrue(title == null, "#getTitle is unexpected " + title);
+        logMsg("#getTitle( returns null as expected");
+    }
+
+    /*
+     * @testName: getTypeTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:795;
+     * 
+     * @test_Strategy: Returns the value associated with the link "type" param, or
+     * null if this param is not specified.
+     */
+    @Test
+    public void getTypeTest() throws Fault {
+        Builder builder = Link.fromUri(uri("get"));
+        builder.rel("RELREL").title("TITLETITLE").type("TYPETYPE");
+        Link link = builder.build();
+        String type = link.getType();
+
+        assertTrue(type != null, "#getType() did NOT return expected title");
+        assertContains(type, "TYPETYPE");
+    }
+
+    /*
+     * @testName: getTypeIsNullTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:795;
+     * 
+     * @test_Strategy: Returns the value associated with the link "type" param, or
+     * null if this param is not specified.
+     */
+    @Test
+    public void getTypeIsNullTest() throws Fault {
+        Link link = linkFromResource("get");
+        String type = link.getType();
+        assertTrue(type == null, "#getType is unexpected " + type);
+        logMsg("#getType( returns null as expected");
+    }
+
+    /*
+     * @testName: getUriTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:796;
+     * 
+     * @test_Strategy: Returns the underlying URI associated with this link.
+     */
+    @Test
+    public void getUriTest() throws Fault {
+        URI uri = uri("get");
+        Builder builder = Link.fromUri(uri);
+        Link link = builder.build();
+        URI uriFromLink = link.getUri();
+
+        assertTrue(uri.equals(uriFromLink), "#getUri() " + uriFromLink + " differes from original uri " + uri);
+        logMsg("Original URI", uri, "equals obtained", uriFromLink);
+    }
+
+    /*
+     * @testName: getUriBuilderTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:797;
+     * 
+     * @test_Strategy: Convenience method that returns a
+     * jakarta.ws.rs.core.UriBuilder initialized with this link's underlying URI.
+     */
+    @Test
+    public void getUriBuilderTest() throws Fault {
+        URI uri = uri("get");
+        Builder builder = Link.fromUri(uri);
+        Link link = builder.build();
+        UriBuilder uriBuilder = link.getUriBuilder();
+        assertTrue(uriBuilder != null, "#getUriBuilder is null");
+        URI uriFromLink = uriBuilder.build();
+
+        assertTrue(uri.equals(uriFromLink), "#getUri() " + uriFromLink + " differes from original uri " + uri);
+        logMsg("Original URI", uri, "equals obtained", uriFromLink);
+    }
+
+    /*
+     * @testName: serializationFromResourceTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:800; JAXRS:JAVADOC:801;
+     * 
+     * @test_Strategy: Returns a string representation as a link header (RFC 5988)
+     * 
+     * Simple parser to convert link header string representations into a link
+     * (valueOf)
+     */
+    @Test
+    public void serializationFromResourceTest() throws Fault {
+        Method[] methods = Resource.class.getDeclaredMethods();
+        for (Method method : methods) {
+            logMsg("Serialization for method", method);
+            String name = method.getName();
+            Link link = linkFromResource(name);
+            String string = link.toString();
+            Link fromValueOf = Link.valueOf(string);
+            assertEquals(link.toString(), fromValueOf.toString(), "links", link, fromValueOf, "are not equal");
+            logMsg("serialization works for method", name);
+        }
+        logMsg("Serialization with #toString() of Resource method links is sucessfull");
+    }
+
+    /*
+     * @testName: valueOfThrowsIllegalArgumentExceptionTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:801;
+     * 
+     * @test_Strategy: throws IllegalArgumentException if a syntax error is found
+     */
+    @Test
+    public void valueOfThrowsIllegalArgumentExceptionTest() throws Fault {
+        try {
+            Link.valueOf("</>>");
+            throw new Fault("IllegalArgumentException was not thrown");
+        } catch (IllegalArgumentException e) {
+            logMsg("Link#vaueOf() throws IllegalArgumentException as expected");
+        }
+    }
+
+    /*
+     * @testName: getRelsTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:956;
+     * 
+     * @test_Strategy: Returns the value associated with the link "rel" param as a
+     * list of strings or the empty list if "rel" is not defined.
+     */
+    @Test
+    public void getRelsTest() throws Fault {
+        String[] rels = { "RELREL", "REL", "relrelrel", "RELRELREL" };
+        Builder builder = Link.fromUri(uri("get"));
+        for (int i = 0; i != rels.length; i++)
+            builder = builder.rel(rels[i]);
+        Link link = builder.build();
+        assertNotNull(link.getRels(), "#getRels is null");
+        assertEqualsInt(link.getRels().size(), 4, "Unexpected #getRels size", link.getRels().size(), "Should be 4");
+        String list = ";" + JaxrsUtil.iterableToString(";", link.getRels()) + ";";
+        for (int i = 0; i != rels.length; i++)
+            assertContains(list, ";" + rels[i] + ";", "Relation", rels[i], "has not been found in #getRels", list);
+        logMsg("#getRel() return expected rels", list);
+    }
+
+    /*
+     * @testName: getRelsIsEmptyTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:956;
+     * 
+     * @test_Strategy: Returns the value associated with the link "rel" param as a
+     * list of strings or the empty list if "rel" is not defined.
+     */
+    @Test
+    public void getRelsIsEmptyTest() throws Fault {
+        Builder builder = Link.fromUri(uri("get"));
+        Link link = builder.build();
+        assertNotNull(link.getRels(), "#getRels is null");
+        assertEqualsInt(link.getRels().size(), 0, "Unexpected #getRels size", link.getRels().size(), "Should be 0");
+        logMsg("#getRel() return empty list as expected");
+    }
+
+    /*
+     * @testName: fromResourceTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:1039;
+     * 
+     * @test_Strategy: Convenience method to build a link from a resource.
+     */
+    @Test
+    public void fromResourceTest() throws Fault {
+        Link link = Link.fromResource(Resource.class).build();
+        String resource = link.toString();
+        assertContains(resource, "<resource>");
+        assertNotContains(resource, "type");
+        logMsg("Link", resource, "has been created");
+    }
+
+    /*
+     * @testName: fromResourceWithMediaTypeTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:1004;
+     * 
+     * @test_Strategy: Convenience method to build a link from a resource.
+     */
+    @Test
+    public void fromResourceWithMediaTypeTest() throws Fault {
+        Link link = Link.fromResource(ResourceWithProduces.class).build();
+        String resource = link.toString();
+        assertContains(resource, "<producesresource>");
+        assertNotContains(resource, "type=\"" + MediaType.TEXT_HTML + "\"");
+        logMsg("Link", resource, "has been created");
+    }
+
+    /*
+     * @testName: fromResourceThrowsIAEWhenNullClassTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:1039;
+     * 
+     * @test_Strategy: IllegalArgumentException - if any argument is null or no
+     * method is found.
+     */
+    @Test
+    public void fromResourceThrowsIAEWhenNullClassTest() throws Fault {
+        try {
+            Link link = Link.fromResource((Class<?>) null).build();
+            logMsg("Unexpectedly thrown no exception and created link", link);
+        } catch (IllegalArgumentException e) {
+            logMsg("IllegalArgumentException has been thrown as expected", e);
+        }
+    }
+
+    /*
+     * @testName: fromUriBuilderTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:1005;
+     * 
+     * @test_Strategy: Create a new builder instance initialized from a URI builder.
+     */
+    @Test
+    public void fromUriBuilderTest() throws Fault {
+        String segment = "goto/label/ten/";
+        Link link = Link.fromUri(uri(segment)).build();
+        UriBuilder builder = link.getUriBuilder();
+        Builder fromBuilder = Link.fromUriBuilder(builder);
+
+        String sBuilder = builder.build().toASCIIString();
+        String sFromBuilder = fromBuilder.build().getUri().toASCIIString();
+        assertContains(sFromBuilder, sBuilder, "Original builder", sBuilder, "not found in #fromUriBuilder",
+                sFromBuilder);
+        logMsg("#fromUriBuilder", sFromBuilder, "contains the original", sBuilder);
+    }
+
+    /*
+     * @testName: fromPathTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:1038;
+     * 
+     * @test_Strategy: Convenience method to build a link from a path. Equivalent to
+     * fromUriBuilder(UriBuilder.fromPath(path)).
+     */
+    @Test
+    public void fromPathTest() throws Fault {
+        String path = "somewhere/somehow";
+        UriBuilder builder = UriBuilder.fromPath(path);
+        Link.Builder linkBuilder = Link.fromUriBuilder(builder);
+        Link.Builder fromPathBuilder = Link.fromPath(path);
+        String fromUriBuilderString = linkBuilder.build().toString();
+        String fromPathString = fromPathBuilder.build().toString();
+        assertEquals(fromUriBuilderString, fromPathString, "fromUriBuilder()=", fromUriBuilderString,
+                "differs from Link.fromPath()", fromPathString);
+        logMsg("fromUriBuilder(UriBuilder.fromPath(path)) is equivalent to fromPath(path)", "The link is",
+                fromPathString);
+    }
+
+    /*
+     * @testName: fromPathWithUriTemplateParamsTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:1038;
+     * 
+     * @test_Strategy: Convenience method to build a link from a path. Equivalent to
+     * fromUriBuilder(UriBuilder.fromPath(path)).
+     */
+    @Test
+    public void fromPathWithUriTemplateParamsTest() throws Fault {
+        String path = "somewhere/somehow/{p1}/{p2}";
+        String param1 = "param1", param2 = "param2";
+        UriBuilder builder = UriBuilder.fromPath(path);
+        Link.Builder linkBuilder = Link.fromUriBuilder(builder);
+        Link.Builder fromPathBuilder = Link.fromPath(path);
+        String fromUriBuilderString = linkBuilder.build(param1, param2).toString();
+        String fromPathString = fromPathBuilder.build(param1, param2).toString();
+        assertEquals(fromUriBuilderString, fromPathString, "fromUriBuilder(UriBuilder.fromPath(,", path, "))=",
+                fromUriBuilderString, "differs from Link.fromPath(", path, ")", fromPathString);
+        logMsg("fromUriBuilder(UriBuilder.fromPath(", path, ")) is equivalent to fromPath(", path, ")", "The link is",
+                fromPathString);
+    }
+
+    /*
+     * @testName: fromPathThrowsIAETest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:1038;
+     * 
+     * @test_Strategy: Throws: java.lang.IllegalArgumentException - if path is null.
+     */
+    @Test
+    public void fromPathThrowsIAETest() throws Fault {
+        try {
+            UriBuilder.fromPath((String) null);
+            fault("fromPath(null) does not throws IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            logMsg("fromPath(null) throws IllegalArgumentException as expected");
+        }
+    }
+
+    /*
+     * @testName: fromLinkTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:783;
+     * 
+     * @test_Strategy: Throws: java.lang.IllegalArgumentException - if path is null.
+     */
+    @Test
+    public void fromLinkTest() throws Fault {
+        Link link = RuntimeDelegate.getInstance().createLinkBuilder().baseUri(url()).rel("relation relation2")
+                .title("titleX").param("param1", "value1").param("param2", "value2")
+                .type(MediaType.APPLICATION_OCTET_STREAM).build();
+        Link fromLink = Link.fromLink(link).build();
+        assertEquals(link, fromLink, "fromLink(link)=", fromLink, "differes from original Link", link);
+        logMsg("fromLink() is equal to original link", link, "as expected");
+    }
+
+    // ///////////////////////////////////////////////////////////////////
+    protected static Link linkFromResource(String method) {
+        Builder builder = Link.fromMethod(Resource.class, method);
+        Link link = builder.build();
+        return link;
+    }
+
+    protected void assertContains(String string, String substring) throws Fault {
+        super.assertContainsIgnoreCase(string, substring, string, "does not contain expected", substring);
+        logMsg("Found expected", substring);
+    }
+
+    protected void assertNotContains(String string, String substring) throws Fault {
+        assertTrue(!string.toLowerCase().contains(substring.toLowerCase()),
+                string + " does unexpectedly contain " + substring);
+        logMsg(substring, "is not in", string, "as expected");
+    }
+
+    protected URI uri(String method) throws Fault {
+        URI uri = null;
+        try {
+            uri = new URI(url() + "resource/" + method);
+        } catch (URISyntaxException e) {
+            throw new Fault(e);
+        }
+        return uri;
+    }
+
+    protected static String url() {
+        return "http://oracle.com:888/";
+    }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/link/Resource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/link/Resource.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.core.link;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.tck.common.impl.TRACE;
+
+@Path("resource")
+public class Resource {
+
+  @GET
+  @Path("get")
+  public String get() {
+    return "GET";
+  }
+
+  @DELETE
+  @Path("delete")
+  public String delete() {
+    return "DELETE";
+  }
+
+  @TRACE
+  @Path("trace")
+  public String trace() {
+    return "TRACE";
+  }
+
+  @GET
+  @Produces(MediaType.APPLICATION_SVG_XML)
+  @Path("producessvgxml")
+  public String producesSvgXml() {
+    return MediaType.APPLICATION_SVG_XML;
+  }
+
+  @POST
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Path("consumesappjson")
+  public String consumesAppJson() {
+    return MediaType.APPLICATION_JSON;
+  }
+
+  @POST
+  @Produces({ MediaType.APPLICATION_XHTML_XML, MediaType.APPLICATION_ATOM_XML,
+      MediaType.APPLICATION_SVG_XML })
+  @Path("producesxml")
+  public String producesXml() {
+    return MediaType.APPLICATION_XHTML_XML;
+  }
+
+  @POST
+  @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+  @Path("consumesform")
+  public String consumesForm() {
+    return MediaType.APPLICATION_FORM_URLENCODED;
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/link/ResourceWithProduces.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/link/ResourceWithProduces.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.core.link;
+
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("producesresource")
+@Produces(MediaType.TEXT_HTML)
+public class ResourceWithProduces {
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/linkbuilder/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/linkbuilder/JAXRSClientIT.java
@@ -1,0 +1,838 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.core.linkbuilder;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.Charset;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.core.Link;
+import jakarta.ws.rs.core.Link.Builder;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.UriBuilder;
+import jakarta.ws.rs.core.UriBuilderException;
+import jakarta.ws.rs.ext.RuntimeDelegate;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.common.util.JaxrsUtil;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+    private static final long serialVersionUID = -4301370250466608838L;
+
+    @BeforeEach
+    void logStartTest(TestInfo testInfo) {
+        TestUtil.logMsg("STARTING TEST : " + testInfo.getDisplayName());
+    }
+
+    @AfterEach
+    void logFinishTest(TestInfo testInfo) {
+        TestUtil.logMsg("FINISHED TEST : " + testInfo.getDisplayName());
+    }
+
+    /* Run test */
+
+    /*
+     * @testName: buildNoArgTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:804;
+     * 
+     * @test_Strategy: Finish building this link and return the instance
+     */
+    @Test
+    public void buildNoArgTest() throws Fault {
+        Link link = builderFromResource("get").build();
+        assertTrue(link != null, "#build should return an instance");
+        assertTrue(link.getUri().toASCIIString().length() > 0, "Link is empty");
+        logMsg("#build() finished building a link and returned the instance");
+    }
+
+    /*
+     * @testName: buildNoArgsThrowsUriBuilderExceptionTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:804;
+     * 
+     * @test_Strategy: throws UriBuilderException if a URI cannot be constructed
+     * based on the current state of the underlying URI builder.
+     */
+    @Test
+    public void buildNoArgsThrowsUriBuilderExceptionTest() throws Fault {
+        Link.Builder builder = Link.fromUri("http://:@");
+        try {
+            Link link = builder.build();
+            assertTrue(false, "No exception has been thrown for link " + link);
+        } catch (UriBuilderException e) {
+            logMsg("#build() throw UriBuilderException as expected");
+        }
+    }
+
+    /*
+     * @testName: buildObjectsTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:804;
+     * 
+     * @test_Strategy: Finish building this link using the supplied values as URI
+     * parameters.
+     */
+    @Test
+    public void buildObjectsTest() throws Fault {
+        StringBuilder path1 = new StringBuilder().append("p1");
+        ByteArrayInputStream path2 = new ByteArrayInputStream("p2".getBytes(Charset.defaultCharset())) {
+            @Override
+            public String toString() {
+                return "p2";
+            }
+        };
+        URI path3;
+        try {
+            path3 = new URI("p3");
+        } catch (URISyntaxException e) {
+            throw new Fault(e);
+        }
+        String expected = "<" + url() + "p1/p2/p3" + ">";
+        Link.Builder builder = Link.fromUri(url() + "{x1}/{x2}/{x3}");
+        Link link = builder.build(path1, path2, path3);
+        assertTrue(link != null, "#build should return an instance");
+        assertTrue(link.toString().equals(expected), "Link " + link + " differs from expected " + expected);
+        logMsg("#build() finished building a link and returned the instance", link);
+    }
+
+    /*
+     * @testName: buildThrowsIAEWhenSuppliedJustOneValueOutOfThreeTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:804;
+     * 
+     * @test_Strategy: Throws: java.lang.IllegalArgumentException - if there are any
+     * URI template parameters without a supplied value
+     */
+    @Test
+    public void buildThrowsIAEWhenSuppliedJustOneValueOutOfThreeTest() throws Fault {
+        Builder linkBuilder = Link.fromUri(url() + "{x1}/{x2}/{x3}"); // rfc6570
+        try {
+            Link link = linkBuilder.build("p");
+            fault("IllegalArgumentException has not been thrown when value is not supplied, link=", link.toString());
+        } catch (IllegalArgumentException iae) {
+            logMsg("IllegalArgumentException has been thrown as expected when a value has not been supplied");
+        }
+    }
+
+    /*
+     * @testName: buildObjectsThrowsUriBuilderExceptionTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:804;
+     * 
+     * @test_Strategy: throws UriBuilderException if a URI cannot be constructed
+     * based on the current state of the underlying URI builder.
+     */
+    @Test
+    public void buildObjectsThrowsUriBuilderExceptionTest() throws Fault {
+        Link.Builder builder = Link.fromUri("http://:@");
+        try {
+            Link link = builder.build("aaa");
+            assertTrue(false, "No exception has been thrown for link " + link);
+        } catch (UriBuilderException e) {
+            logMsg("#build(someNonURIObjects) throw UriBuilderException as expected");
+        }
+    }
+
+    /*
+     * @testName: paramTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:807; JAXRS:JAVADOC:1053;
+     * 
+     * @test_Strategy: Set an arbitrary parameter on this link.
+     * 
+     * jakarta.ws.rs.ext.RuntimeDelegate.createLinkBuilder
+     */
+    @Test
+    public void paramTest() throws Fault {
+        String[] params = { "param1", "param2" };
+        String[] values = { "param1value1", "param1value2" };
+        Link.Builder builder = RuntimeDelegate.getInstance().createLinkBuilder().uri(url());
+        builder = builder.param(params[0], values[0]).param(params[1], values[1]);
+        Link link = builder.build();
+        assertParams(link, params, values);
+
+        logMsg("#param set correct parameters");
+    }
+
+    /*
+     * @testName: paramThrowsExceptionWhenNullNameTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:807; JAXRS:JAVADOC:1053;
+     * 
+     * @test_Strategy: throws IlleagalArgumentException - if either the name or
+     * value are null
+     * 
+     * jakarta.ws.rs.ext.RuntimeDelegate.createLinkBuilder
+     */
+    @Test
+    public void paramThrowsExceptionWhenNullNameTest() throws Fault {
+        Link.Builder builder = RuntimeDelegate.getInstance().createLinkBuilder().uri(url());
+        try {
+            builder.param((String) null, "value");
+            throw new Fault("No exception has been thrown when null name");
+        } catch (IllegalArgumentException e) {
+            logMsg("#param throws IllegalArgumentException as expected");
+        }
+    }
+
+    /*
+     * @testName: paramThrowsExceptionWhenNullValueTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:807; JAXRS:JAVADOC:1053;
+     * 
+     * @test_Strategy: throws IlleagalArgumentException - if either the name or
+     * value are null
+     * 
+     * jakarta.ws.rs.ext.RuntimeDelegate.createLinkBuilder *
+     */
+    @Test
+    public void paramThrowsExceptionWhenNullValueTest() throws Fault {
+        Link.Builder builder = RuntimeDelegate.getInstance().createLinkBuilder().uri(url());
+        try {
+            builder.param((String) null, "value");
+            throw new Fault("No exception has been thrown when null name");
+        } catch (IllegalArgumentException e) {
+            logMsg("#param throws IllegalArgumentException as expected");
+        }
+    }
+
+    /*
+     * @testName: relTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:809; JAXRS:JAVADOC:1053;
+     * 
+     * @test_Strategy: Convenience method to set a link relation. More than one rel
+     * value can be specified using this method.
+     * 
+     * jakarta.ws.rs.ext.RuntimeDelegate.createLinkBuilder
+     */
+    @Test
+    public void relTest() throws Fault {
+        String[] names = { "name1", "name2" };
+        Link.Builder builder = RuntimeDelegate.getInstance().createLinkBuilder().uri(url());
+        for (String name : names) {
+            Link link = builder.rel(name).build();
+            assertTrue(link.getRel().contains(name), "Rel " + name + " not found in " + link);
+        }
+        logMsg("#rel added expected relations");
+    }
+
+    /*
+     * @testName: relMoreNamesTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:809; JAXRS:JAVADOC:1053;
+     * 
+     * @test_Strategy: More than one "rel" value can be specified by using one or
+     * more whitespace characters as delimiters according to RFC 5988. The effect of
+     * calling this method is cumulative; relations are appended using a single
+     * space character as separator.
+     * 
+     * jakarta.ws.rs.ext.RuntimeDelegate.createLinkBuilder
+     */
+    @Test
+    public void relMoreNamesTest() throws Fault {
+        String[] names = { "name1", "name2" };
+        Link.Builder builder = RuntimeDelegate.getInstance().createLinkBuilder().uri(url());
+        for (String name : names)
+            builder = builder.rel(name);
+        Link link = builder.build();
+        String search = JaxrsUtil.iterableToString(" ", (Object[]) names);
+        assertTrue(link.getRel().contains(search), "rel " + search + " not found in " + link);
+        logMsg("#rel added expected relations");
+    }
+
+    /*
+     * @testName: titleTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:810; JAXRS:JAVADOC:1053;
+     * 
+     * @test_Strategy: Convenience method to set a title on this link. If called
+     * more than once, the previous value of title is overwritten.
+     * 
+     * jakarta.ws.rs.ext.RuntimeDelegate.createLinkBuilder
+     */
+    @Test
+    public void titleTest() throws Fault {
+        String[] titles = { "tiTle1", "titlE2", "titLe3" };
+        Link.Builder builder = RuntimeDelegate.getInstance().createLinkBuilder().uri(url());
+        for (String title : titles) {
+            builder = builder.title(title);
+            Link link = builder.build();
+            assertTrue(link.getTitle().equals(title), "Title " + title + " not found in " + link);
+        }
+        logMsg("#title set expected title");
+    }
+
+    /*
+     * @testName: typeTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:811; JAXRS:JAVADOC:1053;
+     * 
+     * @test_Strategy: Convenience method to set a type on this link. If called more
+     * than once, the previous value of title is overwritten.
+     * 
+     * jakarta.ws.rs.ext.RuntimeDelegate.createLinkBuilder
+     */
+    @Test
+    public void typeTest() throws Fault {
+        String[] types = { "type1", "type2", "type3" };
+        Link.Builder builder = RuntimeDelegate.getInstance().createLinkBuilder().uri(url());
+        for (String type : types) {
+            Link link = builder.type(type).build();
+            assertTrue(link.getType().equals(type), "type " + type + " not found in " + link);
+        }
+        logMsg("#type set correct types");
+    }
+
+    /*
+     * @testName: uriUriTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:812; JAXRS:JAVADOC:1053;
+     * 
+     * @test_Strategy: Set underlying URI template for the link being constructed.
+     * 
+     * jakarta.ws.rs.ext.RuntimeDelegate.createLinkBuilder
+     */
+    @Test
+    public void uriUriTest() throws Fault {
+        URI uri = uri("get");
+        Link.Builder builder = RuntimeDelegate.getInstance().createLinkBuilder().uri(uri);
+        Link link = builder.build();
+        assertTrue(link.toString().contains(uri.toASCIIString()), "uri(URI) " + uri + " not used in " + link);
+        logMsg("#uri(URI) affected link", link, "as expected");
+    }
+
+    /*
+     * @testName: uriStringTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:813; JAXRS:JAVADOC:1053;
+     * 
+     * @test_Strategy: Set underlying string representing URI template for the link
+     * being constructed.
+     * 
+     * jakarta.ws.rs.ext.RuntimeDelegate.createLinkBuilder
+     */
+    @Test
+    public void uriStringTest() throws Fault {
+        Link.Builder builder = RuntimeDelegate.getInstance().createLinkBuilder().uri(url());
+        Link link = builder.build();
+        assertTrue(link.toString().contains(url()), "uri(String) " + url() + " not used in " + link);
+        logMsg("#uri(String) affected link", link, "as expected");
+    }
+
+    /*
+     * @testName: uriStringThrowsIAETest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:813; JAXRS:JAVADOC:1053;
+     * 
+     * @test_Strategy: throws IllegalArgumentException - if string representation of
+     * URI is invalid
+     * 
+     * jakarta.ws.rs.ext.RuntimeDelegate.createLinkBuilder
+     */
+    @Test
+    public void uriStringThrowsIAETest() throws Fault {
+        try {
+            RuntimeDelegate.getInstance().createLinkBuilder().uri((String) null).build();
+            fault("IllegalArgumentException has not been thrown for uri(null)");
+        } catch (IllegalArgumentException e) {
+            logMsg("#uri(nonUriString) throws IllegalArgumentException as expected");
+        }
+    }
+
+    /*
+     * @testName: uriBuilderTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:1006; JAXRS:JAVADOC:1053;
+     * 
+     * @test_Strategy: Set underlying URI builder representing the URI template for
+     * the link being constructed.
+     * 
+     * jakarta.ws.rs.ext.RuntimeDelegate.createLinkBuilder
+     */
+    @Test
+    public void uriBuilderTest() throws Fault {
+        String segment = "goto/label/ten/";
+        Link link = Link.fromUri(uri(segment)).build();
+        UriBuilder uriBuilder = link.getUriBuilder();
+
+        Builder linkBuilder = RuntimeDelegate.getInstance().createLinkBuilder().uriBuilder(uriBuilder);
+        String sBuilder = uriBuilder.build().toASCIIString();
+        String sFromBuilder = linkBuilder.build().getUri().toASCIIString();
+        assertContains(sFromBuilder, sBuilder, "Original builder", sBuilder, "not found in #fromUriBuilder",
+                sFromBuilder);
+        logMsg("#fromUriBuilder", sFromBuilder, "contains the original", sBuilder);
+    }
+
+    /*
+     * @testName: baseUriURITest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:1125; JAXRS:JAVADOC:1053;
+     * 
+     * @test_Strategy: Set the base URI for resolution of relative URIs.
+     * 
+     * jakarta.ws.rs.ext.RuntimeDelegate.createLinkBuilder
+     */
+    @Test
+    public void baseUriURITest() throws Fault {
+        URI uri = null;
+        try {
+            uri = new URI(url());
+        } catch (URISyntaxException use) {
+            fault(use);
+        }
+        Builder linkBuilder = RuntimeDelegate.getInstance().createLinkBuilder();
+        linkBuilder = linkBuilder.baseUri(uri);
+        URI createdUri = linkBuilder.uri("/a/b/c").build().getUri();
+        logMsg("Created URI", createdUri.toASCIIString());
+        assertContains(createdUri.toASCIIString(), uri.toASCIIString());
+    }
+
+    /*
+     * @testName: baseUriIsNotJustBaseURITest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:1125; JAXRS:JAVADOC:1053;
+     * 
+     * @test_Strategy: Set the base URI for resolution of relative URIs. Provide a
+     * URI that is not just base, i.e. schema and authority, but also a path
+     * 
+     * jakarta.ws.rs.ext.RuntimeDelegate.createLinkBuilder
+     */
+    @Test
+    public void baseUriIsNotJustBaseURITest() throws Fault {
+        URI uri = uri("something");
+        Builder linkBuilder = RuntimeDelegate.getInstance().createLinkBuilder();
+        linkBuilder = linkBuilder.baseUri(uri);
+        URI createdUri = linkBuilder.uri("/a/b/c").build().getUri();
+        logMsg("Created URI", createdUri.toASCIIString());
+        assertFalse(createdUri.toASCIIString().contains(uri.toASCIIString()), "Base Uri " + uri.toASCIIString() +
+                " is not a base uri built as " + createdUri.toASCIIString());
+        assertContains(createdUri.toASCIIString(), url());
+    }
+
+    /*
+     * @testName: baseUriIsIgnoredURITest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:1125; JAXRS:JAVADOC:1053;
+     * 
+     * @test_Strategy: If the underlying URI is already absolute, the base URI is
+     * ignored.
+     * 
+     * jakarta.ws.rs.ext.RuntimeDelegate.createLinkBuilder
+     */
+    @Test
+    public void baseUriIsIgnoredURITest() throws Fault {
+        String ignored = "http://ignored.com";
+        URI ignoredUri = null;
+        try {
+            ignoredUri = new URI(ignored);
+        } catch (URISyntaxException e) {
+            fault(ignored);
+        }
+        URI uri = uri("something");
+        Builder linkBuilder = RuntimeDelegate.getInstance().createLinkBuilder();
+        linkBuilder = linkBuilder.uri(uri);
+        linkBuilder = linkBuilder.baseUri(ignoredUri);
+        URI createdUri = linkBuilder.build().getUri();
+        logMsg("Created URI", createdUri.toASCIIString());
+        assertFalse(createdUri.toASCIIString().contains(ignored), "Base Uri " + ignored + " is not ignored, though " +
+                uri.toASCIIString() + " is absolute");
+        assertContains(createdUri.toASCIIString(), url());
+        logMsg("The base uri", ignored, "has been ignored as expected");
+    }
+
+    /*
+     * @testName: baseUriStringTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:1126; JAXRS:JAVADOC:1053;
+     * 
+     * @test_Strategy: Set the base URI as a string for resolution of relative URIs.
+     * 
+     * jakarta.ws.rs.ext.RuntimeDelegate.createLinkBuilder
+     */
+    @Test
+    public void baseUriStringTest() throws Fault {
+        URI uri = null;
+        try {
+            uri = new URI(url());
+        } catch (URISyntaxException use) {
+            fault(use);
+        }
+        Builder linkBuilder = RuntimeDelegate.getInstance().createLinkBuilder();
+        linkBuilder = linkBuilder.baseUri(uri.toASCIIString());
+        URI createdUri = linkBuilder.uri("/a/b/c").build().getUri();
+        logMsg("Created URI", createdUri.toASCIIString());
+        assertContains(createdUri.toASCIIString(), uri.toASCIIString());
+    }
+
+    /*
+     * @testName: baseUriStringThrowsIAETest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:1126; JAXRS:JAVADOC:1053;
+     * 
+     * @test_Strategy: throws java.lang.IllegalArgumentException - if string
+     * representation of URI is invalid.
+     * 
+     * jakarta.ws.rs.ext.RuntimeDelegate.createLinkBuilder
+     */
+    @Test
+    public void baseUriStringThrowsIAETest() throws Fault {
+        Builder linkBuilder = RuntimeDelegate.getInstance().createLinkBuilder();
+        try {
+            linkBuilder.baseUri("?:!@#$%^&*()");
+            fault("IllegalArgumentException has not been thrown");
+        } catch (IllegalArgumentException iae) {
+            logMsg("IllegalArgumentException has been thrown as expected");
+        }
+    }
+
+    /*
+     * @testName: baseUriIsNotJustBaseStringTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:1126; JAXRS:JAVADOC:1053;
+     * 
+     * @test_Strategy: Set the base URI as a string for resolution of relative URIs.
+     * Provide a URI that is not just base, i.e. schema and authority, but also a
+     * path
+     * 
+     * jakarta.ws.rs.ext.RuntimeDelegate.createLinkBuilder
+     */
+    @Test
+    public void baseUriIsNotJustBaseStringTest() throws Fault {
+        URI uri = uri("something");
+        Builder linkBuilder = RuntimeDelegate.getInstance().createLinkBuilder();
+        linkBuilder = linkBuilder.baseUri(uri.toASCIIString());
+        URI createdUri = linkBuilder.uri("/a/b/c").build().getUri();
+        logMsg("Created URI", createdUri.toASCIIString());
+        assertFalse(createdUri.toASCIIString().contains(uri.toASCIIString()), "Base Uri " + uri.toASCIIString() +
+                " is not a base uri built as " + createdUri.toASCIIString());
+        assertContains(createdUri.toASCIIString(), url());
+    }
+
+    /*
+     * @testName: baseUriIsIgnoredStringTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:1126; JAXRS:JAVADOC:1053;
+     * 
+     * @test_Strategy: If the underlying URI is already absolute, the base URI is
+     * ignored. jakarta.ws.rs.ext.RuntimeDelegate.createLinkBuilder
+     */
+    @Test
+    public void baseUriIsIgnoredStringTest() throws Fault {
+        String ignored = "http://ignored.com";
+        URI uri = uri("something");
+        Builder linkBuilder = RuntimeDelegate.getInstance().createLinkBuilder();
+        linkBuilder = linkBuilder.uri(uri);
+        linkBuilder = linkBuilder.baseUri(ignored);
+        URI createdUri = linkBuilder.build().getUri();
+        logMsg("Created URI", createdUri.toASCIIString());
+        assertFalse(createdUri.toASCIIString().contains(ignored), "Base Uri " + ignored + " is not ignored, though " +
+                uri.toASCIIString() + "is absolute");
+        assertContains(createdUri.toASCIIString(), url());
+        logMsg("The base uri", ignored, "has been ignored as expected");
+    }
+
+    /*
+     * @testName: buildRelativizedTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:1054; JAXRS:JAVADOC:1053;
+     * 
+     * @test_Strategy: Finish building this link using the supplied values as URI
+     * parameters and relativize the result with respect to the supplied URI.
+     * jakarta.ws.rs.ext.RuntimeDelegate.createLinkBuilder
+     */
+    @Test
+    public void buildRelativizedTest() throws Fault {
+        String relative = "a/b/c";
+        URI underlay = uri(relative), respect = uri("");
+        Builder linkBuilder = RuntimeDelegate.getInstance().createLinkBuilder();
+        linkBuilder = linkBuilder.uri(underlay);
+        Link link = linkBuilder.buildRelativized(respect);
+        assertFalse(link.toString().contains(url()), "Found unexpected absolute path " + url());
+        assertContains(link.toString(), relative);
+        logMsg("Absolute", url(), "has not been found as expected in link", link.toString());
+    }
+
+    /*
+     * @testName: buildRelativizedDoesNotSharePrefixTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:1054;
+     * 
+     * @test_Strategy: If the underlying link is absolute but does not share a
+     * prefix with the supplied URI, this method is equivalent to calling
+     * build(java.lang.Object[])
+     */
+    @Test
+    public void buildRelativizedDoesNotSharePrefixTest() throws Fault {
+        String relative = "a/b/c";
+        String prefix = "ssh";
+        URI underlay = null, respect = null;
+        try {
+            underlay = new URI(url() + relative);
+            respect = new URI(url().replace("http", prefix));
+        } catch (URISyntaxException e) {
+            fault(e);
+        }
+        Builder linkBuilder = RuntimeDelegate.getInstance().createLinkBuilder();
+        linkBuilder = linkBuilder.uri(underlay);
+        Link link = linkBuilder.buildRelativized(respect);
+        Link build = linkBuilder.build(respect);
+        assertContains(link.toString(), relative);
+        assertContains(link.toString(), url());
+        assertContains(link.toString(), build.getUri().toASCIIString()); // |=|
+        logMsg("When a prefix is not shared, the methods is equivalent to build() as expected");
+    }
+
+    /*
+     * @testName: buildRelativizedThrowsIAEWhenNotSuppliedValuesTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:1054;
+     * 
+     * @test_Strategy: Throws: java.lang.IllegalArgumentException - if there are any
+     * URI template parameters without a supplied value
+     */
+    @Test
+    public void buildRelativizedThrowsIAEWhenNotSuppliedValuesTest() throws Fault {
+        Builder linkBuilder = Link.fromUri(url() + "{x1}/{x2}/{x3}"); // rfc6570
+        URI respect = null;
+        try {
+            respect = new URI(url());
+        } catch (URISyntaxException e) {
+            fault(e);
+        }
+        try {
+            Link link = linkBuilder.buildRelativized(respect);
+            fault("IllegalArgumentException has not been thrown when value is not supplied, link=", link.toString());
+        } catch (IllegalArgumentException iae) {
+            logMsg("IllegalArgumentException has been thrown as expected when a value has not been supplied");
+        }
+    }
+
+    /*
+     * @testName: buildRelativizedThrowsIAEWhenSuppliedJustOneValueOutOfThreeTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:1054;
+     * 
+     * @test_Strategy: Throws: java.lang.IllegalArgumentException - if there are any
+     * URI template parameters without a supplied value
+     */
+    @Test
+    public void buildRelativizedThrowsIAEWhenSuppliedJustOneValueOutOfThreeTest() throws Fault {
+        Builder linkBuilder = Link.fromUri(url() + "{x1}/{x2}/{x3}"); // rfc6570
+        URI respect = null;
+        try {
+            respect = new URI(url());
+        } catch (URISyntaxException e) {
+            fault(e);
+        }
+        try {
+            Link link = linkBuilder.buildRelativized(respect, "p");
+            fault("IllegalArgumentException has not been thrown when value is not supplied, link=", link.toString());
+        } catch (IllegalArgumentException iae) {
+            logMsg("IllegalArgumentException has been thrown as expected when a value has not been supplied");
+        }
+    }
+
+    /*
+     * @testName: buildRelativizedThrowsIAEWhenSuppliedValueIsNullTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:1054;
+     * 
+     * @test_Strategy: Throws: java.lang.IllegalArgumentException - if a value is
+     * null.
+     */
+    @Test
+    public void buildRelativizedThrowsIAEWhenSuppliedValueIsNullTest() throws Fault {
+        Builder linkBuilder = Link.fromUri(url() + "{x1}/{x2}/{x3}"); // rfc6570
+        URI respect = null;
+        try {
+            respect = new URI(url());
+        } catch (URISyntaxException e) {
+            fault(e);
+        }
+        try {
+            Link link = linkBuilder.buildRelativized(respect, new Object[] { (String) null });
+            fault("IllegalArgumentException has not been thrown when value is not supplied, link=", link.toString());
+        } catch (IllegalArgumentException iae) {
+            logMsg("IllegalArgumentException has been thrown as expected when a supplied value is null");
+        }
+    }
+
+    /*
+     * @testName: buildRelativizedThrowsUriBuilderExceptionTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:1054; JAXRS:JAVADOC:1053;
+     * 
+     * @test_Strategy: Throws: UriBuilderException - if a URI cannot be constructed
+     * based on the current state of the underlying URI builder.
+     * jakarta.ws.rs.ext.RuntimeDelegate.createLinkBuilder
+     */
+    @Test
+    public void buildRelativizedThrowsUriBuilderExceptionTest() throws Fault {
+        Builder linkBuilder = RuntimeDelegate.getInstance().createLinkBuilder();
+        URI respect = null;
+        try {
+            respect = new URI(url());
+        } catch (URISyntaxException e) {
+            fault(e);
+        }
+        try {
+            Link link = linkBuilder.uri("http://@").buildRelativized(respect);
+            fault("UriBuilderException has not been thrown, link=", link.toString());
+        } catch (UriBuilderException iae) {
+            logMsg("UriBuilderException has been thrown as expected");
+        }
+    }
+
+    /*
+     * @testName: linkLinkTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:1042; JAXRS:JAVADOC:1053;
+     * 
+     * @test_Strategy: Initialize builder using another link. Sets underlying URI
+     * and copies all parameters.
+     * jakarta.ws.rs.ext.RuntimeDelegate.createLinkBuilder
+     */
+    @Test
+    public void linkLinkTest() throws Fault {
+        String title = "Ttttlll";
+        String rel = "RlrL";
+        String[] params = { "Param1", "parAM2", "paRam3" };
+        String[] values = { "vAlUe", "ValuEe", "VVallue" };
+        Builder lb = RuntimeDelegate.getInstance().createLinkBuilder();
+        lb = lb.baseUri(url()).title(title).rel(rel).type(MediaType.TEXT_XML);
+        for (int i = 0; i != params.length; i++)
+            lb = lb.param(params[i], values[i]);
+        Link link = lb.build();
+        Builder lb2 = RuntimeDelegate.getInstance().createLinkBuilder();
+        lb2 = lb2.link(link);
+        link = lb2.build();
+        // rel & title is param of Link
+        assertContains(link.getRel(), rel, "link(Link) does not pass relation");
+        assertContains(link.getTitle(), title, "link(Link) does noot pass title");
+        assertContains(link.getType(), MediaType.TEXT_XML, "link(Link) does not pass type");
+        assertParams(link, params, values);
+        assertContains(link.toString(), url());
+        logMsg("parameters and underlaying URI were copied as expected to a new link", link);
+    }
+
+    /*
+     * @testName: linkStringTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:1043; JAXRS:JAVADOC:1053;
+     * 
+     * @test_Strategy: Initialize builder using another link represented as a
+     * string. Uses simple parser to convert string representation into a link.
+     */
+    @Test
+    public void linkStringTest() throws Fault {
+        String title = "Ttttlll";
+        String rel = "RlrL";
+        String[] params = { "Param1", "parAM2", "paRam3" };
+        String[] values = { "vAlUe", "ValuEe", "VVallue" };
+        StringBuilder sb = new StringBuilder().append("<").append(url()).append(">;").append("rel=\"").append(rel)
+                .append("\";");
+        for (int i = 0; i != params.length; i++)
+            sb = sb.append(params[i]).append("=\"").append(values[i]).append("\";");
+        sb = sb.append("title=\"").append(title).append("\";");
+        sb = sb.append("type=\"").append(MediaType.TEXT_XML).append("\"");
+        String originalLink = sb.toString();
+        Builder lb = RuntimeDelegate.getInstance().createLinkBuilder();
+        lb = lb.link(originalLink);
+        Link link = lb.build();
+        // rel & title is param of Link
+        assertContains(link.getRel(), rel, "link(Link) does not pass relation");
+        assertContains(link.getTitle(), title, "link(Link) does noot pass title");
+        assertContains(link.getType(), MediaType.TEXT_XML, "link(Link) does not pass type");
+        assertParams(link, params, values);
+        assertContains(link.toString(), url());
+        logMsg("parameters and underlaying URI were copied as expected to a new link", link);
+    }
+
+    /*
+     * @testName: linkStringThrowsIAETest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:1043; JAXRS:JAVADOC:1053;
+     * 
+     * @test_Strategy: Throws: java.lang.IllegalArgumentException - if string
+     * representation of URI is invalid.
+     */
+    @Test
+    public void linkStringThrowsIAETest() throws Fault {
+        Builder lb = RuntimeDelegate.getInstance().createLinkBuilder();
+        try {
+            lb.link("<>>");
+            fault("IllegalArgumentException has not been throw when invalid uri");
+        } catch (IllegalArgumentException e) {
+            logMsg("IllegalArgumentException has been thrown as expected");
+        }
+    }
+
+    // ///////////////////////////////////////////////////////////////////
+    protected static Link.Builder builderFromResource(String method) {
+        Builder builder = Link.fromMethod(Resource.class, method);
+        return builder;
+    }
+
+    private static//
+    void assertParams(Link link, String[] params, String[] values) throws Fault {
+        Map<String, String> map = link.getParams();
+        for (int i = 0; i != params.length; i++) {
+            String list = map.get(params[i]);
+            assertContains(list, values[i], "Link.getParams", map, "does not contain", values[i]);
+            logMsg("Found", values[i], "in map", map, "as expected");
+        }
+    }
+
+    protected void assertContains(String string, String substring) throws Fault {
+        assertTrue(string.toLowerCase().contains(substring.toLowerCase()), string + " does not contain expected " +
+                substring);
+        logMsg("Found expected", substring);
+    }
+
+    protected URI uri(String method) throws Fault {
+        URI uri = null;
+        try {
+            uri = new URI(url() + "resource/" + method);
+        } catch (URISyntaxException e) {
+            throw new Fault(e);
+        }
+        return uri;
+    }
+
+    protected static String url() {
+        return "http://oracle.com:888/";
+    }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/linkbuilder/Resource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/linkbuilder/Resource.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.core.linkbuilder;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.tck.common.impl.TRACE;
+
+@Path("resource")
+public class Resource {
+
+  @GET
+  @Path("get")
+  public String get() {
+    return "GET";
+  }
+
+  @DELETE
+  @Path("delete")
+  public String delete() {
+    return "DELETE";
+  }
+
+  @TRACE
+  @Path("trace")
+  public String trace() {
+    return "TRACE";
+  }
+
+  @GET
+  @Produces(MediaType.APPLICATION_SVG_XML)
+  @Path("producessvgxml")
+  public String producesSvgXml() {
+    return MediaType.APPLICATION_SVG_XML;
+  }
+
+  @POST
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Path("consumesAppJson")
+  public String consumesAppJson() {
+    return MediaType.APPLICATION_JSON;
+  }
+
+  @POST
+  @Produces({ MediaType.APPLICATION_XHTML_XML, MediaType.APPLICATION_ATOM_XML,
+      MediaType.APPLICATION_SVG_XML })
+  @Path("producesxml")
+  public String producesXml() {
+    return MediaType.APPLICATION_XHTML_XML;
+  }
+
+  @POST
+  @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+  @Path("consumesform")
+  public String consumesForm() {
+    return MediaType.APPLICATION_FORM_URLENCODED;
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/linkjaxbadapter/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/linkjaxbadapter/JAXRSClientIT.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.core.linkjaxbadapter;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.Charset;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.core.Link;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.ext.RuntimeDelegate;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+    private static final long serialVersionUID = -5902280515880564932L;
+
+    protected static final String url = "some://where.at:port/";
+
+    protected static final String rel = "Relation";
+
+    protected static final String media = MediaType.APPLICATION_SVG_XML;
+
+    protected static final String title = "XTitleX";
+
+    protected static final String[] param_names = { "name1", "name2" };
+
+    protected static final String[] param_vals = { "val1", "val2" };
+
+    @BeforeEach
+    void logStartTest(TestInfo testInfo) {
+        TestUtil.logMsg("STARTING TEST : " + testInfo.getDisplayName());
+    }
+
+    @AfterEach
+    void logFinishTest(TestInfo testInfo) {
+        TestUtil.logMsg("FINISHED TEST : " + testInfo.getDisplayName());
+    }
+
+    /*
+     * @testName: marshallTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:815; JAXRS:JAVADOC:816;
+     * 
+     * @test_Strategy:
+     */
+    @Test
+    @Disabled("Can't find implementation for jakarta.xml.bind-api")
+    public byte[] marshallTest() throws Fault {
+        Link link = RuntimeDelegate.getInstance().createLinkBuilder().uri(url).title(title).rel(rel).type(media)
+                .param(param_names[0], param_vals[0]).param(param_names[1], param_vals[1]).build();
+        Model model = new Model(link);
+
+        ByteArrayOutputStream ostream = new ByteArrayOutputStream(1000);
+        JAXBContext jc = null;
+        Marshaller marshaller = null;
+        byte[] array = null;
+        try {
+            jc = JAXBContext.newInstance(Model.class);
+            marshaller = jc.createMarshaller();
+            marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+            marshaller.marshal(model, ostream);
+
+            array = ostream.toByteArray();
+            String string = new String(array, Charset.defaultCharset());
+            assertContains(string, "link href=", "Marshalled Link", string,
+                    "does not contain expected uri reference field");
+            assertContains(string, url, "Marshalled Link", string, " does not contain expected uri reference", url);
+            assertContains(string, media, "MediaType has not been marshalled in", string);
+            assertContains(string, title, "Title has not been marshalled in", string);
+            assertContains(string, rel, "Relation has not been marshalled in", string);
+            assertContains(string, param_names[0], "parameter name", param_names[0], "has not been marshalled in",
+                    string);
+            assertContains(string, param_names[1], "parameter name", param_names[1], "has not been marshalled in",
+                    string);
+            assertContains(string, param_vals[0], "parameter value", param_vals[0], "has not been marshalled in",
+                    string);
+            assertContains(string, param_vals[1], "parameter value", param_vals[1], "has not been marshalled in",
+                    string);
+            logMsg("Marshalled Link contains expected", string);
+        } catch (JAXBException e) {
+            throw new Fault(e);
+        }
+        return array;
+    }
+
+    /*
+     * @testName: unmarshallTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:815; JAXRS:JAVADOC:816; JAXRS:JAVADOC:818;
+     * 
+     * @test_Strategy: Test whether a class with Link can be unmarshalled fine
+     */
+    @Test
+    @Disabled("Can't find implementation for jakarta.xml.bind-api")
+    public void unmarshallTest() throws Fault {
+        JAXBContext jc = null;
+        Unmarshaller unmarshaller = null;
+        ByteArrayInputStream istream = null;
+        Model unmarshalledModel = null;
+        try {
+            byte[] array = marshallTest();
+            istream = new ByteArrayInputStream(array);
+
+            jc = JAXBContext.newInstance(Model.class);
+            unmarshaller = jc.createUnmarshaller();
+            unmarshalledModel = (Model) unmarshaller.unmarshal(istream);
+            Link link = unmarshalledModel.getLink();
+
+            assertContains(link.toString(), url, "unmarshalled link", link, "does not contain expected url", url);
+            assertContains(link.getRel(), rel, "unmarshalled link", link, "does not contain expected relation", rel);
+            assertContains(link.getTitle(), title, "unmarshalled link", link, "does not contain expected title", title);
+            assertContains(link.getType(), media, "unmarshalled link", link, "does not contain expected media type",
+                    media);
+            assertTrue(link.getParams().size() > 2,
+                    "unmarshalled link " + link + " does not contain expected parameters");
+            assertContains(link.getParams().get(param_names[0]), param_vals[0], "unmarshalled link", link,
+                    "does not contain expected parameter", param_names[0], "=", param_vals[0]);
+            assertContains(link.getParams().get(param_names[1]), param_vals[1], "unmarshalled link", link,
+                    "does not contain expected parameter", param_names[1], "=", param_vals[1]);
+            logMsg("unmarshalled Link contains expected url, title, media type, and parameters", link);
+        } catch (JAXBException e) {
+            throw new Fault(e);
+        }
+    }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/linkjaxbadapter/JaxbAdapterEx.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/linkjaxbadapter/JaxbAdapterEx.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.core.linkjaxbadapter;
+
+import jakarta.ws.rs.core.Link;
+import jakarta.ws.rs.core.Link.JaxbAdapter;
+import jakarta.ws.rs.core.Link.JaxbLink;
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
+
+public class JaxbAdapterEx extends XmlAdapter<JaxbLinkEx, Link> {
+
+    /**
+     * Convert a {@link JaxbLink} into a {@link Link}.
+     * 
+     * @param v instance of type {@link JaxbLink}.
+     * @return mapped instance of type {@link JaxbLink}
+     */
+    @Override
+    public Link unmarshal(JaxbLinkEx ex) {
+        JaxbLink link = new JaxbLink(ex.getUri(), ex.getParams());
+        return new JaxbAdapter().unmarshal(link);
+    }
+
+    /**
+     * Convert a {@link Link} into a {@link JaxbLink}.
+     * 
+     * @param v instance of type {@link Link}.
+     * @return mapped instance of type {@link JaxbLink}.
+     */
+    @Override
+    public JaxbLinkEx marshal(Link v) {
+        JaxbLink link = new JaxbAdapter().marshal(v);
+        JaxbLinkEx jle = new JaxbLinkEx(link.getUri(), link.getParams());
+        return jle;
+    }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/linkjaxbadapter/JaxbLinkEx.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/linkjaxbadapter/JaxbLinkEx.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.core.linkjaxbadapter;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.xml.namespace.QName;
+
+import jakarta.xml.bind.annotation.XmlAnyAttribute;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+/**
+ * JaxbLink with setters and xml annotations
+ */
+@XmlRootElement
+public class JaxbLinkEx {
+
+    protected URI uri;
+
+    protected Map<QName, Object> params;
+
+    /**
+     * Default constructor needed during unmarshalling.
+     */
+    public JaxbLinkEx() {
+    }
+
+    /**
+     * Construct an instance from a URI and no parameters.
+     * 
+     * @param uri underlying URI.
+     */
+    public JaxbLinkEx(URI uri) {
+        this.uri = uri;
+    }
+
+    /**
+     * Construct an instance from a URI and some parameters.
+     * 
+     * @param uri    underlying URI.
+     * @param params parameters of this link.
+     */
+    public JaxbLinkEx(URI uri, Map<QName, Object> params) {
+        this.uri = uri;
+        this.params = params;
+    }
+
+    /**
+     * Get the underlying URI for this link.
+     * 
+     * @return underlying URI.
+     */
+    @XmlAttribute(name = "href")
+    public URI getUri() {
+        return uri;
+    }
+
+    /**
+     * Get the parameter map for this link.
+     * 
+     * @return parameter map.
+     */
+    @XmlAnyAttribute
+    public Map<QName, Object> getParams() {
+        if (params == null) {
+            params = new HashMap<QName, Object>();
+        }
+        return params;
+    }
+
+    public void setUri(final URI uri) {
+        this.uri = uri;
+    }
+
+    public void setParams(final Map<QName, Object> params) {
+        this.params = params;
+    }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/linkjaxbadapter/Model.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/linkjaxbadapter/Model.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.core.linkjaxbadapter;
+
+import jakarta.ws.rs.core.Link;
+import jakarta.ws.rs.ext.RuntimeDelegate;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Model {
+
+    public Model(Link link) {
+        super();
+        this.link = link;
+    }
+
+    public Model() {
+        link = RuntimeDelegate.getInstance().createLinkBuilder().uri("default://constructor.model/was/used").build();
+    }
+
+    @XmlElement
+    @XmlJavaTypeAdapter(JaxbAdapterEx.class)
+    Link link;
+
+    public Link getLink() {
+        return link;
+    }
+
+    public void setLink(Link lnk) {
+        link = lnk;
+    }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/linkjaxblink/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/linkjaxblink/JAXRSClientIT.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2014, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.core.linkjaxblink;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+
+import javax.xml.namespace.QName;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.core.Link;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = -6053007016837644641L;
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : " + testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : " + testInfo.getDisplayName());
+  }
+
+  /*
+   * @testName: defaultConstructorTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:822; JAXRS:JAVADOC:820; JAXRS:JAVADOC:821;
+   * 
+   * @test_Strategy: Default constructor needed during unmarshalling.
+   * JaxbLink.getParams; JaxbLink.getUri
+   */
+  @Test
+  public void defaultConstructorTest() throws Fault {
+    Link.JaxbLink jaxbLink = new Link.JaxbLink();
+    boolean getUri = jaxbLink.getUri() == null || jaxbLink.getUri().toASCIIString() == null
+        || jaxbLink.getUri().toASCIIString().isEmpty();
+    assertTrue(getUri, "JaxbLink.getUri() is unexpectedly preset to " + jaxbLink.getUri());
+    logMsg("Link.JaxbLink.getUri() is empty as expected");
+    boolean params = jaxbLink.getParams() == null || jaxbLink.getParams().isEmpty();
+    assertTrue(params, "JaxbLink.getParams() is unexpectedly preset to " + jaxbLink.getParams());
+    logMsg("Link.JaxbLink.getParams() is empty as expected");
+  }
+
+  /*
+   * @testName: uriConstructorTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:823; JAXRS:JAVADOC:820; JAXRS:JAVADOC:821;
+   * 
+   * @test_Strategy: Construct an instance from a URI and no parameters.
+   * JaxbLink.getParams; JaxbLink.getUri
+   */
+  @Test
+  public void uriConstructorTest() throws Fault {
+    String uri = "protocol://domain2.domain1:port";
+    URI fromString = uriFromString(uri);
+    Link.JaxbLink jaxbLink = new Link.JaxbLink(fromString);
+
+    boolean getUri = jaxbLink.getUri().equals(fromString);
+    assertTrue(getUri, "JaxbLink.getUri() is unexpectedly preset to " + jaxbLink.getUri());
+    logMsg("Link.JaxbLink.getUri() is", uri, "as expected");
+
+    boolean params = jaxbLink.getParams() == null || jaxbLink.getParams().isEmpty();
+    assertTrue(params, "JaxbLink.getParams() is unexpectedly preset to " + jaxbLink.getParams());
+    logMsg("Link.JaxbLink.getParams() is empty as expected");
+  }
+
+  /*
+   * @testName: uriParamsConstructorTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:824; JAXRS:JAVADOC:820; JAXRS:JAVADOC:821;
+   * 
+   * @test_Strategy: Construct an instance from a URI and some parameters.
+   * JaxbLink.getParams; JaxbLink.getUri
+   */
+  @Test
+  public void uriParamsConstructorTest() throws Fault {
+    String uri = "protocol://domain2.domain1:port";
+    String q = "qName";
+    QName qName = new QName(q);
+    URI fromString = uriFromString(uri);
+    java.util.Map<QName, Object> map;
+    map = new HashMap<QName, Object>();
+    map.put(qName, q);
+    Link.JaxbLink jaxbLink = new Link.JaxbLink(fromString, map);
+
+    boolean getUri = jaxbLink.getUri().equals(fromString);
+    assertTrue(getUri, "JaxbLink.getUri() is unexpectedly preset to " + jaxbLink.getUri());
+    logMsg("Link.JaxbLink.getUri() is", uri, "as expected");
+
+    boolean params = jaxbLink.getParams().containsKey(qName) && jaxbLink.getParams().get(qName).equals(q);
+    assertTrue(params, "JaxbLink.getParams() is unexpectedly set to " + jaxbLink.getParams());
+    logMsg("Link.JaxbLink.getParams() contains", q, "as expected");
+  }
+
+  // //////////////////////////////////////////////////////////////////////
+  private static URI uriFromString(String uri) throws Fault {
+    URI fromString = null;
+    try {
+      fromString = new URI(uri);
+    } catch (URISyntaxException e) {
+      throw new Fault(e);
+    }
+    return fromString;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/mediatype/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/mediatype/JAXRSClientIT.java
@@ -1,0 +1,615 @@
+/*
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.core.mediatype;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost; webServerPort; ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = 3136740904552966415L;
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : " + testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : " + testInfo.getDisplayName());
+  }
+  
+  /* Run test */
+
+  /*
+   * @testName: constructorTest1
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:92; JAXRS:JAVADOC:84; JAXRS:JAVADOC:85;
+   * 
+   * @test_Strategy: Create an MediaType instance using MediaType()
+   */
+  @Test
+  public void constructorTest1() throws Fault {
+    String type = MediaType.MEDIA_TYPE_WILDCARD;
+    String subtype = MediaType.MEDIA_TYPE_WILDCARD;
+
+    MediaType mt1 = new MediaType();
+    verifyMediaType(mt1, type, subtype);
+  }
+
+  /*
+   * @testName: constructorTest2
+   * 
+   * @assertion_ids: JAXRS:SPEC:33.8; JAXRS:SPEC:33.7; JAXRS:JAVADOC:91;
+   * JAXRS:JAVADOC:84; JAXRS:JAVADOC:85;
+   * 
+   * @test_Strategy: Create an MediaType instance using MediaType(String, String)
+   */
+  @Test
+  public void constructorTest2() throws Fault {
+    String type = "application";
+    String subtype = "atom+xml";
+
+    MediaType mt2 = new MediaType(type, subtype);
+
+    verifyMediaType(mt2, type, subtype);
+  }
+
+  /*
+   * @testName: constructorTest3
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:90; JAXRS:JAVADOC:83; JAXRS:JAVADOC:84;
+   * JAXRS:JAVADOC:85;
+   * 
+   * @test_Strategy: Create an MediaType instance using MediaType(String, String,
+   * Map)
+   */
+  @Test
+  public void constructorTest3() throws Fault {
+    String type = "application";
+    String subtype = "x-www-form-urlencoded";
+    Map<String, String> params = new HashMap<String, String>();
+
+    MediaType mt3 = new MediaType(type, subtype, params);
+
+    verifyMediaType(mt3, type, subtype, params, new String[0]);
+  }
+
+  /*
+   * @testName: constructorStringStringStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:825; JAXRS:JAVADOC:84; JAXRS:JAVADOC:85;
+   * JAXRS:JAVADOC:93;
+   * 
+   * @test_Strategy: Creates a new instance of MediaType with the supplied type,
+   * subtype and ""charset"" parameter.
+   * 
+   * getSubtype, getType, toString
+   */
+  @Test
+  public void constructorStringStringStringTest() throws Fault {
+    String type = MediaType.APPLICATION_FORM_URLENCODED_TYPE.getType();
+    String subtype = MediaType.APPLICATION_FORM_URLENCODED_TYPE.getSubtype();
+    String[] charsets = { "UTF-8", "ISO-8859-2", "UTF-16", null };
+    for (String charset : charsets) {
+      MediaType mt = new MediaType(type, subtype, charset);
+      verifyMediaType(mt, type, subtype);
+      if (charset != null)
+        assertCharset(mt, charset);
+    }
+  }
+
+  /*
+   * @testName: isCompatibleTest1
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:91; JAXRS:JAVADOC:87;
+   * 
+   * @test_Strategy: Create an MediaType instance using MediaType(String, String),
+   * verify method isCompatible works.
+   */
+  @Test
+  public void isCompatibleTest1() throws Fault {
+    String type = "text";
+    String subtype = "plain";
+
+    MediaType mt3 = new MediaType(type, subtype);
+
+    if (!mt3.isCompatible(jakarta.ws.rs.core.MediaType.TEXT_PLAIN_TYPE)) {
+      throw new Fault("isCompatible test failed.");
+    }
+  }
+
+  /*
+   * @testName: isCompatibleTest2
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:90; JAXRS:JAVADOC:91; JAXRS:JAVADOC:87;
+   * 
+   * @test_Strategy: Create two MediaType instances using MediaType(String,
+   * String), and MediaType(String, String, Map<String, String>) verify method
+   * isCompatible works.
+   */
+  @Test
+  public void isCompatibleTest2() throws Fault {
+    String type = "text";
+    String subtype = "plain";
+    Map<String, String> params = new HashMap<String, String>();
+
+    params.put("charset", "iso-8859-1");
+
+    MediaType mt5 = new MediaType(type, subtype);
+    MediaType mt6 = new MediaType(type, subtype, params);
+
+    if (!mt5.isCompatible(mt6)) {
+      throw new Fault("isCompatible test failed: " + "Expecting " + mt5.toString() + ", got " + mt6.toString());
+    }
+  }
+
+  /*
+   * @testName: isCompatibleTest3
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:91; JAXRS:JAVADOC:87;
+   * 
+   * @test_Strategy: Create two MediaType instances using MediaType(String,
+   * String), and MediaType(String, String, Map<String, String>) verify method
+   * isCompatible works.
+   */
+  @Test
+  public void isCompatibleTest3() throws Fault {
+    String type = "text";
+    String subtype = "plain";
+    String subtype1 = "html";
+
+    MediaType mt5 = new MediaType(type, subtype);
+    MediaType mt6 = new MediaType(type, subtype1);
+
+    if (mt5.isCompatible(mt6)) {
+      throw new Fault("isCompatible test failed: " + "Expecting " + mt5.toString() + ", got " + mt6.toString());
+    }
+  }
+
+  /*
+   * @testName: hashCodeTest1
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:91; JAXRS:JAVADOC:86;
+   * 
+   * @test_Strategy: Create an MediaType instance using MediaType(String, String),
+   * verify method hashCode works.
+   */
+  @Test
+  public void hashCodeTest1() throws Fault {
+    String type = "text";
+    String subtype = "plain";
+
+    MediaType mt3 = new MediaType(type, subtype);
+
+    if (mt3.hashCode() != jakarta.ws.rs.core.MediaType.TEXT_PLAIN_TYPE.hashCode()) {
+      throw new Fault("hashCode test failed." + " Expecting " + mt3.hashCode() + ", got "
+          + jakarta.ws.rs.core.MediaType.TEXT_PLAIN_TYPE.hashCode());
+    }
+  }
+
+  /*
+   * @testName: hashCodeTest2
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:90; JAXRS:JAVADOC:91; JAXRS:JAVADOC:86;
+   * 
+   * @test_Strategy: Create two MediaType instances using MediaType(String,
+   * String), and MediaType(String, String, Map<String, String>) verify method
+   * hashCode works.
+   */
+  @Test
+  public void hashCodeTest2() throws Fault {
+    String type = "text";
+    String subtype = "plain";
+    Map<String, String> params = new HashMap<String, String>();
+
+    params.put("charset", "iso-8859-1");
+
+    MediaType mt5 = new MediaType(type, subtype);
+    MediaType mt6 = new MediaType(type, subtype, params);
+
+    if (mt5.hashCode() == mt6.hashCode()) {
+      throw new Fault(
+          "hashCode test failed." + " Expecting different hashCode than " + mt5.hashCode() + ", got the same");
+    }
+  }
+
+  /*
+   * @testName: hashCodeTest3
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:91; JAXRS:JAVADOC:86;
+   * 
+   * @test_Strategy: Create two MediaType instances using MediaType(String,
+   * String), and MediaType(String, String, Map<String, String>) verify method
+   * hashCode works.
+   */
+  @Test
+  public void hashCodeTest3() throws Fault {
+    String type = "text";
+    String subtype = "plain";
+    String subtype1 = "html";
+
+    MediaType mt5 = new MediaType(type, subtype);
+    MediaType mt6 = new MediaType(type, subtype1);
+
+    int hc = mt5.hashCode();
+    int hc1 = mt6.hashCode();
+    if (hc == hc1) {
+      throw new Fault("hashCode test failed: " + "Expecting " + mt5.toString() + ", got " + mt6.toString());
+    }
+  }
+
+  /*
+   * @testName: equalsTest1
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:91; JAXRS:JAVADOC:82;
+   * 
+   * @test_Strategy: Create an MediaType instance using MediaType(String, String)
+   * Verify method equals works
+   */
+  @Test
+  public void equalsTest1() throws Fault {
+    String type = "text";
+    String subtype = "html";
+
+    MediaType mt4 = new MediaType(type, subtype);
+
+    if (!mt4.equals(jakarta.ws.rs.core.MediaType.TEXT_HTML_TYPE)) {
+      throw new Fault(
+          "Equals test failed" + "Expecting " + MediaType.TEXT_PLAIN_TYPE.toString() + ", got " + mt4.toString());
+    }
+  }
+
+  /*
+   * @testName: equalsTest2
+   * 
+   * @assertion_ids: JAXRS:SPEC:33.8; JAXRS:SPEC:33.7; JAXRS:JAVADOC:91;
+   * JAXRS:JAVADOC:82;
+   * 
+   * @test_Strategy: Create two MediaType instances using MediaType(String,
+   * String) Verify method equals works
+   */
+  @Test
+  public void equalsTest2() throws Fault {
+    String type = "application";
+    String subtype = "xml";
+    String type1 = "Application";
+    String subtype1 = "XML";
+
+    MediaType mt7 = new MediaType(type, subtype);
+    MediaType mt8 = new MediaType(type1, subtype1);
+
+    if (!mt7.equals(mt8)) {
+      throw new Fault("Equals test failed" + "Expecting " + mt7.toString() + ", got " + mt8.toString());
+    }
+  }
+
+  /*
+   * @testName: equalsTest3
+   * 
+   * @assertion_ids: JAXRS:SPEC:33.8; JAXRS:SPEC:33.7; JAXRS:JAVADOC:90;
+   * JAXRS:JAVADOC:91; JAXRS:JAVADOC:82;
+   * 
+   * @test_Strategy: Create two MediaType instances using MediaType(String,
+   * String) MediaType(String, String, Map<String, String>) Verify method equals
+   * works
+   */
+  @Test
+  public void equalsTest3() throws Fault {
+    String type = "application";
+    String subtype = "svg+xml";
+    Map<String, String> params = new HashMap<String, String>();
+
+    MediaType mt5 = new MediaType(type, subtype);
+    MediaType mt6 = new MediaType(type, subtype, params);
+
+    if (!mt5.equals(mt6)) {
+      throw new Fault("Equals test failed" + "Expecting " + mt5.toString() + ", got " + mt6.toString());
+    }
+  }
+
+  /*
+   * @testName: equalsTest4
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:90; JAXRS:JAVADOC:82;
+   * 
+   * @test_Strategy: Create two MediaType instances using MediaType(String,
+   * String, Map<String, String>) MediaType(String, String, Map<String, String>)
+   * Verify method equals works
+   */
+  @Test
+  public void equalsTest4() throws Fault {
+    String type = "text";
+    String subtype = "plain";
+    Map<String, String> params = new HashMap<String, String>();
+    Map<String, String> params1 = new HashMap<String, String>();
+    params1.put("charset", "iso-8859-1");
+
+    MediaType mt5 = new MediaType(type, subtype, params);
+    MediaType mt6 = new MediaType(type, subtype, params1);
+
+    if (mt5.equals(mt6)) {
+      throw new Fault("Equals test failed" + "Expecting " + mt5.toString() + ", got " + mt6.toString());
+    }
+  }
+
+  /*
+   * @testName: toStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:90; JAXRS:JAVADOC:93;
+   * 
+   * @test_Strategy: Create a MediaType instances using MediaType(String, String,
+   * Map<String, String>) Verify method toString works
+   */
+  @Test
+  public void toStringTest() throws Fault {
+    boolean pass = true;
+    StringBuffer sb = new StringBuffer();
+
+    String type = "text";
+    String subtype = "plain";
+    Map<String, String> params = new HashMap<String, String>();
+    params.put("charset", "iso-8859-1");
+
+    MediaType mt6 = new MediaType(type, subtype, params);
+
+    String to_verify = mt6.toString();
+
+    if (!to_verify.toLowerCase().contains(type)) {
+      pass = false;
+      sb.append("Type is missing");
+    }
+
+    if (!to_verify.toLowerCase().contains(subtype)) {
+      pass = false;
+      sb.append("Subtype is missing");
+    }
+
+    if (!to_verify.toLowerCase().contains("char")) {
+      pass = false;
+      sb.append("Parameter's name is missing");
+    }
+
+    if (!to_verify.toLowerCase().contains("iso-8859-1")) {
+      pass = false;
+      sb.append("Parameter's value is missing");
+    }
+
+    assertTrue(pass, "At least one assertion failed: " + sb.toString());
+  }
+
+  /*
+   * @testName: wildcardTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:92; JAXRS:JAVADOC:88; JAXRS:JAVADOC:89;
+   * 
+   * @test_Strategy: Create an MediaType instance using MediaType() Verify that
+   * method isWildCardType() works Verify that method isWildCardSubtype() works
+   */
+  @Test
+  public void wildcardTest() throws Fault {
+    boolean pass = true;
+    StringBuffer sb = new StringBuffer();
+
+    MediaType mt2 = new MediaType();
+
+    if (!mt2.isWildcardType()) {
+      pass = false;
+      sb.append("Failed WildcardType test");
+    }
+
+    if (!mt2.isWildcardSubtype()) {
+      pass = false;
+      sb.append("Failed WildcardSubtype test");
+    }
+
+    assertTrue(pass, "At least one assertion failed: " + sb.toString());
+  }
+
+  /*
+   * @testName: valueOfTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:94;
+   * 
+   * @test_Strategy: Create an MediaType instance using method
+   * MediaType.valueOf(String) Verify that all type, subtype and parameters are
+   * preserved.
+   */
+  @Test
+  public void valueOfTest() throws Fault {
+    String type = "text";
+    String subtype = "plain";
+    String toParse = "text/plain; charset=us-ascii";
+
+    MediaType mt10 = MediaType.valueOf(toParse);
+
+    Map<String, String> params = new HashMap<String, String>();
+    params.put("charset", "us-ascii");
+    String[] pname = { "charset" };
+
+    verifyMediaType(mt10, type, subtype, params, pname);
+  }
+
+  /*
+   * @testName: valueOfTest1
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:94;
+   * 
+   * @test_Strategy: Create an MediaType instance using method
+   * MediaType.valueOf(null) Verify that IllegalArgumentException is thrown.
+   */
+  @Test
+  public void valueOfTest1() throws Fault {
+    try {
+      MediaType.valueOf(null);
+      throw new Fault("Expected IllegalArgumentException now thrown.  Test Failed");
+    } catch (IllegalArgumentException ilex) {
+      logMsg("IllegalArgumentException has been thrown as expected");
+    }
+  }
+
+  /*
+   * @testName: withCharsetTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:826; JAXRS:JAVADOC:84; JAXRS:JAVADOC:85;
+   * JAXRS:JAVADOC:93;
+   * 
+   * @test_Strategy: Create a new MediaType instance with the same type, subtype
+   * and parameters copied from the original instance and the supplied ""charset""
+   * parameter.
+   * 
+   * getSubtype, getType, toString
+   */
+  @Test
+  public void withCharsetTest() throws Fault {
+    String type = MediaType.APPLICATION_FORM_URLENCODED_TYPE.getType();
+    String subtype = MediaType.APPLICATION_FORM_URLENCODED_TYPE.getSubtype();
+    MediaType original = new MediaType(type, subtype);
+    String[] charsets = { "UTF-8", "ISO-8859-2", "UTF-16", null };
+    // test the original does not have the charset
+    for (int i = 0; i != charsets.length - 1; i++)
+      assertTrue(!original.toString().toLowerCase().contains(charsets[i].toLowerCase()));
+    // create new MediaType
+    for (String charset : charsets) {
+      MediaType created = original.withCharset(charset);
+      verifyMediaType(created, type, subtype);
+      if (charset != null) {
+        // check the original is not changed
+        assertTrue(!original.toString().toLowerCase().contains(charset.toLowerCase()));
+        // check the charset in new mediaType
+        assertContainsIgnoreCase(created.toString(), charset, "MediaType", created,
+            "does not contain expected character set", charset);
+        logMsg("MediaType", created, "contains expected character set", charset);
+      }
+    }
+  }
+
+  /*
+   * @testName: withCharsetNullOrEmptyCharsetTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:826;
+   * 
+   * @test_Strategy: Create a new MediaType instance with the same type, subtype
+   * and parameters copied from the original instance and the supplied ""charset""
+   * parameter.
+   * 
+   * If null or empty the ""charset"" parameter will not be set or updated.
+   */
+  @Test
+  public void withCharsetNullOrEmptyCharsetTest() throws Fault {
+    String charset = "UTF-8";
+    String type = MediaType.APPLICATION_FORM_URLENCODED_TYPE.getType();
+    String subtype = MediaType.APPLICATION_FORM_URLENCODED_TYPE.getSubtype();
+    MediaType original = new MediaType(type, subtype, charset);
+    for (String newCharset : new String[] { null, "" }) {
+      MediaType created = original.withCharset(newCharset);
+      verifyMediaType(created, type, subtype);
+      assertTrue(created != original, "withCharset(null) did NOT create a new instance");
+      assertCharset(created, charset);
+      assertCharset(original, charset);
+    }
+  }
+
+  // ////////////////////////////////////////////////////////////////////////
+
+  private static//
+  void assertCharset(MediaType mediaType, String charset) throws Fault {
+    String characterSet = MediaType.CHARSET_PARAMETER + "=" + charset;
+    assertContainsIgnoreCase(mediaType.toString(), characterSet, "MediaType", mediaType, "does not contain expected",
+        characterSet);
+    logMsg("MediaType", mediaType, "contains character set", characterSet, "as expected");
+  }
+
+  private static void verifyMediaType(MediaType mt, String type, String subtype) throws Fault {
+    StringBuffer sb = new StringBuffer();
+    boolean pass = true;
+
+    if (!mt.getType().equals(type)) {
+      pass = false;
+      sb.append("Failed type test.  Expect " + type + " got " + mt.getType());
+    }
+
+    if (!mt.getSubtype().equals(subtype)) {
+      pass = false;
+      sb.append("Failed subtype test.  Expect " + type + " got " + mt.getSubtype());
+    }
+
+    assertTrue(pass, "at least one assertion failed: " + sb.toString());
+  }
+
+  private static void verifyMediaType(MediaType mt, String type, String subtype, Map<String, String> params,
+      String[] pname) throws Fault {
+    StringBuffer sb = new StringBuffer();
+    boolean pass = true;
+
+    if (!mt.getType().equals(type)) {
+      pass = false;
+      sb.append("Failed type test.  Expect " + type + " got " + mt.getType());
+    }
+
+    if (!mt.getSubtype().equals(subtype)) {
+      pass = false;
+      sb.append("Failed subtype test.  Expect " + type + " got " + mt.getSubtype());
+    }
+
+    Map<String, String> param_actual = mt.getParameters();
+    if (params.size() != param_actual.size()) {
+      pass = false;
+      sb.append(
+          "Parameters size are different. " + " Expecting " + params.size() + ", got " + param_actual.size() + ".");
+    }
+
+    int i = pname.length;
+    int j = 0;
+    while (j < i) {
+      sb.append("Processing Parameter " + j);
+      if (!param_actual.containsKey(pname[j])) {
+        pass = false;
+        sb.append("Parameter Key " + pname[j] + " not found.");
+      } else {
+        String tmp = param_actual.get(pname[j]);
+
+        if (tmp.equals((String) params.get(pname[j]))) {
+          break;
+        } else if (tmp.startsWith("\"") || tmp.equals("\"" + params.get(pname[j]) + "\"")) {
+          break;
+        } else {
+          pass = false;
+          sb.append("Parameter Key " + pname[j] + " returned different value than expected.");
+          sb.append("expecting " + (String) params.get(pname[j]) + ", got " + (String) param_actual.get(pname[j]));
+        }
+        j++;
+      }
+
+      assertTrue(pass, "at least one assertion failed:" + sb.toString());
+    }
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/multivaluedhashmap/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/multivaluedhashmap/JAXRSClientIT.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.core.multivaluedhashmap;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.core.AbstractMultivaluedMap;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+    private static final long serialVersionUID = -4827869994556677693L;
+
+    @BeforeEach
+    void logStartTest(TestInfo testInfo) {
+        TestUtil.logMsg("STARTING TEST : " + testInfo.getDisplayName());
+    }
+
+    @AfterEach
+    void logFinishTest(TestInfo testInfo) {
+        TestUtil.logMsg("FINISHED TEST : " + testInfo.getDisplayName());
+    }
+
+    /* Run test */
+
+    /*
+     * @testName: defaultConstructorTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:827;
+     * 
+     * @test_Strategy: Constructs an empty multivalued hash map with the default
+     * initial capacity (16) and the default load factor (0.75)
+     */
+    @Test
+    public void defaultConstructorTest() throws Fault {
+        MultivaluedHashMap<String, String> map = new MultivaluedHashMap<String, String>();
+        map.addAll("key", VALUES[0], VALUES[1], VALUES[2]);
+        assertContainsDefaultValues(map);
+        assertNotContains(map, "key", VALUES[3], VALUES[4]);
+    }
+
+    /*
+     * @testName: constructorWithInitialCapacityTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:828;
+     * 
+     * @test_Strategy: Constructs an empty multivalued hash map with the specified
+     * initial capacity and the default load factor (0.75)
+     */
+    @Test
+    public void constructorWithInitialCapacityTest() throws Fault {
+        MultivaluedHashMap<String, String> map = new MultivaluedHashMap<String, String>(0);
+        map.addAll("key", VALUES[0], VALUES[1], VALUES[2]);
+        assertContainsDefaultValues(map);
+        assertNotContains(map, "key", VALUES[3], VALUES[4]);
+    }
+
+    /*
+     * @testName: constructorWithInitialCapacityThrowsIllegalArgumentExceptionTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:828;
+     * 
+     * @test_Strategy: IllegalArgumentException - if the initial capacity is
+     * negative.
+     */
+    @Test
+    public void constructorWithInitialCapacityThrowsIllegalArgumentExceptionTest() throws Fault {
+        try {
+            new MultivaluedHashMap<String, String>(-1);
+            throw new Fault("IllegalArgumentException has not been thrown");
+        } catch (IllegalArgumentException e) {
+            logMsg("IllegalArgumentException has been thrown as expected");
+        }
+    }
+
+    /*
+     * @testName: constructorWithCapacityAndLoadTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:829;
+     * 
+     * @test_Strategy: Constructs an empty multivalued hash map with the specified
+     * initial capacity and load factor
+     */
+    @Test
+    public void constructorWithCapacityAndLoadTest() throws Fault {
+        MultivaluedHashMap<String, String> map = new MultivaluedHashMap<String, String>(0, 0.99f);
+        map.addAll("key", VALUES[0], VALUES[1], VALUES[2]);
+        assertContainsDefaultValues(map);
+        assertNotContains(map, "key", VALUES[3], VALUES[4]);
+    }
+
+    /*
+     * @testName: constructorWithCapacityAndLoadThrowsExceptionForCapacityTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:829;
+     * 
+     * @test_Strategy: IllegalArgumentException - if the initial capacity is
+     * negative or the load factor is nonpositive
+     */
+    @Test
+    public void constructorWithCapacityAndLoadThrowsExceptionForCapacityTest() throws Fault {
+        try {
+            new MultivaluedHashMap<String, String>(Integer.MIN_VALUE, 0.99f);
+            throw new Fault("IllegalArgumentException has not been thrown");
+        } catch (IllegalArgumentException e) {
+            logMsg("IllegalArgumentException has been thrown as expected");
+        }
+    }
+
+    /*
+     * @testName: constructorWithCapacityAndLoadThrowsExceptionForLoadTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:829;
+     * 
+     * @test_Strategy: IllegalArgumentException - if the initial capacity is
+     * negative or the load factor is nonpositive
+     */
+    @Test
+    public void constructorWithCapacityAndLoadThrowsExceptionForLoadTest() throws Fault {
+        try {
+            new MultivaluedHashMap<String, String>(16, 0f);
+            throw new Fault("IllegalArgumentException has not been thrown");
+        } catch (IllegalArgumentException e) {
+            logMsg("IllegalArgumentException has been thrown as expected");
+        }
+    }
+
+    /*
+     * @testName: constructorWithMapTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:830;
+     * 
+     * @test_Strategy: Constructs a new multivalued hash map with the same mappings
+     * as the specified MultivaluedMap. The List instances holding the values of
+     * each key are created anew instead of being reused.
+     */
+    @Test
+    public void constructorWithMapTest() throws Fault {
+        MultivaluedHashMap<String, String> mapWithMap;
+        MultivaluedHashMap<String, String> map;
+
+        map = new MultivaluedHashMap<String, String>();
+        map.addAll("key", VALUES[0], VALUES[1], VALUES[2]);
+
+        mapWithMap = new MultivaluedHashMap<String, String>(map);
+        assertContainsDefaultValues(mapWithMap);
+
+        mapWithMap.clear(); // clear map, but check the original is untouched
+        assertContainsDefaultValues(map);
+
+        mapWithMap = new MultivaluedHashMap<String, String>(map);
+        map.clear(); // clear original, but check the new is untouched
+        assertContainsDefaultValues(mapWithMap);
+    }
+
+    /*
+     * @testName: constructorWithMapThrowsNPETest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:830;
+     * 
+     * @test_Strategy: NullPointerException - if the specified map is null
+     */
+    @Test
+    public void constructorWithMapThrowsNPETest() throws Fault {
+        try {
+            new MultivaluedHashMap<String, String>((MultivaluedMap<String, String>) null);
+            throw new Fault("NullPointerException has NOT been thrown");
+        } catch (NullPointerException e) {
+            logMsg("NullPointerException has been thrown as expected");
+        }
+    }
+
+    /*
+     * @testName: constructorWithSingleValuedMapTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:831;
+     * 
+     * @test_Strategy: Constructs a new multivalued hash map with the same mappings
+     * as the specified single-valued Map.
+     */
+    @Test
+    public void constructorWithSingleValuedMapTest() throws Fault {
+        MultivaluedHashMap<String, String> mapWithMap;
+        Map<String, String> map;
+
+        map = new HashMap<String, String>();
+        map.put("key", VALUES[0]);
+
+        mapWithMap = new MultivaluedHashMap<String, String>(map);
+        assertContains(mapWithMap, "key", VALUES[0]);
+
+        mapWithMap.clear(); // clear map, but check the original is untouched
+        assertTrue(map.size() == 1, "The original map is empty after MultivaluedHashMap#clear()");
+
+        mapWithMap = new MultivaluedHashMap<String, String>(map);
+        map.clear(); // clear original, but check the new is untouched
+        assertContains(mapWithMap, "key", VALUES[0]);
+    }
+
+    /*
+     * @testName: constructorWithSingleValuedMapThrowsNPETest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:831;
+     * 
+     * @test_Strategy: NullPointerException - if the specified map is null
+     */
+    @Test
+    public void constructorWithSingleValuedMapThrowsNPETest() throws Fault {
+        try {
+            new MultivaluedHashMap<String, String>((Map<String, String>) null);
+            throw new Fault("NullPointerException has NOT been thrown");
+        } catch (NullPointerException e) {
+            logMsg("NullPointerException has been thrown as expected");
+        }
+    }
+
+    // ////////////////////////////////////////////////////////////////////////
+    static final String[] VALUES = { "value1", "value2", "value3", "value4", "value5" };
+
+    protected static void assertContainsDefaultValues(AbstractMultivaluedMap<String, String> map) throws Fault {
+        assertContains(map, "key", VALUES[0], VALUES[1], VALUES[2]);
+    }
+
+    protected static void assertContains(MultivaluedMap<String, String> map, String key, String... values)
+            throws Fault {
+        List<String> list = map.get(key);
+        for (String item : values)
+            assertTrue(list.contains(item), "Given map does not contain value " + item);
+        logMsg("Found key", key, "with following values:");
+        logMsg((Object[]) values);
+    }
+
+    protected static void assertNotContains(AbstractMultivaluedMap<String, String> map, String key, String... values)
+            throws Fault {
+        List<String> list = map.get(key);
+        if (list != null)
+            for (String item : values)
+                assertTrue(!list.contains(item), "Given map does contain value " + item);
+        logMsg("For given", key, "the map does not contain following values as expected:");
+        logMsg((Object[]) values);
+    }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/multivaluedmap/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/multivaluedmap/JAXRSClientIT.java
@@ -1,0 +1,394 @@
+/*
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.core.multivaluedmap;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Vector;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+    private static final long serialVersionUID = 5073014935147496028L;
+
+    static final String[] KEYS = { "key0", "key1", "key2" };
+
+    private long id;
+
+    protected MultivaluedMap<String, Object> map;
+
+    protected Vector<Response> vec;
+
+    @BeforeEach
+    void logStartTest(TestInfo testInfo) {
+        TestUtil.logMsg("STARTING TEST : " + testInfo.getDisplayName());
+    }
+
+    @AfterEach
+    void logFinishTest(TestInfo testInfo) {
+        TestUtil.logMsg("FINISHED TEST : " + testInfo.getDisplayName());
+    }
+
+    public JAXRSClientIT() {
+        this.id = serialVersionUID;
+        Response r = Response.ok().build();
+        map = r.getMetadata();
+        vec = new Vector<Response>();
+        vec.add(r);
+    }
+
+    /*
+     * @testName: getFirstWhenEmptyTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:97;
+     * 
+     * @test_Strategy: Ensure getFirst works for empty map
+     */
+    @Test
+    public void getFirstWhenEmptyTest() throws Fault {
+        assertTrue(map.getFirst(KEYS[0]) == null, "EmptyMultivaluedMap#getFirst() should return null");
+        assertTrue(map.getFirst(null) == null, "EmptyMultivaluedMap#getFirst() should return null");
+    }
+
+    /*
+     * @testName: getFirstWhenSingleItemTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:96; JAXRS:JAVADOC:97;
+     * 
+     * @test_Strategy: Ensure getFirst works for a single item
+     */
+    @Test
+    public void getFirstWhenSingleItemTest() throws Fault {
+        map.add(KEYS[0], this);
+        assertTrue(map.size() == 1, "MultivaluedMap contains nothing when item added");
+        JAXRSClientIT that = ((JAXRSClientIT) map.getFirst(KEYS[0]));
+        assertTrue(that.id == serialVersionUID, "MultivaluedMap#getFirst() should contain what added first");
+    }
+
+    /*
+     * @testName: getFirstWhenMoreItemsTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:96; JAXRS:JAVADOC:97;
+     * 
+     * @test_Strategy: Ensure getFirst works for more items
+     */
+    @Test
+    public void getFirstWhenMoreItemsTest() throws Fault {
+        map.add(KEYS[0], this);
+        map.add(KEYS[0], vec);
+        assertTrue(map.size() == 1, "There is more items in the map, but only a single key added");
+        JAXRSClientIT that = ((JAXRSClientIT) map.getFirst(KEYS[0]));
+        assertTrue(that.id == serialVersionUID, "MultivaluedMap#getFirst() should contain what added first");
+        assertTrue(map.get(KEYS[0]).size() == 2, "There shall be two items in a list when added for a single key");
+    }
+
+    /*
+     * @testName: getFirstWhenFirstErasedTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:96; JAXRS:JAVADOC:97;
+     * 
+     * @test_Strategy: Ensure getFirst works getFirst() item is erased
+     */
+    @Test
+    public void getFirstWhenFirstErasedTest() throws Fault {
+        map.add(KEYS[0], this);
+        map.add(KEYS[0], vec);
+        ListIterator<Object> i = map.get(KEYS[0]).listIterator();
+        while (i.hasNext()) {
+            Object o = i.next(); // check the items in a list are the inserted
+            assertTrue(o.getClass() == Vector.class || o.getClass() == JAXRSClientIT.class,
+                    "Only items added to a map shall be there");
+            if (o.getClass() == JAXRSClientIT.class) // remove first
+                i.remove();
+        }
+        @SuppressWarnings("unchecked")
+        Vector<Response> anotherVec = ((Vector<Response>) map.getFirst(KEYS[0]));
+        assertTrue(anotherVec.getClass() == Vector.class,
+                "MultivaluedMap#getFirst() should not point to a removed instance");
+    }
+
+    /*
+     * @testName: getFirstWhenListClearedTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:96; JAXRS:JAVADOC:97;
+     * 
+     * @test_Strategy: Try what to happen when remove all items in a list
+     */
+    @Test
+    public void getFirstWhenListClearedTest() throws Fault {
+        map.add(KEYS[0], this);
+        map.add(KEYS[0], vec);
+        map.get(KEYS[0]).clear();
+        assertTrue(map.getFirst(KEYS[0]) == null, "MultivaluedMap#getFirst() should be null when list is empty");
+    }
+
+    /*
+     * @testName: getFirstWhenKeyIsNullTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:96; JAXRS:JAVADOC:97;
+     * 
+     * @test_Strategy: Try the null key
+     */
+    @Test
+    public void getFirstWhenKeyIsNullTest() throws Fault {
+        map.add(KEYS[0], this);
+        map.add(null, vec);
+        map.add(null, this);
+        assertTrue(map.get(null).size() == 2, "There shall be two items in a list when added for a null key");
+        assertTrue(map.size() == 2, "There shall be two items in a list when added items for two keys");
+        assertTrue(map.getFirst(null).getClass() == Vector.class,
+                "The first item for a null key was not the one retreived");
+    }
+
+    /*
+     * @testName: putSingleTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:98; JAXRS:JAVADOC:97;
+     * 
+     * @test_Strategy: Try putSingle with a key and null key
+     */
+    @Test
+    public void putSingleTest() throws Fault {
+        map.putSingle(KEYS[0], this);
+        map.putSingle(KEYS[0], vec);
+        map.putSingle(null, vec);
+        map.putSingle(null, this);
+        assertTrue(map.get(null).size() == 1, "There shall be one item in a list when putSingle() several times");
+        assertTrue(map.size() == 2, "There shall be two items in a list when added items for two keys");
+        assertTrue(map.getFirst(KEYS[0]).getClass() == Vector.class,
+                "The first item for a null key was not the last put by putSingle()");
+        assertTrue(map.getFirst(null).getClass() == JAXRSClientIT.class,
+                "The first item for a null key was not the last put by putSingle()");
+    }
+
+    /*
+     * @testName: addAllValuesTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:832;
+     * 
+     * @test_Strategy: Add multiple values to the current list of values for the
+     * supplied key. If the supplied array of new values is empty, method returns
+     * immediately.
+     */
+    @Test
+    public void addAllValuesTest() throws Fault {
+        JAXRSClientIT client1 = new JAXRSClientIT();
+        map.addAll(KEYS[0], this, vec, client1);
+        assertTrue(map.get(KEYS[0]).size() == 3, "Not all objects were added by #addAll");
+        assertTrue(map.get(KEYS[0]).contains(vec), "given Vector has not been found in a map");
+        assertTrue(map.get(KEYS[0]).contains(client1), "given JAXRSClient has not been found in a map");
+        assertTrue(map.get(KEYS[0]).contains(this), "this class has not been found in a map");
+        logMsg("All values have been added for key", KEYS[0]);
+    }
+
+    /*
+     * @testName: addAllValuesNullKeyTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:832;
+     * 
+     * @test_Strategy: Add multiple values to the current list of values for the
+     * supplied key. If the supplied array of new values is empty, method returns
+     * immediately.
+     */
+    @Test
+    public void addAllValuesNullKeyTest() throws Fault {
+        JAXRSClientIT client1 = new JAXRSClientIT();
+        map.addAll(null, this, vec, client1);
+        assertTrue(map.get(null).size() == 3, "Not all objects were added by #addAll");
+        assertTrue(map.get(null).contains(vec), "given Vector has not been found in a map");
+        assertTrue(map.get(null).contains(client1), "given JAXRSClient has not been found in a map");
+        assertTrue(map.get(null).contains(this), "this class has not been found in a map");
+        logMsg("All values have been added for null key");
+    }
+
+    /*
+     * @testName: addAllValuesEmptyReturnsImmediatellyTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:832;
+     * 
+     * @test_Strategy: Add multiple values to the current list of values for the
+     * supplied key. If the supplied array of new values is empty, method returns
+     * immediately.
+     */
+    @Test
+    public void addAllValuesEmptyReturnsImmediatellyTest() throws Fault {
+        map.addAll(KEYS[0], new Object[0]);
+        assertTrue(!map.containsKey(KEYS[0]), "Method did not return immediatelly for empty array");
+        logMsg("Method did return immediatelly for empty array");
+    }
+
+    /*
+     * @testName: addAllValuesThrowNPETest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:832;
+     * 
+     * @test_Strategy: Method throws a NullPointerException if the supplied array of
+     * values is null.
+     */
+    @Test
+    public void addAllValuesThrowNPETest() throws Fault {
+        try {
+            map.addAll(KEYS[0], (Object[]) null);
+            throw new Fault("NullPointerException has not been thrown");
+        } catch (NullPointerException e) {
+            logMsg("NullPointerException has been thrown as expected");
+        }
+    }
+
+    /*
+     * @testName: addAllListTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:833;
+     * 
+     * @test_Strategy: Add all the values from the supplied value list to the
+     * current list of values for the supplied key. If the supplied value list is
+     * empty, method returns immediately.
+     */
+    @Test
+    public void addAllListTest() throws Fault {
+        JAXRSClientIT client1 = new JAXRSClientIT();
+        map.addAll(KEYS[0], Arrays.asList((Object) this, vec, client1));
+        assertTrue(map.get(KEYS[0]).size() == 3, "Not all objects were added by #addAll");
+        assertTrue(map.get(KEYS[0]).contains(vec), "given Vector has not been found in a map");
+        assertTrue(map.get(KEYS[0]).contains(client1), "given JAXRSClient has not been found in a map");
+        assertTrue(map.get(KEYS[0]).contains(this), "this class has not been found in a map");
+        logMsg("All values have been added for key", KEYS[0]);
+    }
+
+    /*
+     * @testName: addAllListNullKeyTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:833;
+     * 
+     * @test_Strategy: Add all the values from the supplied value list to the
+     * current list of values for the supplied key. If the supplied value list is
+     * empty, method returns immediately.
+     */
+    @Test
+    public void addAllListNullKeyTest() throws Fault {
+        JAXRSClientIT client1 = new JAXRSClientIT();
+        map.addAll(null, Arrays.asList((Object) this, vec, client1));
+        assertTrue(map.get(null).size() == 3, "Not all objects were added by #addAll");
+        assertTrue(map.get(null).contains(vec), "given Vector has not been found in a map");
+        assertTrue(map.get(null).contains(client1), "given JAXRSClient has not been found in a map");
+        assertTrue(map.get(null).contains(this), "this class has not been found in a map");
+        logMsg("All values have been added for null key");
+    }
+
+    /*
+     * @testName: addAllListEmptyReturnsImmediatellyTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:833;
+     * 
+     * @test_Strategy: Add all the values from the supplied value list to the
+     * current list of values for the supplied key. If the supplied value list is
+     * empty, method returns immediately.
+     */
+    @Test
+    public void addAllListEmptyReturnsImmediatellyTest() throws Fault {
+        map.addAll(KEYS[0], new ArrayList<Object>());
+        assertTrue(!map.containsKey(KEYS[0]), "Method did not return immediatelly for empty array");
+        logMsg("Method did return immediatelly for empty array");
+    }
+
+    /*
+     * @testName: addAllListThrowNPETest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:833;
+     * 
+     * @test_Strategy: throws NullPointerException - if the supplied value list is
+     * null.
+     */
+    @Test
+    public void addAllListThrowNPETest() throws Fault {
+        try {
+            map.addAll(KEYS[0], (List<Object>) null);
+            throw new Fault("NullPointerException has not been thrown");
+        } catch (NullPointerException e) {
+            logMsg("NullPointerException has been thrown as expected");
+        }
+    }
+
+    /*
+     * @testName: addFirstTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:834;
+     * 
+     * @test_Strategy: Add a value to the first position in the current list of
+     * values for the supplied key.
+     */
+    @Test
+    public void addFirstTest() throws Fault {
+        map.addAll(null, vec, this);
+        map.addFirst(null, new StringBuilder().append("test"));
+        assertTrue(map.getFirst(null).getClass() == StringBuilder.class, "#addFirst didn't add new StringBuilder, but " +
+                map.getFirst(null).getClass());
+        logMsg("#addFirst added new item to a first position");
+    }
+
+    /*
+     * @testName: equalsIgnoreValueOrderTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:835;
+     * 
+     * @test_Strategy: Compare the specified map with this map for equality modulo
+     * the order of values for each key. Specifically, the values associated with
+     * each key are compared as if they were ordered lists.
+     */
+    @Test
+    public void equalsIgnoreValueOrderTest() throws Fault {
+        Object o1 = new StringBuilder().append(KEYS[0]);
+        Object o2 = new StringBuffer().append(KEYS[1]);
+        Object o3 = new Object() {
+            @Override
+            public String toString() {
+                return KEYS[2];
+            }
+        };
+        map.add(KEYS[0], o1);
+        map.add(KEYS[0], o2);
+        map.add(KEYS[0], o3);
+
+        MultivaluedHashMap<String, Object> map2 = new MultivaluedHashMap<String, Object>();
+        map2.addAll(KEYS[0], o3, o1, o2);
+
+        assertTrue(map.equalsIgnoreValueOrder(map2), map + " and " + map2 + " are not equalIgnoreValueOrder");
+        assertFalse(map.equals(map2), map + " and " + map2 + " are equal");
+        logMsg("#equalsIgnoreValueOrder compared maps", map, "and", map2, "as expected");
+    }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/newcookie/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/newcookie/JAXRSClientIT.java
@@ -1,0 +1,1096 @@
+/*
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.core.newcookie;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.core.Cookie;
+import jakarta.ws.rs.core.NewCookie;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = 295711558453778471L;
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  /*
+   * @testName: constructorTest1
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:107; JAXRS:JAVADOC:100; JAXRS:JAVADOC:101;
+   * JAXRS:JAVADOC:103; JAXRS:JAVADOC:51; JAXRS:JAVADOC:53; JAXRS:JAVADOC:54;
+   * JAXRS:JAVADOC:55; JAXRS:JAVADOC:56;
+   * 
+   * @test_Strategy: Create a NewCookie instance using constructor
+   * Cookie(String, String) NewCookie(Cookie)
+   */
+  @Test
+  public void constructorTest1() throws Fault {
+    String name = "name_1";
+    String value = "value_1";
+    String comment = "";
+    String domain = "";
+    String path = "";
+    int maxage = jakarta.ws.rs.core.NewCookie.DEFAULT_MAX_AGE;
+    int version = 1;
+    boolean secure = false;
+
+    Cookie ck1 = new Cookie(name, value);
+    NewCookie nck1 = new NewCookie(ck1);
+
+    verifyNewCookie(nck1, name, value, path, domain, version, comment, maxage,
+        secure);
+  }
+
+  /*
+   * @testName: constructorTest2
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:107; JAXRS:JAVADOC:100; JAXRS:JAVADOC:101;
+   * JAXRS:JAVADOC:103; JAXRS:JAVADOC:50; JAXRS:JAVADOC:53; JAXRS:JAVADOC:54;
+   * JAXRS:JAVADOC:55; JAXRS:JAVADOC:56;
+   * 
+   * @test_Strategy: Create a NewCookie instance using constructor
+   * Cookie(String, String, String, String) NewCookie(Cookie)
+   */
+  @Test
+  public void constructorTest2() throws Fault {
+    String name = "name_1";
+    String value = "value_1";
+    String path = "/acme";
+    String domain = "";
+    String comment = "";
+    int maxage = jakarta.ws.rs.core.NewCookie.DEFAULT_MAX_AGE;
+    int version = 1;
+    boolean secure = false;
+
+    Cookie ck2 = new Cookie(name, value, path, domain);
+    NewCookie nck2 = new NewCookie(ck2);
+
+    verifyNewCookie(nck2, name, value, path, domain, version, comment, maxage,
+        secure);
+  }
+
+  /*
+   * @testName: constructorTest3
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:107; JAXRS:JAVADOC:100; JAXRS:JAVADOC:101;
+   * JAXRS:JAVADOC:103; JAXRS:JAVADOC:50; JAXRS:JAVADOC:53; JAXRS:JAVADOC:54;
+   * JAXRS:JAVADOC:55; JAXRS:JAVADOC:56;
+   * 
+   * @test_Strategy: Create a NewCookie instance using constructor
+   * Cookie(String, String, String, String) NewCookie(Cookie)
+   */
+  @Test
+  public void constructorTest3() throws Fault {
+    String name = "name_1";
+    String value = "value_1";
+    String path = "";
+    String domain = "y.x.foo.com";
+    String comment = "";
+    int maxage = jakarta.ws.rs.core.NewCookie.DEFAULT_MAX_AGE;
+    int version = 1;
+    boolean secure = false;
+
+    Cookie ck3 = new Cookie(name, value, path, domain);
+    NewCookie nck3 = new NewCookie(ck3);
+
+    verifyNewCookie(nck3, name, value, path, domain, version, comment, maxage,
+        secure);
+  }
+
+  /*
+   * @testName: constructorTest4
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:107; JAXRS:JAVADOC:100; JAXRS:JAVADOC:101;
+   * JAXRS:JAVADOC:103; JAXRS:JAVADOC:49; JAXRS:JAVADOC:53; JAXRS:JAVADOC:54;
+   * JAXRS:JAVADOC:55; JAXRS:JAVADOC:56;
+   * 
+   * @test_Strategy: Create a version 1 NewCookie instance using constructor
+   * Cookie(String, String, String, String, int) NewCookie(Cookie)
+   */
+  @Test
+  public void constructorTest4() throws Fault {
+    String name = "name_1";
+    String value = "value_1";
+    String path = "/acme";
+    String domain = "y.x.foo.com";
+    String comment = "";
+    int maxage = jakarta.ws.rs.core.NewCookie.DEFAULT_MAX_AGE;
+    int version = 1;
+    boolean secure = false;
+
+    Cookie ck4 = new Cookie(name, value, path, domain, version);
+    NewCookie nck4 = new NewCookie(ck4);
+
+    verifyNewCookie(nck4, name, value, path, domain, version, comment, maxage,
+        secure);
+  }
+
+  /*
+   * @testName: constructorTest5
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:107; JAXRS:JAVADOC:100; JAXRS:JAVADOC:101;
+   * JAXRS:JAVADOC:103; JAXRS:JAVADOC:49; JAXRS:JAVADOC:53; JAXRS:JAVADOC:54;
+   * JAXRS:JAVADOC:55; JAXRS:JAVADOC:56;
+   * 
+   * @test_Strategy: Create a version 0 NewCookie instance using constructor
+   * Cookie(String, String, String, String, int) NewCookie(Cookie)
+   */
+  @Test
+  public void constructorTest5() throws Fault {
+    String name = "name_1";
+    String value = "value_1";
+    String path = "/acme";
+    String domain = "y.x.foo.com";
+    int version = 0;
+    String comment = "";
+    int maxage = jakarta.ws.rs.core.NewCookie.DEFAULT_MAX_AGE;
+    boolean secure = false;
+
+    Cookie ck5 = new Cookie(name, value, path, domain, version);
+    NewCookie nck5 = new NewCookie(ck5);
+
+    verifyNewCookie(nck5, name, value, path, domain, version, comment, maxage,
+        secure);
+  }
+
+  /*
+   * @testName: constructorTest6
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:104; JAXRS:JAVADOC:100; JAXRS:JAVADOC:101;
+   * JAXRS:JAVADOC:103; JAXRS:JAVADOC:53; JAXRS:JAVADOC:54; JAXRS:JAVADOC:55;
+   * JAXRS:JAVADOC:56;
+   * 
+   * @test_Strategy: Create a version 0 NewCookie instance using constructor
+   * NewCookie(String, String)
+   */
+  @Test
+  public void constructorTest6() throws Fault {
+    String name = "name_1";
+    String value = "value_1";
+    String comment = "";
+    String domain = "";
+    String path = "";
+    int maxage = jakarta.ws.rs.core.NewCookie.DEFAULT_MAX_AGE;
+    int version = 1;
+    boolean secure = false;
+
+    NewCookie nck6 = new NewCookie(name, value);
+
+    verifyNewCookie(nck6, name, value, path, domain, version, comment, maxage,
+        secure);
+  }
+
+  /*
+   * @testName: constructorTest7
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:105; JAXRS:JAVADOC:100; JAXRS:JAVADOC:101;
+   * JAXRS:JAVADOC:103; JAXRS:JAVADOC:53; JAXRS:JAVADOC:54; JAXRS:JAVADOC:55;
+   * JAXRS:JAVADOC:56;
+   * 
+   * @test_Strategy: Create a NewCookie instance using constructor
+   * NewCookie(java.lang.String name, java.lang.String value, java.lang.String
+   * path, java.lang.String domain, java.lang.String comment, int maxAge,
+   * boolean secure)
+   */
+  @Test
+  public void constructorTest7() throws Fault {
+    String name = "name_1";
+    String value = "value_1";
+    String path = "/acme";
+    String domain = "";
+    String comment = "";
+    int maxage = jakarta.ws.rs.core.NewCookie.DEFAULT_MAX_AGE;
+    int version = 1;
+    boolean secure = false;
+
+    NewCookie nck7 = new NewCookie(name, value, path, domain, comment, maxage,
+        secure);
+
+    verifyNewCookie(nck7, name, value, path, domain, version, comment, maxage,
+        secure);
+  }
+
+  /*
+   * @testName: constructorTest8
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:105; JAXRS:JAVADOC:100; JAXRS:JAVADOC:101;
+   * JAXRS:JAVADOC:103; JAXRS:JAVADOC:53; JAXRS:JAVADOC:54; JAXRS:JAVADOC:55;
+   * JAXRS:JAVADOC:56;
+   * 
+   * @test_Strategy: Create a NewCookie instance using constructor
+   * NewCookie(java.lang.String name, java.lang.String value, java.lang.String
+   * path, java.lang.String domain, java.lang.String comment, int maxAge,
+   * boolean secure)
+   */
+  @Test
+  public void constructorTest8() throws Fault {
+    String name = "name_1";
+    String value = "value_1";
+    String path = "";
+    String domain = "y.x.foo.com";
+    String comment = "";
+    int maxage = jakarta.ws.rs.core.NewCookie.DEFAULT_MAX_AGE;
+    int version = 1;
+    boolean secure = false;
+
+    NewCookie nck8 = new NewCookie(name, value, path, domain, comment, maxage,
+        secure);
+
+    verifyNewCookie(nck8, name, value, path, domain, version, comment, maxage,
+        secure);
+  }
+
+  /*
+   * @testName: constructorTest9
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:105; JAXRS:JAVADOC:100; JAXRS:JAVADOC:101;
+   * JAXRS:JAVADOC:103; JAXRS:JAVADOC:53; JAXRS:JAVADOC:54; JAXRS:JAVADOC:55;
+   * JAXRS:JAVADOC:56;
+   * 
+   * @test_Strategy: Create a version 1 NewCookie instance using constructor
+   * NewCookie(java.lang.String name, java.lang.String value, java.lang.String
+   * path, java.lang.String domain, java.lang.String comment, int maxAge,
+   * boolean secure)
+   */
+  @Test
+  public void constructorTest9() throws Fault {
+    String name = "name_1";
+    String value = "value_1";
+    String path = "/acme";
+    String domain = "y.x.foo.com";
+    String comment = "cts test comment";
+    int maxage = jakarta.ws.rs.core.NewCookie.DEFAULT_MAX_AGE;
+    int version = 1;
+    boolean secure = false;
+
+    NewCookie nck9 = new NewCookie(name, value, path, domain, comment, maxage,
+        secure);
+
+    verifyNewCookie(nck9, name, value, path, domain, version, comment, maxage,
+        secure);
+  }
+
+  /*
+   * @testName: constructorTest10
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:105; JAXRS:JAVADOC:100; JAXRS:JAVADOC:101;
+   * JAXRS:JAVADOC:103; JAXRS:JAVADOC:53; JAXRS:JAVADOC:54; JAXRS:JAVADOC:55;
+   * JAXRS:JAVADOC:56;
+   * 
+   * @test_Strategy: Create a version 1 NewCookie instance using constructor
+   * NewCookie(java.lang.String name, java.lang.String value, java.lang.String
+   * path, java.lang.String domain, java.lang.String comment, int maxAge,
+   * boolean secure)
+   */
+  @Test
+  public void constructorTest10() throws Fault {
+    String name = "name_1";
+    String value = "value_1";
+    String path = "/acme";
+    String domain = "y.x.foo.com";
+    int version = 1;
+    String comment = "cts test comment";
+    int maxage = jakarta.ws.rs.core.NewCookie.DEFAULT_MAX_AGE;
+    boolean secure = true;
+
+    NewCookie nck10 = new NewCookie(name, value, path, domain, comment, maxage,
+        secure);
+
+    verifyNewCookie(nck10, name, value, path, domain, version, comment, maxage,
+        secure);
+  }
+
+  /*
+   * @testName: constructorTest11
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:106; JAXRS:JAVADOC:100; JAXRS:JAVADOC:101;
+   * JAXRS:JAVADOC:103; JAXRS:JAVADOC:53; JAXRS:JAVADOC:54; JAXRS:JAVADOC:55;
+   * JAXRS:JAVADOC:56;
+   * 
+   * @test_Strategy: Create a NewCookie instance using constructor
+   * NewCookie(java.lang.String name, java.lang.String value, java.lang.String
+   * path, java.lang.String domain, java.lang.String comment, int maxAge,
+   * boolean secure)
+   */
+  @Test
+  public void constructorTest11() throws Fault {
+    String name = "name_1";
+    String value = "value_1";
+    String path = "/acme";
+    String domain = "y.x.foo.com";
+    int version = 1;
+    String comment = "cts test comment";
+    int maxage = 12345;
+    boolean secure = false;
+
+    NewCookie nck11 = new NewCookie(name, value, path, domain, version, comment,
+        maxage, secure);
+
+    verifyNewCookie(nck11, name, value, path, domain, version, comment, maxage,
+        secure);
+  }
+
+  /*
+   * @testName: constructorTest12
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:106; JAXRS:JAVADOC:100; JAXRS:JAVADOC:101;
+   * JAXRS:JAVADOC:103; JAXRS:JAVADOC:53; JAXRS:JAVADOC:54; JAXRS:JAVADOC:55;
+   * JAXRS:JAVADOC:56;
+   * 
+   * @test_Strategy: Create a NewCookie instance using constructor
+   * NewCookie(java.lang.String name, java.lang.String value, java.lang.String
+   * path, java.lang.String domain, int version, java.lang.String comment, int
+   * maxAge, boolean secure)
+   */
+  @Test
+  public void constructorTest12() throws Fault {
+    String name = "name_1";
+    String value = "value_1";
+    String path = "/acme";
+    String domain = "";
+    String comment = "";
+    int maxage = jakarta.ws.rs.core.NewCookie.DEFAULT_MAX_AGE;
+    int version = 1;
+    boolean secure = false;
+
+    NewCookie nck12 = new NewCookie(name, value, path, domain, version, comment,
+        maxage, secure);
+
+    verifyNewCookie(nck12, name, value, path, domain, version, comment, maxage,
+        secure);
+  }
+
+  /*
+   * @testName: constructorTest13
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:106; JAXRS:JAVADOC:100; JAXRS:JAVADOC:101;
+   * JAXRS:JAVADOC:103; JAXRS:JAVADOC:53; JAXRS:JAVADOC:54; JAXRS:JAVADOC:55;
+   * JAXRS:JAVADOC:56;
+   * 
+   * @test_Strategy: Create a NewCookie instance using constructor
+   * NewCookie(java.lang.String name, java.lang.String value, java.lang.String
+   * path, java.lang.String domain, int version, java.lang.String comment, int
+   * maxAge, boolean secure)
+   */
+  @Test
+  public void constructorTest13() throws Fault {
+    String name = "name_1";
+    String value = "value_1";
+    String path = "";
+    String domain = "y.x.foo.com";
+    String comment = "";
+    int maxage = jakarta.ws.rs.core.NewCookie.DEFAULT_MAX_AGE;
+    int version = 1;
+    boolean secure = false;
+
+    NewCookie nck13 = new NewCookie(name, value, path, domain, version, comment,
+        maxage, secure);
+
+    verifyNewCookie(nck13, name, value, path, domain, version, comment, maxage,
+        secure);
+  }
+
+  /*
+   * @testName: constructorTest14
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:106; JAXRS:JAVADOC:100; JAXRS:JAVADOC:101;
+   * JAXRS:JAVADOC:103; JAXRS:JAVADOC:53; JAXRS:JAVADOC:54; JAXRS:JAVADOC:55;
+   * JAXRS:JAVADOC:56;
+   * 
+   * @test_Strategy: Create a version 1 NewCookie instance using constructor
+   * NewCookie(java.lang.String name, java.lang.String value, java.lang.String
+   * path, java.lang.String domain, int version, java.lang.String comment, int
+   * maxAge, boolean secure)
+   */
+  @Test
+  public void constructorTest14() throws Fault {
+    String name = "name_1";
+    String value = "value_1";
+    String path = "/acme";
+    String domain = "y.x.foo.com";
+    String comment = "cts test comment";
+    int maxage = jakarta.ws.rs.core.NewCookie.DEFAULT_MAX_AGE;
+    int version = 1;
+    boolean secure = false;
+
+    NewCookie nck14 = new NewCookie(name, value, path, domain, version, comment,
+        maxage, secure);
+
+    verifyNewCookie(nck14, name, value, path, domain, version, comment, maxage,
+        secure);
+  }
+
+  /*
+   * @testName: constructorTest15
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:106; JAXRS:JAVADOC:100; JAXRS:JAVADOC:101;
+   * JAXRS:JAVADOC:103; JAXRS:JAVADOC:53; JAXRS:JAVADOC:54; JAXRS:JAVADOC:55;
+   * JAXRS:JAVADOC:56;
+   *
+   * @test_Strategy: Create a version 1 NewCookie instance using constructor
+   * NewCookie(java.lang.String name, java.lang.String value, java.lang.String
+   * path, java.lang.String domain, int version, java.lang.String comment, int
+   * maxAge, boolean secure)
+   */
+  @Test
+  public void constructorTest15() throws Fault {
+    String name = "name_1";
+    String value = "value_1";
+    String path = "/acme";
+    String domain = "y.x.foo.com";
+    int version = 0;
+    String comment = "cts test comment";
+    int maxage = jakarta.ws.rs.core.NewCookie.DEFAULT_MAX_AGE;
+    boolean secure = true;
+
+    NewCookie nck15 = new NewCookie(name, value, path, domain, version, comment,
+        maxage, secure);
+
+    verifyNewCookie(nck15, name, value, path, domain, version, comment, maxage,
+        secure);
+  }
+
+  /*
+   * @testName: constructorTest16
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:106; JAXRS:JAVADOC:100; JAXRS:JAVADOC:101;
+   * JAXRS:JAVADOC:103; JAXRS:JAVADOC:53; JAXRS:JAVADOC:54; JAXRS:JAVADOC:55;
+   * JAXRS:JAVADOC:56;
+   * 
+   * @test_Strategy: Create a version 1 NewCookie instance using constructor
+   * NewCookie(java.lang.String name, java.lang.String value, java.lang.String
+   * path, java.lang.String domain, int version, java.lang.String comment, int
+   * maxAge, boolean secure)
+   */
+  @Test
+  public void constructorTest16() throws Fault {
+    // ToDo: Create a list of name, value, path, domain
+    String name = "name_1";
+    String value = "value_1";
+    String path = "/acme";
+    String domain = "y.x.foo.com";
+    int version = 0;
+    String comment = "cts test comment";
+    int maxage = jakarta.ws.rs.core.NewCookie.DEFAULT_MAX_AGE;
+    boolean secure = true;
+
+    NewCookie nck16 = new NewCookie(name, value, path, domain, version, comment,
+        maxage, secure);
+
+    verifyNewCookie(nck16, name, value, path, domain, version, comment, maxage,
+        secure);
+  }
+
+  /*
+   * @testName: constructorTest17
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:106; JAXRS:JAVADOC:100; JAXRS:JAVADOC:101;
+   * JAXRS:JAVADOC:103; JAXRS:JAVADOC:53; JAXRS:JAVADOC:54; JAXRS:JAVADOC:55;
+   * JAXRS:JAVADOC:56;
+   * 
+   * @test_Strategy: Create a version 1 NewCookie instance using constructor
+   * NewCookie(java.lang.String name, java.lang.String value, java.lang.String
+   * path, java.lang.String domain, int version, java.lang.String comment, int
+   * maxAge, boolean secure)
+   */
+  @Test
+  public void constructorTest17() throws Fault {
+    // ToDo: Create a list of name, value, path, domain
+    String name = "name_1";
+    String value = "value_1";
+    String path = "/acme";
+    String domain = "y.x.foo.com";
+    int version = 1;
+    String comment = "cts test comment";
+    int maxage = 123456;
+    boolean secure = true;
+
+    NewCookie nck17 = new NewCookie(name, value, path, domain, version, comment,
+        maxage, secure);
+
+    verifyNewCookie(nck17, name, value, path, domain, version, comment, maxage,
+        secure);
+  }
+
+  /*
+   * @testName: constructorTest18
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:108; JAXRS:JAVADOC:100; JAXRS:JAVADOC:101;
+   * JAXRS:JAVADOC:103; JAXRS:JAVADOC:51; JAXRS:JAVADOC:53; JAXRS:JAVADOC:54;
+   * JAXRS:JAVADOC:55; JAXRS:JAVADOC:56;
+   * 
+   * @test_Strategy: Create a NewCookie instance using constructor
+   * Cookie(String, String) NewCookie(Cookie, String comment, int maxAge,
+   * boolean secure)
+   */
+  @Test
+  public void constructorTest18() throws Fault {
+    String name = "name_1";
+    String value = "value_1";
+    String comment = "";
+    String domain = "";
+    String path = "";
+    int maxage = jakarta.ws.rs.core.NewCookie.DEFAULT_MAX_AGE;
+    int version = 1;
+    boolean secure = false;
+
+    Cookie ck18 = new Cookie(name, value);
+    NewCookie nck18 = new NewCookie(ck18, comment, maxage, secure);
+
+    verifyNewCookie(nck18, name, value, path, domain, version, comment, maxage,
+        secure);
+  }
+
+  /*
+   * @testName: constructorTest19
+   *
+   * @assertion_ids: JAXRS:JAVADOC:108; JAXRS:JAVADOC:100; JAXRS:JAVADOC:101;
+   * JAXRS:JAVADOC:103; JAXRS:JAVADOC:50; JAXRS:JAVADOC:53; JAXRS:JAVADOC:54;
+   * JAXRS:JAVADOC:55; JAXRS:JAVADOC:56;
+   *
+   * @test_Strategy: Create a NewCookie instance using constructor
+   * Cookie(String, String, String, String) NewCookie(Cookie, String comment,
+   * int maxAge, boolean secure)
+   */
+  @Test
+  public void constructorTest19() throws Fault {
+
+    String name = "name_1";
+    String value = "value_1";
+    String path = "/acme";
+    String domain = "";
+    String comment = "";
+    int maxage = jakarta.ws.rs.core.NewCookie.DEFAULT_MAX_AGE;
+    int version = 1;
+    boolean secure = false;
+
+    Cookie ck2 = new Cookie(name, value, path, domain);
+    NewCookie nck2 = new NewCookie(ck2, comment, maxage, secure);
+
+    verifyNewCookie(nck2, name, value, path, domain, version, comment, maxage,
+        secure);
+  }
+
+  /*
+   * @testName: constructorTest20
+   *
+   * @assertion_ids: JAXRS:JAVADOC:108; JAXRS:JAVADOC:100; JAXRS:JAVADOC:101;
+   * JAXRS:JAVADOC:103; JAXRS:JAVADOC:50; JAXRS:JAVADOC:53; JAXRS:JAVADOC:54;
+   * JAXRS:JAVADOC:55; JAXRS:JAVADOC:56;
+   *
+   * @test_Strategy: Create a NewCookie instance using constructor
+   * Cookie(String, String, String, String) NewCookie(Cookie, String comment,
+   * int maxAge, boolean secure)
+   */
+  @Test
+  public void constructorTest20() throws Fault {
+    String name = "name_1";
+    String value = "value_1";
+    String path = "";
+    String domain = "y.x.foo.com";
+    String comment = "";
+    int maxage = jakarta.ws.rs.core.NewCookie.DEFAULT_MAX_AGE;
+    int version = 1;
+    boolean secure = false;
+
+    Cookie ck20 = new Cookie(name, value, path, domain);
+    NewCookie nck20 = new NewCookie(ck20, comment, maxage, secure);
+
+    verifyNewCookie(nck20, name, value, path, domain, version, comment, maxage,
+        secure);
+  }
+
+  /*
+   * @testName: constructorTest21
+   *
+   * @assertion_ids: JAXRS:JAVADOC:108; JAXRS:JAVADOC:100; JAXRS:JAVADOC:101;
+   * JAXRS:JAVADOC:103; JAXRS:JAVADOC:49; JAXRS:JAVADOC:53; JAXRS:JAVADOC:54;
+   * JAXRS:JAVADOC:55; JAXRS:JAVADOC:56;
+   *
+   * @test_Strategy: Create a version 1 NewCookie instance using constructor
+   * Cookie(String, String, String, String, int) NewCookie(Cookie, String
+   * comment, int maxAge, boolean secure)
+   */
+  @Test
+  public void constructorTest21() throws Fault {
+    String name = "name_1";
+    String value = "value_1";
+    String path = "/acme";
+    String domain = "y.x.foo.com";
+    String comment = "";
+    int maxage = jakarta.ws.rs.core.NewCookie.DEFAULT_MAX_AGE;
+    int version = 1;
+    boolean secure = false;
+
+    Cookie ck21 = new Cookie(name, value, path, domain, version);
+    NewCookie nck21 = new NewCookie(ck21, comment, maxage, secure);
+
+    verifyNewCookie(nck21, name, value, path, domain, version, comment, maxage,
+        secure);
+  }
+
+  /*
+   * @testName: constructorTest22
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:108; JAXRS:JAVADOC:100; JAXRS:JAVADOC:101;
+   * JAXRS:JAVADOC:103; JAXRS:JAVADOC:49; JAXRS:JAVADOC:53; JAXRS:JAVADOC:54;
+   * JAXRS:JAVADOC:55; JAXRS:JAVADOC:56;
+   * 
+   * @test_Strategy: Create a version 1 NewCookie instance using constructor
+   * Cookie(String, String, String, String, int) NewCookie(Cookie, String
+   * comment, int maxAge, boolean secure)
+   */
+  @Test
+  public void constructorTest22() throws Fault {
+    String name = "name_1";
+    String value = "value_1";
+    String path = "/acme";
+    String domain = "y.x.foo.com";
+    int version = 1;
+    String comment = "cts test comment";
+    int maxage = jakarta.ws.rs.core.NewCookie.DEFAULT_MAX_AGE;
+    boolean secure = false;
+
+    Cookie ck22 = new Cookie(name, value, path, domain, version);
+    NewCookie nck22 = new NewCookie(ck22, comment, maxage, secure);
+
+    verifyNewCookie(nck22, name, value, path, domain, version, comment, maxage,
+        secure);
+  }
+
+  /*
+   * @testName: constructorTest23
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:108; JAXRS:JAVADOC:100; JAXRS:JAVADOC:101;
+   * JAXRS:JAVADOC:103; JAXRS:JAVADOC:49; JAXRS:JAVADOC:53; JAXRS:JAVADOC:54;
+   * JAXRS:JAVADOC:55; JAXRS:JAVADOC:56;
+   * 
+   * @test_Strategy: Create a version 1 NewCookie instance using constructor
+   * Cookie(String, String, String, String, int) NewCookie(Cookie, String
+   * comment, int maxAge, boolean secure)
+   */
+  @Test
+  public void constructorTest23() throws Fault {
+    String name = "name_1";
+    String value = "value_1";
+    String path = "/acme";
+    String domain = "y.x.foo.com";
+    int version = 0;
+    String comment = "cts test comment";
+    int maxage = jakarta.ws.rs.core.NewCookie.DEFAULT_MAX_AGE;
+    boolean secure = false;
+
+    Cookie ck22 = new Cookie(name, value, path, domain, version);
+    NewCookie nck22 = new NewCookie(ck22, comment, maxage, secure);
+
+    verifyNewCookie(nck22, name, value, path, domain, version, comment, maxage,
+        secure);
+  }
+
+  /*
+   * @testName: constructorTest24
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:108; JAXRS:JAVADOC:100; JAXRS:JAVADOC:101;
+   * JAXRS:JAVADOC:103; JAXRS:JAVADOC:49; JAXRS:JAVADOC:53; JAXRS:JAVADOC:54;
+   * JAXRS:JAVADOC:55; JAXRS:JAVADOC:56;
+   * 
+   * @test_Strategy: Create a version 1 NewCookie instance using constructor
+   * Cookie(String, String, String, String, int) NewCookie(Cookie, String
+   * comment, int maxAge, boolean secure)
+   */
+  @Test
+  public void constructorTest24() throws Fault {
+    String name = "name_1";
+    String value = "value_1";
+    String path = "/acme";
+    String domain = "y.x.foo.com";
+    int version = 1;
+    String comment = "cts test comment";
+    int maxage = jakarta.ws.rs.core.NewCookie.DEFAULT_MAX_AGE;
+    boolean secure = true;
+
+    Cookie ck24 = new Cookie(name, value, path, domain, version);
+    NewCookie nck24 = new NewCookie(ck24, comment, maxage, secure);
+
+    verifyNewCookie(nck24, name, value, path, domain, version, comment, maxage,
+        secure);
+  }
+
+  /*
+   * @testName: constructorTest25
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:108; JAXRS:JAVADOC:100; JAXRS:JAVADOC:101;
+   * JAXRS:JAVADOC:103; JAXRS:JAVADOC:49; JAXRS:JAVADOC:53; JAXRS:JAVADOC:54;
+   * JAXRS:JAVADOC:55; JAXRS:JAVADOC:56;
+   * 
+   * @test_Strategy: Create a version 1 NewCookie instance using constructor
+   * Cookie(String, String, String, String, int) NewCookie(Cookie, String
+   * comment, int maxAge, boolean secure)
+   */
+  @Test
+  public void constructorTest25() throws Fault {
+    String name = "name_1";
+    String value = "value_1";
+    String path = "/acme";
+    String domain = "y.x.foo.com";
+    int version = 1;
+    String comment = "cts test comment";
+    int maxage = 12345;
+    boolean secure = false;
+
+    Cookie ck25 = new Cookie(name, value, path, domain, version);
+    NewCookie nck25 = new NewCookie(ck25, comment, maxage, secure);
+
+    verifyNewCookie(nck25, name, value, path, domain, version, comment, maxage,
+        secure);
+  }
+
+  /*
+   * @testName: parseTest1
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:111; JAXRS:JAVADOC:100; JAXRS:JAVADOC:101;
+   * JAXRS:JAVADOC:103; JAXRS:JAVADOC:53; JAXRS:JAVADOC:54; JAXRS:JAVADOC:55;
+   * JAXRS:JAVADOC:56;
+   * 
+   * @test_Strategy: Create a version 0 Cookie instance by Parsing a String
+   */
+  @Test
+  public void parseTest1() throws Fault {
+    String NewCookie_toParse = "NAME_1=Value_1;";
+    String name = "name_1";
+    String value = "value_1";
+    String path = "";
+    String domain = "";
+    int version = 1;
+
+    NewCookie nck26 = jakarta.ws.rs.core.NewCookie.valueOf(NewCookie_toParse);
+
+    verifyNewCookie(nck26, name, value, path, domain, version, "", -1, false);
+  }
+
+  /*
+   * @testName: parseTest2
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:111; JAXRS:JAVADOC:100; JAXRS:JAVADOC:101;
+   * JAXRS:JAVADOC:103; JAXRS:JAVADOC:53; JAXRS:JAVADOC:54; JAXRS:JAVADOC:55;
+   * JAXRS:JAVADOC:56;
+   * 
+   * @test_Strategy: Create a version 0 NewCookie instance by Parsing a String
+   */
+  @Test
+  public void parseTest2() throws Fault {
+    String newCookie_toParse = "Customer=WILE_E_COYOTE; Path=/acme; Version=1";
+
+    String name = "customer";
+    String value = "wile_e_coyote";
+    String path = "/acme";
+    String domain = "";
+    int version = 1;
+
+    NewCookie nck27 = jakarta.ws.rs.core.NewCookie.valueOf(newCookie_toParse);
+
+    verifyNewCookie(nck27, name, value, path, domain, version, "", -1, false);
+  }
+
+  /*
+   * @testName: parseTest3
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:111;
+   * 
+   * @test_Strategy: Create a NewCookie instance by Parsing a null String.
+   * Verify that IllegalArgumentException is thrown
+   */
+  @Test
+  public void parseTest3() throws Fault {
+    try {
+      jakarta.ws.rs.core.NewCookie.valueOf(null);
+      throw new Fault(
+          "Expected IllegalArgumentException not thrown. Test Failed.");
+    } catch (IllegalArgumentException ilex) {
+      logMsg("IllegalArgumentException has been thrown as expected");
+    }
+  }
+
+  /*
+   * @testName: equalsTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:99; JAXRS:JAVADOC:102;
+   * 
+   * @test_Strategy: Create two NewCookie instances using constructor
+   * Cookie(String, String, String, String, int) NewCookie(Cookie, String
+   * comment, int maxAge, boolean secure) and NewCokie(String name, String
+   * value, String path, String domain, int version, String comment, int maxAge,
+   * boolean secure) Verify that equals and hashCode methods work.
+   */
+  @Test
+  @Disabled("fails: NewCookie.hashcode() throws a NullPointerException because sameSite is null")
+  public void equalsTest() throws Fault {
+    boolean pass = true;
+    StringBuffer sb = new StringBuffer();
+
+    String name = "name_1";
+    String value = "value_1";
+    String path = "/acme";
+    String domain = "y.x.foo.com";
+    int version = 1;
+    String comment = "cts test comment";
+    int maxage = 12345;
+    boolean secure = false;
+
+    Cookie ck28 = new Cookie(name, value, path, domain, version);
+    NewCookie nck28 = new NewCookie(ck28, comment, maxage, secure);
+    NewCookie nck29 = new NewCookie(name, value, path, domain, version, comment,
+        maxage, secure);
+
+    if (!nck28.equals(nck29)) {
+      pass = false;
+      sb.append("Equal test failed.").append(newline);
+      sb.append("First  :").append(nck28.toString()).append(newline);
+      sb.append("Second :").append(nck29.toString()).append(newline);
+    }
+
+    if (nck28.hashCode() != nck29.hashCode()) {
+      pass = false;
+      sb.append("HashCode equal test failed.").append(newline);
+    }
+
+    name = "name1";
+    nck29 = new NewCookie(name, value, path, domain, version, comment, maxage,
+        secure);
+    if (nck28.equals(nck29)) {
+      pass = false;
+      sb.append("UnEqual test failed at name.").append(newline);
+      sb.append("First  :").append(nck28.toString()).append(newline);
+      sb.append("Second :").append(nck29.toString()).append(newline);
+    }
+
+    if (nck28.hashCode() == nck29.hashCode()) {
+      pass = false;
+      sb.append("HashCode unequal test failed at name.").append(newline);
+    }
+
+    assertTrue(pass, "At least one assertion failed: " + sb.toString());
+  }
+
+  /*
+   * @testName: toCookieTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:109; JAXRS:JAVADOC:52; JAXRS:JAVADOC:58;
+   * 
+   * @test_Strategy: Create a Cookie instance using constructor Cookie(String,
+   * String, String, String, int) and a NewCookie instance NewCokie(String name,
+   * String value, String path, String domain, int version, String comment, int
+   * maxAge, boolean secure) NewCookie(Cookie, String comment, int maxAge,
+   * boolean secure) Verify that toCookie method works by using .equals and
+   * hashCode method.
+   */
+  @Test
+  public void toCookieTest() throws Fault {
+    boolean pass = true;
+    StringBuffer sb = new StringBuffer();
+
+    String name = "name_1";
+    String value = "value_1";
+    String path = "/acme";
+    String domain = "y.x.foo.com";
+    int version = 1;
+    String comment = "cts test comment";
+    int maxage = 12345;
+    boolean secure = false;
+
+    Cookie ck30 = new Cookie(name, value, path, domain, version);
+    NewCookie nck30 = new NewCookie(name, value, path, domain, version, comment,
+        maxage, secure);
+    Cookie ck31 = nck30.toCookie();
+
+    if (!ck30.equals(ck31)) {
+      pass = false;
+      sb.append("Equal test failed.").append(newline);
+      sb.append("First  :").append(ck30.toString()).append(newline);
+      sb.append("Second :").append(ck31.toString()).append(newline);
+    }
+
+    if (ck30.hashCode() != ck31.hashCode()) {
+      pass = false;
+      sb.append("HashCode equal test failed.").append(newline);
+    }
+
+    assertTrue(pass, "At least one assertion failed: " + sb.toString());
+  }
+
+  /*
+   * @testName: toStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:110; JAXRS:JAVADOC:52; JAXRS:JAVADOC:58;
+   * 
+   * @test_Strategy: Create a NewCookie instance NewCokie(String name, String
+   * value, String path, String domain, int version, String comment, int maxAge,
+   * boolean secure) Verify that toString method works.
+   */
+  @Test
+  public void toStringTest() throws Fault {
+    boolean pass = true;
+    StringBuffer sb = new StringBuffer();
+
+    String name = "name_1";
+    String value = "value_1";
+    String path = "/acme";
+    String domain = "y.x.foo.com";
+    int version = 1;
+    String comment = "cts test comment";
+    int maxage = 12345;
+    boolean secure = false;
+
+    List<String> tobeVerified = Arrays.asList(name, value, path, domain,
+        Integer.valueOf(version).toString(), comment,
+        Integer.valueOf(maxage).toString(),
+        secure ? Boolean.valueOf(secure).toString() : null);
+
+    NewCookie nck31 = new NewCookie(name, value, path, domain, version, comment,
+        maxage, secure);
+
+    String nk_String = nck31.toString();
+
+    for (String nk_part : tobeVerified) {
+      if (nk_part != null) {
+        if (!nk_String.contains(nk_part)) {
+          sb.append("Test failed.  Expected ").append(nk_part + " not faound.")
+              .append(newline);
+          pass = false;
+        } else {
+          sb.append("Expected ").append(nk_part).append(" faound.")
+              .append(newline);
+        }
+      }
+    }
+
+    sb.append("Expected NewCookie: ").append(nk_String).append(newline);
+
+    assertTrue(pass, "At least one assertion failed: " + sb.toString());
+    TestUtil.logTrace(sb.toString());
+  }
+
+  private static boolean verifyNewCookie(NewCookie nck, String name,
+      String value, String path, String domain, int version, String comment,
+      int maxage, boolean secure) throws Fault {
+
+    StringBuffer sb = new StringBuffer();
+    boolean pass = true;
+
+    if (name == "" || name == null) {
+      pass = false;
+      sb.append("NewCookie's name is empty");
+    } else if (!nck.getName().toLowerCase().equals(name)) {
+      pass = false;
+      sb.append("Failed name test.  Expect ").append(name)
+          .append(" got " + nck.getName());
+    }
+
+    if (value == "" || value == null) {
+      pass = false;
+      sb.append("NewCookie's value is empty");
+    } else if (!nck.getValue().toLowerCase().equals(value)) {
+      pass = false;
+      sb.append("Failed value test.  Expect ").append(value)
+          .append(" got " + nck.getValue());
+    }
+
+    if (nck.getVersion() != version) {
+      pass = false;
+      sb.append("Failed version test.  Expect ").append(version)
+          .append(" got " + nck.getVersion());
+    }
+
+    if (comment == "" || comment == null) {
+      if (nck.getComment() != "" && nck.getComment() != null) {
+        pass = false;
+        sb.append("Failed comment test.  Expect null String, got <"
+            + nck.getComment()).append(">");
+      }
+    } else if (!nck.getComment().toLowerCase().equals(comment)) {
+      pass = false;
+      sb.append("Failed comment test.  Expect ").append(comment)
+          .append(" got " + nck.getComment());
+    }
+
+    if (path == "" || path == null) {
+      if (nck.getPath() != "" && nck.getPath() != null) {
+        pass = false;
+        sb.append(
+            "Failed path test.  Expect null String, got " + nck.getPath());
+      }
+    } else if (nck.getPath() == null || nck.getPath() == "") {
+      pass = false;
+      sb.append("Failed path test.  Got null, expecting ").append(path);
+    } else if (!nck.getPath().toLowerCase().equals(path)) {
+      pass = false;
+      sb.append("Failed path test.  Expect ").append(path)
+          .append(" got " + nck.getPath());
+    }
+
+    if (domain == "" || domain == null) {
+      if (nck.getDomain() != "" && nck.getDomain() != null) {
+        pass = false;
+        sb.append("Failed path test.  Expect ").append(domain)
+            .append(" got " + nck.getDomain());
+      }
+    } else if (!nck.getDomain().toLowerCase().equals(domain)) {
+      pass = false;
+      sb.append("Failed domain test.  Expect ").append(domain)
+          .append(" got " + nck.getDomain());
+    }
+
+    if (nck.getMaxAge() != maxage) {
+      pass = false;
+      sb.append("Failed maxage test.  Expect ").append(maxage)
+          .append(" got " + nck.getMaxAge());
+    }
+
+    if (nck.isSecure() != secure) {
+      pass = false;
+      sb.append("Failed secure test.  Expect ").append(secure)
+          .append(" got " + nck.isSecure());
+    }
+
+    assertTrue(pass, "At least one assertion falied: " + sb.toString());
+    return pass;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/nocontentexception/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/nocontentexception/JAXRSClientIT.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2014, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.core.nocontentexception;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.core.NoContentException;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+    private static final long serialVersionUID = 3227433857540172402L;
+
+    @BeforeEach
+    void logStartTest(TestInfo testInfo) {
+      TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+    }
+  
+    @AfterEach
+    void logFinishTest(TestInfo testInfo) {
+      TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+    }
+  
+    private static final String MESSAGE = "Any NoContentException message";
+  
+    /* Run test */
+  
+    /*
+     * @testName: constructorStringTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:1127;
+     * 
+     * @test_Strategy: Construct a new NoContentException instance. message - the
+     * detail message (which is saved for later retrieval by the
+     * Throwable.getMessage() method).
+     */
+    @Test
+    public void constructorStringTest() throws Fault {
+      NoContentException e = new NoContentException(MESSAGE);
+      assertMessage(MESSAGE, e);
+    }
+  
+    /*
+     * @testName: constructorNullStringTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:1127;
+     * 
+     * @test_Strategy: Construct a new NoContentException instance. message - the
+     * detail message (which is saved for later retrieval by the
+     * Throwable.getMessage() method).
+     */
+    @Test
+    public void constructorNullStringTest() throws Fault {
+      NoContentException e = new NoContentException((String) null);
+      assertNullMessage(e);
+    }
+  
+    /*
+     * @testName: constructorStringThrowableTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:1128;
+     * 
+     * @test_Strategy: Construct a new NoContentException instance.
+     */
+    @Test
+    public void constructorStringThrowableTest() throws Fault {
+      Throwable[] throwables = new Throwable[] { new RuntimeException(),
+          new IOException(), new Error(), new Throwable() };
+      for (Throwable t : throwables) {
+        NoContentException e = new NoContentException(MESSAGE, t);
+        assertMessage(MESSAGE, e);
+        assertCause(e, t);
+  
+        e = new NoContentException(null, t);
+        assertNullMessage(e);
+        assertCause(e, t);
+      }
+    }
+  
+    /*
+     * @testName: constructorThrowableTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:1129;
+     * 
+     * @test_Strategy: Construct a new NoContentException instance.
+     */
+    @Test
+    public void constructorThrowableTest() throws Fault {
+      Throwable[] throwables = new Throwable[] { new RuntimeException(),
+          new IOException(), new Error(), new Throwable() };
+      for (Throwable t : throwables) {
+        NoContentException e = new NoContentException(t);
+        assertCause(e, t);
+      }
+    }
+  
+    // /////////////////////////////////////////////////////////////
+    private static void //
+        assertMessage(String message, Exception exception) throws Fault {
+      assertEquals(message, exception.getMessage(),
+          "Unexpected message in exception", exception.getMessage(),
+          "expected was", message);
+      logMsg("The exception contains expected", "#getMessage()");
+    }
+  
+    private static void //
+        assertNullMessage(Exception exception) throws Fault {
+      assertNull(exception.getMessage(), "Unexpected message in exception",
+          exception.getMessage(), "expected was null");
+      logMsg("The exception contains expected", "#getMessage()");
+    }
+  
+    private static void //
+        assertCause(NoContentException e, Throwable expected) throws Fault {
+      assertEquals(e.getCause(), expected, "#getCause does not contain expected",
+          expected, "but", e.getCause());
+      logMsg("getCause contains expected", expected);
+    }
+    
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/responsestatustype/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/responsestatustype/JAXRSClientIT.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.core.responsestatustype;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.core.Response.Status.Family;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+import jakarta.ws.rs.core.Response.StatusType;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = -4533695636737308500L;
+
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  // name it to ensure sorting
+  static final int[] status_codes = { 200, 201, 202, 204, 205, 206, 301, 302,
+      303, 304, 305, 307, 400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410,
+      411, 412, 413, 414, 415, 416, 417, 500, 501, 502, 503, 504, 505 };
+
+  // name it to ensure sorting
+  static final Response.Status.Family[] status_family = {
+      Response.Status.Family.SUCCESSFUL, Response.Status.Family.SUCCESSFUL,
+      Response.Status.Family.SUCCESSFUL, Response.Status.Family.SUCCESSFUL,
+      Response.Status.Family.SUCCESSFUL, Response.Status.Family.SUCCESSFUL,
+      Response.Status.Family.REDIRECTION, Response.Status.Family.REDIRECTION,
+      Response.Status.Family.REDIRECTION, Response.Status.Family.REDIRECTION,
+      Response.Status.Family.REDIRECTION, Response.Status.Family.REDIRECTION,
+      Response.Status.Family.CLIENT_ERROR, Response.Status.Family.CLIENT_ERROR,
+      Response.Status.Family.CLIENT_ERROR, Response.Status.Family.CLIENT_ERROR,
+      Response.Status.Family.CLIENT_ERROR, Response.Status.Family.CLIENT_ERROR,
+      Response.Status.Family.CLIENT_ERROR, Response.Status.Family.CLIENT_ERROR,
+      Response.Status.Family.CLIENT_ERROR, Response.Status.Family.CLIENT_ERROR,
+      Response.Status.Family.CLIENT_ERROR, Response.Status.Family.CLIENT_ERROR,
+      Response.Status.Family.CLIENT_ERROR, Response.Status.Family.CLIENT_ERROR,
+      Response.Status.Family.CLIENT_ERROR, Response.Status.Family.CLIENT_ERROR,
+      Response.Status.Family.CLIENT_ERROR, Response.Status.Family.CLIENT_ERROR,
+      Response.Status.Family.SERVER_ERROR, Response.Status.Family.SERVER_ERROR,
+      Response.Status.Family.SERVER_ERROR, Response.Status.Family.SERVER_ERROR,
+      Response.Status.Family.SERVER_ERROR,
+      Response.Status.Family.SERVER_ERROR };
+
+  final String[] status = { "OK", "Created", "Accepted", "No Content",
+      "Reset Content", "Partial Content", "Moved Permanently", "Found",
+      "See Other", "Not Modified", "Use Proxy", "Temporary Redirect",
+      "Bad Request", "Unauthorized", "Payment Required", "Forbidden",
+      "Not Found", "Method Not Allowed", "Not Acceptable",
+      "Proxy Authentication Required", "Request Timeout", "Conflict", "Gone",
+      "Length Required", "Precondition Failed", "Request Entity Too Large",
+      "Request-URI Too Long", "Unsupported Media Type",
+      "Requested Range Not Satisfiable", "Expectation Failed",
+      "Internal Server Error", "Not Implemented", "Bad Gateway",
+      "Service Unavailable", "Gateway Timeout", "HTTP Version Not Supported" };
+
+  /* Run test */
+
+  /*
+   * @testName: getFamilyTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:302;
+   * 
+   * @test_Strategy: Get the class of status code
+   */
+  @Test
+  public void getFamilyTest() throws Fault {
+    Response response;
+    for (int i = 0; i != status_codes.length; i++) {
+      response = Response.status(status_codes[i]).build();
+      StatusType type = response.getStatusInfo();
+      Family family = type.getFamily();
+      assertTrue(family == status_family[i], "unexpected family " + family +
+          " differs from " + status_family[i]);
+      logMsg("Found expected family", family, "for status", status_codes[i]);
+    }
+  }
+
+  /*
+   * @testName: getReasonPhraseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:303;
+   * 
+   * @test_Strategy: Get the reason phrase
+   */
+  @Test
+  public void getReasonPhraseTest() throws Fault {
+    Response response;
+    for (int i = 0; i != status_codes.length; i++) {
+      response = Response.status(status_codes[i]).build();
+      StatusType type = response.getStatusInfo();
+      String phrase = type.getReasonPhrase();
+      assertTrue(phrase.equals(status[i]), "unexpected phrase " + phrase +
+          " differs from " + status[i]);
+      logMsg("Found expected phrase", phrase, "for status", status_codes[i]);
+
+    }
+  }
+
+  /*
+   * @testName: getStatusCodeTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:304;
+   * 
+   * @test_Strategy: Get the associated status code.
+   */
+  @Test
+  public void getStatusCodeTest() throws Fault {
+    Response response;
+    for (int i = 0; i != status_codes.length; i++) {
+      response = Response.status(status_codes[i]).build();
+      StatusType type = response.getStatusInfo();
+      int code = type.getStatusCode();
+      assertTrue(code == status_codes[i], "unexpected status code " + code +
+          " differs from " + status_codes[i]);
+      logMsg("Found expected status code", code, "for status", status_codes[i]);
+    }
+  }
+
+  /*
+   * @testName: familyOfTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:885;
+   * 
+   * @test_Strategy: Get the response status family for the status code.
+   */
+  @Test
+  public void familyOfTest() throws Fault {
+    for (int i = 0; i != status_codes.length; i++) {
+      Family family = Status.Family.familyOf(status_codes[i]);
+      assertTrue(family == status_family[i], family + " differs from expected: " +
+          status_family[i]);
+    }
+    logMsg("#familyOf() returned expected Family for given statuses");
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/variant/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/variant/JAXRSClientIT.java
@@ -1,0 +1,720 @@
+/*
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.core.variant;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Variant;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost; webServerPort; ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+    private static final long serialVersionUID = 396770878268682189L;
+
+    public JAXRSClientIT() {
+      setContextRoot("/jaxrs_rs_core_variantTest_web");
+    }
+
+    @BeforeEach
+    void logStartTest(TestInfo testInfo) {
+      TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+    }
+  
+    @AfterEach
+    void logFinishTest(TestInfo testInfo) {
+      TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+    }
+  
+    /* Run test */
+  
+    /*
+     * @testName: constructorTest1
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:255; JAXRS:JAVADOC:256; JAXRS:JAVADOC:257;
+     * JAXRS:JAVADOC:261; JAXRS:JAVADOC:262;
+     * 
+     * @test_Strategy: Create an MediaType instance using MediaType()
+     */
+    @Test
+    public void constructorTest1() throws Fault {
+      String type = jakarta.ws.rs.core.MediaType.MEDIA_TYPE_WILDCARD;
+      String subtype = jakarta.ws.rs.core.MediaType.MEDIA_TYPE_WILDCARD;
+      String encoding = "ISO8859-15";
+      Locale lang = new Locale("en", "US");
+  
+      MediaType mt1 = new MediaType();
+  
+      Variant vt = new Variant(mt1, lang, encoding);
+      verifyVariant(vt, type, subtype, lang, encoding);
+    }
+  
+    /*
+     * @testName: constructorTest2
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:255; JAXRS:JAVADOC:256; JAXRS:JAVADOC:257;
+     * JAXRS:JAVADOC:261; JAXRS:JAVADOC:262;
+     * 
+     * @test_Strategy: Create an MediaType instance using MediaType(String,
+     * String)
+     */
+    @Test
+    public void constructorTest2() throws Fault {
+      String type = "application";
+      String subtype = "atom+xml";
+      String encoding = "";
+      Locale lang = null;
+  
+      MediaType mt2 = new MediaType(type, subtype);
+  
+      Variant vt = new Variant(mt2, lang, encoding);
+      verifyVariant(vt, type, subtype, lang, encoding);
+    }
+  
+    /*
+     * @testName: constructorTest3
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:255; JAXRS:JAVADOC:256; JAXRS:JAVADOC:257;
+     * JAXRS:JAVADOC:261; JAXRS:JAVADOC:262;
+     * 
+     * @test_Strategy: Create an MediaType instance using MediaType(String,
+     * String)
+     */
+    @Test
+    public void constructorTest3() throws Fault {
+      String type = "application";
+      String subtype = "x-www-form-urlencoded";
+      Map<String, String> params = new HashMap<String, String>();
+      String encoding = null;
+      Locale lang = null;
+  
+      MediaType mt3 = new MediaType(type, subtype, params);
+      Variant vt = new Variant(mt3, lang, encoding);
+      verifyVariant(vt, type, subtype, params, new String[0], lang, encoding);
+    }
+  
+    /*
+     * @testName: constructorMediaStringStringTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:900;
+     * 
+     * @test_Strategy: Create a Variant(MediaType, String, String)
+     */
+    @Test
+    public void constructorMediaStringStringTest() throws Fault {
+      Variant vt = null;
+      String[] encodings = { null, "CP1250", "UTF8", "ISO8859-2" };
+      Locale[] langs = { null, Locale.CANADA, Locale.FRENCH };
+  
+      for (String encoding : encodings)
+        for (Locale lang : langs) {
+          vt = new Variant(MediaType.APPLICATION_XHTML_XML_TYPE,
+              lang == null ? null : lang.toString(), encoding);
+          verifyVariant(vt, MediaType.APPLICATION_XHTML_XML_TYPE.getType(),
+              MediaType.APPLICATION_XHTML_XML_TYPE.getSubtype(), lang, encoding);
+        }
+    }
+  
+    /*
+     * @testName: constructorMediaStringStringThrowsIllegalArgumentExceptionTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:900;
+     * 
+     * @test_Strategy: throws IllegalArgumentException - if all the parameters are
+     * null.
+     */
+    @Test
+    public void constructorMediaStringStringThrowsIllegalArgumentExceptionTest()
+        throws Fault {
+      try {
+        new Variant((MediaType) null, (String) null, (String) null);
+        throw new Fault("Did not throw IllegalArgumentException for all nulls");
+      } catch (IllegalArgumentException e) {
+        logMsg("Thrown IllegalArgumentException as expected");
+      }
+    }
+  
+    /*
+     * @testName: constructorMediaStringStringStringTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:901;
+     * 
+     * @test_Strategy: Create a Variant(MediaType, String, String, String)
+     */
+    @Test
+    public void constructorMediaStringStringStringTest() throws Fault {
+      Variant vt = null;
+      String[] encodings = { null, "CP1250", "UTF8", "ISO8859-2" };
+      Locale[] langs = { null, Locale.CANADA, Locale.FRENCH };
+  
+      for (String encoding : encodings)
+        for (Locale lang : langs) {
+          vt = new Variant(MediaType.APPLICATION_XHTML_XML_TYPE,
+              lang == null ? null : lang.getLanguage(),
+              lang == null ? null : lang.getCountry(), encoding);
+          verifyVariant(vt, MediaType.APPLICATION_XHTML_XML_TYPE.getType(),
+              MediaType.APPLICATION_XHTML_XML_TYPE.getSubtype(), lang, encoding);
+        }
+    }
+  
+    /*
+     * @testName:
+     * constructorMediaStringStringStringThrowsIllegalArgumentExceptionTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:901;
+     * 
+     * @test_Strategy: throws IllegalArgumentException - if all the parameters are
+     * null.
+     */
+    @Test
+    public void constructorMediaStringStringStringThrowsIllegalArgumentExceptionTest()
+        throws Fault {
+      try {
+        new Variant((MediaType) null, (String) null, (String) null,
+            (String) null);
+        throw new Fault("Did not throw IllegalArgumentException for all nulls");
+      } catch (IllegalArgumentException e) {
+        logMsg("Thrown IllegalArgumentException as expected");
+      }
+    }
+  
+    /*
+     * @testName: constructorMediaStringStringStringStringTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:902;
+     * 
+     * @test_Strategy: Create a Variant(MediaType, String, String, String, String)
+     */
+    @Test
+    public void constructorMediaStringStringStringStringTest() throws Fault {
+      Variant vt = null;
+      String[] encodings = { null, "CP1250", "UTF8", "ISO8859-2" };
+      Locale[] langs = { null, Locale.CANADA, Locale.FRENCH };
+  
+      for (String encoding : encodings)
+        for (Locale lang : langs) {
+          vt = new Variant(MediaType.APPLICATION_XHTML_XML_TYPE,
+              lang == null ? null : lang.getLanguage(),
+              lang == null ? null : lang.getCountry(),
+              lang == null ? null : lang.getVariant(), encoding);
+          verifyVariant(vt, MediaType.APPLICATION_XHTML_XML_TYPE.getType(),
+              MediaType.APPLICATION_XHTML_XML_TYPE.getSubtype(), lang, encoding);
+        }
+    }
+  
+    /*
+     * @testName:
+     * constructorMediaStringStringStringStringThrowsIllegalArgumentExceptionTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:902;
+     * 
+     * @test_Strategy: throws IllegalArgumentException - if all the parameters are
+     * null.
+     */
+    @Test
+    public void constructorMediaStringStringStringStringThrowsIllegalArgumentExceptionTest()
+        throws Fault {
+      try {
+        new Variant((MediaType) null, (String) null, (String) null, (String) null,
+            (String) null);
+        throw new Fault("Did not throw IllegalArgumentException for all nulls");
+      } catch (IllegalArgumentException e) {
+        logMsg("Thrown IllegalArgumentException as expected");
+      }
+    }
+  
+    /*
+     * @testName: equalTest1
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:262; JAXRS:JAVADOC:254; JAXRS:JAVADOC:258;
+     * 
+     * @test_Strategy: Create two Variants with different Locale. Verify
+     * Variant.equals and Variant.hasCode methods work properly using those two
+     * Variant objects.
+     */
+    @Test
+    public void equalTest1() throws Fault {
+      StringBuffer sb = new StringBuffer();
+      boolean pass;
+  
+      String type = jakarta.ws.rs.core.MediaType.MEDIA_TYPE_WILDCARD;
+      String subtype = jakarta.ws.rs.core.MediaType.MEDIA_TYPE_WILDCARD;
+  
+      MediaType mt1 = new MediaType();
+      pass = checkMediaTypeForEqualTest1(sb, mt1);
+  
+      MediaType mt2 = new MediaType(type, subtype);
+      pass &= checkMediaTypeForEqualTest1(sb, mt2);
+  
+      assertTrue(pass, "At least one assertion failed: " + sb.toString());
+    }
+  
+    private static boolean checkMediaTypeForEqualTest1(StringBuffer sb,
+        MediaType type) {
+      String encoding = "ISO8859-15";
+      Locale lang1 = new Locale("en", "US");
+      Locale lang2 = null;
+      Boolean pass = true;
+  
+      Variant vt1 = new Variant(type, lang1, encoding);
+      Variant vt2 = new Variant(type, lang2, encoding);
+  
+      if (vt1.equals(vt2)) {
+        pass = false;
+        sb.append("Equals Test1 Failed" + newline);
+      }
+  
+      if (vt1.hashCode() == vt2.hashCode()) {
+        sb.append(
+            "hasCode Test1 Failed: vt1.hashCode()=" + vt1.hashCode() + newline);
+        sb.append(
+            "                      vt2.hashCode()=" + vt2.hashCode() + newline);
+        pass = false;
+      }
+      return pass;
+    }
+  
+    /*
+     * @testName: equalsTest2
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:262; JAXRS:JAVADOC:254; JAXRS:JAVADOC:258;
+     * 
+     * @test_Strategy: Create two Variants with different MediaType. Verify
+     * Variant.equals and Variant.hasCode methods work properly using those two
+     * Variant objects.
+     */
+    @Test
+    public void equalsTest2() throws Fault {
+      StringBuffer sb = new StringBuffer();
+      Boolean pass = true;
+  
+      String type = "application";
+      String subtype = "atom+xml";
+      String subtype1 = "xml";
+      String encoding = "";
+      Locale lang = null;
+  
+      MediaType mt1 = new MediaType(type, subtype);
+      MediaType mt2 = new MediaType(type, subtype1);
+  
+      Variant vt1 = new Variant(mt1, lang, encoding);
+      Variant vt2 = new Variant(mt2, lang, encoding);
+  
+      if (vt1.equals(vt2)) {
+        pass = false;
+        sb.append("Equals Test2 Failed" + newline);
+      }
+  
+      if (vt1.hashCode() == vt2.hashCode()) {
+        sb.append(
+            "hasCode Test2 Failed: vt1.hashCode()=" + vt1.hashCode() + newline);
+        sb.append(
+            "                      vt2.hashCode()=" + vt2.hashCode() + newline);
+        pass = false;
+      }
+  
+      assertTrue(pass, "At least one assertion failed: " + sb.toString());
+    }
+  
+    /*
+     * @testName: equalsTest3
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:262; JAXRS:JAVADOC:254; JAXRS:JAVADOC:258;
+     * 
+     * @test_Strategy: Create two Variants with the same properties. Verify
+     * Variant.equals and Variant.hasCode methods work properly using those two
+     * Variant objects.
+     */
+    @Test
+    public void equalsTest3() throws Fault {
+      StringBuffer sb = new StringBuffer();
+      Boolean pass = true;
+  
+      String type = "application";
+      String subtype = "x-www-form-urlencoded";
+      Map<String, String> params = new HashMap<String, String>();
+      String encoding = null;
+      Locale lang = null;
+  
+      MediaType mt4 = new MediaType(type, subtype, params);
+  
+      Variant vt1 = new Variant(mt4, lang, encoding);
+      Variant vt2 = new Variant(mt4, lang, encoding);
+  
+      if (!vt1.equals(vt2)) {
+        pass = false;
+        sb.append("Equals Test3 Failed" + newline);
+      }
+  
+      if (vt1.hashCode() != vt2.hashCode()) {
+        sb.append(
+            "hasCode Test3 Failed: vt1.hashCode()=" + vt1.hashCode() + newline);
+        sb.append(
+            "                      vt2.hashCode()=" + vt2.hashCode() + newline);
+        pass = false;
+      }
+  
+      assertTrue(pass, "At least one assertion failed: " + sb.toString());
+    }
+  
+    /*
+     * @testName: languagesTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:259;
+     * 
+     * @test_Strategy: Call Variant.languages(Locale ...) with three Locales,
+     * Verify that three Variant instances created properly
+     */
+    @Test
+    public void languagesTest() throws Fault {
+      List<String> encodingS = null;
+      List<MediaType> mts = null;
+  
+      List<Variant> vts = Variant.languages(new Locale("en", "US"),
+          new Locale("en", "GB"), new Locale("zh", "CN")).add().build();
+  
+      verifyVariants(vts, mts, getLangList(), encodingS);
+    }
+  
+    /*
+     * @testName: getLanguageStringTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:899;
+     * 
+     * @test_Strategy: Get the string representation of the variant language
+     */
+    @Test
+    public void getLanguageStringTest() throws Fault {
+      Locale[] langs = { null, Locale.CHINA, Locale.PRC, Locale.CANADA_FRENCH,
+          Locale.GERMAN };
+      for (Locale lang : langs) {
+        Variant v = new Variant(MediaType.TEXT_PLAIN_TYPE, lang, (String) null);
+        if (lang != null)
+          assertTrue(v.getLanguageString().contains(lang.getLanguage()),
+              "Created variant contained " + v.getLanguageString() +
+              "but was expected " + lang.getLanguage());
+        else
+          assertTrue(v.getLanguageString() == null, "#getLanguageString was " +
+              v.getLanguageString() + " expected was null");
+      }
+      logMsg("#getLanguageString returned exected language string");
+    }
+  
+    /*
+     * @testName: encodingsTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:253;
+     * 
+     * @test_Strategy: Call Variant.encodings(String ...) with three Encodings,
+     * Verify that three Variant instances created properly
+     */
+    @Test
+    public void encodingsTest() throws Fault {
+      String encoding1 = "ISO8859-15";
+      String encoding2 = "GB2312";
+      String encoding3 = "UTF-8";
+  
+      List<String> encodingS = Arrays.asList(encoding1, encoding2, encoding3);
+      List<String> langS = null;
+      List<MediaType> mts = null;
+  
+      List<Variant> vts = Variant.encodings(encoding1, encoding2, encoding3).add()
+          .build();
+  
+      verifyVariants(vts, mts, langS, encodingS);
+    }
+  
+    /*
+     * @testName: mediaTypesTest
+     * 
+     * @assertion_ids: JAXRS:JAVADOC:260;
+     * 
+     * @test_Strategy: Call Variant.mediaTypes(MediaType ...) with three MediaType
+     * objects, Verify that three Variant instances created properly
+     */
+    @Test
+    public void mediaTypesTest() throws Fault {
+      String type = "application";
+      String subtype = "x-www-form-urlencoded";
+  
+      MediaType mt = new MediaType(type, subtype);
+  
+      type = "application";
+      subtype = "atom+xml";
+  
+      MediaType mt1 = new MediaType(type, subtype);
+  
+      type = jakarta.ws.rs.core.MediaType.MEDIA_TYPE_WILDCARD;
+      subtype = jakarta.ws.rs.core.MediaType.MEDIA_TYPE_WILDCARD;
+  
+      MediaType mt2 = new MediaType();
+  
+      List<String> langS = null;
+      List<String> encodingS = null;
+      List<MediaType> mts = Arrays.asList(mt, mt1, mt2);
+  
+      List<Variant> vts = Variant.mediaTypes(mt, mt1, mt2).add().build();
+  
+      verifyVariants(vts, mts, langS, encodingS);
+    }
+  
+    // ////////////////////////////////////////////////////////////////////////
+  
+    private static void verifyVariants(List<Variant> vts, List<MediaType> mts,
+        List<String> langs, List<String> encodings) throws Fault {
+      StringBuffer sb = new StringBuffer();
+      boolean pass = true;
+  
+      for (Variant vt : vts) {
+        if (mts != null) {
+          MediaType mt = vt.getMediaType();
+  
+          if (mt != null && !mts.contains(mt)) {
+            pass = false;
+            sb.append("MediaType is not found: " + mt + newline);
+          }
+        }
+  
+        if (langs != null) {
+          if (!langs.contains(vt.getLanguage().toString())) {
+            sb.append("Language not found: " + vt.getLanguage() + "." + newline);
+  
+          }
+        }
+  
+        if (encodings != null) {
+          if (!encodings.contains(vt.getEncoding())) {
+            pass = false;
+            sb.append("Encoding not found: " + vt.getEncoding() + newline);
+          }
+        }
+      }
+  
+      int m = 1;
+      int e = 1;
+      int l = 1;
+      if (mts != null) {
+        m = mts.size();
+      }
+  
+      if (encodings != null) {
+        e = encodings.size();
+      }
+  
+      if (langs != null) {
+        l = langs.size();
+      }
+  
+      if (vts.size() != m * e * l) {
+        pass = false;
+        sb.append("Number of Variants is incorrect, expecting " + m + "*" + e
+            + "*" + l + ", got " + vts.size() + newline);
+      }
+  
+      if (!pass) {
+  
+        sb.append("Expected language: ");
+        if (langs != null) {
+          for (String lang : langs) {
+            sb.append(lang + ", ");
+          }
+          sb.append(newline);
+        }
+  
+        sb.append("Expected encodings: ");
+        if (encodings != null) {
+          for (String encoding : encodings) {
+            sb.append(encoding + ", ");
+          }
+          sb.append(newline);
+        }
+  
+        sb.append("Expected MediaType: ");
+        for (MediaType mt : mts) {
+          sb.append(mt.toString() + ", ");
+        }
+        sb.append(newline);
+  
+        throw new Fault("at least one assertion failed: " + sb.toString());
+      }
+    }
+  
+    private static void verifyVariant(Variant vt, String type, String subtype,
+        Locale lang, String encoding) throws Fault {
+      StringBuffer sb = new StringBuffer();
+      boolean pass = true;
+  
+      MediaType mt = vt.getMediaType();
+  
+      if (!equals(mt.getType(), type)) {
+        pass = false;
+        append(sb, "Failed type test.  Expect ", type, mt.getType());
+      }
+  
+      if (!equals(mt.getSubtype(), subtype)) {
+        pass = false;
+        append(sb, "Failed subtype test.", type, mt.getSubtype());
+      }
+  
+      if (vt.getLanguage() == null && lang != null) {
+        pass = false;
+        append(sb, "Failed langauge test", lang, vt.getLanguage());
+      } else if (vt.getLanguage() != null
+          && !vt.getLanguage().toString().equalsIgnoreCase(lang.toString())) {
+        pass = false;
+        append(sb, "Failed langauge test.", lang, vt.getLanguage());
+      }
+  
+      if (encoding == null || encoding.equals("")) {
+        if (!(vt.getEncoding() == null || vt.getEncoding().equals(""))) {
+          pass = false;
+          append(sb, "Failed encoding test", encoding, vt.getEncoding());
+        }
+      } else if (!equals(vt.getEncoding(), encoding)) {
+        pass = false;
+        append(sb, "Failed encoding test.", encoding, vt.getEncoding());
+      }
+  
+      pass &= verifyToString(vt, sb);
+      assertTrue(pass, "At least one assertion failed: " + sb.toString());
+    }
+  
+    private static void verifyVariant(Variant vt, String type, String subtype,
+        Map<String, String> params, String[] pname, Locale lang, String encoding)
+        throws Fault {
+      StringBuffer sb = new StringBuffer();
+      boolean pass = true;
+      MediaType mt = vt.getMediaType();
+  
+      if (!equals(mt.getType(), type)) {
+        pass = false;
+        append(sb, "Failed type test.", type, mt.getType());
+      }
+  
+      if (!equals(mt.getSubtype(), subtype)) {
+        pass = false;
+        append(sb, "Failed subtype test.", subtype, mt.getSubtype());
+      }
+  
+      Map<String, String> param_actual = mt.getParameters();
+      if (params.size() != param_actual.size()) {
+        pass = false;
+        append(sb, "Parameters size are different.", params.size(),
+            param_actual.size());
+      }
+  
+      int i = pname.length;
+      int j = 0;
+      while (j < i) {
+        sb.append("Processing Parameter " + j);
+        if (!param_actual.containsKey(pname[j])) {
+          pass = false;
+          sb.append("Parameter Key " + pname[j] + " not found." + newline);
+        } else {
+          String tmp = param_actual.get(pname[j]);
+  
+          if (equals(tmp, params.get(pname[j]))) {
+            break;
+          } else if (tmp.startsWith("\"")
+              || tmp.equals("\"" + params.get(pname[j]) + "\"")) {
+            break;
+          } else {
+            pass = false;
+            sb.append("Parameter Key ").append(pname[j])
+                .append(" returned different value than expected.")
+                .append(newline);
+            append(sb, "", params.get(pname[j]), param_actual.get(pname[j]));
+          }
+          j++;
+        }
+  
+        assertTrue(pass, "At least one assertion failed: " + sb.toString());
+      }
+  
+      if (vt.getLanguage() == null) {
+        if (lang != null) {
+          pass = false;
+          append(sb, "Failed language test.", lang, vt.getLanguage());
+        }
+      } else if (!equals(vt.getLanguage(), lang)) {
+        pass = false;
+        append(sb, "Failed language test.", lang, vt.getLanguage());
+      }
+  
+      if (encoding == null || encoding == "") {
+        if (!(vt.getEncoding() == null || vt.getEncoding().equals(""))) {
+          pass = false;
+          append(sb, "Failed encoding test.", encoding, vt.getEncoding());
+        }
+      } else if (!equals(vt.getEncoding(), encoding)) {
+        pass = false;
+        append(sb, "Failed encoding test.", encoding, vt.getEncoding());
+      }
+  
+      pass &= verifyToString(vt, sb);
+    }
+  
+    /**
+     * Check whether the toString() method has been overridden. Compare the result
+     * String of toString() with what Object.toString() would return.
+     * 
+     * @param variant
+     * @param sb
+     * @return False if toString() has NOT been overridden
+     */
+    private static boolean verifyToString(Variant variant, StringBuffer sb) {
+      String badPrefix = Variant.class.getName() + "@";
+      boolean startsWith = variant.toString().startsWith(badPrefix);
+      startsWith &= variant.toString().length() <= badPrefix.length() + 8;
+      if (startsWith)
+        sb.append("Variant.toString() is not overridden");
+      return !startsWith;
+    }
+  
+    private static void append(StringBuffer sb, Object... args) {
+      sb.append(args[0]);
+      sb.append(" Expect ");
+      sb.append(args[1]);
+      sb.append(" got ");
+      sb.append(args[2]);
+      sb.append(newline);
+    }
+  
+    private static <T> boolean equals(T first, T second) {
+      return first == null ? null == second : first.equals(second);
+    }
+  
+    protected List<String> getLangList() {
+      return Arrays.asList("en-US", "en-GB", "zh-CN");
+    }
+    
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/variantlistbuilder/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/core/variantlistbuilder/JAXRSClientIT.java
@@ -1,0 +1,385 @@
+/*
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.core.variantlistbuilder;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Variant;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost; webServerPort; ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = 1L;
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : " + testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : " + testInfo.getDisplayName());
+  }
+
+  /* Run test */
+
+  /*
+   * @testName: newInstanceTest
+   *
+   * @assertion_ids: JAXRS:JAVADOC:268; JAXRS:JAVADOC:264;
+   *
+   * @test_Strategy: Create a VariantListBuilder instance using
+   * Variant.VariantListBuilder.newInstance() Verify that no Variant in the
+   * returned List
+   */
+  @Test
+  public void newInstanceTest() throws Fault {
+    List<Variant> vt = Variant.VariantListBuilder.newInstance().build();
+    if (!vt.isEmpty()) {
+      throw new Fault("List<Variant> returned is not empty.  It includes " + vt.size() + " Variant.");
+    }
+  }
+
+  /*
+   * @testName: mediaTypesTest1
+   * 
+   * @assertion_ids: JAXRS:SPEC:33.7; JAXRS:SPEC:33.8; JAXRS:JAVADOC:268;
+   * JAXRS:JAVADOC:264; JAXRS:JAVADOC:267; JAXRS:JAVADOC:263; JAXRS:JAVADOC:255;
+   * JAXRS:JAVADOC:256; JAXRS:JAVADOC:257;
+   * 
+   * @test_Strategy: Create a VariantListBuilder instance using
+   * Variant.VariantListBuilder.newInstance(); Add two MediaType to it; Verify
+   * that two Variant in the returned List
+   */
+  @Test
+  public void mediaTypesTest1() throws Fault {
+    boolean pass = true;
+    StringBuffer sb = new StringBuffer();
+
+    List<String> encoding = new ArrayList<String>();
+    List<String> lang = new ArrayList<String>();
+
+    MediaType mt1 = new MediaType();
+    MediaType mt2 = new MediaType("application", "atom+xml");
+
+    List<MediaType> types = Arrays.asList(mt1, mt2);
+
+    List<Variant> vts = Variant.VariantListBuilder.newInstance().mediaTypes(mt1, mt2).add().build();
+
+    String status = verifyVariants(vts, types, encoding, lang, 2);
+    if (status.endsWith("false")) {
+      pass = false;
+    }
+    sb.append(status);
+
+    assertTrue(pass, "At least one assertion faled: " + sb.toString());
+    TestUtil.logTrace(sb.toString());
+  }
+
+  /*
+   * @testName: mediaTypesTest2
+   * 
+   * @assertion_ids: JAXRS:SPEC:33.7; JAXRS:SPEC:33.8; JAXRS:SPEC:33.9;
+   * JAXRS:JAVADOC:268; JAXRS:JAVADOC:264; JAXRS:JAVADOC:267; JAXRS:JAVADOC:263;
+   * JAXRS:JAVADOC:255; JAXRS:JAVADOC:256; JAXRS:JAVADOC:257;
+   * 
+   * @test_Strategy: Create a VariantListBuilder instance using
+   * Variant.VariantListBuilder.newInstance(); Add three MediaType to it; Verify
+   * that two Variant in the returned List
+   */
+  @Test
+  public void mediaTypesTest2() throws Fault {
+    boolean pass = true;
+    StringBuffer sb = new StringBuffer();
+
+    List<String> encoding = new ArrayList<String>();
+    List<String> lang = new ArrayList<String>();
+
+    Map<String, String> params = new HashMap<String, String>();
+
+    MediaType mt1 = new MediaType();
+    MediaType mt2 = new MediaType("application", "atom+xml");
+    MediaType mt3 = new MediaType("application", "x-www-form-urlencoded", params);
+    List<MediaType> types = Arrays.asList(mt1, mt2, mt3);
+
+    List<Variant> vts = Variant.VariantListBuilder.newInstance().mediaTypes(mt1, mt2, mt3).add().build();
+    String status = verifyVariants(vts, types, encoding, lang, 3);
+    if (status.endsWith("false")) {
+      pass = false;
+    }
+    sb.append(status);
+
+    assertTrue(pass, "At least one assertion faled: " + sb.toString());
+    TestUtil.logTrace(sb.toString());
+  }
+
+  /*
+   * @testName: languageTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:268; JAXRS:JAVADOC:264; JAXRS:JAVADOC:267;
+   * JAXRS:JAVADOC:263; JAXRS:JAVADOC:266; JAXRS:JAVADOC:255; JAXRS:JAVADOC:256;
+   * JAXRS:JAVADOC:257;
+   * 
+   * @test_Strategy: Create a VariantListBuilder instance using
+   * Variant.VariantListBuilder.newInstance(); Add one MediaType to it with three
+   * languages; Verify that three Variant in the returned List
+   */
+  @Test
+  public void languageTest() throws Fault {
+    boolean pass = true;
+    StringBuffer sb = new StringBuffer();
+
+    List<String> encoding = new ArrayList<String>();
+
+    MediaType mt1 = new MediaType();
+    List<MediaType> types = Arrays.asList(mt1);
+
+    List<Variant> vts = Variant.VariantListBuilder.newInstance().mediaTypes(mt1)
+        .languages(new Locale("en", "US"), new Locale("en", "GB"), new Locale("zh", "CN")).add().build();
+    int size = vts.size();
+    sb.append("size================== " + size + newline);
+    String status = verifyVariants(vts, types, encoding, getLangList(), 3);
+    if (status.endsWith("false")) {
+      pass = false;
+    }
+    sb.append(status);
+
+    assertTrue(pass, "At least one assertion faled: " + sb.toString());
+    TestUtil.logTrace(sb.toString());
+  }
+
+  /*
+   * @testName: encodingTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:268; JAXRS:JAVADOC:264; JAXRS:JAVADOC:267;
+   * JAXRS:JAVADOC:263; JAXRS:JAVADOC:265; JAXRS:JAVADOC:255; JAXRS:JAVADOC:256;
+   * JAXRS:JAVADOC:257;
+   * 
+   * @test_Strategy: Create a VariantListBuilder instance using
+   * Variant.VariantListBuilder.newInstance(); Add one MediaType to it with two
+   * encodings; Verify that two variants in the returned List
+   */
+  @Test
+  public void encodingTest() throws Fault {
+    boolean pass = true;
+    StringBuffer sb = new StringBuffer();
+
+    List<String> encoding = Arrays.asList("gzip", "compress");
+    List<String> lang = new ArrayList<String>();
+
+    MediaType mt1 = new MediaType();
+    List<MediaType> types = Arrays.asList(mt1);
+
+    List<Variant> vts = Variant.VariantListBuilder.newInstance().mediaTypes(mt1).encodings("gzip", "compress").add()
+        .build();
+
+    String status = verifyVariants(vts, types, encoding, lang, 2);
+    if (status.endsWith("false")) {
+      pass = false;
+    }
+    sb.append(status);
+
+    TestUtil.logTrace(sb.toString());
+    assertTrue(pass, "At least one assertion faled: " + sb.toString());
+  }
+
+  /*
+   * @testName: complexTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:33.7; JAXRS:SPEC:33.8; JAXRS:JAVADOC:268;
+   * JAXRS:JAVADOC:264; JAXRS:JAVADOC:267; JAXRS:JAVADOC:263; JAXRS:JAVADOC:265;
+   * JAXRS:JAVADOC:266; JAXRS:JAVADOC:255; JAXRS:JAVADOC:256; JAXRS:JAVADOC:257;
+   * 
+   * @test_Strategy: Create a VariantListBuilder instance using
+   * Variant.VariantListBuilder.newInstance(); Add two MediaType to it with three
+   * language and two encodings; Verify that 12 variants in the returned List
+   */
+  @Test
+  public void complexTest() throws Fault {
+    boolean pass = true;
+    StringBuffer sb = new StringBuffer();
+
+    List<String> encoding = Arrays.asList("gzip", "compress");
+
+    MediaType mt1 = new MediaType();
+    MediaType mt2 = new MediaType("application", "atom+xml");
+    List<MediaType> types = Arrays.asList(mt1, mt2);
+
+    List<Variant> vts = getVariantList(encoding, mt1, mt2);
+
+    String status = verifyVariants(vts, types, encoding, getLangList(), 12);
+    if (status.endsWith("false")) {
+      pass = false;
+    }
+    sb.append(status);
+
+    TestUtil.logTrace(sb.toString());
+    assertTrue(pass, "At least one assertion faled: " + sb.toString());
+  }
+
+  private static String verifyVariants(List<Variant> vts, List<MediaType> types, List<String> encoding,
+      List<String> lang, int size_expected) {
+    StringBuffer sb = new StringBuffer();
+    boolean pass = true;
+    List<MediaType> actual_types = new ArrayList<MediaType>();
+
+    sb.append(newline + "========== Verifying Variants" + newline);
+
+    int size_vt = vts.size();
+
+    if (size_vt != size_expected) {
+      sb.append(indent + "Test Failed: List<Variant> returned is not right.  It includes " + size_vt
+          + " Variant Objects. Expecting " + size_expected + newline);
+
+      pass = false;
+
+      for (int j = 0; j < vts.size(); j++) {
+        Variant vt = vts.get(j);
+        sb.append(indent + "Variant " + j + ": MediaType: " + vt.getMediaType().toString() + "; " + "Langauge: "
+            + vt.getLanguage() + "; Encoding: " + vt.getEncoding() + newline);
+      }
+    } else {
+      sb.append(indent + "Correct number of Variant returned: " + size_expected + newline);
+    }
+
+    for (Variant vt : vts) {
+
+      sb.append(indent + "===== Verifying Variant" + newline);
+      MediaType mt = vt.getMediaType();
+
+      if (!types.contains(mt)) {
+        pass = false;
+        sb.append(indent + "Unexpected MediaType found in variant: type=" + mt.getType() + " subtype = "
+            + mt.getSubtype() + newline);
+        sb.append(indent + "Expecting the following MediaType:" + newline);
+        for (MediaType tmp : types) {
+          sb.append(indent + indent + tmp.getType() + "/" + tmp.getSubtype() + newline);
+        }
+      } else {
+        sb.append(
+            indent + "Expected MediaType found Variant: " + mt.getType() + " subtype = " + mt.getSubtype() + newline);
+        actual_types.add(mt);
+      }
+
+      if (encoding == null || encoding.isEmpty()) {
+        if (vt.getEncoding() != null) {
+          pass = false;
+          sb.append(indent + "Unexpected encoding found: " + vt.getEncoding().toString());
+        }
+      } else {
+        if (vt.getEncoding() == null) {
+          pass = false;
+          sb.append(indent + "No encoding found: " + vt.getEncoding() + newline);
+          sb.append(indent + "Expecting the following encodings: " + newline);
+
+          for (String tmp : encoding) {
+            sb.append(indent + indent + tmp + newline);
+          }
+        } else if (!encoding.contains(vt.getEncoding().toString().toLowerCase())) {
+          sb.append(indent + "Unexpected encoding found: " + vt.getEncoding() + newline);
+          sb.append(indent + "Expecting the following encodings: " + newline);
+          for (String tmp : lang) {
+            sb.append(indent + indent + tmp + newline);
+          }
+          pass = false;
+        } else {
+          sb.append(indent + "Found expected encoding " + vt.getEncoding() + newline);
+        }
+
+        if (lang == null || lang.isEmpty()) {
+          if (vt.getLanguage() != null) {
+            pass = false;
+            sb.append(indent + "Unexpected language found: " + vt.getLanguage().toString());
+          }
+        } else {
+          if (vt.getLanguage() == null) {
+            pass = false;
+            sb.append(indent + "No language found: " + vt.getLanguage() + newline);
+            sb.append(indent + "Expecting the following languages: " + newline);
+
+            for (String tmp : lang) {
+              sb.append(indent + indent + tmp + newline);
+            }
+          } else if (!lang.contains(langToString(vt.getLanguage()))) {
+            sb.append(indent + "Unexpected language found: " + vt.getLanguage() + newline);
+            sb.append(indent + "Expecting the following languages: " + newline);
+            for (String tmp : lang) {
+              sb.append(indent + indent + tmp + newline);
+            }
+            pass = false;
+          } else {
+            sb.append(indent + "Found expected language " + vt.getLanguage() + newline);
+          }
+        }
+      }
+    }
+
+    Set<MediaType> set = new LinkedHashSet<MediaType>();
+    set.addAll(actual_types);
+    List<MediaType> final_types = new ArrayList<MediaType>(set);
+
+    if (types.size() != final_types.size()) {
+      pass = false;
+      sb.append("Some missing MediaType: expecting " + types.size() + ", only got " + final_types.size() + newline);
+
+      for (int i = 0; i < final_types.size(); i++) {
+        sb.append(final_types.get(i).toString() + newline);
+      }
+    }
+    sb.append(pass);
+    return sb.toString();
+  }
+
+  protected static List<String> getLangList() {
+    return Arrays.asList("en-US", "en-GB", "zh-CN");
+  }
+
+  protected static List<Variant> getVariantList(List<String> encoding, MediaType... mt) {
+    return Variant.VariantListBuilder.newInstance().mediaTypes(mt)
+        .languages(new Locale("en", "US"), new Locale("en", "GB"), new Locale("zh", "CN"))
+        .encodings(encoding.toArray(new String[0])).add().build();
+  }
+
+  protected static String langToString(Object object) {
+    Locale locale = null;
+    if (object instanceof List)
+      object = ((List<?>) object).iterator().next();
+    if (object instanceof Locale)
+      locale = (Locale) object;
+    return locale == null ? object.toString() : locale.toString().replace("_", "-");
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/ContextOperation.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/ContextOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/InputStreamReaderProvider.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/InputStreamReaderProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,14 +23,13 @@ import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
-import jakarta.ws.rs.tck.common.util.JaxrsUtil;
-
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.ext.MessageBodyReader;
 import jakarta.ws.rs.ext.MessageBodyWriter;
 import jakarta.ws.rs.ext.Provider;
+import jakarta.ws.rs.tck.common.util.JaxrsUtil;
 
 @Provider
 public class InputStreamReaderProvider implements

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/InterceptorBodyOne.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/InterceptorBodyOne.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/InterceptorBodyTwo.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/InterceptorBodyTwo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,9 +19,8 @@ package jakarta.ws.rs.tck.api.rs.ext.interceptor;
 import java.io.IOException;
 import java.util.Collection;
 
-import jakarta.ws.rs.tck.common.util.JaxrsUtil;
-
 import jakarta.ws.rs.ext.InterceptorContext;
+import jakarta.ws.rs.tck.common.util.JaxrsUtil;
 
 public class InterceptorBodyTwo<CONTEXT extends InterceptorContext>
     extends TemplateInterceptorBody<CONTEXT> {

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/InterceptorCallbackMethods.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/InterceptorCallbackMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/TemplateInterceptorBody.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/TemplateInterceptorBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,9 +19,8 @@ package jakarta.ws.rs.tck.api.rs.ext.interceptor;
 import java.io.IOException;
 import java.lang.reflect.Method;
 
-import jakarta.ws.rs.tck.common.util.JaxrsUtil;
-
 import jakarta.ws.rs.ext.InterceptorContext;
+import jakarta.ws.rs.tck.common.util.JaxrsUtil;
 
 /**
  * Body for both reader and writer interceptor body The body is injected into

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/reader/ReaderClient.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/reader/ReaderClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,12 +18,11 @@ package jakarta.ws.rs.tck.api.rs.ext.interceptor.reader;
 
 import java.io.IOException;
 
-import jakarta.ws.rs.tck.api.rs.ext.interceptor.TemplateInterceptorBody;
-import jakarta.ws.rs.tck.common.client.JaxrsCommonClient;
-
 import jakarta.ws.rs.client.ClientRequestContext;
 import jakarta.ws.rs.client.ClientRequestFilter;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.tck.api.rs.ext.interceptor.TemplateInterceptorBody;
+import jakarta.ws.rs.tck.common.client.JaxrsCommonClient;
 
 /**
  * Client with given ContextOperation enum, so that an enum name is passed as a

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/reader/TemplateReaderInterceptor.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/reader/TemplateReaderInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,13 +19,12 @@ package jakarta.ws.rs.tck.api.rs.ext.interceptor.reader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-import jakarta.ws.rs.tck.api.rs.ext.interceptor.InterceptorCallbackMethods;
-import jakarta.ws.rs.tck.api.rs.ext.interceptor.TemplateInterceptorBody;
-
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.ext.ReaderInterceptor;
 import jakarta.ws.rs.ext.ReaderInterceptorContext;
+import jakarta.ws.rs.tck.api.rs.ext.interceptor.InterceptorCallbackMethods;
+import jakarta.ws.rs.tck.api.rs.ext.interceptor.TemplateInterceptorBody;
 
 /**
  * This class is a superclass for any interceptor @Provider. Any such provider

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/reader/interceptorcontext/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/reader/interceptorcontext/JAXRSClientIT.java
@@ -1,0 +1,476 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.ext.interceptor.reader.interceptorcontext;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.lang.annotation.Annotation;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.ResponseBuilder;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.tck.api.rs.ext.interceptor.ContextOperation;
+import jakarta.ws.rs.tck.api.rs.ext.interceptor.InputStreamReaderProvider;
+import jakarta.ws.rs.tck.api.rs.ext.interceptor.TemplateInterceptorBody;
+import jakarta.ws.rs.tck.api.rs.ext.interceptor.reader.ReaderClient;
+import jakarta.ws.rs.tck.common.util.JaxrsUtil;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+@Disabled("Tests fail with IllegalStateException: HttpRequest is null")
+public class JAXRSClientIT extends ReaderClient<ContextOperation> {
+
+  private static final long serialVersionUID = -8828149277776372718L;
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+  
+  /*
+   * @testName: getAnnotationsTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:903; JAXRS:JAVADOC:920; JAXRS:SPEC:85;
+   * 
+   * @test_Strategy: Get an array of the annotations formally declared on the
+   * artifact that initiated the intercepted entity provider invocation. The
+   * annotations are not on client reader.
+   * 
+   * ReaderInterceptor.aroundReadFrom If abortWith is invoked, execution is
+   * aborted
+   */
+  @Test
+  public void getAnnotationsTest() throws Fault {
+    Annotation[] annotations = ContextOperation.class.getAnnotations();
+    ResponseBuilder builder = createResponse(ContextOperation.GETANNOTATIONS);
+    Response fake = builder.entity(TemplateInterceptorBody.ENTITY, annotations)
+        .build();
+    addProviders(fake);
+    for (Annotation a : annotations)
+      setProperty(Property.UNEXPECTED_RESPONSE_MATCH,
+          a.annotationType().getName());
+    invoke();
+  }
+
+  /*
+   * @testName: getGenericTypeTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:904; JAXRS:JAVADOC:920; JAXRS:SPEC:85;
+   * 
+   * @test_Strategy: Get an array of the annotations formally declared on the
+   * artifact that initiated the intercepted entity provider invocation.
+   * 
+   * If abortWith is invoked, execution is aborted
+   */
+  @Test
+  public void getGenericTypeTest() throws Fault {
+    ResponseBuilder builder = createResponse(ContextOperation.GETGENERICTYPE);
+    Response fake = builder.build();
+
+    addProviders(fake);
+    setProperty(Property.SEARCH_STRING, String.class.getName());
+    invoke();
+  }
+
+  /*
+   * @testName: getMediaTypeTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:905; JAXRS:JAVADOC:920; JAXRS:SPEC:85;
+   * 
+   * @test_Strategy: Get media type of HTTP entity.
+   *
+   * ReaderInterceptor.aroundReadFrom If abortWith is invoked, execution is
+   * aborted
+   */
+  @Test
+  public void getMediaTypeTest() throws Fault {
+    ResponseBuilder builder = createResponse(ContextOperation.GETMEDIATYPE);
+    Response fake = builder.type(MediaType.APPLICATION_JSON_TYPE).build();
+
+    addProviders(fake);
+    setProperty(Property.SEARCH_STRING, MediaType.APPLICATION_JSON);
+    invoke();
+  }
+
+  /*
+   * @testName: getPropertyIsNullTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:906; JAXRS:JAVADOC:920; JAXRS:SPEC:85;
+   * 
+   * @test_Strategy: Returns null if there is no property by that name.
+   * 
+   * ReaderInterceptor.aroundReadFrom If abortWith is invoked, execution is
+   * aborted
+   */
+  @Test
+  public void getPropertyIsNullTest() throws Fault {
+    ResponseBuilder builder = createResponse(ContextOperation.GETPROPERTY);
+    Response fake = builder.build();
+
+    addProviders(fake);
+    setProperty(Property.SEARCH_STRING, TemplateInterceptorBody.NULL);
+    invoke();
+  }
+
+  /*
+   * @testName: getPropertyNamesTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1007; JAXRS:JAVADOC:920; JAXRS:SPEC:85;
+   * 
+   * @test_Strategy: Returns immutable java.util.Collection collection
+   * containing the property names available within the context of the current
+   * request/response exchange context.
+   * 
+   * ReaderInterceptor.aroundReadFrom If abortWith is invoked, execution is
+   * aborted
+   */
+  @Test
+  public void getPropertyNamesTest() throws Fault {
+    ResponseBuilder builder = createResponse(ContextOperation.GETPROPERTYNAMES);
+    Response fake = builder.build();
+
+    addProviders(fake);
+    for (int i = 0; i != 5; i++)
+      setProperty(Property.UNORDERED_SEARCH_STRING,
+          TemplateInterceptorBody.PROPERTY + i);
+    invoke();
+  }
+
+  /*
+   * @testName: getPropertyNamesIsReadOnlyTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1007; JAXRS:JAVADOC:920; JAXRS:SPEC:85;
+   * 
+   * @test_Strategy: Returns immutable java.util.Collection containing the
+   * property names available within the context of the current request/response
+   * exchange context.
+   * 
+   * ReaderInterceptor.aroundReadFrom If abortWith is invoked, execution is
+   * aborted
+   */
+  @Test
+  public void getPropertyNamesIsReadOnlyTest() throws Fault {
+    ResponseBuilder builder = createResponse(
+        ContextOperation.GETPROPERTYNAMESISREADONLY);
+    Response fake = builder.build();
+
+    addProviders(fake);
+    setProperty(Property.UNORDERED_SEARCH_STRING, TemplateInterceptorBody.NULL);
+    invoke();
+  }
+
+  /*
+   * @testName: getTypeTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:908; JAXRS:JAVADOC:920; JAXRS:SPEC:85;
+   * 
+   * @test_Strategy: Get Java type supported by corresponding message body
+   * provider.
+   * 
+   * ReaderInterceptor.aroundReadFrom If abortWith is invoked, execution is
+   * aborted
+   */
+  @Test
+  public void getTypeTest() throws Fault {
+    ResponseBuilder builder = createResponse(ContextOperation.GETTYPE);
+    Response fake = builder.build();
+
+    addProviders(fake);
+    setProperty(Property.SEARCH_STRING, String.class.getName());
+    invoke();
+  }
+
+  /*
+   * @testName: removePropertyTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:909; JAXRS:JAVADOC:920; JAXRS:SPEC:85;
+   * 
+   * @test_Strategy: Removes a property with the given name from the current
+   * request/response exchange context. After removal, subsequent calls to
+   * getProperty(java.lang.String) to retrieve the property value will return
+   * null.
+   * 
+   * ReaderInterceptor.aroundReadFrom If abortWith is invoked, execution is
+   * aborted
+   */
+  @Test
+  public void removePropertyTest() throws Fault {
+    ResponseBuilder builder = createResponse(ContextOperation.REMOVEPROPERTY);
+    Response fake = builder.build();
+
+    addProviders(fake);
+    setProperty(Property.SEARCH_STRING, TemplateInterceptorBody.NULL);
+    invoke();
+  }
+
+  /*
+   * @testName: setAnnotationsTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:910; JAXRS:JAVADOC:920; JAXRS:SPEC:85;
+   * 
+   * @test_Strategy: Update annotations on the formal declaration of the
+   * artifact that initiated the intercepted entity provider invocation.
+   * 
+   * ReaderInterceptor.aroundReadFrom If abortWith is invoked, execution is
+   * aborted
+   */
+  @Test
+  public void setAnnotationsTest() throws Fault {
+    Annotation[] annotations = ReaderInterceptorOne.class.getAnnotations();
+    ResponseBuilder builder = createResponse(ContextOperation.SETANNOTATIONS);
+    Response fake = builder.build();
+    addProviders(fake);
+    for (Annotation a : annotations)
+      setProperty(Property.UNORDERED_SEARCH_STRING,
+          a.annotationType().getName());
+    invoke();
+  }
+
+  /*
+   * @testName: setAnnotationsNullThrowsNPETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:910; JAXRS:JAVADOC:920;
+   * 
+   * @test_Strategy: Throws NullPointerException - in case the input parameter
+   * is null.
+   * 
+   * ReaderInterceptor.aroundReadFrom If abortWith is invoked, execution is
+   * aborted
+   */
+  @Test
+  public void setAnnotationsNullThrowsNPETest() throws Fault {
+    ResponseBuilder builder = createResponse(
+        ContextOperation.SETANNOTATIONSNULL);
+    Response fake = builder.entity(TemplateInterceptorBody.ENTITY).build();
+    addProviders(fake);
+    setProperty(Property.SEARCH_STRING, TemplateInterceptorBody.NPE);
+    invoke();
+  }
+
+  /*
+   * @testName: setGenericTypeTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:911; JAXRS:JAVADOC:920; JAXRS:SPEC:85;
+   * 
+   * @test_Strategy: Update type of the object to be produced or written.
+   * 
+   * ReaderInterceptor.aroundReadFrom If abortWith is invoked, execution is
+   * aborted
+   */
+  @Test
+  public void setGenericTypeTest() throws Fault {
+    ResponseBuilder builder = createResponse(ContextOperation.SETGENERICTYPE);
+    Response fake = builder.build();
+
+    addProviders(fake);
+    setProperty(Property.SEARCH_STRING, "[B");
+    invoke();
+  }
+
+  /*
+   * @testName: setMediaTypeTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:912; JAXRS:JAVADOC:920; JAXRS:SPEC:85;
+   * 
+   * @test_Strategy: Update media type of HTTP entity.
+   * 
+   * ReaderInterceptor.aroundReadFrom If abortWith is invoked, execution is
+   * aborted
+   */
+  @Test
+  public void setMediaTypeTest() throws Fault {
+    ResponseBuilder builder = createResponse(ContextOperation.SETMEDIATYPE);
+    Response fake = builder.build();
+
+    addProviders(fake);
+    setProperty(Property.SEARCH_STRING, MediaType.APPLICATION_FORM_URLENCODED);
+    invoke();
+  }
+
+  /*
+   * @testName: setPropertyTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:913; JAXRS:JAVADOC:920; JAXRS:SPEC:85;
+   * 
+   * @test_Strategy: Binds an object to a given property name in the current
+   * request/response exchange context. If the name specified is already used
+   * for a property, this method will replace the value of the property with the
+   * new value.
+   * 
+   * ReaderInterceptor.aroundReadFrom If abortWith is invoked, execution is
+   * aborted
+   */
+  @Test
+  public void setPropertyTest() throws Fault {
+    ResponseBuilder builder = createResponse(ContextOperation.SETPROPERTY);
+    Response fake = builder.build();
+
+    addProviders(fake);
+    setProperty(Property.SEARCH_STRING, TemplateInterceptorBody.ENTITY2);
+    invoke();
+  }
+
+  /*
+   * @testName: setPropertyNullTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:913; JAXRS:JAVADOC:920; JAXRS:SPEC:85;
+   * 
+   * @test_Strategy: If a null value is passed, the effect is the same as
+   * calling the removeProperty(String) method.
+   * 
+   * ReaderInterceptor.aroundReadFrom If abortWith is invoked, execution is
+   * aborted
+   */
+  @Test
+  public void setPropertyNullTest() throws Fault {
+    ResponseBuilder builder = createResponse(ContextOperation.SETPROPERTYNULL);
+    Response fake = builder.build();
+
+    addProviders(fake);
+    setProperty(Property.SEARCH_STRING, TemplateInterceptorBody.NULL);
+    invoke();
+  }
+
+  /*
+   * @testName: setTypeTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:914; JAXRS:JAVADOC:920; JAXRS:SPEC:85;
+   * 
+   * @test_Strategy: Update Java type before calling message body provider.
+   * 
+   * ReaderInterceptor.aroundReadFrom If abortWith is invoked, execution is
+   * aborted
+   */
+  @Test
+  public void setTypeTest() throws Fault {
+    ResponseBuilder builder = createResponse(ContextOperation.SETTYPE);
+    ByteArrayInputStream bais = new ByteArrayInputStream(
+        TemplateInterceptorBody.ENTITY.getBytes());
+    Reader reader = new InputStreamReader(bais);
+    Response fake = builder.entity(reader).build();
+
+    addProviders(fake);
+    addProvider(InputStreamReaderProvider.class);
+    invoke();
+    InputStreamReader isr = getResponseBody(InputStreamReader.class);
+    try {
+      String entity = JaxrsUtil.readFromReader(isr);
+      assertTrue(entity.contains(InputStreamReader.class.getName()),
+          "Expected " + InputStreamReader.class.getName() + " not found");
+      logMsg("#setType set correct type", entity);
+    } catch (IOException e) {
+      throw new Fault(e);
+    }
+  }
+
+  /*
+   * @testName: ioExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:921; JAXRS:JAVADOC:920; JAXRS:SPEC:85;
+   * 
+   * @test_Strategy: Throws IOException - if an IO error arises.
+   * 
+   * ReaderInterceptor.aroundReadFrom If abortWith is invoked, execution is
+   * aborted
+   */
+  @Test
+  public void ioExceptionTest() throws Fault {
+    ResponseBuilder builder = createResponse(ContextOperation.IOEXCEPTION);
+    Response fake = builder.build();
+    addProviders(fake);
+    invoke();
+    try {
+      getResponseBody();
+    } catch (Exception e) {
+      assertNotNull(e.getMessage(), "Returned unexpected exception", e);
+      IOException io = assertCause(e, IOException.class,
+          "Unexpected exception has been found:", e);
+      assertContains(io.getMessage(), TemplateInterceptorBody.IOE,
+          "Found unexpected message from IOException", e.getMessage());
+      logMsg("found expected IOException", io);
+      return;
+    }
+    fault("Expected IOException not found");
+  }
+
+  /*
+   * @testName: webApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:922; JAXRS:JAVADOC:920; JAXRS:SPEC:85;
+   * 
+   * @test_Strategy: throws WebApplicationException thrown by wrapped method.
+   * 
+   * ReaderInterceptor.aroundReadFrom If abortWith is invoked, execution is
+   * aborted
+   */
+  @Test
+  public void webApplicationExceptionTest() throws Fault {
+    ResponseBuilder builder = createResponse(
+        ContextOperation.WEBAPPLICATIONEXCEPTION);
+    Response fake = builder.build();
+    addProviders(fake);
+    invoke();
+    try {
+      getResponseBody();
+    } catch (Exception e) {
+      WebApplicationException we = assertCause(e, WebApplicationException.class,
+          "Found unexpected exception", e);
+      assertNotNull(we.getResponse(),
+          "WebApplicationException.getResponse is null");
+      Response response = we.getResponse();
+      String entity = response.getEntity().toString();
+      assertEqualsInt(Status.CONFLICT.getStatusCode(), response.getStatus(),
+          "Unexcpected status returned from WebApplicationException.getResponse",
+          response.getStatus());
+      assertEquals(TemplateInterceptorBody.ENTITY2, entity,
+          "Found unexpected body content from WebApplicationException.getResponse",
+          entity);
+      logMsg("found expected WebApplicationException", we);
+      return;
+    }
+    fault("Expected WebApplicationException not found");
+  }
+
+  // /////////////////////////////////////////////////////////////////////
+  @Override
+  protected void addProviders(Response response) throws Fault {
+    super.addProviders(response);
+    addProvider(ReaderInterceptorTwo.class);
+    addProvider(new ReaderInterceptorOne());
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/reader/interceptorcontext/ReaderInterceptorOne.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/reader/interceptorcontext/ReaderInterceptorOne.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,12 +16,11 @@
 
 package jakarta.ws.rs.tck.api.rs.ext.interceptor.reader.interceptorcontext;
 
-import jakarta.ws.rs.tck.api.rs.ext.interceptor.InterceptorBodyOne;
-import jakarta.ws.rs.tck.api.rs.ext.interceptor.reader.TemplateReaderInterceptor;
-
 import jakarta.annotation.Priority;
 import jakarta.ws.rs.ext.Provider;
 import jakarta.ws.rs.ext.ReaderInterceptorContext;
+import jakarta.ws.rs.tck.api.rs.ext.interceptor.InterceptorBodyOne;
+import jakarta.ws.rs.tck.api.rs.ext.interceptor.reader.TemplateReaderInterceptor;
 
 @Provider
 @Priority(100)

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/reader/interceptorcontext/ReaderInterceptorTwo.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/reader/interceptorcontext/ReaderInterceptorTwo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,12 +16,11 @@
 
 package jakarta.ws.rs.tck.api.rs.ext.interceptor.reader.interceptorcontext;
 
-import jakarta.ws.rs.tck.api.rs.ext.interceptor.InterceptorBodyTwo;
-import jakarta.ws.rs.tck.api.rs.ext.interceptor.reader.TemplateReaderInterceptor;
-
 import jakarta.annotation.Priority;
 import jakarta.ws.rs.ext.Provider;
 import jakarta.ws.rs.ext.ReaderInterceptorContext;
+import jakarta.ws.rs.tck.api.rs.ext.interceptor.InterceptorBodyTwo;
+import jakarta.ws.rs.tck.api.rs.ext.interceptor.reader.TemplateReaderInterceptor;
 
 @Provider
 @Priority(200)

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/reader/readerinterceptorcontext/ContextOperation.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/reader/readerinterceptorcontext/ContextOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/reader/readerinterceptorcontext/ExceptionThrowingStringBean.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/reader/readerinterceptorcontext/ExceptionThrowingStringBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,10 +18,9 @@ package jakarta.ws.rs.tck.api.rs.ext.interceptor.reader.readerinterceptorcontext
 
 import java.io.IOException;
 
+import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.tck.api.rs.ext.interceptor.TemplateInterceptorBody;
 import jakarta.ws.rs.tck.common.provider.StringBean;
-
-import jakarta.ws.rs.WebApplicationException;
 
 public class ExceptionThrowingStringBean extends StringBean {
 

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/reader/readerinterceptorcontext/ExceptionThrowingStringBeanEntityProvider.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/reader/readerinterceptorcontext/ExceptionThrowingStringBeanEntityProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,14 +22,13 @@ import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
-import jakarta.ws.rs.tck.common.util.JaxrsUtil;
-
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.ext.MessageBodyReader;
 import jakarta.ws.rs.ext.MessageBodyWriter;
 import jakarta.ws.rs.ext.Provider;
+import jakarta.ws.rs.tck.common.util.JaxrsUtil;
 
 @Provider
 public class ExceptionThrowingStringBeanEntityProvider

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/reader/readerinterceptorcontext/InterceptorOneBody.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/reader/readerinterceptorcontext/InterceptorOneBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,13 +20,12 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import jakarta.ws.rs.tck.api.rs.ext.interceptor.TemplateInterceptorBody;
-import jakarta.ws.rs.tck.common.provider.StringBean;
-import jakarta.ws.rs.tck.common.util.JaxrsUtil;
-
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.ext.ReaderInterceptorContext;
+import jakarta.ws.rs.tck.api.rs.ext.interceptor.TemplateInterceptorBody;
+import jakarta.ws.rs.tck.common.provider.StringBean;
+import jakarta.ws.rs.tck.common.util.JaxrsUtil;
 
 public class InterceptorOneBody
     extends TemplateInterceptorBody<ReaderInterceptorContext> {

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/reader/readerinterceptorcontext/InterceptorTwoBody.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/reader/readerinterceptorcontext/InterceptorTwoBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,12 +19,11 @@ package jakarta.ws.rs.tck.api.rs.ext.interceptor.reader.readerinterceptorcontext
 import java.io.IOException;
 import java.io.InputStream;
 
-import jakarta.ws.rs.tck.api.rs.ext.interceptor.TemplateInterceptorBody;
-import jakarta.ws.rs.tck.common.util.JaxrsUtil;
-
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.ext.ReaderInterceptorContext;
+import jakarta.ws.rs.tck.api.rs.ext.interceptor.TemplateInterceptorBody;
+import jakarta.ws.rs.tck.common.util.JaxrsUtil;
 
 public class InterceptorTwoBody
     extends TemplateInterceptorBody<ReaderInterceptorContext> {

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/reader/readerinterceptorcontext/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/reader/readerinterceptorcontext/JAXRSClientIT.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.ext.interceptor.reader.readerinterceptorcontext;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.ResponseBuilder;
+import jakarta.ws.rs.tck.api.rs.ext.interceptor.TemplateInterceptorBody;
+import jakarta.ws.rs.tck.api.rs.ext.interceptor.reader.ReaderClient;
+import jakarta.ws.rs.tck.common.client.TextCaser;
+import jakarta.ws.rs.tck.common.provider.StringBean;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+@Disabled("Tests fail with IllegalStateException: HttpRequest is null")
+public class JAXRSClientIT extends ReaderClient<ContextOperation> {
+
+  private static final long serialVersionUID = -6962070973647934636L;
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  /*
+   * @testName: getHeadersOperationSetTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:923; JAXRS:JAVADOC:920; JAXRS:SPEC:85;
+   * 
+   * @test_Strategy: Get mutable map of HTTP headers.
+   * 
+   * ReaderInterceptor.aroundReadFrom If abortWith is invoked, execution is
+   * aborted
+   */
+  @Test
+  public void getHeadersOperationSetTest() throws Fault {
+    ResponseBuilder builder = createResponse(ContextOperation.GETHEADERS);
+    Response fake = builder.build();
+
+    addProviders(fake);
+    setProperty(Property.SEARCH_STRING_IGNORE_CASE,
+        TemplateInterceptorBody.OPERATION);
+    invoke();
+  }
+
+  /*
+   * @testName: getHeadersHeadersSetTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:923; JAXRS:JAVADOC:920; JAXRS:SPEC:85;
+   * 
+   * @test_Strategy: Get mutable map of HTTP headers.
+   * 
+   * ReaderInterceptor.aroundReadFrom If abortWith is invoked, execution is
+   * aborted
+   */
+  @Test
+  public void getHeadersHeadersSetTest() throws Fault {
+    ResponseBuilder builder = createResponse(ContextOperation.GETHEADERS);
+    for (int i = 0; i != 5; i++) {
+      setProperty(Property.UNORDERED_SEARCH_STRING,
+          TemplateInterceptorBody.PROPERTY + i);
+      builder = builder.header(TemplateInterceptorBody.PROPERTY + i, "any");
+    }
+    Response fake = builder.build();
+
+    addProviders(fake);
+    setTextCaser(TextCaser.LOWER);
+    setProperty(Property.UNORDERED_SEARCH_STRING,
+        TemplateInterceptorBody.OPERATION);
+    invoke();
+  }
+
+  /* Run test */
+  /*
+   * @testName: getHeadersIsMutableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:923; JAXRS:JAVADOC:920; JAXRS:SPEC:85;
+   * 
+   * @test_Strategy: Get mutable map of HTTP headers.
+   * 
+   * ReaderInterceptor.aroundReadFrom If abortWith is invoked, execution is
+   * aborted
+   */
+  @Test
+  public void getHeadersIsMutableTest() throws Fault {
+    ResponseBuilder builder = createResponse(
+        ContextOperation.GETHEADERSISMUTABLE);
+    Response fake = builder.build();
+
+    addProviders(fake);
+    setProperty(Property.SEARCH_STRING, TemplateInterceptorBody.PROPERTY);
+    invoke();
+  }
+
+  /*
+   * @testName: getInputStreamTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:924; JAXRS:JAVADOC:920; JAXRS:SPEC:85;
+   * 
+   * @test_Strategy: Get the input stream of the object to be read.
+   * 
+   * ReaderInterceptor.aroundReadFrom If abortWith is invoked, execution is
+   * aborted
+   */
+  @Test
+  public void getInputStreamTest() throws Fault {
+    String entity = "getInputStreamEntity";
+    ResponseBuilder builder = createResponse(ContextOperation.GETINPUTSTREAM);
+    Response fake = builder.entity(entity).build();
+
+    addProviders(fake);
+    setProperty(Property.SEARCH_STRING, entity);
+    invoke();
+  }
+
+  /*
+   * @testName: proceedThrowsIOExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:925; JAXRS:JAVADOC:926; JAXRS:JAVADOC:920;
+   * JAXRS:SPEC:85;
+   * 
+   * @test_Strategy: Throws: IOException - if an IO error arises
+   * 
+   * Proceed is tested in any of the interceptor tests.
+   * 
+   * ReaderInterceptor.aroundReadFrom If abortWith is invoked, execution is
+   * aborted
+   */
+  @Test
+  public void proceedThrowsIOExceptionTest() throws Fault {
+    ResponseBuilder builder = createResponse(
+        ContextOperation.PROCEEDTHROWSIOEXCEPTION);
+    Response fake = builder.build();
+
+    addProviders(fake);
+    setProperty(Property.SEARCH_STRING, TemplateInterceptorBody.IOE);
+    invoke();
+  }
+
+  /*
+   * @testName: proceedThrowsWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:925; JAXRS:JAVADOC:1008; JAXRS:JAVADOC:920;
+   * JAXRS:SPEC:85;
+   * 
+   * @test_Strategy: Throws: WebApplicationException - thrown by the wrapped
+   * {@code MessageBodyReader.readFrom} method.
+   * 
+   * Proceed is tested in any of the intercepter tests.
+   * 
+   * ReaderInterceptor.aroundReadFrom If abortWith is invoked, execution is
+   * aborted
+   */
+  @Test
+  public void proceedThrowsWebApplicationExceptionTest() throws Fault {
+    ResponseBuilder builder = createResponse(
+        ContextOperation.PROCEEDTHROWSWEBAPPEXCEPTION);
+    Response fake = builder.build();
+    addProviders(fake);
+    addProvider(ExceptionThrowingStringBeanEntityProvider.class);
+    invoke();
+    // Exception thrown, caught in InterceptorBodyOne
+    StringBean bean = getResponseBody(ExceptionThrowingStringBean.class);
+    //
+    assertContains(bean.get(), TemplateInterceptorBody.WAE,
+        "WebApplicationException has not been thrown and the message is",
+        bean.get());
+    logMsg("WebApplicationException has been thrown as expected", bean.get());
+  }
+
+  /*
+   * @testName: setInputStreamTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:927; JAXRS:JAVADOC:920; JAXRS:SPEC:85;
+   * 
+   * @test_Strategy: Update the input stream of the object to be read.
+   * 
+   * ReaderInterceptor.aroundReadFrom If abortWith is invoked, execution is
+   * aborted
+   */
+  @Test
+  public void setInputStreamTest() throws Fault {
+    ResponseBuilder builder = createResponse(ContextOperation.SETINPUTSTREAM);
+    Response fake = builder.build();
+
+    addProviders(fake);
+    setProperty(Property.SEARCH_STRING, TemplateInterceptorBody.ENTITY2);
+    invoke();
+  }
+
+  // ///////////////////////////////////////////////////////////////////////
+  /**
+   * Do not forget to register providers
+   */
+  @Override
+  protected void addProviders(Response response) throws Fault {
+    super.addProviders(response);
+    addProvider(ReaderInterceptorTwo.class);
+    addProvider(ReaderInterceptorOne.class);
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/reader/readerinterceptorcontext/ReaderInterceptorOne.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/reader/readerinterceptorcontext/ReaderInterceptorOne.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,10 +16,9 @@
 
 package jakarta.ws.rs.tck.api.rs.ext.interceptor.reader.readerinterceptorcontext;
 
-import jakarta.ws.rs.tck.api.rs.ext.interceptor.reader.TemplateReaderInterceptor;
-
 import jakarta.annotation.Priority;
 import jakarta.ws.rs.ext.Provider;
+import jakarta.ws.rs.tck.api.rs.ext.interceptor.reader.TemplateReaderInterceptor;
 
 @Provider
 @Priority(100)

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/reader/readerinterceptorcontext/ReaderInterceptorTwo.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/interceptor/reader/readerinterceptorcontext/ReaderInterceptorTwo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,10 +16,9 @@
 
 package jakarta.ws.rs.tck.api.rs.ext.interceptor.reader.readerinterceptorcontext;
 
-import jakarta.ws.rs.tck.api.rs.ext.interceptor.reader.TemplateReaderInterceptor;
-
 import jakarta.annotation.Priority;
 import jakarta.ws.rs.ext.Provider;
+import jakarta.ws.rs.tck.api.rs.ext.interceptor.reader.TemplateReaderInterceptor;
 
 @Provider
 @Priority(200)

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/runtimedelegate/JAXRSDelegateClient.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/runtimedelegate/JAXRSDelegateClient.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.ext.runtimedelegate;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.ws.rs.ext.RuntimeDelegate;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSDelegateClient extends JAXRSCommonClient {
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Check what is the RuntimeDelegate
+   * 
+   * @param wantTckRuntimeDelegate
+   * @throws Fault
+   *           when wantTckRuntimeDelegate && RuntimeDelegate.getInstance !=
+   *           TckRuntimeDelegate when !wantTckRuntimeDelegate &&
+   *           RuntimeDelegate.getInstance == TckRuntimeDelegate
+   */
+  protected void assertRuntimeDelegate(boolean wantTckRuntimeDelegate)
+      throws Fault {
+    RuntimeDelegate delegate = RuntimeDelegate.getInstance();
+    Class<? extends RuntimeDelegate> clazz = delegate.getClass();
+    boolean check = clazz == TckRuntimeDelegate.class;
+    check = (wantTckRuntimeDelegate ? check : !check);
+    assertTrue(check, "TckRuntimeDelegate was " +
+        (wantTckRuntimeDelegate ? "" : " not ") + "set, got " + clazz.getName());
+    logMsg("Found", clazz.getName());
+  }
+
+  protected void assertRuntimeDelegate() throws Fault {
+    assertRuntimeDelegate(true);
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/runtimedelegate/TckRuntimeDelegate.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/runtimedelegate/TckRuntimeDelegate.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.ext.runtimedelegate;
+
+import java.util.concurrent.CompletionStage;
+
+import jakarta.ws.rs.SeBootstrap;
+import jakarta.ws.rs.SeBootstrap.Instance;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.EntityPart;
+import jakarta.ws.rs.core.Link;
+import jakarta.ws.rs.core.Response.ResponseBuilder;
+import jakarta.ws.rs.core.UriBuilder;
+import jakarta.ws.rs.core.Variant.VariantListBuilder;
+import jakarta.ws.rs.ext.RuntimeDelegate;
+import jakarta.ws.rs.ext.RuntimeDelegate.HeaderDelegate;
+
+public class TckRuntimeDelegate extends RuntimeDelegate {
+
+  @Override
+  public <T> T createEndpoint(Application application, Class<T> endpointType)
+      throws IllegalArgumentException, UnsupportedOperationException {
+    return null;
+  }
+
+  @Override
+  public <T> HeaderDelegate<T> createHeaderDelegate(Class<T> type) {
+    return null;
+  }
+
+  @Override
+  public ResponseBuilder createResponseBuilder() {
+    return null;
+  }
+
+  @Override
+  public UriBuilder createUriBuilder() {
+    return null;
+  }
+
+  @Override
+  public VariantListBuilder createVariantListBuilder() {
+    return null;
+  }
+
+  @Override
+  public Link.Builder createLinkBuilder() {
+    return null;
+  }
+
+  @Override
+  public SeBootstrap.Configuration.Builder createConfigurationBuilder() {
+    return null;
+  }
+
+  @Override
+  public EntityPart.Builder createEntityPartBuilder(String partName) throws IllegalArgumentException {
+    return null;
+  }
+
+  @Override
+  public CompletionStage<Instance> bootstrap(Application application, SeBootstrap.Configuration configuration) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage<Instance> bootstrap(Class<? extends Application> application, SeBootstrap.Configuration configuration) {
+    return null;
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/runtimedelegate/create/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/runtimedelegate/create/JAXRSClientIT.java
@@ -1,0 +1,352 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.ext.runtimedelegate.create;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+
+import com.sun.net.httpserver.HttpHandler;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.CacheControl;
+import jakarta.ws.rs.core.Cookie;
+import jakarta.ws.rs.core.EntityTag;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.NewCookie;
+import jakarta.ws.rs.core.Response.ResponseBuilder;
+import jakarta.ws.rs.core.UriBuilder;
+import jakarta.ws.rs.core.Variant.VariantListBuilder;
+import jakarta.ws.rs.ext.RuntimeDelegate;
+import jakarta.ws.rs.ext.RuntimeDelegate.HeaderDelegate;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = 24421214489103680L;
+
+  transient RuntimeDelegate delegate;
+
+  public JAXRSClientIT() {
+    delegate = RuntimeDelegate.getInstance();
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  /*
+   * @testName: createEndpointTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:284; JAXRS:JAVADOC:285; JAXRS:JAVADOC:286;
+   * 
+   * @test_Strategy: Create a configured instance of the supplied endpoint type.
+   * How the returned endpoint instance is published is dependent on the type of
+   * endpoint.
+   * 
+   * IllegalArgumentException - if application is null or the requested endpoint
+   * type is not supported. UnsupportedOperationException - if the
+   * implementation supports no endpoint types.
+   * 
+   * Note that these assertions are almost untestable, as it can either create
+   * an instance or throw one exception or the other.
+   */
+  @Test
+  public void createEndpointTest() throws Fault {
+    Application application = new Application() {
+      public java.util.Set<java.lang.Class<?>> getClasses() {
+        java.util.Set<java.lang.Class<?>> set = new HashSet<Class<?>>();
+        set.add(Resource.class);
+        return set;
+      };
+    };
+    RuntimeDelegate delegate = RuntimeDelegate.getInstance();
+    HttpHandler handler = null;
+    try {
+      handler = delegate.createEndpoint(application,
+          com.sun.net.httpserver.HttpHandler.class);
+    } catch (IllegalArgumentException e) {
+      logMsg("IllegalArgumentException has been thrown as expected", e);
+      return;
+    } catch (UnsupportedOperationException e) {
+      logMsg("UnsupportedOperationException has been thrown as expected", e);
+      return;
+    }
+    assertNotNull(handler,
+        "HttpHandler end point should be created, or an exception thrown otherwise");
+    logMsg("HttpHandler endpoint has been sucessfully created");
+  }
+
+  /*
+   * @testName: createEndpointThrowsIllegalArgumentExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:285;
+   * 
+   * @test_Strategy: IllegalArgumentException - if application is null or the
+   * requested endpoint type is not supported.
+   */
+  @Test
+  public void createEndpointThrowsIllegalArgumentExceptionTest() throws Fault {
+    try {
+      delegate.createEndpoint((Application) null,
+          com.sun.net.httpserver.HttpHandler.class);
+      fault("IllegalArgumentException has not been thrown");
+    } catch (IllegalArgumentException e) {
+      logMsg("IllegalArgumentException has been thrown as expected");
+    }
+  }
+
+  /*
+   * @testName: checkCreatedUriBuilderTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:289;
+   * 
+   * @test_Strategy: Check that RuntimeDelegate.createUriBuilder makes no
+   * exception and is not null
+   * 
+   */
+  @Test
+  public void checkCreatedUriBuilderTest() throws Fault {
+    UriBuilder builder = delegate.createUriBuilder();
+    assertTrue(builder != null, "UriBuilder has not been created");
+  }
+
+  /*
+   * @testName: checkCreatedVariantListBuilderTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:290;
+   * 
+   * @test_Strategy: Check that RuntimeDelegate.createVariantListBuilder makes
+   * no exception and is not null
+   * 
+   */
+  @Test
+  public void checkCreatedVariantListBuilderTest() throws Fault {
+    VariantListBuilder builder = delegate.createVariantListBuilder();
+    assertTrue(builder != null, "VariantListBuilder has not been created");
+  }
+
+  /*
+   * @testName: checkCreatedResponseBuilderTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:288;
+   * 
+   * @test_Strategy: Check that RuntimeDelegate.createResponseBuilder makes no
+   * exception and is not null
+   * 
+   */
+  @Test
+  public void checkCreatedResponseBuilderTest() throws Fault {
+    ResponseBuilder builder = delegate.createResponseBuilder();
+    assertTrue(builder != null, "ResponseBuilderTest has not been created");
+  }
+
+  /*
+   * @testName: checkCreatedHeaderDelegateCookieTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:287; JAXRS:JAVADOC:294; JAXRS:JAVADOC:296;
+   * 
+   * @test_Strategy: Check that RuntimeDelegate.createHeaderDelegate<Cookie>
+   * makes no exception and is not null
+   * 
+   */
+  @Test
+  public void checkCreatedHeaderDelegateCookieTest() throws Fault {
+    String cookieName = "cookieName";
+    String cookieValue = "cookieValue";
+    HeaderDelegate<Cookie> hdc = delegate.createHeaderDelegate(Cookie.class);
+    assertTrue(hdc != null, "HeaderDelegate<Cookie> has not been created");
+
+    Cookie cookie = new Cookie(cookieName, cookieValue);
+    String result = hdc.toString(cookie);
+    Cookie serialized = hdc.fromString(result);
+    assertTrue(cookieName.equals(serialized.getName()),
+        "HeaderDelegate<Cookie> fromString(),toString() failed");
+  }
+
+  /*
+   * @testName: checkCreatedHeaderDelegateCacheControlTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:287; JAXRS:JAVADOC:294; JAXRS:JAVADOC:296;
+   * 
+   * @test_Strategy: Check that
+   * RuntimeDelegate.createHeaderDelegate<CacheControl> makes no exception and
+   * is not null
+   * 
+   */
+  @Test
+  public void checkCreatedHeaderDelegateCacheControlTest() throws Fault {
+    HeaderDelegate<CacheControl> hdcc = delegate
+        .createHeaderDelegate(CacheControl.class);
+    assertTrue(hdcc != null,
+        "HeaderDelegate<CacheControl> has not been created");
+
+    CacheControl control = new CacheControl();
+    control.setMaxAge(1000);
+    control.setSMaxAge(500);
+    control.setNoTransform(false);
+    control.setPrivate(true);
+
+    String toString = hdcc.toString(control);
+    CacheControl serialized = hdcc.fromString(toString);
+
+    assertTrue(
+        serialized.getMaxAge() == 1000 && serialized.getSMaxAge() == 500
+            && !serialized.isNoTransform() && serialized.isPrivate(),
+        "HeaderDelegate<CacheControl> fromString(),toString() failed");
+  }
+
+  /*
+   * @testName: checkCreatedHeaderDelegateEntityTagTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:287; JAXRS:JAVADOC:294; JAXRS:JAVADOC:296;
+   * 
+   * @test_Strategy: Check that RuntimeDelegate.createHeaderDelegateEntityTag
+   * makes no exception and is not null
+   * 
+   */
+  @Test
+  public void checkCreatedHeaderDelegateEntityTagTest() throws Fault {
+    String tagValue = "tagValue";
+    HeaderDelegate<EntityTag> hdet = delegate
+        .createHeaderDelegate(EntityTag.class);
+    assertTrue(hdet != null, "HeaderDelegate<EntityTag> has not been created");
+
+    EntityTag tag = new EntityTag(tagValue);
+    String toString = hdet.toString(tag);
+    EntityTag serialized = hdet.fromString(toString);
+
+    assertTrue(tagValue.equals(serialized.getValue()),
+        "HeaderDelegate<EntityTag> fromString(),toString() failed");
+  }
+
+  /*
+   * @testName: checkCreatedHeaderDelegateNewCookieTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:287; JAXRS:JAVADOC:294; JAXRS:JAVADOC:296;
+   * 
+   * @test_Strategy: Check that RuntimeDelegate.createHeaderDelegate<NewCookie>
+   * makes no exception and is not null
+   * 
+   */
+  @Test
+  public void checkCreatedHeaderDelegateNewCookieTest() throws Fault {
+    String cookieName = "cookieName";
+    String cookieValue = "cookieValue";
+
+    HeaderDelegate<NewCookie> hdnc = delegate
+        .createHeaderDelegate(NewCookie.class);
+    assertTrue(hdnc != null, "HeaderDelegate<NewCookie> has not been created");
+
+    NewCookie cookie = new NewCookie(cookieName, cookieValue);
+    String result = hdnc.toString(cookie);
+    NewCookie serialized = hdnc.fromString(result);
+    assertTrue(cookieName.equals(serialized.getName()),
+        "HeaderDelegate<NewCookie> fromString(),toString() failed");
+
+  }
+
+  /*
+   * @testName: checkCreatedHeaderDelegateMediaTypeTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:287; JAXRS:JAVADOC:294; JAXRS:JAVADOC:296;
+   * 
+   * @test_Strategy: Check that RuntimeDelegate.createHeaderDelegate<MediaType>
+   * makes no exception and is not null
+   * 
+   */
+  @Test
+  public void checkCreatedHeaderDelegateMediaTypeTest() throws Fault {
+    HeaderDelegate<MediaType> hdmt = delegate
+        .createHeaderDelegate(MediaType.class);
+    assertTrue(hdmt != null, "HeaderDelegate<MediaType> has not been created");
+
+    MediaType type = new MediaType("text", "html");
+    String toString = hdmt.toString(type);
+    MediaType serialized = hdmt.fromString(toString);
+    assertTrue(serialized.isCompatible(MediaType.TEXT_HTML_TYPE),
+        "HeaderDelegate<MediaType> fromString(),toString() failed");
+  }
+
+  /*
+   * @testName: checkCreatedHeaderDelegateNullPointerTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:287; JAXRS:JAVADOC:294; JAXRS:JAVADOC:296;
+   * 
+   * @test_Strategy: Check that RuntimeDelegate.createHeaderDelegate<MediaType>
+   * makes no exception and is not null, but .toString(null) and
+   * fromString(null) throw IAE
+   */
+  @Test
+  public void checkCreatedHeaderDelegateNullPointerTest() throws Fault {
+    HeaderDelegate<MediaType> hdmt = delegate
+        .createHeaderDelegate(MediaType.class);
+    assertTrue(hdmt != null, "HeaderDelegate<MediaType> has not been created");
+
+    try {
+      hdmt.fromString(null);
+      throw new Fault(
+          "HeaderDelegate.fromString(null) did not throw IllegalArgumentException");
+    } catch (IllegalArgumentException iae) {
+    }
+
+    try {
+      hdmt.toString(null);
+      throw new Fault(
+          "HeaderDelegate.toString(null) did not throw IllegalArgumentException");
+    } catch (IllegalArgumentException iae) {
+    }
+  }
+
+  /*
+   * @testName: createHeaderDelegateThrowsIllegalArgumentExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:928;
+   * 
+   * @test_Strategy: Check that RuntimeDelegate.createHeaderDelegate
+   * ((Class)null) throws IAE
+   */
+  @Test
+  public void createHeaderDelegateThrowsIllegalArgumentExceptionTest()
+      throws Fault {
+    try {
+      delegate.createHeaderDelegate((Class<MediaType>) null);
+      throw new Fault("IllegalArgumentException has not been thrown");
+    } catch (IllegalArgumentException e) {
+      logMsg("IllegalArgumentException has been thrown as expected");
+    }
+
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/runtimedelegate/create/Resource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/runtimedelegate/create/Resource.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.ext.runtimedelegate.create;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+@Path("resource")
+public class Resource {
+  @GET
+  public String neverCalledMethod() {
+    return null;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/runtimedelegate/setinstance/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/ext/runtimedelegate/setinstance/JAXRSClientIT.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.ext.runtimedelegate.setinstance;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.ext.RuntimeDelegate;
+import jakarta.ws.rs.tck.api.rs.ext.runtimedelegate.JAXRSDelegateClient;
+import jakarta.ws.rs.tck.api.rs.ext.runtimedelegate.TckRuntimeDelegate;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSDelegateClient {
+
+  private static final long serialVersionUID = -5586431064207012301L;
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  /*
+   * @testName: askForTckRuntimeDelegateGivenBySetInstanceTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:291;JAXRS:JAVADOC:292;
+   * 
+   * @test_Strategy: Set new RuntimeDelegate and check it is TckRuntimeDelegate
+   * 
+   */
+  @Test
+  public void askForTckRuntimeDelegateGivenBySetInstanceTest() throws Fault {
+    RuntimeDelegate original = RuntimeDelegate.getInstance();
+    RuntimeDelegate.setInstance(new TckRuntimeDelegate());
+    try {
+      assertRuntimeDelegate();
+    } finally {
+      RuntimeDelegate.setInstance(original);
+      assertRuntimeDelegate(false);
+    }
+  }
+
+  /*
+   * @testName: checkTckRuntimeDelegateIsNotDefaultTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:292;
+   * 
+   * @test_Strategy: Check by default, it is not our RuntimeDelegate
+   */
+  @Test
+  public void checkTckRuntimeDelegateIsNotDefaultTest() throws Fault {
+    assertRuntimeDelegate(false);
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/forbiddenexception/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/forbiddenexception/JAXRSClientIT.java
@@ -1,0 +1,357 @@
+/*
+ * Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.forbiddenexception;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.ForbiddenException;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = -2548045403083271236L;
+
+  private static final Status STATUS = Status.FORBIDDEN;
+
+  protected static final String MESSAGE = "TCK ForbiddenException description";
+
+  protected static final String HOST = "www.jcp.org";
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  /*
+   * @testName: constructorTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:970; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "forbidden" exception.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorTest() throws Fault {
+    ForbiddenException e = new ForbiddenException();
+    assertResponse(e);
+  }
+
+  /*
+   * @testName: constructorResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:971; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "forbidden" exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 403.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorResponseTest() throws Fault {
+    Response response = buildResponse();
+    ForbiddenException e = new ForbiddenException(response);
+    assertResponse(e, HOST);
+  }
+
+  /*
+   * @testName: constructorResponseThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:971;
+   * 
+   * @test_Strategy: Construct a new "forbidden" exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 403.
+   */
+  @Test
+  public void constructorResponseThrowsExceptionTest() throws Fault {
+    for (Status status : Status.values())
+      if (status != STATUS)
+        try {
+          Response response = Response.status(status).build();
+          ForbiddenException e = new ForbiddenException(response);
+          fault("IllegalArgumentException has not been thrown; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg("IllegalArgumentException has been thrown for status", status,
+              "as expected");
+        }
+  }
+
+  /*
+   * @testName: constructorThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:972; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "forbidden" exception. cause - the
+   * underlying cause of the exception.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      ForbiddenException e = new ForbiddenException(t);
+      assertResponse(e);
+      assertCause(e, t);
+    }
+  }
+
+  /*
+   * @testName: constructorResponseThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:973; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "forbidden" exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 403.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorResponseThrowableTest() throws Fault {
+    Response response = buildResponse();
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      ForbiddenException e = new ForbiddenException(response, t);
+      assertResponse(e, HOST);
+      assertCause(e, t);
+    }
+  }
+
+  /*
+   * @testName: constructorResponseThrowableThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:973;
+   * 
+   * @test_Strategy: Construct a new "forbidden" exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 403.
+   */
+  @Test
+  public void constructorResponseThrowableThrowsExceptionTest() throws Fault {
+    for (Status status : Status.values())
+      if (status != STATUS) {
+        Response response = Response.status(status).build();
+        try {
+          ForbiddenException e = new ForbiddenException(response,
+              new Throwable());
+          fault("ForbiddenException has not been thrown for status", status,
+              "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been sucessfully thrown for status",
+              status);
+        }
+      }
+  }
+
+  /*
+   * @testName: constructorStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1066; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "forbidden" exception. getResponse
+   */
+  @Test
+  public void constructorStringTest() throws Fault {
+    ForbiddenException e = new ForbiddenException(MESSAGE);
+    assertResponse(e);
+    assertMessage(e);
+  }
+
+  /*
+   * @testName: constructorStringResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1067; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "forbidden" exception. getResponse
+   */
+  @Test
+  public void constructorStringResponseTest() throws Fault {
+    Response response = buildResponse();
+    ForbiddenException e = new ForbiddenException(MESSAGE, response);
+    assertResponse(e, HOST);
+    assertMessage(e);
+  }
+
+  /*
+   * @testName: constructorStringResponseThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1067;
+   * 
+   * @test_Strategy: Construct a new "forbidden" exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 403.
+   */
+  @Test
+  public void constructorStringResponseThrowsIAETest() throws Fault {
+    for (Status status : Status.values())
+      if (status != STATUS)
+        try {
+          Response response = Response.status(status).build();
+          ForbiddenException e = new ForbiddenException(MESSAGE, response);
+          fault("IllegalArgumentException has not been thrown; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg("IllegalArgumentException has been thrown for status", status,
+              "as expected");
+        }
+  }
+
+  /*
+   * @testName: constructorStringThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1068; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "forbidden" exception. cause - the
+   * underlying cause of the exception.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      ForbiddenException e = new ForbiddenException(MESSAGE, t);
+      assertResponse(e);
+      assertCause(e, t);
+      assertMessage(e);
+    }
+  }
+
+  /*
+   * @testName: constructorStringResponseThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1069; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "forbidden" exception.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringResponseThrowableTest() throws Fault {
+    Response response = buildResponse();
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      ForbiddenException e = new ForbiddenException(MESSAGE, response, t);
+      assertResponse(e, HOST);
+      assertCause(e, t);
+      assertMessage(e);
+    }
+  }
+
+  /*
+   * @testName: constructorStringResponseThrowableThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1069;
+   * 
+   * @test_Strategy: Construct a new "forbidden" exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 403.
+   */
+  @Test
+  public void constructorStringResponseThrowableThrowsIAETest() throws Fault {
+    for (Status status : Status.values())
+      if (status != STATUS) {
+        Response response = Response.status(status).build();
+        try {
+          ForbiddenException e = new ForbiddenException(MESSAGE, response,
+              new Throwable());
+          fault("ForbiddenException has not been thrown for status", status,
+              "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been sucessfully thrown for status",
+              status);
+        }
+      }
+  }
+
+  // /////////////////////////////////////////////////////////////
+
+  protected void assertResponse(ForbiddenException e) throws Fault {
+    assertNotNull(e.getResponse(), "#getResponse is null");
+    Response response = e.getResponse();
+    assertEqualsInt(response.getStatus(), STATUS.getStatusCode(),
+        "response cobtains unexpected status", response.getStatus());
+    logMsg("response contains expected", STATUS, "status");
+  }
+
+  /**
+   * Check the given exception contains a prebuilt response containing the http
+   * header HOST
+   * 
+   * @param e
+   * @param host
+   *          HOST property
+   * @throws Fault
+   */
+  protected void assertResponse(ForbiddenException e, String host)
+      throws Fault {
+    assertResponse(e);
+    String header = e.getResponse().getHeaderString(HttpHeaders.HOST);
+    assertNotNull(header, "http header", HttpHeaders.HOST,
+        " of response is null");
+    assertEquals(host, header, "Found unexpected http", HttpHeaders.HOST,
+        "header", header);
+    logMsg("Found expected http", HttpHeaders.HOST, "header");
+  }
+
+  protected void assertMessage(ForbiddenException e) throws Fault {
+    assertNotNull(e.getMessage(), "getMessage() is null");
+    assertContains(e.getMessage(), MESSAGE, "Unexpected getMessage()",
+        e.getMessage());
+    logMsg("found expected getMessage()=", e.getMessage());
+  }
+
+  protected void assertCause(WebApplicationException e, Throwable expected)
+      throws Fault {
+    assertCause(e, expected.getClass(), "#getCause does not contain expected",
+        expected, "but", e.getCause());
+    logMsg("getCause contains expected", expected);
+  }
+
+  protected Response buildResponse() {
+    Response r = Response.status(STATUS).header(HttpHeaders.HOST, HOST).build();
+    return r;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/internalservererrorexception/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/internalservererrorexception/JAXRSClientIT.java
@@ -1,0 +1,361 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.internalservererrorexception;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = -588383752025277814L;
+
+  private static final Status STATUS = Status.INTERNAL_SERVER_ERROR;
+
+  protected static final String MESSAGE = "TCK InternalServerErrorException description";
+
+  protected static final String HOST = "www.jcp.org";
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  /*
+   * @testName: constructorTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:319; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new internal server error exception.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorTest() throws Fault {
+    InternalServerErrorException e = new InternalServerErrorException();
+    assertResponse(e);
+  }
+
+  /*
+   * @testName: constructorResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:320; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new internal server error exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 500.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorResponseTest() throws Fault {
+    Response response = buildResponse();
+    InternalServerErrorException e = new InternalServerErrorException(response);
+    assertResponse(e, HOST);
+  }
+
+  /*
+   * @testName: constructorResponseThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:320;
+   * 
+   * @test_Strategy: Construct a new internal server error exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 500.
+   */
+  @Test
+  public void constructorResponseThrowsExceptionTest() throws Fault {
+    for (Status status : Status.values())
+      if (status != STATUS)
+        try {
+          Response response = Response.status(status).build();
+          InternalServerErrorException e = new InternalServerErrorException(
+              response);
+          fault("No exception has been thrown for status", status,
+              "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been thrown as expected for status",
+              status);
+        }
+  }
+
+  /*
+   * @testName: constructorThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:321; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new internal server error exception. cause -
+   * the underlying cause of the exception.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      InternalServerErrorException e = new InternalServerErrorException(t);
+      assertResponse(e);
+      assertCause(e, t);
+    }
+  }
+
+  /*
+   * @testName: constructorResponseThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:322; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new internal server error exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 500.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorResponseThrowableTest() throws Fault {
+    Response response = buildResponse();
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      InternalServerErrorException e = new InternalServerErrorException(
+          response, t);
+      assertResponse(e, HOST);
+      assertCause(e, t);
+    }
+  }
+
+  /*
+   * @testName: constructorResponseThrowableThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:322;
+   * 
+   * @test_Strategy: Construct a new internal server error exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 500.
+   */
+  @Test
+  public void constructorResponseThrowableThrowsExceptionTest() throws Fault {
+    for (Status status : Status.values())
+      if (status != STATUS)
+        try {
+          Response response = Response.status(status).build();
+          InternalServerErrorException e = new InternalServerErrorException(
+              response, new Throwable());
+          fault("No exception has been thrown for status", status, "exception",
+              e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been thrown as expected for status",
+              status);
+        }
+  }
+
+  /*
+   * @testName: constructorStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1070;
+   * 
+   * @test_Strategy: message - the detail message (which is saved for later
+   * retrieval by the Throwable.getMessage() method).
+   */
+  @Test
+  public void constructorStringTest() throws Fault {
+    InternalServerErrorException e = new InternalServerErrorException(MESSAGE);
+    assertMessage(e);
+    assertResponse(e);
+  }
+
+  /*
+   * @testName: constructorStringResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1071; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new internal server error exception.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringResponseTest() throws Fault {
+    Response response = buildResponse();
+    InternalServerErrorException e = new InternalServerErrorException(MESSAGE,
+        response);
+    assertResponse(e, HOST);
+    assertMessage(e);
+  }
+
+  /*
+   * @testName: constructorStringResponseThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1071;
+   * 
+   * @test_Strategy: Construct a new internal server error exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 500.
+   */
+  @Test
+  public void constructorStringResponseThrowsIAETest() throws Fault {
+    for (Status status : Status.values())
+      if (status != STATUS)
+        try {
+          Response response = Response.status(status).build();
+          InternalServerErrorException e = new InternalServerErrorException(
+              MESSAGE, response);
+          fault("No exception has been thrown for status", status,
+              "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been thrown as expected for status",
+              status);
+        }
+  }
+
+  /*
+   * @testName: constructorStringThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1072; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new internal server error exception.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      InternalServerErrorException e = new InternalServerErrorException(MESSAGE,
+          t);
+      assertResponse(e);
+      assertCause(e, t);
+      assertMessage(e);
+    }
+  }
+
+  /*
+   * @testName: constructorStringResponseThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1073; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new internal server error exception.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringResponseThrowableTest() throws Fault {
+    Response response = buildResponse();
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      InternalServerErrorException e = new InternalServerErrorException(MESSAGE,
+          response, t);
+      assertResponse(e, HOST);
+      assertCause(e, t);
+      assertMessage(e);
+    }
+  }
+
+  /*
+   * @testName: constructorStringResponseThrowableThrowsIEATest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1073;
+   * 
+   * @test_Strategy: Construct a new internal server error exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 500.
+   */
+  @Test
+  public void constructorStringResponseThrowableThrowsIEATest() throws Fault {
+    for (Status status : Status.values())
+      if (status != STATUS)
+        try {
+          Response response = Response.status(status).build();
+          InternalServerErrorException e = new InternalServerErrorException(
+              MESSAGE, response, new Throwable());
+          fault("No exception has been thrown for status", status, "exception",
+              e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been thrown as expected for status",
+              status);
+        }
+  }
+
+  // /////////////////////////////////////////////////////////////
+  protected Response buildResponse() {
+    Response r = Response.status(STATUS).header(HttpHeaders.HOST, HOST).build();
+    return r;
+  }
+
+  protected void assertResponse(InternalServerErrorException e) throws Fault {
+    assertNotNull(e.getResponse(), "#getResponse is null");
+    Response response = e.getResponse();
+    assertEqualsInt(response.getStatus(), STATUS.getStatusCode(),
+        "response cobtains unexpected status", response.getStatus());
+    logMsg("response contains expected", STATUS, "status");
+  }
+
+  /**
+   * Check the given exception contains a prebuilt response containing the http
+   * header HOST
+   */
+  protected void assertResponse(InternalServerErrorException e, String host)
+      throws Fault {
+    assertResponse(e);
+    String header = e.getResponse().getHeaderString(HttpHeaders.HOST);
+    assertNotNull(header, "http header", HttpHeaders.HOST,
+        " of response is null");
+    assertEquals(host, header, "Found unexpected http", HttpHeaders.HOST,
+        "header", header);
+    logMsg("Found expected http", HttpHeaders.HOST, "header");
+  }
+
+  protected void assertCause(WebApplicationException e, Throwable expected)
+      throws Fault {
+    assertEquals(e.getCause(), expected, "#getCause does not contain expected",
+        expected, "but", e.getCause());
+    logMsg("getCause contains expected", expected);
+  }
+
+  protected void assertMessage(InternalServerErrorException e) throws Fault {
+    assertNotNull(e.getMessage(), "getMessage() is null");
+    assertContains(e.getMessage(), MESSAGE, "Unexpected getMessage()",
+        e.getMessage());
+    logMsg("found expected getMessage()=", e.getMessage());
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/notacceptableexception/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/notacceptableexception/JAXRSClientIT.java
@@ -1,0 +1,355 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.notacceptableexception;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.NotAcceptableException;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = -4988322048715462436L;
+
+  private static final Status STATUS = Status.NOT_ACCEPTABLE;
+
+  protected static final String MESSAGE = "TCK NotAcceptableException description";
+
+  protected static final String HOST = "www.jcp.org";
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  /*
+   * @testName: constructorTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:326; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "request not acceptable" exception.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorTest() throws Fault {
+    NotAcceptableException e = new NotAcceptableException();
+    assertResponse(e);
+  }
+
+  /*
+   * @testName: constructorResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:327; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "request not acceptable" exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 406.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorResponseTest() throws Fault {
+    Response response = buildResponse();
+    NotAcceptableException e = new NotAcceptableException(response);
+    assertResponse(e, HOST);
+  }
+
+  /*
+   * @testName: constructorResponseThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:327;
+   * 
+   * @test_Strategy: Construct a new "request not acceptable" exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 406.
+   */
+  @Test
+  public void constructorResponseThrowsExceptionTest() throws Fault {
+    for (Status status : Status.values())
+      if (status != STATUS)
+        try {
+          Response response = Response.status(status).build();
+          NotAcceptableException e = new NotAcceptableException(response);
+          fault("IllegalArgumentException has not been thrown; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg("IllegalArgumentException has been thrown for status", status,
+              "as expected");
+        }
+  }
+
+  /*
+   * @testName: constructorThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:328; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "request not acceptable" exception. cause -
+   * the underlying cause of the exception.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      NotAcceptableException e = new NotAcceptableException(t);
+      assertResponse(e);
+      assertCause(e, t);
+    }
+  }
+
+  /*
+   * @testName: constructorResponseThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:329; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "request not acceptable" exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 406.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorResponseThrowableTest() throws Fault {
+    Response response = buildResponse();
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      NotAcceptableException e = new NotAcceptableException(response, t);
+      assertResponse(e, HOST);
+      assertCause(e, t);
+    }
+  }
+
+  /*
+   * @testName: constructorResponseThrowableThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:329;
+   * 
+   * @test_Strategy: Construct a new "request not acceptable" exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 406.
+   */
+  @Test
+  public void constructorResponseThrowableThrowsExceptionTest() throws Fault {
+    for (Status status : Status.values())
+      if (status != STATUS) {
+        Response response = Response.status(status).build();
+        try {
+          NotAcceptableException e = new NotAcceptableException(response,
+              new Throwable());
+          fault("NotAcceptableException has not been thrown for status", status,
+              "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been sucessfully thrown for status",
+              status);
+        }
+      }
+  }
+
+  /*
+   * @testName: constructorStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1074;
+   * 
+   * @test_Strategy: Construct a new "request not acceptable" exception.
+   */
+  @Test
+  public void constructorStringTest() throws Fault {
+    NotAcceptableException e = new NotAcceptableException(MESSAGE);
+    assertResponse(e);
+    assertMessage(e);
+  }
+
+  /*
+   * @testName: constructorStringResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1075; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "request not acceptable" exception.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringResponseTest() throws Fault {
+    Response response = buildResponse();
+    NotAcceptableException e = new NotAcceptableException(MESSAGE, response);
+    assertResponse(e, HOST);
+    assertMessage(e);
+  }
+
+  /*
+   * @testName: constructorStringResponseThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1075;
+   * 
+   * @test_Strategy: Construct a new "request not acceptable" exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 406.
+   */
+  @Test
+  public void constructorStringResponseThrowsIAETest() throws Fault {
+    for (Status status : Status.values())
+      if (status != STATUS)
+        try {
+          Response response = Response.status(status).build();
+          NotAcceptableException e = new NotAcceptableException(MESSAGE,
+              response);
+          fault("IllegalArgumentException has not been thrown; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg("IllegalArgumentException has been thrown for status", status,
+              "as expected");
+        }
+  }
+
+  /*
+   * @testName: constructorStringThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1076; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "request not acceptable" exception. cause -
+   * the underlying cause of the exception.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      NotAcceptableException e = new NotAcceptableException(MESSAGE, t);
+      assertResponse(e);
+      assertCause(e, t);
+      assertMessage(e);
+    }
+  }
+
+  /*
+   * @testName: constructorStringResponseThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:329; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "request not acceptable" exception.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringResponseThrowableTest() throws Fault {
+    Response response = buildResponse();
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      NotAcceptableException e = new NotAcceptableException(MESSAGE, response,
+          t);
+      assertResponse(e, HOST);
+      assertCause(e, t);
+      assertMessage(e);
+    }
+  }
+
+  /*
+   * @testName: constructorResponseThrowableThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1077;
+   * 
+   * @test_Strategy: Construct a new "request not acceptable" exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 406.
+   */
+  @Test
+  public void constructorResponseThrowableThrowsIAETest() throws Fault {
+    for (Status status : Status.values())
+      if (status != STATUS) {
+        Response response = Response.status(status).build();
+        try {
+          NotAcceptableException e = new NotAcceptableException(MESSAGE,
+              response, new Throwable());
+          fault("NotAcceptableException has not been thrown for status", status,
+              "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been sucessfully thrown for status",
+              status);
+        }
+      }
+  }
+
+  // /////////////////////////////////////////////////////////////
+  protected Response buildResponse() {
+    Response r = Response.status(STATUS).header(HttpHeaders.HOST, HOST).build();
+    return r;
+  }
+
+  protected void assertResponse(NotAcceptableException e) throws Fault {
+    assertNotNull(e.getResponse(), "#getResponse is null");
+    Response response = e.getResponse();
+    assertEqualsInt(response.getStatus(), STATUS.getStatusCode(),
+        "response cobtains unexpected status", response.getStatus());
+    logMsg("response contains expected", STATUS, "status");
+  }
+
+  /**
+   * Check the given exception contains a prebuilt response containing the http
+   * header HOST
+   */
+  protected void assertResponse(NotAcceptableException e, String host)
+      throws Fault {
+    assertResponse(e);
+    String header = e.getResponse().getHeaderString(HttpHeaders.HOST);
+    assertNotNull(header, "http header", HttpHeaders.HOST,
+        " of response is null");
+    assertEquals(host, header, "Found unexpected http", HttpHeaders.HOST,
+        "header", header);
+    logMsg("Found expected http", HttpHeaders.HOST, "header");
+  }
+
+  protected void assertCause(WebApplicationException e, Throwable expected)
+      throws Fault {
+    assertEquals(e.getCause(), expected, "#getCause does not contain expected",
+        expected, "but", e.getCause());
+    logMsg("getCause contains expected", expected);
+  }
+
+  protected void assertMessage(NotAcceptableException e) throws Fault {
+    assertNotNull(e.getMessage(), "getMessage() is null");
+    assertContains(e.getMessage(), MESSAGE, "Unexpected getMessage()",
+        e.getMessage());
+    logMsg("found expected getMessage()=", e.getMessage());
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/notallowedexception/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/notallowedexception/JAXRSClientIT.java
@@ -1,0 +1,547 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.notallowedexception;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.NotAllowedException;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = 6905238461163637999L;
+
+  private static final Status STATUS = Status.METHOD_NOT_ALLOWED;
+
+  protected static final String MESSAGE = "TCK NotAllowedException description";
+
+  protected static final String HOST = "www.jcp.org";
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  /*
+   * @testName: constructorStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1078; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new method not allowed exception.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringTest() throws Fault {
+    NotAllowedException e = new NotAllowedException(Request.OPTIONS.name(),
+        new String[] { Request.HEAD.name() });
+    assertResponse(e);
+  }
+
+  /*
+   * @testName: constructorStringThrowsNPETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1078;
+   * 
+   * @test_Strategy: Throws: java.lang.NullPointerException - in case the
+   * allowed method is null.
+   */
+  @Test
+  public void constructorStringThrowsNPETest() throws Fault {
+    try {
+      NotAllowedException e = new NotAllowedException((String) null,
+          new String[] { Request.HEAD.name() });
+      fault(
+          "NullPointerException has not been thrown for null method, built exception",
+          e);
+    } catch (NullPointerException e) {
+      logMsg(
+          "NullPointerException has been thrown as expected, for null method");
+    }
+  }
+
+  /*
+   * @testName: constructorResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:331; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new method not allowed exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 405.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorResponseTest() throws Fault {
+    NotAllowedException e = new NotAllowedException(buildResponse(STATUS));
+    assertResponse(e, HOST);
+  }
+
+  /*
+   * @testName: constructorResponseThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:331;
+   * 
+   * @test_Strategy: Construct a new method not allowed exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 405.
+   */
+  @Test
+  public void constructorResponseThrowsExceptionTest() throws Fault {
+    for (Status status : Status.values())
+      if (status != STATUS) {
+        try {
+          NotAllowedException e = new NotAllowedException(
+              buildResponse(status));
+          fault("IllegalArgumentException has not been thrown for status",
+              status, "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been thrown as expected for status",
+              status);
+        }
+      }
+  }
+
+  /*
+   * @testName: constructorResponseDoesNotThrowWhenNoAllowHeaderTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:331; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Note that this constructor does not validate the presence
+   * of HTTP Allow header. I.e. it is possible to use the constructor to create
+   * a client-side exception instance even for an invalid HTTP 405 response
+   * content returned from a server.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorResponseDoesNotThrowWhenNoAllowHeaderTest()
+      throws Fault {
+    Response response = Response.status(STATUS).header(HttpHeaders.HOST, HOST)
+        .build();
+    NotAllowedException e = new NotAllowedException(response);
+    assertResponse(e, HOST);
+  }
+
+  /*
+   * @testName: constructorThrowableStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:332; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new method not allowed exception.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorThrowableStringTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      NotAllowedException e = new NotAllowedException(t, Request.DELETE.name());
+      assertResponse(e);
+      assertCause(e, t);
+    }
+  }
+
+  /*
+   * @testName: constructorThrowableStringThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:332;
+   * 
+   * @test_Strategy: Construct a new method not allowed exception. Throws -
+   * java.lang.IllegalArgumentException - in case the allowed methods varargs
+   * are null.
+   */
+  @Test
+  public void constructorThrowableStringThrowsIAETest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      try {
+        NotAllowedException e = new NotAllowedException(t, (String[]) null);
+        fault(
+            "IllegalArgumentException has NOT been thrown for null methods; exception",
+            e);
+      } catch (IllegalArgumentException iae) {
+        logMsg(
+            "IllegalArgumentException has been thrown as expected for null methods");
+      }
+    }
+  }
+
+  /*
+   * @testName: constructorResponseThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:333; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new method not allowed exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 405. getResponse
+   */
+  @Test
+  public void constructorResponseThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      NotAllowedException e = new NotAllowedException(buildResponse(STATUS), t);
+      assertResponse(e, HOST);
+      assertCause(e, t);
+    }
+  }
+
+  /*
+   * @testName: constructorResponseThrowableThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:333;
+   * 
+   * @test_Strategy: Construct a new method not allowed exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 405.
+   */
+  @Test
+  public void constructorResponseThrowableThrowsExceptionTest() throws Fault {
+    for (Status status : Status.values())
+      if (status != STATUS) {
+        try {
+          NotAllowedException e = new NotAllowedException(buildResponse(status),
+              new Throwable());
+          fault("IllegalArgumentException has not been thrown for status",
+              status, "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been thrown as expected for status",
+              status);
+        }
+      }
+  }
+
+  /*
+   * @testName: constructorResponseThrowableThrowsIAEWhenNoAllowHeaderTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:333;
+   * 
+   * @test_Strategy: Construct a new method not allowed exception.
+   * java.lang.IllegalArgumentException - in case the response does not contain
+   * an HTTP Allow header.
+   */
+  @Test
+  public void constructorResponseThrowableThrowsIAEWhenNoAllowHeaderTest()
+      throws Fault {
+    try {
+      Response response = Response.status(STATUS).build();
+      NotAllowedException e = new NotAllowedException(response,
+          new Throwable());
+      fault(
+          "IllegalArgumentException has not been thrown when no allow header exception",
+          e);
+    } catch (IllegalArgumentException e) {
+      logMsg(
+          "IllegalArgumentException has been thrown as expected for when no allow http header");
+    }
+  }
+
+  /*
+   * @testName: constructorStringStringStringsTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1079; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new method not allowed exception.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringStringStringsTest() throws Fault {
+    NotAllowedException e = new NotAllowedException(MESSAGE,
+        Request.OPTIONS.name(), new String[] { Request.HEAD.name() });
+    assertResponse(e);
+    assertMessage(e);
+  }
+
+  /*
+   * @testName: constructorStringStringStringsThrowsNPETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1079;
+   * 
+   * @test_Strategy: Throws: java.lang.NullPointerException - in case the
+   * allowed method is null.
+   */
+  @Test
+  public void constructorStringStringStringsThrowsNPETest() throws Fault {
+    try {
+      NotAllowedException e = new NotAllowedException(MESSAGE, (String) null,
+          new String[] { Request.HEAD.name() });
+      fault(
+          "NullPointerException has not been thrown for null method, built exception",
+          e);
+    } catch (NullPointerException e) {
+      logMsg(
+          "NullPointerException has been thrown as expected, for null method");
+    }
+  }
+
+  /*
+   * @testName: constructorStringResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1080; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new method not allowed exception.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringResponseTest() throws Fault {
+    NotAllowedException e = new NotAllowedException(MESSAGE,
+        buildResponse(STATUS));
+    assertResponse(e, HOST);
+    assertMessage(e);
+  }
+
+  /*
+   * @testName: constructorStringResponseThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1080;
+   * 
+   * @test_Strategy: Construct a new method not allowed exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 405.
+   */
+  @Test
+  public void constructorStringResponseThrowsIAETest() throws Fault {
+    for (Status status : Status.values())
+      if (status != STATUS) {
+        try {
+          NotAllowedException e = new NotAllowedException(
+              buildResponse(status));
+          fault("IllegalArgumentException has not been thrown for status",
+              status, "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been thrown as expected for status",
+              status);
+        }
+      }
+  }
+
+  /*
+   * @testName: constructorStringResponseDoesNotThrowWhenNoAllowHeaderTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1080; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Note that this constructor does not validate the presence
+   * of HTTP Allow header. I.e. it is possible to use the constructor to create
+   * a client-side exception instance even for an invalid HTTP 405 response
+   * content returned from a server.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringResponseDoesNotThrowWhenNoAllowHeaderTest()
+      throws Fault {
+    Response response = Response.status(STATUS).header(HttpHeaders.HOST, HOST)
+        .build();
+    NotAllowedException e = new NotAllowedException(MESSAGE, response);
+    assertResponse(e, HOST);
+    assertMessage(e);
+  }
+
+  /*
+   * @testName: constructorStringThrowableStringsTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1081; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new method not allowed exception.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringThrowableStringsTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      NotAllowedException e = new NotAllowedException(MESSAGE, t,
+          Request.DELETE.name());
+      assertResponse(e);
+      assertCause(e, t);
+      assertMessage(e);
+    }
+  }
+
+  /*
+   * @testName: constructorStringThrowableStringsThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1081;
+   * 
+   * @test_Strategy: Construct a new method not allowed exception. Throws -
+   * java.lang.IllegalArgumentException - in case the allowed methods varargs
+   * are null.
+   */
+  @Test
+  public void constructorStringThrowableStringsThrowsIAETest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      try {
+        NotAllowedException e = new NotAllowedException(MESSAGE, t,
+            (String[]) null);
+        fault(
+            "IllegalArgumentException has NOT been thrown for null methods; exception",
+            e);
+      } catch (IllegalArgumentException iae) {
+        logMsg(
+            "IllegalArgumentException has been thrown as expected for null methods");
+      }
+    }
+  }
+
+  /*
+   * @testName: constructorStringResponseThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1082; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new method not allowed exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 405. getResponse
+   */
+  @Test
+  public void constructorStringResponseThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      NotAllowedException e = new NotAllowedException(MESSAGE,
+          buildResponse(STATUS), t);
+      assertResponse(e, HOST);
+      assertCause(e, t);
+      assertMessage(e);
+    }
+  }
+
+  /*
+   * @testName: constructorStringResponseThrowableThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1082;
+   * 
+   * @test_Strategy: Construct a new method not allowed exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 405.
+   */
+  @Test
+  public void constructorStringResponseThrowableThrowsExceptionTest()
+      throws Fault {
+    for (Status status : Status.values())
+      if (status != STATUS) {
+        try {
+          NotAllowedException e = new NotAllowedException(MESSAGE,
+              buildResponse(status), new Throwable());
+          fault("IllegalArgumentException has not been thrown for status",
+              status, "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been thrown as expected for status",
+              status);
+        }
+      }
+  }
+
+  /*
+   * @testName: constructorStringResponseThrowableThrowsIAEWhenNoAllowHeaderTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1082;
+   * 
+   * @test_Strategy: Construct a new method not allowed exception.
+   * java.lang.IllegalArgumentException - in case the response does not contain
+   * an HTTP Allow header.
+   */
+  @Test
+  public void constructorStringResponseThrowableThrowsIAEWhenNoAllowHeaderTest()
+      throws Fault {
+    try {
+      Response response = Response.status(STATUS).build();
+      NotAllowedException e = new NotAllowedException(MESSAGE, response,
+          new Throwable());
+      fault(
+          "IllegalArgumentException has not been thrown when no allow header exception",
+          e);
+    } catch (IllegalArgumentException e) {
+      logMsg(
+          "IllegalArgumentException has been thrown as expected for when no allow http header");
+    }
+  }
+
+  // /////////////////////////////////////////////////////////////
+  protected Response buildResponse(Status status) {
+    return Response.status(status).header("allow", Request.OPTIONS)
+        .header("allow", Request.HEAD).header(HttpHeaders.HOST, HOST).build();
+  }
+
+  /**
+   * Check the given exception contains a prebuilt response containing the http
+   * header HOST
+   */
+  protected void assertResponse(NotAllowedException e, String host)
+      throws Fault {
+    assertResponse(e);
+    String header = e.getResponse().getHeaderString(HttpHeaders.HOST);
+    assertNotNull(header, "http header", HttpHeaders.HOST,
+        " of response is null");
+    assertEquals(host, header, "Found unexpected http", HttpHeaders.HOST,
+        "header", header);
+    logMsg("Found expected http", HttpHeaders.HOST, "header");
+  }
+
+  protected void assertResponse(NotAllowedException e) throws Fault {
+    assertNotNull(e.getResponse(), "#getResponse is null");
+    Response response = e.getResponse();
+    assertEqualsInt(response.getStatus(), STATUS.getStatusCode(),
+        "response cobtains unexpected status", response.getStatus());
+    logMsg("response contains expected", STATUS, "status");
+  }
+
+  protected void assertCause(WebApplicationException e, Throwable expected)
+      throws Fault {
+    assertEquals(e.getCause(), expected, "#getCause does not contain expected",
+        expected, "but", e.getCause());
+    logMsg("getCause contains expected", expected);
+  }
+
+  protected void assertMessage(NotAllowedException e) throws Fault {
+    assertNotNull(e.getMessage(), "getMessage() is null");
+    assertContains(e.getMessage(), MESSAGE, "Unexpected getMessage()",
+        e.getMessage());
+    logMsg("found expected getMessage()=", e.getMessage());
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/notauthorizedexception/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/notauthorizedexception/JAXRSClientIT.java
@@ -1,0 +1,432 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.notauthorizedexception;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.NotAuthorizedException;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.common.util.JaxrsUtil;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = -377888431788668222L;
+
+  private static final Status STATUS = Status.UNAUTHORIZED;
+
+  private static final String[] CHALLENGE = { "challenge1", "challenge2",
+      "challenge3" };
+
+  protected static final String MESSAGE = "TCK NotAuthorizedException description";
+
+  protected static final String HOST = "www.jcp.org";
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  /*
+   * @testName: constructorObjectsTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:335; JAXRS:JAVADOC:334; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "not authorized" exception.
+   * 
+   * Get the list of authorization challenges associated with the exception and
+   * applicable to the resource requested by the client.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorObjectsTest() throws Fault {
+    NotAuthorizedException e = new NotAuthorizedException((Object) CHALLENGE[0],
+        CHALLENGE[1], CHALLENGE[2]);
+    assertResponse(e);
+    assertChallenges(e);
+  }
+
+  /*
+   * @testName: constructorObjectsThrowsNPEWhenNullTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:335;
+   * 
+   * @test_Strategy: Throws: java.lang.NullPointerException - in case the
+   * challenge parameter is null.
+   */
+  @Test
+  public void constructorObjectsThrowsNPEWhenNullTest() throws Fault {
+    try {
+      NotAuthorizedException e = new NotAuthorizedException((Object) null,
+          CHALLENGE[1], CHALLENGE[2]);
+      fault(
+          "NullPointerException has NOT been thrown as expected for null challenge; exception",
+          e);
+    } catch (NullPointerException npe) {
+      logMsg(
+          "NullPointerException has been thrown as expected for null challenge");
+    }
+  }
+
+  /*
+   * @testName: constructorResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:336; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "not authorized" exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 401.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorResponseTest() throws Fault {
+    NotAuthorizedException e = new NotAuthorizedException(
+        buildResponse(STATUS));
+    assertResponse(e, HOST);
+  }
+
+  /*
+   * @testName: constructorResponseThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:336;
+   * 
+   * @test_Strategy: Construct a new "not authorized" exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 401.
+   */
+  @Test
+  public void constructorResponseThrowsExceptionTest() throws Fault {
+    for (Status status : Status.values())
+      if (status != STATUS) {
+        try {
+          NotAuthorizedException e = new NotAuthorizedException(
+              buildResponse(status));
+          fault("IllegalArgumentException has not been thrown for status",
+              status, "and exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been thrown as expected for status",
+              status);
+        }
+      }
+  }
+
+  /*
+   * @testName: constructorThrowableObjectTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:337; JAXRS:JAVADOC:334; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "not authorized" exception.
+   * 
+   * Get the list of authorization challenges associated with the exception and
+   * applicable to the resource requested by the client.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorThrowableObjectTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      NotAuthorizedException e = new NotAuthorizedException(t, CHALLENGE[0],
+          CHALLENGE[1], CHALLENGE[2]);
+      assertResponse(e);
+      assertChallenges(e);
+      assertCause(e, t);
+    }
+  }
+
+  /*
+   * @testName: constructorResponseThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:338; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "not authorized" exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 401. getResponse
+   */
+  @Test
+  public void constructorResponseThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      NotAuthorizedException e = new NotAuthorizedException(
+          buildResponse(STATUS), t);
+      assertResponse(e, HOST);
+      assertCause(e, t);
+    }
+  }
+
+  /*
+   * @testName: constructorResponseThrowableThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:338;
+   * 
+   * @test_Strategy: Construct a new "not authorized" exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 401.
+   */
+  @Test
+  public void constructorResponseThrowableThrowsExceptionTest() throws Fault {
+    for (Status status : Status.values())
+      if (status != STATUS) {
+        try {
+          NotAuthorizedException e = new NotAuthorizedException(
+              buildResponse(status), new Throwable());
+          fault("IllegalArgumentException has not been thrown for status",
+              status, "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been thrown as expected for status",
+              status);
+        }
+      }
+  }
+
+  /*
+   * @testName: constructorStringObjectsTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1083; JAXRS:JAVADOC:334; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "not authorized" exception.
+   * 
+   * Get the list of authorization challenges associated with the exception and
+   * applicable to the resource requested by the client.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringObjectsTest() throws Fault {
+    NotAuthorizedException e = new NotAuthorizedException(MESSAGE,
+        (Object) CHALLENGE[0], CHALLENGE[1], CHALLENGE[2]);
+    assertResponse(e);
+    assertChallenges(e);
+    assertMessage(e);
+  }
+
+  /*
+   * @testName: constructorStringObjectsThrowsNPEWhenNullTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1083;
+   * 
+   * @test_Strategy: Throws: java.lang.NullPointerException - in case the
+   * challenge parameter is null.
+   */
+  @Test
+  public void constructorStringObjectsThrowsNPEWhenNullTest() throws Fault {
+    try {
+      NotAuthorizedException e = new NotAuthorizedException(MESSAGE,
+          (Object) null, CHALLENGE[1], CHALLENGE[2]);
+      fault(
+          "NullPointerException has NOT been thrown as expected for null challenge; exception",
+          e);
+    } catch (NullPointerException npe) {
+      logMsg(
+          "NullPointerException has been thrown as expected for null challenge");
+    }
+  }
+
+  /*
+   * @testName: constructorStringResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1084; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "not authorized" exception.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringResponseTest() throws Fault {
+    NotAuthorizedException e = new NotAuthorizedException(MESSAGE,
+        buildResponse(STATUS));
+    assertResponse(e, HOST);
+    assertMessage(e);
+  }
+
+  /*
+   * @testName: constructorStringResponseThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1084;
+   * 
+   * @test_Strategy: Construct a new "not authorized" exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 401.
+   */
+  @Test
+  public void constructorStringResponseThrowsExceptionTest() throws Fault {
+    for (Status status : Status.values())
+      if (status != STATUS) {
+        try {
+          NotAuthorizedException e = new NotAuthorizedException(MESSAGE,
+              buildResponse(status));
+          fault("IllegalArgumentException has not been thrown for status",
+              status, "and exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been thrown as expected for status",
+              status);
+        }
+      }
+  }
+
+  /*
+   * @testName: constructorStringThrowableObjectsTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1085; JAXRS:JAVADOC:334; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "not authorized" exception.
+   * 
+   * Get the list of authorization challenges associated with the exception and
+   * applicable to the resource requested by the client.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringThrowableObjectsTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      NotAuthorizedException e = new NotAuthorizedException(MESSAGE, t,
+          CHALLENGE[0], CHALLENGE[1], CHALLENGE[2]);
+      assertResponse(e);
+      assertChallenges(e);
+      assertCause(e, t);
+      assertMessage(e);
+    }
+  }
+
+  /*
+   * @testName: constructorStringResponseThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1086; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "not authorized" exception. getResponse
+   */
+  @Test
+  public void constructorStringResponseThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      NotAuthorizedException e = new NotAuthorizedException(MESSAGE,
+          buildResponse(STATUS), t);
+      assertResponse(e, HOST);
+      assertCause(e, t);
+      assertMessage(e);
+    }
+  }
+
+  /*
+   * @testName: constructorStringResponseThrowableThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1086;
+   * 
+   * @test_Strategy: Construct a new "not authorized" exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 401.
+   */
+  @Test
+  public void constructorStringResponseThrowableThrowsIAETest() throws Fault {
+    for (Status status : Status.values())
+      if (status != STATUS) {
+        try {
+          NotAuthorizedException e = new NotAuthorizedException(MESSAGE,
+              buildResponse(status), new Throwable());
+          fault("IllegalArgumentException has not been thrown for status",
+              status, "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been thrown as expected for status",
+              status);
+        }
+      }
+  }
+
+  // /////////////////////////////////////////////////////////////
+  protected Response buildResponse(Status status) {
+    return Response.status(status).header(HttpHeaders.HOST, HOST).build();
+  }
+
+  protected void assertResponse(WebApplicationException e) throws Fault {
+    assertNotNull(e.getResponse(), "#getResponse is null");
+    Response response = e.getResponse();
+    assertEqualsInt(response.getStatus(), STATUS.getStatusCode(),
+        "response cobtains unexpected status", response.getStatus());
+    logMsg("response contains expected", STATUS, "status");
+  }
+
+  /**
+   * Check the given exception contains a prebuilt response containing the http
+   * header HOST
+   */
+  protected void assertResponse(WebApplicationException e, String host)
+      throws Fault {
+    assertResponse(e);
+    String header = e.getResponse().getHeaderString(HttpHeaders.HOST);
+    assertNotNull(header, "http header", HttpHeaders.HOST,
+        " of response is null");
+    assertEquals(host, header, "Found unexpected http", HttpHeaders.HOST,
+        "header", header);
+    logMsg("Found expected http", HttpHeaders.HOST, "header");
+  }
+
+  protected void assertCause(WebApplicationException e, Throwable expected)
+      throws Fault {
+    assertEquals(e.getCause(), expected, "#getCause does not contain expected",
+        expected, "but", e.getCause());
+    logMsg("getCause contains expected", expected);
+  }
+
+  protected void assertChallenges(NotAuthorizedException e) throws Fault {
+    List<Object> challenges = e.getChallenges();
+    String list = JaxrsUtil.iterableToString(";", challenges);
+    assertContains(list, CHALLENGE[0], "Challenge", CHALLENGE[0],
+        "not found in", list);
+    assertContains(list, CHALLENGE[1], "Challenge", CHALLENGE[1],
+        "not found in", list);
+    assertContains(list, CHALLENGE[2], "Challenge", CHALLENGE[2],
+        "not found in", list);
+  }
+
+  protected void assertMessage(NotAuthorizedException e) throws Fault {
+    assertNotNull(e.getMessage(), "getMessage() is null");
+    assertContains(e.getMessage(), MESSAGE, "Unexpected getMessage()",
+        e.getMessage());
+    logMsg("found expected getMessage()=", e.getMessage());
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/notfoundexception/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/notfoundexception/JAXRSClientIT.java
@@ -1,0 +1,350 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.notfoundexception;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = -7425306771761061203L;
+
+  private static final Status STATUS = Status.NOT_FOUND;
+
+  protected static final String MESSAGE = "TCK NotFoundException description";
+
+  protected static final String HOST = "www.jcp.org";
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  /*
+   * @testName: constructorTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:339; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "not found" exception.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorTest() throws Fault {
+    NotFoundException e = new NotFoundException();
+    assertResponse(e);
+  }
+
+  /*
+   * @testName: constructorResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:340; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "not found" exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 404.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorResponseTest() throws Fault {
+    NotFoundException e = new NotFoundException(buildResponse(STATUS));
+    assertResponse(e, HOST);
+  }
+
+  /*
+   * @testName: constructorResponseThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:340;
+   * 
+   * @test_Strategy: Construct a new "not found" exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 404.
+   */
+  @Test
+  public void constructorResponseThrowsExceptionTest() throws Fault {
+    for (Status status : Status.values())
+      if (status != STATUS) {
+        try {
+          NotFoundException e = new NotFoundException(buildResponse(status));
+          fault("IllegalArgumentException has not been thrown for status",
+              status, "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been thrown as expected for status",
+              status);
+        }
+      }
+  }
+
+  /*
+   * @testName: constructorThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:341; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "not found" exception.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      NotFoundException e = new NotFoundException(t);
+      assertResponse(e);
+      assertCause(e, t);
+    }
+  }
+
+  /*
+   * @testName: constructorResponseThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:342; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "not found" exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 404. getResponse
+   */
+  @Test
+  public void constructorResponseThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      NotFoundException e = new NotFoundException(buildResponse(STATUS), t);
+      assertResponse(e, HOST);
+      assertCause(e, t);
+    }
+  }
+
+  /*
+   * @testName: constructorResponseThrowableThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:342;
+   * 
+   * @test_Strategy: Construct a new "not found" exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 404.
+   */
+  @Test
+  public void constructorResponseThrowableThrowsExceptionTest() throws Fault {
+    for (Status status : Status.values())
+      if (status != STATUS) {
+        try {
+          NotFoundException e = new NotFoundException(buildResponse(status),
+              new Throwable());
+          fault("IllegalArgumentException has not been thrown for status",
+              status, "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been thrown as expected for status",
+              status);
+        }
+      }
+  }
+
+  /*
+   * @testName: constructorStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1087; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "not found" exception.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringTest() throws Fault {
+    NotFoundException e = new NotFoundException(MESSAGE);
+    assertResponse(e);
+    assertMessage(e);
+  }
+
+  /*
+   * @testName: constructorStringResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1088; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "not found" exception.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringResponseTest() throws Fault {
+    NotFoundException e = new NotFoundException(MESSAGE, buildResponse(STATUS));
+    assertResponse(e, HOST);
+    assertMessage(e);
+  }
+
+  /*
+   * @testName: constructorStringResponseThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1088;
+   * 
+   * @test_Strategy: Construct a new "not found" exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 404.
+   */
+  @Test
+  public void constructorStringResponseThrowsIAETest() throws Fault {
+    for (Status status : Status.values())
+      if (status != STATUS) {
+        try {
+          NotFoundException e = new NotFoundException(MESSAGE,
+              buildResponse(status));
+          fault("IllegalArgumentException has not been thrown for status",
+              status, "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been thrown as expected for status",
+              status);
+        }
+      }
+  }
+
+  /*
+   * @testName: constructorStringThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1089; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "not found" exception.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      NotFoundException e = new NotFoundException(MESSAGE, t);
+      assertResponse(e);
+      assertCause(e, t);
+      assertMessage(e);
+    }
+  }
+
+  /*
+   * @testName: constructorStringResponseThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1090; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "not found" exception. getResponse
+   */
+  @Test
+  public void constructorStringResponseThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      NotFoundException e = new NotFoundException(MESSAGE,
+          buildResponse(STATUS), t);
+      assertResponse(e, HOST);
+      assertCause(e, t);
+      assertMessage(e);
+    }
+  }
+
+  /*
+   * @testName: constructorStringResponseThrowableThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1090;
+   * 
+   * @test_Strategy: Construct a new "not found" exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 404.
+   */
+  @Test
+  public void constructorStringResponseThrowableThrowsExceptionTest()
+      throws Fault {
+    for (Status status : Status.values())
+      if (status != STATUS) {
+        try {
+          NotFoundException e = new NotFoundException(MESSAGE,
+              buildResponse(status), new Throwable());
+          fault("IllegalArgumentException has not been thrown for status",
+              status, "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been thrown as expected for status",
+              status);
+        }
+      }
+  }
+
+  // /////////////////////////////////////////////////////////////
+  protected Response buildResponse(Status status) {
+    return Response.status(status).header(HttpHeaders.HOST, HOST).build();
+  }
+
+  protected void assertResponse(WebApplicationException e) throws Fault {
+    assertNotNull(e.getResponse(), "#getResponse is null");
+    Response response = e.getResponse();
+    assertEqualsInt(response.getStatus(), STATUS.getStatusCode(),
+        "response contains unexpected status", response.getStatus());
+    logMsg("response contains expected", STATUS, "status");
+  }
+
+  /**
+   * Check the given exception contains a prebuilt response containing the http
+   * header HOST
+   */
+  protected void assertResponse(WebApplicationException e, String host)
+      throws Fault {
+    assertResponse(e);
+    String header = e.getResponse().getHeaderString(HttpHeaders.HOST);
+    assertNotNull(header, "http header", HttpHeaders.HOST,
+        " of response is null");
+    assertEquals(host, header, "Found unexpected http", HttpHeaders.HOST,
+        "header", header);
+    logMsg("Found expected http", HttpHeaders.HOST, "header");
+  }
+
+  protected void assertCause(WebApplicationException e, Throwable expected)
+      throws Fault {
+    assertEquals(e.getCause(), expected, "#getCause does not contain expected",
+        expected, "but", e.getCause());
+    logMsg("getCause contains expected", expected);
+  }
+
+  protected void assertMessage(WebApplicationException e) throws Fault {
+    assertNotNull(e.getMessage(), "getMessage() is null");
+    assertContains(e.getMessage(), MESSAGE, "Unexpected getMessage()",
+        e.getMessage());
+    logMsg("found expected getMessage()=", e.getMessage());
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/notsupportedexception/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/notsupportedexception/JAXRSClientIT.java
@@ -1,0 +1,343 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.notsupportedexception;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.NotSupportedException;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = 3399264566368839087L;
+
+  private static final Status STATUS = Status.UNSUPPORTED_MEDIA_TYPE;
+
+  protected static final String MESSAGE = "TCK NotSupportedException description";
+
+  protected static final String HOST = "www.jcp.org";
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  /*
+   * @testName: constructorTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:343; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new unsupported media type exception.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorTest() throws Fault {
+    NotSupportedException e = new NotSupportedException();
+    assertResponse(e);
+  }
+
+  /*
+   * @testName: constructorResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:344; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new unsupported media type exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 415.
+   * 
+   * getResponse
+   */
+  public void constructorResponseTest() throws Fault {
+    NotSupportedException e = new NotSupportedException(buildResponse(STATUS));
+    assertResponse(e, HOST);
+  }
+
+  /*
+   * @testName: constructorResponseThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:344;
+   * 
+   * @test_Strategy: Construct a new unsupported media type exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 415.
+   */
+  public void constructorResponseThrowsExceptionTest() throws Fault {
+    for (Status status : Status.values())
+      if (status != STATUS) {
+        try {
+          NotSupportedException e = new NotSupportedException(
+              buildResponse(status));
+          fault("IllegalArgumentException has not been thrown for status",
+              status, "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been thrown as expected for status",
+              status);
+        }
+      }
+  }
+
+  /*
+   * @testName: constructorThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:345; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new unsupported media type exception.
+   * 
+   * getResponse
+   */
+  public void constructorThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      NotSupportedException e = new NotSupportedException(t);
+      assertResponse(e);
+      assertCause(e, t);
+    }
+  }
+
+  /*
+   * @testName: constructorResponseThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:346; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new unsupported media type exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 415. getResponse
+   */
+  public void constructorResponseThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      NotSupportedException e = new NotSupportedException(buildResponse(STATUS),
+          t);
+      assertResponse(e, HOST);
+      assertCause(e, t);
+    }
+  }
+
+  /*
+   * @testName: constructorResponseThrowableThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:346;
+   * 
+   * @test_Strategy: Construct a new unsupported media type exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 415.
+   */
+  public void constructorResponseThrowableThrowsExceptionTest() throws Fault {
+    for (Status status : Status.values())
+      if (status != STATUS) {
+        try {
+          NotSupportedException e = new NotSupportedException(
+              buildResponse(status), new Throwable());
+          fault("IllegalArgumentException has not been thrown for status",
+              status, "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been thrown as expected for status",
+              status);
+        }
+      }
+  }
+
+  /*
+   * @testName: constructorStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1091; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new unsupported media type exception.
+   * 
+   * getResponse
+   */
+  public void constructorStringTest() throws Fault {
+    NotSupportedException e = new NotSupportedException(MESSAGE);
+    assertResponse(e);
+    assertMessage(e);
+  }
+
+  /*
+   * @testName: constructorStringResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1092; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new unsupported media type exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 415.
+   * 
+   * getResponse
+   */
+  public void constructorStringResponseTest() throws Fault {
+    NotSupportedException e = new NotSupportedException(MESSAGE,
+        buildResponse(STATUS));
+    assertResponse(e, HOST);
+    assertMessage(e);
+  }
+
+  /*
+   * @testName: constructorStringResponseThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1092;
+   * 
+   * @test_Strategy: Construct a new unsupported media type exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 415.
+   */
+  public void constructorStringResponseThrowsIAETest() throws Fault {
+    for (Status status : Status.values())
+      if (status != STATUS) {
+        try {
+          NotSupportedException e = new NotSupportedException(MESSAGE,
+              buildResponse(status));
+          fault("IllegalArgumentException has not been thrown for status",
+              status, "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been thrown as expected for status",
+              status);
+        }
+      }
+  }
+
+  /*
+   * @testName: constructorStringThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1093; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new unsupported media type exception.
+   * 
+   * getResponse
+   */
+  public void constructorStringThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      NotSupportedException e = new NotSupportedException(MESSAGE, t);
+      assertResponse(e);
+      assertCause(e, t);
+      assertMessage(e);
+    }
+  }
+
+  /*
+   * @testName: constructorStringResponseThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1094; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new unsupported media type exception.
+   * getResponse
+   */
+  public void constructorStringResponseThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      NotSupportedException e = new NotSupportedException(MESSAGE,
+          buildResponse(STATUS), t);
+      assertResponse(e, HOST);
+      assertCause(e, t);
+      assertMessage(e);
+    }
+  }
+
+  /*
+   * @testName: constructorStringResponseThrowableThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1094;
+   * 
+   * @test_Strategy: Construct a new unsupported media type exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 415.
+   */
+  public void constructorStringResponseThrowableThrowsIAETest() throws Fault {
+    for (Status status : Status.values())
+      if (status != STATUS) {
+        try {
+          NotSupportedException e = new NotSupportedException(MESSAGE,
+              buildResponse(status), new Throwable());
+          fault("IllegalArgumentException has not been thrown for status",
+              status, "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been thrown as expected for status",
+              status);
+        }
+      }
+  }
+
+  // /////////////////////////////////////////////////////////////
+  protected Response buildResponse(Status status) {
+    return Response.status(status).header(HttpHeaders.HOST, HOST).build();
+  }
+
+  protected void assertResponse(WebApplicationException e) throws Fault {
+    assertNotNull(e.getResponse(), "#getResponse is null");
+    Response response = e.getResponse();
+    assertEqualsInt(response.getStatus(), STATUS.getStatusCode(),
+        "response contains unexpected status", response.getStatus());
+    logMsg("response contains expected", STATUS, "status");
+  }
+
+  /**
+   * Check the given exception contains a prebuilt response containing the http
+   * header HOST
+   */
+  protected void assertResponse(WebApplicationException e, String host)
+      throws Fault {
+    assertResponse(e);
+    String header = e.getResponse().getHeaderString(HttpHeaders.HOST);
+    assertNotNull(header, "http header", HttpHeaders.HOST,
+        " of response is null");
+    assertEquals(host, header, "Found unexpected http", HttpHeaders.HOST,
+        "header", header);
+    logMsg("Found expected http", HttpHeaders.HOST, "header");
+  }
+
+  protected void assertCause(WebApplicationException e, Throwable expected)
+      throws Fault {
+    assertEquals(e.getCause(), expected, "#getCause does not contain expected",
+        expected, "but", e.getCause());
+    logMsg("getCause contains expected", expected);
+  }
+
+  protected void assertMessage(WebApplicationException e) throws Fault {
+    assertNotNull(e.getMessage(), "getMessage() is null");
+    assertContains(e.getMessage(), MESSAGE, "Unexpected getMessage()",
+        e.getMessage());
+    logMsg("found expected getMessage()=", e.getMessage());
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/processingexception/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/processingexception/JAXRSClientIT.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.processingexception;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.ProcessingException;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = -9156519616224592459L;
+
+  public JAXRSClientIT() {
+    setContextRoot("/jaxrs_api_rs_processingexception_web");
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  /*
+   * @testName: constructorWithRuntimeExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1010;
+   * 
+   * @test_Strategy: Constructs a new JAX-RS runtime processing exception with
+   * the specified cause and a detail message of (cause==null ? null :
+   * cause.toString())
+   */
+  @Test
+  public void constructorWithRuntimeExceptionTest() throws Fault {
+    IllegalStateException ile = new IllegalStateException("TCK exception");
+    ProcessingException mpe = new ProcessingException(ile);
+    assertTrue(mpe.getCause().equals(ile),
+        "getCause does not work for ProcessingException and RuntimeException cause");
+    assertTrue(mpe.getMessage().equals(ile.toString()),
+        "getMessage does not work for ProcessingException and RuntimeException cause");
+  }
+
+  /*
+   * @testName: constructorWithCheckedExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1010;
+   * 
+   * @test_Strategy: Constructs a new JAX-RS runtime processing exception with
+   * the specified cause and a detail message of (cause==null ? null :
+   * cause.toString())
+   */
+  @Test
+  public void constructorWithCheckedExceptionTest() throws Fault {
+    IOException ioe = new IOException("TCK exception");
+    ProcessingException mpe = new ProcessingException(ioe);
+    assertTrue(mpe.getCause().equals(ioe),
+        "getCause does not work for ProcessingException and CheckedException cause");
+    assertTrue(mpe.getMessage().equals(ioe.toString()),
+        "getMessage does not work for ProcessingException and CheckedException cause");
+  }
+
+  /*
+   * @testName: constructorWithNullThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1010;
+   * 
+   * @test_Strategy: Constructs a new JAX-RS runtime processing exception with
+   * the specified cause and a detail message of (cause==null ? null :
+   * cause.toString())
+   */
+  @Test
+  public void constructorWithNullThrowableTest() throws Fault {
+    ProcessingException mpe = new ProcessingException((Throwable) null);
+    assertTrue(mpe.getCause() == null,
+        "getCause does not work for ProcessingException and null cause");
+    assertTrue(mpe.getMessage() == null,
+        "getMessage does not work for ProcessingException and null cause");
+  }
+
+  /*
+   * @testName: constructorWithNullThrowableNullMessageTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1011;
+   * 
+   * @test_Strategy: Constructs a new JAX-RS runtime processing exception with
+   * the specified detail message and cause.
+   */
+  @Test
+  public void constructorWithNullThrowableNullMessageTest() throws Fault {
+    ProcessingException mpe = new ProcessingException((String) null,
+        (Throwable) null);
+    assertTrue(mpe.getCause() == null,
+        "getCause does not work for ProcessingException and null cause and null message");
+    assertTrue(mpe.getMessage() == null,
+        "getMessage does not work for ProcessingException and null cause and null message");
+  }
+
+  /*
+   * @testName: constructorWithNullThrowableNotNullMessageTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1011;
+   * 
+   * @test_Strategy: Constructs a new JAX-RS runtime processing exception with
+   * the specified detail message and cause.
+   */
+  @Test
+  public void constructorWithNullThrowableNotNullMessageTest() throws Fault {
+    String msg = "TCK Message";
+    ProcessingException mpe = new ProcessingException(msg, (Throwable) null);
+    assertTrue(mpe.getCause() == null,
+        "getCause does not work for ProcessingException and null cause and not null message");
+    assertTrue(mpe.getMessage().equals(msg),
+        "getMessage does not work for ProcessingException and null cause and not null message");
+  }
+
+  /*
+   * @testName: constructorWithRuntimeExceptionNullMessageTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1011;
+   * 
+   * @test_Strategy: Constructs a new JAX-RS runtime processing exception with
+   * the specified detail message and cause.
+   */
+  @Test
+  public void constructorWithRuntimeExceptionNullMessageTest() throws Fault {
+    IllegalStateException ise = new IllegalStateException(
+        "JAXRS TCK exception");
+    ProcessingException mpe = new ProcessingException((String) null, ise);
+    assertTrue(mpe.getCause().equals(ise),
+        "getCause does not work for ProcessingException and RuntimeException and null message");
+    assertTrue(mpe.getMessage() == null,
+        "getMessage does not work for ProcessingException and RuntimeException and null message");
+  }
+
+  /*
+   * @testName: constructorWithCheckedExceptionNullMessageTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1011;
+   * 
+   * @test_Strategy: Constructs a new JAX-RS runtime processing exception with
+   * the specified detail message and cause.
+   */
+  @Test
+  public void constructorWithCheckedExceptionNullMessageTest() throws Fault {
+    IOException ioe = new IOException("JAXRS TCK exception");
+    ProcessingException mpe = new ProcessingException((String) null, ioe);
+    assertTrue(mpe.getCause().equals(ioe),
+        "getCause does not work for ProcessingException and CheckedException and null message");
+    assertTrue(mpe.getMessage() == null,
+        "getMessage does not work for ProcessingException and CheckedException and null message");
+  }
+
+  /*
+   * @testName: constructorWithRuntimeExceptionAndNotNullMessageTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1011;
+   * 
+   * @test_Strategy: Constructs a new JAX-RS runtime processing exception with
+   * the specified detail message and cause.
+   */
+  @Test
+  public void constructorWithRuntimeExceptionAndNotNullMessageTest()
+      throws Fault {
+    String msg = "TCK Message";
+    IllegalStateException ise = new IllegalStateException(
+        "JAXRS TCK exception");
+    ProcessingException mpe = new ProcessingException(msg, ise);
+    assertTrue(mpe.getCause().equals(ise),
+        "getCause does not work for ProcessingException and RuntimeException and not null message");
+    assertTrue(mpe.getMessage().equals(msg),
+        "getMessage does not work for ProcessingException and RuntimeException and not null message");
+  }
+
+  /*
+   * @testName: constructorWithCheckedExceptionAndNotNullMessageTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1011;
+   * 
+   * @test_Strategy: Constructs a new JAX-RS runtime processing exception with
+   * the specified detail message and cause.
+   */
+  @Test
+  public void constructorWithCheckedExceptionAndNotNullMessageTest()
+      throws Fault {
+    String msg = "TCK Message";
+    IOException ioe = new IOException("JAXRS TCK exception");
+    ProcessingException mpe = new ProcessingException(msg, ioe);
+    assertTrue(mpe.getCause().equals(ioe),
+        "getCause does not work for ProcessingException and CheckedException and not null message");
+    assertTrue(mpe.getMessage().equals(msg),
+        "getMessage does not work for ProcessingException and CheckedException and not null message");
+  }
+
+  /*
+   * @testName: constructorWithNotNullMessageTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1012;
+   * 
+   * @test_Strategy: Constructs a new JAX-RS runtime processing exception with
+   * the specified detail message.
+   */
+  @Test
+  public void constructorWithNotNullMessageTest() throws Fault {
+    String msg = "TCK Message";
+    ProcessingException mpe = new ProcessingException(msg);
+    assertTrue(mpe.getCause() == null,
+        "getCause does not work for ProcessingException and not null message");
+    assertTrue(mpe.getMessage().equals(msg),
+        "getMessage does not work for ProcessingException and not null message");
+  }
+
+  /*
+   * @testName: constructorWithNullMessageTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1012;
+   * 
+   * @test_Strategy: Constructs a new JAX-RS runtime processing exception with
+   * the specified detail message.
+   */
+  @Test
+  public void constructorWithNullMessageTest() throws Fault {
+    ProcessingException mpe = new ProcessingException((String) null);
+    assertTrue(mpe.getCause() == null,
+        "getCause does not work for ProcessingException and null message");
+    assertTrue(mpe.getMessage() == null,
+        "getMessage does not work for ProcessingException and null message");
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/redirectexception/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/redirectexception/JAXRSClientIT.java
@@ -1,0 +1,503 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.redirectexception;
+
+import java.net.URI;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.RedirectionException;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = 1351456637402581583L;
+
+  public static final Status.Family FAMILY = Status.Family.REDIRECTION;
+
+  protected static final String MESSAGE = "TCK RedirectionException description";
+
+  protected static final String HOST = "www.jcp.org";
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  /*
+   * @testName: constructorStatusUriTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:348; JAXRS:JAVADOC:347; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new redirection exception.
+   * java.lang.IllegalArgumentException - in case the status code is null or is
+   * not from Response.Status.Family.REDIRECTION status code family.
+   * 
+   * Get the redirection response location.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStatusUriTest() throws Fault {
+    for (Status status : getStatusesFromFamily()) {
+      RedirectionException e = new RedirectionException(status, LOCATION);
+      assertResponse(e, status);
+      assertLocation(e, LOCATION);
+    }
+  }
+
+  /*
+   * @testName: constructorStatusUriThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:348;
+   * 
+   * @test_Strategy: Construct a new redirection exception.
+   * java.lang.IllegalArgumentException - in case the status code is null or is
+   * not from Response.Status.Family.REDIRECTION status code family.
+   */
+  @Test
+  public void constructorStatusUriThrowsExceptionTest() throws Fault {
+    for (Status status : getStatusesOutsideFamily()) {
+      try {
+        RedirectionException e = new RedirectionException(status, LOCATION);
+        fault("IllegalArgumentException has not been thrown for status", status,
+            "; exception", e);
+      } catch (IllegalArgumentException e) {
+        logMsg(
+            "IllegalArgumentException has been thrown as expected for status",
+            status);
+      }
+    }
+  }
+
+  /*
+   * @testName: constructorStatusNullUriThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:348;
+   * 
+   * @test_Strategy: Construct a new redirection exception.
+   * java.lang.IllegalArgumentException - in case the status code is null or is
+   * not from Response.Status.Family.REDIRECTION status code family.
+   */
+  @Test
+  public void constructorStatusNullUriThrowsExceptionTest() throws Fault {
+    try {
+      RedirectionException e = new RedirectionException((Status) null,
+          LOCATION);
+      fault("IllegalArgumentException has not been thrown for null status",
+          "; exception", e);
+    } catch (IllegalArgumentException e) {
+      logMsg(
+          "IllegalArgumentException has been thrown as expected for null status");
+    }
+  }
+
+  /*
+   * @testName: constructorIntUriTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:349; JAXRS:JAVADOC:347; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new redirection exception.
+   * java.lang.IllegalArgumentException - in case the status code is not a valid
+   * HTTP status code or is not from Response.Status.Family.REDIRECTION status
+   * code family.
+   * 
+   * Get the redirection response location.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorIntUriTest() throws Fault {
+    for (Status status : getStatusesFromFamily()) {
+      RedirectionException e = new RedirectionException(status.getStatusCode(),
+          LOCATION);
+      assertResponse(e, status);
+      assertLocation(e, LOCATION);
+    }
+  }
+
+  /*
+   * @testName: constructorIntUriThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:349;
+   * 
+   * @test_Strategy: Construct a new redirection exception.
+   * java.lang.IllegalArgumentException - in case the status code is not a valid
+   * HTTP status code or is not from Response.Status.Family.REDIRECTION status
+   * code family.
+   */
+  @Test
+  public void constructorIntUriThrowsExceptionTest() throws Fault {
+    for (Status status : getStatusesOutsideFamily()) {
+      try {
+        RedirectionException e = new RedirectionException(
+            status.getStatusCode(), LOCATION);
+        fault("IllegalArgumentException has not been thrown for status", status,
+            "; exception", e);
+      } catch (IllegalArgumentException e) {
+        logMsg(
+            "IllegalArgumentException has been thrown as expected for status",
+            status);
+      }
+    }
+  }
+
+  /*
+   * @testName: constructorIntNotValidStatusThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:349;
+   * 
+   * @test_Strategy: Construct a new server error exception.
+   * java.lang.IllegalArgumentException - in case the status code is not a valid
+   * HTTP status code or is not from Response.Status.Family.REDIRECTION status
+   * code family.
+   */
+  @Test
+  public void constructorIntNotValidStatusThrowsExceptionTest() throws Fault {
+    for (int status : new int[] { -1, Integer.MAX_VALUE, Integer.MIN_VALUE }) {
+      try {
+        RedirectionException e = new RedirectionException(status, LOCATION);
+        fault("IllegalArgumentException has not been thrown for status", status,
+            "; exception", e);
+      } catch (IllegalArgumentException e) {
+        logMsg(
+            "IllegalArgumentException has been thrown as expected for status",
+            status);
+      }
+    }
+  }
+
+  /*
+   * @testName: constructorResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:350; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new redirection exception.
+   * java.lang.IllegalArgumentException - in case the response status code is
+   * not from the Response.Status.Family.REDIRECTION status code family.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorResponseTest() throws Fault {
+    for (Status status : getStatusesFromFamily()) {
+      RedirectionException e = new RedirectionException(buildResponse(status));
+      assertResponse(e, status, HOST);
+    }
+  }
+
+  /*
+   * @testName: constructorResponseThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:350;
+   * 
+   * @test_Strategy: Construct a new redirection exception.
+   * java.lang.IllegalArgumentException - in case the response status code is
+   * not from the Response.Status.Family.REDIRECTION status code family.
+   */
+  @Test
+  public void constructorResponseThrowsExceptionTest() throws Fault {
+    for (Status status : getStatusesOutsideFamily())
+      try {
+        RedirectionException e = new RedirectionException(
+            buildResponse(status));
+        fault("IllegalArgumentException has not been thrown for status", status,
+            "; exception", e);
+      } catch (IllegalArgumentException e) {
+        logMsg(
+            "IllegalArgumentException has been thrown as expected for status",
+            status);
+      }
+  }
+
+  /*
+   * @testName: constructorStringStatusUriTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1095; JAXRS:JAVADOC:347; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new redirection exception.
+   * java.lang.IllegalArgumentException - in case the status code is null or is
+   * not from Response.Status.Family.REDIRECTION status code family.
+   * 
+   * Get the redirection response location.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringStatusUriTest() throws Fault {
+    for (Status status : getStatusesFromFamily()) {
+      RedirectionException e = new RedirectionException(MESSAGE, status,
+          LOCATION);
+      assertResponse(e, status);
+      assertLocation(e, LOCATION);
+      assertMessage(e);
+    }
+  }
+
+  /*
+   * @testName: constructorStringStatusUriThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1095;
+   * 
+   * @test_Strategy: Construct a new redirection exception.
+   * java.lang.IllegalArgumentException - in case the status code is null or is
+   * not from Response.Status.Family.REDIRECTION status code family.
+   */
+  @Test
+  public void constructorStringStatusUriThrowsIAETest() throws Fault {
+    for (Status status : getStatusesOutsideFamily()) {
+      try {
+        RedirectionException e = new RedirectionException(MESSAGE, status,
+            LOCATION);
+        fault("IllegalArgumentException has not been thrown for status", status,
+            "; exception", e);
+      } catch (IllegalArgumentException e) {
+        logMsg(
+            "IllegalArgumentException has been thrown as expected for status",
+            status);
+      }
+    }
+  }
+
+  /*
+   * @testName: constructorStringStatusNullUriThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1095;
+   * 
+   * @test_Strategy: Construct a new redirection exception.
+   * java.lang.IllegalArgumentException - in case the status code is null or is
+   * not from Response.Status.Family.REDIRECTION status code family.
+   */
+  @Test
+  public void constructorStringStatusNullUriThrowsIAETest() throws Fault {
+    try {
+      RedirectionException e = new RedirectionException(MESSAGE, (Status) null,
+          LOCATION);
+      fault("IllegalArgumentException has not been thrown for null status",
+          "; exception", e);
+    } catch (IllegalArgumentException e) {
+      logMsg(
+          "IllegalArgumentException has been thrown as expected for null status");
+    }
+  }
+
+  /*
+   * @testName: constructorStringIntUriTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1096; JAXRS:JAVADOC:347; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new redirection exception.
+   * java.lang.IllegalArgumentException - in case the status code is not a valid
+   * HTTP status code or is not from Response.Status.Family.REDIRECTION status
+   * code family.
+   * 
+   * Get the redirection response location.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringIntUriTest() throws Fault {
+    for (Status status : getStatusesFromFamily()) {
+      RedirectionException e = new RedirectionException(MESSAGE,
+          status.getStatusCode(), LOCATION);
+      assertResponse(e, status);
+      assertLocation(e, LOCATION);
+      assertMessage(e);
+    }
+  }
+
+  /*
+   * @testName: constructorStringIntUriThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1096;
+   * 
+   * @test_Strategy: Construct a new redirection exception.
+   * java.lang.IllegalArgumentException - in case the status code is not a valid
+   * HTTP status code or is not from Response.Status.Family.REDIRECTION status
+   * code family.
+   */
+  @Test
+  public void constructorStringIntUriThrowsIAETest() throws Fault {
+    for (Status status : getStatusesOutsideFamily()) {
+      try {
+        RedirectionException e = new RedirectionException(MESSAGE,
+            status.getStatusCode(), LOCATION);
+        fault("IllegalArgumentException has not been thrown for status", status,
+            "; exception", e);
+      } catch (IllegalArgumentException e) {
+        logMsg(
+            "IllegalArgumentException has been thrown as expected for status",
+            status);
+      }
+    }
+  }
+
+  /*
+   * @testName: constructorStringIntNotValidStatusThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1096;
+   * 
+   * @test_Strategy: Construct a new server error exception.
+   * java.lang.IllegalArgumentException - in case the status code is not a valid
+   * HTTP status code or is not from Response.Status.Family.REDIRECTION status
+   * code family.
+   */
+  @Test
+  public void constructorStringIntNotValidStatusThrowsIAETest() throws Fault {
+    for (int status : new int[] { -1, Integer.MAX_VALUE, Integer.MIN_VALUE }) {
+      try {
+        RedirectionException e = new RedirectionException(MESSAGE, status,
+            LOCATION);
+        fault("IllegalArgumentException has not been thrown for status", status,
+            "; exception", e);
+      } catch (IllegalArgumentException e) {
+        logMsg(
+            "IllegalArgumentException has been thrown as expected for status",
+            status);
+      }
+    }
+  }
+
+  /*
+   * @testName: constructorStringResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1097; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new redirection exception.
+   * java.lang.IllegalArgumentException - in case the response status code is
+   * not from the Response.Status.Family.REDIRECTION status code family.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringResponseTest() throws Fault {
+    for (Status status : getStatusesFromFamily()) {
+      RedirectionException e = new RedirectionException(MESSAGE,
+          buildResponse(status));
+      assertResponse(e, status, HOST);
+      assertMessage(e);
+    }
+  }
+
+  /*
+   * @testName: constructorStringResponseThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1097;
+   * 
+   * @test_Strategy: Construct a new redirection exception.
+   * java.lang.IllegalArgumentException - in case the response status code is
+   * not from the Response.Status.Family.REDIRECTION status code family.
+   */
+  @Test
+  public void constructorStringResponseThrowsIAETest() throws Fault {
+    for (Status status : getStatusesOutsideFamily())
+      try {
+        RedirectionException e = new RedirectionException(MESSAGE,
+            buildResponse(status));
+        fault("IllegalArgumentException has not been thrown for status", status,
+            "; exception", e);
+      } catch (IllegalArgumentException e) {
+        logMsg(
+            "IllegalArgumentException has been thrown as expected for status",
+            status);
+      }
+  }
+
+  // /////////////////////////////////////////////////////////////
+  protected Response buildResponse(Status status) {
+    return Response.status(status).header(HttpHeaders.HOST, HOST).build();
+  }
+
+  protected static void assertResponse(WebApplicationException e, Status status)
+      throws Fault {
+    assertNotNull(e.getResponse(), "#getResponse is null");
+    Response response = e.getResponse();
+    assertEqualsInt(response.getStatus(), status.getStatusCode(),
+        "response contains unexpected status", response.getStatus());
+    logMsg("response contains expected", status, "status");
+  }
+
+  /**
+   * Check the given exception contains a prebuilt response containing the http
+   * header HOST
+   */
+  protected void assertResponse(WebApplicationException e, Status status,
+      String host) throws Fault {
+    assertResponse(e, status);
+    String header = e.getResponse().getHeaderString(HttpHeaders.HOST);
+    assertNotNull(header, "http header", HttpHeaders.HOST,
+        " of response is null");
+    assertEquals(host, header, "Found unexpected http", HttpHeaders.HOST,
+        "header", header);
+    logMsg("Found expected http", HttpHeaders.HOST, "header");
+  }
+
+  protected static void assertLocation(RedirectionException e, URI expected)
+      throws Fault {
+    URI location = e.getLocation();
+    assertEquals(location, expected, "#getLocation()={", location,
+        "} differs from expected", expected);
+    logMsg("Found expected location", location);
+  }
+
+  protected static List<Status> getStatusesFromFamily() {
+    List<Status> list = new LinkedList<Status>();
+    for (Status status : Status.values())
+      if (Status.Family.familyOf(status.getStatusCode()).equals(FAMILY))
+        list.add(status);
+    return list;
+  }
+
+  protected static List<Status> getStatusesOutsideFamily() {
+    List<Status> list = new LinkedList<Status>();
+    for (Status status : Status.values())
+      if (!Status.Family.familyOf(status.getStatusCode()).equals(FAMILY))
+        list.add(status);
+    return list;
+  }
+
+  protected void assertMessage(WebApplicationException e) throws Fault {
+    assertNotNull(e.getMessage(), "getMessage() is null");
+    assertContains(e.getMessage(), MESSAGE, "Unexpected getMessage()",
+        e.getMessage());
+    logMsg("found expected getMessage()=", e.getMessage());
+  }
+
+  protected static final URI LOCATION = URI
+      .create("http://oracle.com:888/" + FAMILY + "test");
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/runtimetype/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/runtimetype/JAXRSClientIT.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.runtimetype;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.RuntimeType;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+  private static final long serialVersionUID = -2994744934835260890L;
+
+  final static String[] names = { "CLIENT", "SERVER" };
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  /*
+   * @testName: valueOfTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:974;
+   * 
+   * @test_Strategy: Test valueOf method
+   */
+  @Test
+  public void valueOfTest() throws Fault {
+    assertEqualsInt(RuntimeType.values().length, 2,
+        "Unexpected number of values of RuntimeType enum");
+    RuntimeType type = RuntimeType.valueOf(names[0]);
+    assertEquals(RuntimeType.CLIENT, type, "Unexpected RuntimeType", type);
+    logMsg("#valueOf(", names[0], ") equals", type, "as expected");
+
+    type = RuntimeType.valueOf(names[1]);
+    assertEquals(RuntimeType.SERVER, type, "Unexpected RuntimeType", type);
+    logMsg("#valueOf(", names[1], ") equals", type, "as expected");
+  }
+
+  /*
+   * @testName: valuesTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:975;
+   * 
+   * @test_Strategy: Test values method
+   */
+  @Test
+  public void valuesTest() throws Fault {
+    RuntimeType[] types = RuntimeType.values();
+    assertEqualsInt(types.length, 2,
+        "Unexpected number of values of RuntimeType enum");
+
+    String[] dynamicNames = { types[0].name(), types[1].name() };
+    String singleDynamicName = dynamicNames[0] + ", " + dynamicNames[1];
+
+    for (String name : names) {
+      assertContains(singleDynamicName, name, name,
+          "has unexpectedly not found in list", singleDynamicName);
+      logMsg("Found", name, "in valus()", singleDynamicName);
+    }
+
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/servererrorexception/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/servererrorexception/JAXRSClientIT.java
@@ -1,0 +1,869 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.servererrorexception;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.ServerErrorException;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = -143670490120851422L;
+
+  public static final Status.Family FAMILY = Status.Family.SERVER_ERROR;
+
+  protected static final String MESSAGE = "TCK ServerErrorException description";
+
+  protected static final String HOST = "www.jcp.org";
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  /*
+   * @testName: constructorStatusTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:351; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new server error exception.
+   * java.lang.IllegalArgumentException - in case the status code is null or is
+   * not from Response.Status.Family.SERVER_ERROR status code family.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStatusTest() throws Fault {
+    for (Status status : getStatusesFromFamily()) {
+      ServerErrorException e = new ServerErrorException(status);
+      assertResponse(e, status);
+    }
+  }
+
+  /*
+   * @testName: constructorStatusThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:351;
+   * 
+   * @test_Strategy: Construct a new server error exception.
+   * java.lang.IllegalArgumentException - in case the status code is null or is
+   * not from Response.Status.Family.SERVER_ERROR status code family.
+   */
+  @Test
+  public void constructorStatusThrowsExceptionTest() throws Fault {
+    for (Status status : getStatusesOutsideFamily()) {
+      try {
+        ServerErrorException e = new ServerErrorException(status);
+        fault("IllegalArgumentException has not been thrown for status", status,
+            "; exception", e);
+      } catch (IllegalArgumentException e) {
+        logMsg(
+            "IllegalArgumentException has been thrown as expected for status",
+            status);
+      }
+    }
+  }
+
+  /*
+   * @testName: constructorStatusNullThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:351;
+   * 
+   * @test_Strategy: Construct a new server error exception.
+   * java.lang.IllegalArgumentException - in case the status code is null or is
+   * not from Response.Status.Family.SERVER_ERROR status code family.
+   */
+  @Test
+  public void constructorStatusNullThrowsExceptionTest() throws Fault {
+    try {
+      ServerErrorException e = new ServerErrorException((Status) null);
+      fault("IllegalArgumentException has not been thrown for null status",
+          "; exception", e);
+    } catch (IllegalArgumentException e) {
+      logMsg(
+          "IllegalArgumentException has been thrown as expected for null status");
+    }
+  }
+
+  /*
+   * @testName: constructorIntTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:352; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new server error exception.
+   * java.lang.IllegalArgumentException - in case the status code is not a valid
+   * HTTP status code or is not from Response.Status.Family.SERVER_ERROR status
+   * code family.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorIntTest() throws Fault {
+    for (Status status : getStatusesFromFamily()) {
+      ServerErrorException e = new ServerErrorException(status.getStatusCode());
+      assertResponse(e, status);
+    }
+  }
+
+  /*
+   * @testName: constructorIntThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:352;
+   * 
+   * @test_Strategy: Construct a new server error exception.
+   * java.lang.IllegalArgumentException - in case the status code is not a valid
+   * HTTP status code or is not from Response.Status.Family.SERVER_ERROR status
+   * code family.
+   */
+  @Test
+  public void constructorIntThrowsExceptionTest() throws Fault {
+    for (Status status : getStatusesOutsideFamily()) {
+      try {
+        ServerErrorException e = new ServerErrorException(
+            status.getStatusCode());
+        fault("IllegalArgumentException has not been thrown for status", status,
+            "; exception", e);
+      } catch (IllegalArgumentException e) {
+        logMsg(
+            "IllegalArgumentException has been thrown as expected for status",
+            status);
+      }
+    }
+  }
+
+  /*
+   * @testName: constructorIntNotValidStatusThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:352;
+   * 
+   * @test_Strategy: Construct a new server error exception.
+   * java.lang.IllegalArgumentException - in case the status code is not a valid
+   * HTTP status code or is not from Response.Status.Family.SERVER_ERROR status
+   * code family.
+   */
+  @Test
+  public void constructorIntNotValidStatusThrowsExceptionTest() throws Fault {
+    for (int status : new int[] { -1, Integer.MAX_VALUE, Integer.MIN_VALUE }) {
+      try {
+        ServerErrorException e = new ServerErrorException(status);
+        fault("IllegalArgumentException has not been thrown for status", status,
+            "; exception", e);
+      } catch (IllegalArgumentException e) {
+        logMsg(
+            "IllegalArgumentException has been thrown as expected for status",
+            status);
+      }
+    }
+  }
+
+  /*
+   * @testName: constructorResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:353; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new server error exception.
+   * java.lang.IllegalArgumentException - in case the response status code is
+   * not from the Response.Status.Family.SERVER_ERROR status code family.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorResponseTest() throws Fault {
+    for (Status status : getStatusesFromFamily()) {
+      ServerErrorException e = new ServerErrorException(buildResponse(status));
+      assertResponse(e, status, HOST);
+    }
+  }
+
+  /*
+   * @testName: constructorResponseThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:353;
+   * 
+   * @test_Strategy: Construct a new server error exception.
+   * java.lang.IllegalArgumentException - in case the response status code is
+   * not from the Response.Status.Family.SERVER_ERROR status code family.
+   */
+  @Test
+  public void constructorResponseThrowsExceptionTest() throws Fault {
+    for (Status status : getStatusesOutsideFamily())
+      try {
+        ServerErrorException e = new ServerErrorException(
+            buildResponse(status));
+        fault("IllegalArgumentException has not been thrown for status", status,
+            "; exception", e);
+      } catch (IllegalArgumentException e) {
+        logMsg(
+            "IllegalArgumentException has been thrown as expected for status",
+            status);
+      }
+  }
+
+  /*
+   * @testName: constructorStatusThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:354; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new server error exception.
+   * java.lang.IllegalArgumentException - in case the status code is null or is
+   * not from Response.Status.Family.SERVER_ERROR status code family.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStatusThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Status status : getStatusesFromFamily())
+      for (Throwable throwable : throwables) {
+        ServerErrorException e = new ServerErrorException(status, throwable);
+        assertResponse(e, status);
+        assertCause(e, throwable);
+      }
+  }
+
+  /*
+   * @testName: constructorStatusThrowableThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:354;
+   * 
+   * @test_Strategy: Construct a new server error exception.
+   * java.lang.IllegalArgumentException - in case the status code is null or is
+   * not from Response.Status.Family.SERVER_ERROR status code family.
+   */
+  @Test
+  public void constructorStatusThrowableThrowsExceptionTest() throws Fault {
+    Throwable throwable = new Throwable();
+    for (Status status : getStatusesOutsideFamily()) {
+      try {
+        ServerErrorException e = new ServerErrorException(status, throwable);
+        fault("IllegalArgumentException has not been thrown for status", status,
+            "; exception", e);
+      } catch (IllegalArgumentException e) {
+        logMsg(
+            "IllegalArgumentException has been thrown as expected for status",
+            status);
+      }
+    }
+  }
+
+  /*
+   * @testName: constructorStatusNullThrowableThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:354;
+   * 
+   * @test_Strategy: Construct a new server error exception.
+   * java.lang.IllegalArgumentException - in case the status code is null or is
+   * not from Response.Status.Family.SERVER_ERROR status code family.
+   */
+  @Test
+  public void constructorStatusNullThrowableThrowsExceptionTest() throws Fault {
+    Throwable throwable = new Throwable();
+    try {
+      ServerErrorException e = new ServerErrorException((Status) null,
+          throwable);
+      fault("IllegalArgumentException has not been thrown for null status",
+          "; exception", e);
+    } catch (IllegalArgumentException e) {
+      logMsg(
+          "IllegalArgumentException has been thrown as expected for null status");
+    }
+  }
+
+  /*
+   * @testName: constructorIntThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:355; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new server error exception.
+   * java.lang.IllegalArgumentException - in case the status code is not a valid
+   * HTTP status code or is not from Response.Status.Family.SERVER_ERROR status
+   * code family.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorIntThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Status status : getStatusesFromFamily())
+      for (Throwable throwable : throwables) {
+        ServerErrorException e = new ServerErrorException(
+            status.getStatusCode(), throwable);
+        assertResponse(e, status);
+        assertCause(e, throwable);
+      }
+  }
+
+  /*
+   * @testName: constructorIntThrowableThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:355;
+   * 
+   * @test_Strategy: Construct a new server error exception.
+   * java.lang.IllegalArgumentException - in case the status code is not a valid
+   * HTTP status code or is not from Response.Status.Family.SERVER_ERROR status
+   * code family.
+   */
+  @Test
+  public void constructorIntThrowableThrowsExceptionTest() throws Fault {
+    Throwable throwable = new Throwable();
+    for (Status status : getStatusesOutsideFamily())
+      try {
+        ServerErrorException e = new ServerErrorException(
+            status.getStatusCode(), throwable);
+        fault("IllegalArgumentException has not been thrown for status", status,
+            "; exception", e);
+      } catch (IllegalArgumentException e) {
+        logMsg(
+            "IllegalArgumentException has been thrown as expected for status",
+            status);
+      }
+  }
+
+  /*
+   * @testName: constructorIntNotValidStatusThrowableThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:355;
+   * 
+   * @test_Strategy: Construct a new server error exception.
+   * java.lang.IllegalArgumentException - in case the status code is not a valid
+   * HTTP status code or is not from Response.Status.Family.SERVER_ERROR status
+   * code family.
+   */
+  @Test
+  public void constructorIntNotValidStatusThrowableThrowsExceptionTest()
+      throws Fault {
+    Throwable throwable = new Throwable();
+    for (int status : new int[] { -1, Integer.MAX_VALUE, Integer.MIN_VALUE }) {
+      try {
+        ServerErrorException e = new ServerErrorException(status, throwable);
+        fault("IllegalArgumentException has not been thrown for status", status,
+            "; exception", e);
+      } catch (IllegalArgumentException e) {
+        logMsg(
+            "IllegalArgumentException has been thrown as expected for status",
+            status);
+      }
+    }
+  }
+
+  /*
+   * @testName: constructorResponseThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:356; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new server error exception.
+   * java.lang.IllegalArgumentException - in case the response status code is
+   * not from the Response.Status.Family.SERVER_ERROR status code family.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorResponseThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Status status : getStatusesFromFamily())
+      for (Throwable throwable : throwables) {
+        ServerErrorException e = new ServerErrorException(buildResponse(status),
+            throwable);
+        assertResponse(e, status, HOST);
+        assertCause(e, throwable);
+      }
+  }
+
+  /*
+   * @testName: constructorResponseThrowableThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:356;
+   * 
+   * @test_Strategy: Construct a new server error exception.
+   * java.lang.IllegalArgumentException - in case the response status code is
+   * not from the Response.Status.Family.SERVER_ERROR status code family.
+   */
+  @Test
+  public void constructorResponseThrowableThrowsExceptionTest() throws Fault {
+    Throwable throwable = new Throwable();
+    for (Status status : getStatusesOutsideFamily())
+      try {
+        ServerErrorException e = new ServerErrorException(buildResponse(status),
+            throwable);
+        fault("IllegalArgumentException has not been thrown for status", status,
+            "; exception", e);
+      } catch (IllegalArgumentException e) {
+        logMsg(
+            "IllegalArgumentException has been thrown as expected for status",
+            status);
+      }
+  }
+
+  /*
+   * @testName: constructorStringStatusTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1098; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new server error exception.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringStatusTest() throws Fault {
+    for (Status status : getStatusesFromFamily()) {
+      ServerErrorException e = new ServerErrorException(MESSAGE, status);
+      assertResponse(e, status);
+      assertMessage(e);
+    }
+  }
+
+  /*
+   * @testName: constructorStringStatusThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1098;
+   * 
+   * @test_Strategy: Construct a new server error exception.
+   * java.lang.IllegalArgumentException - in case the status code is null or is
+   * not from Response.Status.Family.SERVER_ERROR status code family.
+   */
+  @Test
+  public void constructorStringStatusThrowsIAETest() throws Fault {
+    for (Status status : getStatusesOutsideFamily()) {
+      try {
+        ServerErrorException e = new ServerErrorException(MESSAGE, status);
+        fault("IllegalArgumentException has not been thrown for status", status,
+            "; exception", e);
+      } catch (IllegalArgumentException e) {
+        logMsg(
+            "IllegalArgumentException has been thrown as expected for status",
+            status);
+      }
+    }
+  }
+
+  /*
+   * @testName: constructorStringStatusNullThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1098;
+   * 
+   * @test_Strategy: Construct a new server error exception.
+   * java.lang.IllegalArgumentException - in case the status code is null or is
+   * not from Response.Status.Family.SERVER_ERROR status code family.
+   */
+  @Test
+  public void constructorStringStatusNullThrowsExceptionTest() throws Fault {
+    try {
+      ServerErrorException e = new ServerErrorException(MESSAGE, (Status) null);
+      fault("IllegalArgumentException has not been thrown for null status",
+          "; exception", e);
+    } catch (IllegalArgumentException e) {
+      logMsg(
+          "IllegalArgumentException has been thrown as expected for null status");
+    }
+  }
+
+  /*
+   * @testName: constructorStringIntTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1099; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new server error exception.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringIntTest() throws Fault {
+    for (Status status : getStatusesFromFamily()) {
+      ServerErrorException e = new ServerErrorException(MESSAGE,
+          status.getStatusCode());
+      assertResponse(e, status);
+      assertMessage(e);
+    }
+  }
+
+  /*
+   * @testName: constructorStringIntThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1099;
+   * 
+   * @test_Strategy: Construct a new server error exception.
+   * java.lang.IllegalArgumentException - in case the status code is not a valid
+   * HTTP status code or is not from Response.Status.Family.SERVER_ERROR status
+   * code family.
+   */
+  @Test
+  public void constructorStringIntThrowsIAETest() throws Fault {
+    for (Status status : getStatusesOutsideFamily()) {
+      try {
+        ServerErrorException e = new ServerErrorException(MESSAGE,
+            status.getStatusCode());
+        fault("IllegalArgumentException has not been thrown for status", status,
+            "; exception", e);
+      } catch (IllegalArgumentException e) {
+        logMsg(
+            "IllegalArgumentException has been thrown as expected for status",
+            status);
+      }
+    }
+  }
+
+  /*
+   * @testName: constructorStringIntNotValidStatusThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1099;
+   * 
+   * @test_Strategy: Construct a new server error exception.
+   * java.lang.IllegalArgumentException - in case the status code is not a valid
+   * HTTP status code or is not from Response.Status.Family.SERVER_ERROR status
+   * code family.
+   */
+  @Test
+  public void constructorStringIntNotValidStatusThrowsIAETest() throws Fault {
+    for (int status : new int[] { -1, Integer.MAX_VALUE, Integer.MIN_VALUE }) {
+      try {
+        ServerErrorException e = new ServerErrorException(MESSAGE, status);
+        fault("IllegalArgumentException has not been thrown for status", status,
+            "; exception", e);
+      } catch (IllegalArgumentException e) {
+        logMsg(
+            "IllegalArgumentException has been thrown as expected for status",
+            status);
+      }
+    }
+  }
+
+  /*
+   * @testName: constructorStringResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1100; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new server error exception.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringResponseTest() throws Fault {
+    for (Status status : getStatusesFromFamily()) {
+      ServerErrorException e = new ServerErrorException(MESSAGE,
+          buildResponse(status));
+      assertResponse(e, status, HOST);
+      assertMessage(e);
+    }
+  }
+
+  /*
+   * @testName: constructorStringResponseThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1100;
+   * 
+   * @test_Strategy: Construct a new server error exception.
+   * java.lang.IllegalArgumentException - in case the response status code is
+   * not from the Response.Status.Family.SERVER_ERROR status code family.
+   */
+  @Test
+  public void constructorStringResponseThrowsIAETest() throws Fault {
+    for (Status status : getStatusesOutsideFamily())
+      try {
+        ServerErrorException e = new ServerErrorException(MESSAGE,
+            buildResponse(status));
+        fault("IllegalArgumentException has not been thrown for status", status,
+            "; exception", e);
+      } catch (IllegalArgumentException e) {
+        logMsg(
+            "IllegalArgumentException has been thrown as expected for status",
+            status);
+      }
+  }
+
+  /*
+   * @testName: constructorStringStatusThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1101; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new server error exception.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringStatusThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Status status : getStatusesFromFamily())
+      for (Throwable throwable : throwables) {
+        ServerErrorException e = new ServerErrorException(MESSAGE, status,
+            throwable);
+        assertResponse(e, status);
+        assertCause(e, throwable);
+        assertMessage(e);
+      }
+  }
+
+  /*
+   * @testName: constructorStringStatusThrowableThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1101;
+   * 
+   * @test_Strategy: Construct a new server error exception.
+   * java.lang.IllegalArgumentException - in case the status code is null or is
+   * not from Response.Status.Family.SERVER_ERROR status code family.
+   */
+  @Test
+  public void constructorStringStatusThrowableThrowsIAETest() throws Fault {
+    Throwable throwable = new Throwable();
+    for (Status status : getStatusesOutsideFamily()) {
+      try {
+        ServerErrorException e = new ServerErrorException(MESSAGE, status,
+            throwable);
+        fault("IllegalArgumentException has not been thrown for status", status,
+            "; exception", e);
+      } catch (IllegalArgumentException e) {
+        logMsg(
+            "IllegalArgumentException has been thrown as expected for status",
+            status);
+      }
+    }
+  }
+
+  /*
+   * @testName: constructorStringStatusNullThrowableThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1101;
+   * 
+   * @test_Strategy: Construct a new server error exception.
+   * java.lang.IllegalArgumentException - in case the status code is null or is
+   * not from Response.Status.Family.SERVER_ERROR status code family.
+   */
+  @Test
+  public void constructorStringStatusNullThrowableThrowsExceptionTest()
+      throws Fault {
+    Throwable throwable = new Throwable();
+    try {
+      ServerErrorException e = new ServerErrorException(MESSAGE, (Status) null,
+          throwable);
+      fault("IllegalArgumentException has not been thrown for null status",
+          "; exception", e);
+    } catch (IllegalArgumentException e) {
+      logMsg(
+          "IllegalArgumentException has been thrown as expected for null status");
+    }
+  }
+
+  /*
+   * @testName: constructorStringIntThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1102; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new server error exception.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringIntThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Status status : getStatusesFromFamily())
+      for (Throwable throwable : throwables) {
+        ServerErrorException e = new ServerErrorException(MESSAGE,
+            status.getStatusCode(), throwable);
+        assertResponse(e, status);
+        assertCause(e, throwable);
+        assertMessage(e);
+      }
+  }
+
+  /*
+   * @testName: constructorStringIntThrowableThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1102;
+   * 
+   * @test_Strategy: Construct a new server error exception.
+   * java.lang.IllegalArgumentException - in case the status code is not a valid
+   * HTTP status code or is not from Response.Status.Family.SERVER_ERROR status
+   * code family.
+   */
+  @Test
+  public void constructorStringIntThrowableThrowsIAETest() throws Fault {
+    Throwable throwable = new Throwable();
+    for (Status status : getStatusesOutsideFamily())
+      try {
+        ServerErrorException e = new ServerErrorException(MESSAGE,
+            status.getStatusCode(), throwable);
+        fault("IllegalArgumentException has not been thrown for status", status,
+            "; exception", e);
+      } catch (IllegalArgumentException e) {
+        logMsg(
+            "IllegalArgumentException has been thrown as expected for status",
+            status);
+      }
+  }
+
+  /*
+   * @testName: constructorStringIntNotValidStatusThrowableThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1102;
+   * 
+   * @test_Strategy: Construct a new server error exception.
+   * java.lang.IllegalArgumentException - in case the status code is not a valid
+   * HTTP status code or is not from Response.Status.Family.SERVER_ERROR status
+   * code family.
+   */
+  @Test
+  public void constructorStringIntNotValidStatusThrowableThrowsExceptionTest()
+      throws Fault {
+    Throwable throwable = new Throwable();
+    for (int status : new int[] { -1, Integer.MAX_VALUE, Integer.MIN_VALUE }) {
+      try {
+        ServerErrorException e = new ServerErrorException(MESSAGE, status,
+            throwable);
+        fault("IllegalArgumentException has not been thrown for status", status,
+            "; exception", e);
+      } catch (IllegalArgumentException e) {
+        logMsg(
+            "IllegalArgumentException has been thrown as expected for status",
+            status);
+      }
+    }
+  }
+
+  /*
+   * @testName: constructorStringResponseThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1103; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new server error exception.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringResponseThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Status status : getStatusesFromFamily())
+      for (Throwable throwable : throwables) {
+        ServerErrorException e = new ServerErrorException(MESSAGE,
+            buildResponse(status), throwable);
+        assertResponse(e, status, HOST);
+        assertCause(e, throwable);
+        assertMessage(e);
+      }
+  }
+
+  /*
+   * @testName: constructorStringResponseThrowableThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1103;
+   * 
+   * @test_Strategy: Construct a new server error exception.
+   * java.lang.IllegalArgumentException - in case the response status code is
+   * not from the Response.Status.Family.SERVER_ERROR status code family.
+   */
+  @Test
+  public void constructorStringResponseThrowableThrowsIAETest() throws Fault {
+    Throwable throwable = new Throwable();
+    for (Status status : getStatusesOutsideFamily())
+      try {
+        ServerErrorException e = new ServerErrorException(MESSAGE,
+            buildResponse(status), throwable);
+        fault("IllegalArgumentException has not been thrown for status", status,
+            "; exception", e);
+      } catch (IllegalArgumentException e) {
+        logMsg(
+            "IllegalArgumentException has been thrown as expected for status",
+            status);
+      }
+  }
+
+  // /////////////////////////////////////////////////////////////
+  protected Response buildResponse(Status status) {
+    return Response.status(status).header(HttpHeaders.HOST, HOST).build();
+  }
+
+  protected static void assertResponse(WebApplicationException e, Status status)
+      throws Fault {
+    assertNotNull(e.getResponse(), "#getResponse is null");
+    Response response = e.getResponse();
+    assertEqualsInt(response.getStatus(), status.getStatusCode(),
+        "response contains unexpected status", response.getStatus());
+    logMsg("response contains expected", status, "status");
+  }
+
+  /**
+   * Check the given exception contains a prebuilt response containing the http
+   * header HOST
+   */
+  protected void assertResponse(WebApplicationException e, Status status,
+      String host) throws Fault {
+    assertResponse(e, status);
+    String header = e.getResponse().getHeaderString(HttpHeaders.HOST);
+    assertNotNull(header, "http header", HttpHeaders.HOST,
+        " of response is null");
+    assertEquals(host, header, "Found unexpected http", HttpHeaders.HOST,
+        "header", header);
+    logMsg("Found expected http", HttpHeaders.HOST, "header");
+  }
+
+  protected void assertCause(WebApplicationException e, Throwable expected)
+      throws Fault {
+    assertEquals(e.getCause(), expected, "#getCause does not contain expected",
+        expected, "but", e.getCause());
+    logMsg("getCause contains expected", expected);
+  }
+
+  protected static List<Status> getStatusesFromFamily() {
+    List<Status> list = new LinkedList<Status>();
+    for (Status status : Status.values())
+      if (Status.Family.familyOf(status.getStatusCode()).equals(FAMILY))
+        list.add(status);
+    return list;
+  }
+
+  protected static List<Status> getStatusesOutsideFamily() {
+    List<Status> list = new LinkedList<Status>();
+    for (Status status : Status.values())
+      if (!Status.Family.familyOf(status.getStatusCode()).equals(FAMILY))
+        list.add(status);
+    return list;
+  }
+
+  protected void assertMessage(WebApplicationException e) throws Fault {
+    assertNotNull(e.getMessage(), "getMessage() is null");
+    assertContains(e.getMessage(), MESSAGE, "Unexpected getMessage()",
+        e.getMessage());
+    logMsg("found expected getMessage()=", e.getMessage());
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/serviceunavailableexception/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/serviceunavailableexception/JAXRSClientIT.java
@@ -1,0 +1,624 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.serviceunavailableexception;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.Calendar;
+import java.util.Date;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.ServiceUnavailableException;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = 4296616216116337115L;
+
+  private static final Status STATUS = Status.SERVICE_UNAVAILABLE;
+
+  protected static final String MESSAGE = "TCK ServiceUnavailableException description";
+
+  protected static final String HOST = "www.jcp.org";
+
+  protected Date date = Calendar.getInstance().getTime();
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  /*
+   * @testName: constructorTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:359; JAXRS:JAVADOC:357; JAXRS:JAVADOC:358;
+   * JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "service unavailable" exception without any
+   * "Retry-After" information specified for the failed request.
+   * 
+   * Get the retry time for the failed request.
+   * 
+   * Check if the underlying response contains the information on when is it
+   * possible to HttpHeaders#RETRY_AFTER retry the request.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorTest() throws Fault {
+    ServiceUnavailableException e = new ServiceUnavailableException();
+    assertResponse(e);
+    assertRetryTimeIsNull(e, true);
+    assertHasRetryAfter(e, false);
+  }
+
+  /*
+   * @testName: constructorLongTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:360; JAXRS:JAVADOC:357; JAXRS:JAVADOC:358;
+   * JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "service unavailable" exception with an
+   * interval specifying the "Retry-After" information for the failed request.
+   * 
+   * Get the retry time for the failed request.
+   * 
+   * Check if the underlying response contains the information on when is it
+   * possible to HttpHeaders#RETRY_AFTER retry the request.
+   * 
+   * getResponse
+   */
+  public void constructorLongTest() throws Fault {
+    ServiceUnavailableException e = new ServiceUnavailableException(5L);
+    assertResponse(e);
+    assertRetryTimeMin(e, 5);
+    assertHasRetryAfter(e, true);
+  }
+
+  /*
+   * @testName: constructorDateTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:361; JAXRS:JAVADOC:357; JAXRS:JAVADOC:358;
+   * JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "service unavailable" exception with an
+   * interval specifying the "Retry-After" information for the failed request.
+   * 
+   * Get the retry time for the failed request.
+   * 
+   * Check if the underlying response contains the information on when is it
+   * possible to HttpHeaders#RETRY_AFTER retry the request.
+   * 
+   * getResponse
+   */
+  public void constructorDateTest() throws Fault {
+    Calendar calendar = Calendar.getInstance();
+    calendar.add(Calendar.SECOND, 50);
+    ServiceUnavailableException e = new ServiceUnavailableException(
+        calendar.getTime());
+    assertResponse(e);
+    assertRetryTimeMin(e, 50);
+    assertHasRetryAfter(e, true);
+  }
+
+  /*
+   * @testName: constructorResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:362; JAXRS:JAVADOC:357; JAXRS:JAVADOC:358;
+   * JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "service unavailable" exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 503.
+   * 
+   * Get the retry time for the failed request.
+   * 
+   * Check if the underlying response contains the information on when is it
+   * possible to HttpHeaders#RETRY_AFTER retry the request.
+   * 
+   * getResponse
+   */
+  public void constructorResponseTest() throws Fault {
+    ServiceUnavailableException e = new ServiceUnavailableException(
+        buildResponse(STATUS));
+    assertResponse(e, HOST);
+    assertRetryTimeIsNull(e, true);
+    assertHasRetryAfter(e, false);
+  }
+
+  /*
+   * @testName: constructorResponseThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:362;
+   * 
+   * @test_Strategy: Construct a new "service unavailable" exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 503.
+   */
+  public void constructorResponseThrowsExceptionTest() throws Fault {
+    for (Status status : Status.values())
+      if (status != STATUS) {
+        try {
+          ServiceUnavailableException e = new ServiceUnavailableException(
+              buildResponse(status));
+          fault("IllegalArgumentException has not been thrown for status",
+              status, "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been thrown as expected for status",
+              status);
+        }
+      }
+  }
+
+  /*
+   * @testName: constructorDateThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:363; JAXRS:JAVADOC:357; JAXRS:JAVADOC:358;
+   * JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "service unavailable" exception with a date
+   * specifying the "Retry-After" information for the failed request and an
+   * underlying request failure cause.
+   *
+   * Get the retry time for the failed request.
+   * 
+   * Check if the underlying response contains the information on when is it
+   * possible to HttpHeaders#RETRY_AFTER retry the request.
+   * 
+   * getResponse
+   */
+  public void constructorDateThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    Calendar calendar = Calendar.getInstance();
+    calendar.add(Calendar.SECOND, 40);
+
+    for (Throwable t : throwables) {
+      ServiceUnavailableException e = new ServiceUnavailableException(
+          calendar.getTime(), t);
+      assertResponse(e);
+      assertCause(e, t);
+      assertRetryTimeMin(e, 40);
+      assertHasRetryAfter(e, true);
+    }
+  }
+
+  /*
+   * @testName: constructorLongThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:364; JAXRS:JAVADOC:357; JAXRS:JAVADOC:358;
+   * JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "service unavailable" exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 503.
+   *
+   * Get the retry time for the failed request.
+   * 
+   * Check if the underlying response contains the information on when is it
+   * possible to HttpHeaders#RETRY_AFTER retry the request.
+   * 
+   * getResponse
+   */
+  public void constructorLongThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      ServiceUnavailableException e = new ServiceUnavailableException(30L, t);
+      assertResponse(e);
+      assertCause(e, t);
+      assertRetryTimeMin(e, 30);
+      assertHasRetryAfter(e, true);
+    }
+  }
+
+  /*
+   * @testName: constructorResponseThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:365; JAXRS:JAVADOC:357; JAXRS:JAVADOC:358;
+   * JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "service unavailable" exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 503.
+   *
+   * Get the retry time for the failed request.
+   * 
+   * Check if the underlying response contains the information on when is it
+   * possible to HttpHeaders#RETRY_AFTER retry the request.
+   * 
+   * getResponse
+   */
+  public void constructorResponseThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      ServiceUnavailableException e = new ServiceUnavailableException(
+          buildResponse(STATUS), t);
+      assertResponse(e, HOST);
+      assertCause(e, t);
+      assertRetryTimeIsNull(e, true);
+      assertHasRetryAfter(e, false);
+    }
+  }
+
+  /*
+   * @testName: constructorResponseThrowableThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:365;
+   * 
+   * @test_Strategy: Construct a new "service unavailable" exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 503.
+   */
+  public void constructorResponseThrowableThrowsExceptionTest() throws Fault {
+    for (Status status : Status.values())
+      if (status != STATUS) {
+        try {
+          ServiceUnavailableException e = new ServiceUnavailableException(
+              buildResponse(status), new Throwable());
+          fault("IllegalArgumentException has not been thrown for status",
+              status, "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been thrown as expected for status",
+              status);
+        }
+      }
+  }
+
+  /*
+   * @testName: constructorStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1104; JAXRS:JAVADOC:357; JAXRS:JAVADOC:358;
+   * JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "service unavailable" exception without any
+   * "Retry-After" information specified for the failed request.
+   * 
+   * Get the retry time for the failed request.
+   * 
+   * Check if the underlying response contains the information on when is it
+   * possible to HttpHeaders#RETRY_AFTER retry the request.
+   * 
+   * getResponse
+   */
+  public void constructorStringTest() throws Fault {
+    ServiceUnavailableException e = new ServiceUnavailableException(MESSAGE);
+    assertResponse(e);
+    assertRetryTimeIsNull(e, true);
+    assertHasRetryAfter(e, false);
+    assertMessage(e);
+  }
+
+  /*
+   * @testName: constructorStringLongTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1105; JAXRS:JAVADOC:357; JAXRS:JAVADOC:358;
+   * JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "service unavailable" exception with an
+   * interval specifying the "Retry-After" information for the failed request.
+   * 
+   * Get the retry time for the failed request.
+   * 
+   * Check if the underlying response contains the information on when is it
+   * possible to HttpHeaders#RETRY_AFTER retry the request.
+   * 
+   * getResponse
+   */
+  public void constructorStringLongTest() throws Fault {
+    ServiceUnavailableException e = new ServiceUnavailableException(MESSAGE,
+        5L);
+    assertResponse(e);
+    assertRetryTimeMin(e, 5);
+    assertHasRetryAfter(e, true);
+    assertMessage(e);
+  }
+
+  /*
+   * @testName: constructorStringDateTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1106; JAXRS:JAVADOC:357; JAXRS:JAVADOC:358;
+   * JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "service unavailable" exception with an
+   * interval specifying the "Retry-After" information for the failed request.
+   * 
+   * Get the retry time for the failed request.
+   * 
+   * Check if the underlying response contains the information on when is it
+   * possible to HttpHeaders#RETRY_AFTER retry the request.
+   * 
+   * getResponse
+   */
+  public void constructorStringDateTest() throws Fault {
+    Calendar calendar = Calendar.getInstance();
+    calendar.add(Calendar.SECOND, 50);
+    ServiceUnavailableException e = new ServiceUnavailableException(MESSAGE,
+        calendar.getTime());
+    assertResponse(e);
+    assertRetryTimeMin(e, 50);
+    assertHasRetryAfter(e, true);
+    assertMessage(e);
+  }
+
+  /*
+   * @testName: constructorStringResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1107; JAXRS:JAVADOC:357; JAXRS:JAVADOC:358;
+   * JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "service unavailable" exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 503.
+   * 
+   * Get the retry time for the failed request.
+   * 
+   * Check if the underlying response contains the information on when is it
+   * possible to HttpHeaders#RETRY_AFTER retry the request.
+   * 
+   * getResponse
+   */
+  public void constructorStringResponseTest() throws Fault {
+    ServiceUnavailableException e = new ServiceUnavailableException(MESSAGE,
+        buildResponse(STATUS));
+    assertResponse(e, HOST);
+    assertRetryTimeIsNull(e, true);
+    assertHasRetryAfter(e, false);
+    assertMessage(e);
+  }
+
+  /*
+   * @testName: constructorStringResponseThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1107;
+   * 
+   * @test_Strategy: Construct a new "service unavailable" exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 503.
+   */
+  public void constructorStringResponseThrowsIAETest() throws Fault {
+    for (Status status : Status.values())
+      if (status != STATUS) {
+        try {
+          ServiceUnavailableException e = new ServiceUnavailableException(
+              MESSAGE, buildResponse(status));
+          fault("IllegalArgumentException has not been thrown for status",
+              status, "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been thrown as expected for status",
+              status);
+        }
+      }
+  }
+
+  /*
+   * @testName: constructorStringDateThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1108; JAXRS:JAVADOC:357; JAXRS:JAVADOC:358;
+   * JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "service unavailable" exception with a date
+   * specifying the "Retry-After" information for the failed request and an
+   * underlying request failure cause.
+   *
+   * Get the retry time for the failed request.
+   * 
+   * Check if the underlying response contains the information on when is it
+   * possible to HttpHeaders#RETRY_AFTER retry the request.
+   * 
+   * getResponse
+   */
+  public void constructorStringDateThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    Calendar calendar = Calendar.getInstance();
+    calendar.add(Calendar.SECOND, 40);
+
+    for (Throwable t : throwables) {
+      ServiceUnavailableException e = new ServiceUnavailableException(MESSAGE,
+          calendar.getTime(), t);
+      assertResponse(e);
+      assertCause(e, t);
+      assertRetryTimeMin(e, 40);
+      assertHasRetryAfter(e, true);
+      assertMessage(e);
+    }
+  }
+
+  /*
+   * @testName: constructorStringLongThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1109; JAXRS:JAVADOC:357; JAXRS:JAVADOC:358;
+   * JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "service unavailable" exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 503.
+   *
+   * Get the retry time for the failed request.
+   * 
+   * Check if the underlying response contains the information on when is it
+   * possible to HttpHeaders#RETRY_AFTER retry the request.
+   * 
+   * getResponse
+   */
+  public void constructorStringLongThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      ServiceUnavailableException e = new ServiceUnavailableException(MESSAGE,
+          30L, t);
+      assertResponse(e);
+      assertCause(e, t);
+      assertRetryTimeMin(e, 30);
+      assertHasRetryAfter(e, true);
+      assertMessage(e);
+    }
+  }
+
+  /*
+   * @testName: constructorStringResponseThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1110; JAXRS:JAVADOC:357; JAXRS:JAVADOC:358;
+   * JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new "service unavailable" exception.
+   * 
+   * Get the retry time for the failed request.
+   * 
+   * Check if the underlying response contains the information on when is it
+   * possible to HttpHeaders#RETRY_AFTER retry the request.
+   * 
+   * getResponse
+   */
+  public void constructorStringResponseThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      ServiceUnavailableException e = new ServiceUnavailableException(MESSAGE,
+          buildResponse(STATUS), t);
+      assertResponse(e, HOST);
+      assertCause(e, t);
+      assertRetryTimeIsNull(e, true);
+      assertHasRetryAfter(e, false);
+      assertMessage(e);
+    }
+  }
+
+  /*
+   * @testName: constructorStringResponseThrowableThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1110;
+   * 
+   * @test_Strategy: Construct a new "service unavailable" exception.
+   * java.lang.IllegalArgumentException - in case the status code set in the
+   * response is not HTTP 503.
+   */
+  public void constructorStringResponseThrowableThrowsIAETest() throws Fault {
+    for (Status status : Status.values())
+      if (status != STATUS) {
+        try {
+          ServiceUnavailableException e = new ServiceUnavailableException(
+              MESSAGE, buildResponse(status), new Throwable());
+          fault("IllegalArgumentException has not been thrown for status",
+              status, "; exception", e);
+        } catch (IllegalArgumentException e) {
+          logMsg(
+              "IllegalArgumentException has been thrown as expected for status",
+              status);
+        }
+      }
+  }
+
+  // /////////////////////////////////////////////////////////////
+  protected Response buildResponse(Status status) {
+    return Response.status(status).header(HttpHeaders.HOST, HOST).build();
+  }
+
+  protected static void assertResponse(WebApplicationException e) throws Fault {
+    assertNotNull(e.getResponse(), "#getResponse is null");
+    Response response = e.getResponse();
+    assertEqualsInt(response.getStatus(), STATUS.getStatusCode(),
+        "response contains unexpected status", response.getStatus());
+    logMsg("response contains expected", STATUS, "status");
+  }
+
+  /**
+   * Check the given exception contains a prebuilt response containing the http
+   * header HOST
+   */
+  protected void assertResponse(WebApplicationException e, String host)
+      throws Fault {
+    assertResponse(e);
+    String header = e.getResponse().getHeaderString(HttpHeaders.HOST);
+    assertNotNull(header, "http header", HttpHeaders.HOST,
+        " of response is null");
+    assertEquals(host, header, "Found unexpected http", HttpHeaders.HOST,
+        "header", header);
+    logMsg("Found expected http", HttpHeaders.HOST, "header");
+  }
+
+  protected static void assertCause(WebApplicationException e,
+      Throwable expected) throws Fault {
+    assertEquals(e.getCause(), expected, "#getCause does not contain expected",
+        expected, "but", e.getCause());
+    logMsg("getCause contains expected", expected);
+  }
+
+  protected void assertRetryTimeIsNull(ServiceUnavailableException e,
+      boolean isNull) throws Fault {
+    Date retryTime = e.getRetryTime(date);
+    assertTrue((isNull && retryTime == null) || (!isNull && retryTime != null),
+        "RetryTime was unexpectedly " + retryTime);
+    logMsg("Found expected retry time", retryTime);
+  }
+
+  protected void assertRetryTimeMin(ServiceUnavailableException e, int seconds)
+      throws Fault {
+    Date retryTime = e.getRetryTime(date);
+    assertNotNull(date, "#getRetryTime is null");
+
+    Calendar calendar = Calendar.getInstance();
+    calendar.setTime(date);
+    calendar.add(Calendar.SECOND, seconds);
+    Date minTime = calendar.getTime();
+
+    assertTrue(retryTime.compareTo(minTime) >= -1000, "RetryTime " +
+        retryTime.getTime() + " was unexpectedly lower then expected " +
+        minTime.getTime());
+    logMsg("Found expected retry time", retryTime);
+  }
+
+  protected static void assertHasRetryAfter(ServiceUnavailableException e,
+      boolean hasIt) throws Fault {
+    boolean retry = e.hasRetryAfter();
+    assertEqualsBool(hasIt, retry, "#hasRetryAfter is unexpectedly", retry);
+    logMsg("#hasRetryAfter returned expected", retry, "value");
+  }
+
+  protected static void assertMessage(WebApplicationException e) throws Fault {
+    assertNotNull(e.getMessage(), "getMessage() is null");
+    assertContains(e.getMessage(), MESSAGE, "Unexpected getMessage()",
+        e.getMessage());
+    logMsg("found expected getMessage()=", e.getMessage());
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/webapplicationexceptiontest/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/api/rs/webapplicationexceptiontest/JAXRSClientIT.java
@@ -1,0 +1,410 @@
+/*
+ * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.api.rs.webapplicationexceptiontest;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * WebApplicationException tests are also at ee/resource/webappexception/nomapper
+ */
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = 8214271241869777148L;
+
+  private static final Status STATUS = Status.INTERNAL_SERVER_ERROR;
+
+  protected static final String MESSAGE = "TCK WebApplicationException description";
+
+  protected static final String HOST = "www.jcp.org";
+
+  public JAXRSClientIT() {
+    setContextRoot("/jaxrs_api_rs_webapplicationexceptiontest_web");
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  /*
+   * @class.setup_props: webServerHost; webServerPort; ts_home;
+   */
+
+  /*
+   * @testName: statusNullTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:16;
+   * 
+   * @test_Strategy: Verify that WebApplicationException(Status Null) works.
+   */
+  @Test
+  public void statusNullTest() throws Fault {
+    Response.Status st = null;
+    try {
+      WebApplicationException e = new WebApplicationException(st);
+      throw new Fault("No exception thrown.  Test FAILED", e);
+    } catch (IllegalArgumentException ilex) {
+      TestUtil.logTrace("Expected exception caught.  Test PASSED");
+    } catch (Throwable th) {
+      throw new Fault("Wrong exception caught.  Test FAILED", th.getCause());
+    }
+  }
+
+  /*
+   * @testName: throwableStatusTest1
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:20;
+   * 
+   * @test_Strategy: Verify that WebApplicationException(Throwable, Status Null)
+   * works.
+   */
+  @Test
+  public void throwableStatusTest1() throws Fault {
+    Response.Status st = null;
+    try {
+      WebApplicationException e = new WebApplicationException(new Throwable(
+          "CTS-WebApplicationExceptionTest-throwableStatusTest1-FAIL"), st);
+      throw new Fault("No exception thrown.  Test FAILED", e);
+    } catch (IllegalArgumentException ilex) {
+      TestUtil.logTrace("Expected exception thrown.  Test PASS");
+    } catch (Throwable th) {
+      throw new Fault("Wrong-Exception", th.getCause());
+    }
+  }
+
+  /*
+   * @testName: constructorStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1111; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new instance with a blank message and default
+   * HTTP status code of 500.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringTest() throws Fault {
+    WebApplicationException e = new WebApplicationException(MESSAGE);
+    assertResponse(e, STATUS);
+    assertMessage(e);
+  }
+
+  /*
+   * @testName: constructorStringResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1112; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new instance using the supplied response.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringResponseTest() throws Fault {
+    for (Status status : Status.values()) {
+      Response response = buildResponse(status);
+      WebApplicationException e = new WebApplicationException(MESSAGE,
+          response);
+      assertResponse(e, status, HOST);
+      assertMessage(e);
+    }
+  }
+
+  /*
+   * @testName: constructorStringNullResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1112; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new instance using the supplied response. a
+   * value of null will be replaced with an internal server error response
+   * (status code 500).
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringNullResponseTest() throws Fault {
+    WebApplicationException e = new WebApplicationException(MESSAGE,
+        (Response) null);
+    assertResponse(e, STATUS);
+    assertMessage(e);
+  }
+
+  /*
+   * @testName: constructorStringIntTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1113; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new instance with a message and specified HTTP
+   * status code.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringIntTest() throws Fault {
+    for (Status status : Status.values()) {
+      WebApplicationException e = new WebApplicationException(MESSAGE,
+          status.getStatusCode());
+      assertResponse(e, status);
+      assertMessage(e);
+    }
+  }
+
+  /*
+   * @testName: constructorStringStatusTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1114; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new instance with a message and specified HTTP
+   * status code.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringStatusTest() throws Fault {
+    for (Status status : Status.values()) {
+      WebApplicationException e = new WebApplicationException(MESSAGE, status);
+      assertResponse(e, status);
+      assertMessage(e);
+    }
+  }
+
+  /*
+   * @testName: constructorStringNullStatusThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1114;
+   * 
+   * @test_Strategy: Throws java.lang.IllegalArgumentException - if status is
+   * null.
+   */
+  @Test
+  public void constructorStringNullStatusThrowsIAETest() throws Fault {
+    try {
+      WebApplicationException e = new WebApplicationException(MESSAGE,
+          (Status) null);
+      fault("No IllegalArgumentException has been thrown, built expcetion is",
+          e);
+    } catch (IllegalArgumentException e) {
+      logMsg("IllegalArgumentException has been thrown as expected when",
+          "null Status");
+    }
+  }
+
+  /*
+   * @testName: constructorStringThrowableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1115; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new instance with a message and default HTTP
+   * status code of 500.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringThrowableTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      WebApplicationException e = new WebApplicationException(MESSAGE, t);
+      assertResponse(e, STATUS);
+      assertMessage(e);
+      assertCause(e, t);
+    }
+  }
+
+  /*
+   * @testName: constructorStringThrowableResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1116; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new instance using the supplied response.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringThrowableResponseTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Status status : Status.values()) {
+      Response response = buildResponse(status);
+      for (Throwable t : throwables) {
+        WebApplicationException e = new WebApplicationException(MESSAGE, t,
+            response);
+        assertResponse(e, status, HOST);
+        assertMessage(e);
+        assertCause(e, t);
+      }
+    }
+  }
+
+  /*
+   * @testName: constructorStringThrowableNullResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1116; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new instance using the supplied response. a
+   * value of null will be replaced with an internal server error response
+   * (status code 500).
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringThrowableNullResponseTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      WebApplicationException e = new WebApplicationException(MESSAGE, t,
+          (Response) null);
+      assertResponse(e, STATUS);
+      assertMessage(e);
+      assertCause(e, t);
+    }
+  }
+
+  /*
+   * @testName: constructorStringThrowableIntTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1117; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new instance with a message and specified HTTP
+   * status code.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringThrowableIntTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Status status : Status.values()) {
+      for (Throwable t : throwables) {
+        WebApplicationException e = new WebApplicationException(MESSAGE, t,
+            status.getStatusCode());
+        assertResponse(e, status);
+        assertMessage(e);
+        assertCause(e, t);
+      }
+    }
+  }
+
+  /*
+   * @testName: constructorStringThrowableStatusTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1118; JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Construct a new instance with a message and specified HTTP
+   * status code.
+   * 
+   * getResponse
+   */
+  @Test
+  public void constructorStringThrowableStatusTest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Status status : Status.values()) {
+      for (Throwable t : throwables) {
+        WebApplicationException e = new WebApplicationException(MESSAGE, t,
+            status);
+        assertResponse(e, status);
+        assertMessage(e);
+        assertCause(e, t);
+      }
+    }
+  }
+
+  /*
+   * @testName: constructorStringThrowableNullStatusThrowsIAETest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1118;
+   * 
+   * @test_Strategy: Throws java.lang.IllegalArgumentException - if status is
+   * null.
+   */
+  @Test
+  public void constructorStringThrowableNullStatusThrowsIAETest() throws Fault {
+    Throwable[] throwables = new Throwable[] { new RuntimeException(),
+        new IOException(), new Error(), new Throwable() };
+    for (Throwable t : throwables) {
+      try {
+        WebApplicationException e = new WebApplicationException(MESSAGE, t,
+            (Status) null);
+        fault("IllegalArgumentException has not been thrown, exception:", e);
+      } catch (IllegalArgumentException e) {
+        logMsg("IllegalArgumentException has been thrown when",
+            "null Status as expected");
+      }
+    }
+  }
+
+  // /////////////////////////////////////////////////////////////
+  protected Response buildResponse(Status status) {
+    return Response.status(status).header(HttpHeaders.HOST, HOST).build();
+  }
+
+  protected static void assertResponse(WebApplicationException e, Status status)
+      throws Fault {
+    assertNotNull(e.getResponse(), "#getResponse is null");
+    Response response = e.getResponse();
+    assertEqualsInt(response.getStatus(), status.getStatusCode(),
+        "response contains unexpected status", response.getStatus(),
+        "response:", response);
+    logMsg("response contains expected", status, "status");
+  }
+
+  /**
+   * Check the given exception contains a prebuilt response containing the http
+   * header HOST
+   */
+  protected void assertResponse(WebApplicationException e, Status status,
+      String host) throws Fault {
+    assertResponse(e, status);
+    String header = e.getResponse().getHeaderString(HttpHeaders.HOST);
+    assertNotNull(header, "http header", HttpHeaders.HOST,
+        " of response is null");
+    assertEquals(host, header, "Found unexpected http", HttpHeaders.HOST,
+        "header", header);
+    logMsg("Found expected http", HttpHeaders.HOST, "header");
+  }
+
+  protected static void assertCause(WebApplicationException e,
+      Throwable expected) throws Fault {
+    assertEquals(e.getCause(), expected, "#getCause does not contain expected",
+        expected, "but", e.getCause());
+    logMsg("getCause contains expected", expected);
+  }
+
+  protected static void assertMessage(WebApplicationException e) throws Fault {
+    assertNotNull(e.getMessage(), "getMessage() is null");
+    assertContains(e.getMessage(), MESSAGE, "Unexpected getMessage()",
+        e.getMessage());
+    logMsg("found expected getMessage()=", e.getMessage());
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/common/provider/StringBeanWithAnnotation.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/common/provider/StringBeanWithAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at


### PR DESCRIPTION
This PR migrates all tests from `jakartaee-tck/src/com/sun/ts/tests/jaxrs/api` in https://github.com/eclipse-ee4j/jakartaee-tck.

Linked issues: #1015 

To test the changes :

```
export JAVA_HOME=<JDK11_HOME>
export M2_HOME=<MAVEN_HOME>
export PATH=$M2_HOME/bin:$JAVA_HOME/bin:$PATH
```

In `jaxrs-tck/`:
`mvn clean install`

In `jersey-tck/`:
run all tests : `mvn clean verify -Parq-glassfish-managed`

**Test failures:** (those should be tracked in #1020)

* `api/rs/core/newcookie`: `equalsTest` fails because `NewCookie.hashcode()` throws a `NullPointerException` because sameSite is `null` (test disabled)
* `api/rs/core/linkjaxbadapter`: Implementation for `jakarta.xml.bind-api` cannot be found and I don't know how to add it (tests disabled)
* `api/rs/ext/interceptor`: Tests fail with `IllegalStateException: [FATAL] HttpRequest is null` (tests disabled)