### PR TITLE
Clarify exception processing by CompletionCallback and the default ExceptionMapper

### DIFF
--- a/jaxrs-api/src/main/java/jakarta/ws/rs/container/CompletionCallback.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/container/CompletionCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,7 +21,7 @@ package jakarta.ws.rs.container;
  * <p>
  * A completion callback is invoked when the whole request processing is over, i.e. once a response for the request has
  * been processed and sent back to the client or in when an unmapped exception or error is being propagated to the
- * container.
+ * default exception mapper.
  * </p>
  *
  * @author Marek Potociar
@@ -30,19 +30,19 @@ package jakarta.ws.rs.container;
 public interface CompletionCallback {
     /**
      * A completion callback notification method that will be invoked when the request processing is finished, after a
-     * response is processed and is sent back to the client or when an unmapped throwable has been propagated to the hosting
-     * I/O container.
+     * response is processed and is sent back to the client or when an unmapped throwable has been propagated to the default
+     * exception mapper.
      * <p>
-     * An unmapped throwable is propagated to the hosting I/O container in case no {@link jakarta.ws.rs.ext.ExceptionMapper
+     * An unmapped throwable is propagated to the default exception mapper in case no {@link jakarta.ws.rs.ext.ExceptionMapper
      * exception mapper} has been found for a throwable indicating a request processing failure. In this case a
      * non-{@code null} unmapped throwable instance is passed to the method. Note that the throwable instance represents the
-     * actual unmapped exception thrown during the request processing, before it has been wrapped into an I/O
-     * container-specific exception that was used to propagate the throwable to the hosting I/O container.
+     * actual unmapped exception thrown during the request processing before it has been mapped to the response by the
+     * default exception mapper.
      * </p>
      *
      * @param throwable is {@code null}, if the request processing has completed with a response that has been sent to the
-     * client. In case the request processing resulted in an unmapped exception or error that has been propagated to the
-     * hosting I/O container, this parameter contains the unmapped exception instance.
+     * client. In case the request processing resulted in an unmapped exception or error that has yet to be propagated to the
+     * default exception mapper, this parameter contains the unmapped exception instance.
      */
     public void onComplete(Throwable throwable);
 }

--- a/jaxrs-spec/src/main/asciidoc/chapters/providers/_exceptionmapper.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/providers/_exceptionmapper.adoc
@@ -1,6 +1,6 @@
 ////
 *******************************************************************
-* Copyright (c) 2019 Eclipse Foundation
+* Copyright (c) 2019, 2021 Eclipse Foundation
 *
 * This specification document is made available under the terms
 * of the Eclipse Foundation Specification License v1.0, which is
@@ -36,6 +36,9 @@ set the response status to 500.
 
 When the default exception mapping provider handles a WebApplicationException, it MUST
 return the embedded Response, and it MUST respect the status code in the Response.
+
+Any registered CompletionCallback MUST be invoked with an unmapped exception before the
+default exception mapping provider maps the unmapped exception to a Response.
 
 To avoid a potentially infinite loop, a single exception mapper must be
 used during the processing of a request and its corresponding response.


### PR DESCRIPTION
Signed-off-by: jansupol <jan.supol@oracle.com>