### PR TITLE
TCK Migration: Move pending tests from jakartaee-tck/src/com/sun/ts/tests/jaxrs/servlet3

### DIFF
--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/common/provider/StringBeanParamConverter.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/common/provider/StringBeanParamConverter.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2012, 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.common.provider;
+
+import jakarta.ws.rs.ext.ParamConverter;
+
+public class StringBeanParamConverter implements ParamConverter<StringBean> {
+
+  public static final String VALUE = "Converted value: ";
+
+  @Override
+  public StringBean fromString(String value) throws IllegalArgumentException {
+    return new StringBean(VALUE + value);
+  }
+
+  @Override
+  public String toString(StringBean value) throws IllegalArgumentException {
+    return VALUE + value.get();
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/common/provider/StringBeanParamConverterProvider.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/common/provider/StringBeanParamConverterProvider.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2012, 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.common.provider;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import jakarta.ws.rs.ext.ParamConverter;
+import jakarta.ws.rs.ext.ParamConverterProvider;
+import jakarta.ws.rs.ext.Provider;
+
+@Provider
+public class StringBeanParamConverterProvider
+    implements ParamConverterProvider {
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T> ParamConverter<T> getConverter(Class<T> rawType, Type genericType,
+      Annotation[] annotations) {
+    if (rawType == StringBean.class)
+      return (ParamConverter<T>) new StringBeanParamConverter();
+    return null;
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/servlet3/rs/applicationpath/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/servlet3/rs/applicationpath/JAXRSClientIT.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2012, 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.servlet3.rs.applicationpath;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = 1L;
+    
+  public JAXRSClientIT() {
+    setup();
+    setContextRoot("/jaxrs_ee_applicationpath");
+  }
+
+  @Deployment(testable = false)
+  public static WebArchive createDeployment() throws IOException {
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_ee_applicationpath.war");
+    archive.addClasses(TSAppConfig.class, Resource.class); 
+    
+    return archive;
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  /*
+   * @testName: applicationPathAnnotationEncodedTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:297
+   * 
+   * @test_Strategy: Check the ApplicationPath annotation on Application works
+   * 
+   * Note that percent encoded values are allowed in the value, an
+   * implementation will recognize such values and will not double encode the
+   * '%' character.
+   */
+  @Test
+  public void applicationPathAnnotationEncodedTest() throws Fault {
+    setProperty(Property.REQUEST,
+        buildRequest(Request.GET, "ApplicationPath!/Resource"));
+    invoke();
+  }
+
+  /*
+   * @testName: applicationPathAnnotationNotUsedTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:297
+   * 
+   * @test_Strategy: Check the ApplicationPath is used properly
+   */
+  @Test
+  public void applicationPathAnnotationNotUsedTest() throws Fault {
+    setProperty(Property.REQUEST, buildRequest(Request.GET, "Resource"));
+    setProperty(Property.STATUS_CODE, "-1");
+    invoke();
+    Status status = getResponseStatusCode();
+    assertTrue(status != Status.OK && status != Status.NO_CONTENT,
+        "unexpected status code received " + status);
+    logMsg("Received expected status code", status);
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/servlet3/rs/applicationpath/Resource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/servlet3/rs/applicationpath/Resource.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2012, 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.servlet3.rs.applicationpath;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+@Path("/Resource")
+public class Resource {
+  @GET
+  public Response returnOk() {
+    return Response.ok().build();
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/servlet3/rs/applicationpath/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/servlet3/rs/applicationpath/TSAppConfig.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2012, 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.servlet3.rs.applicationpath;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("ApplicationPath%21")
+public class TSAppConfig extends Application {
+
+  @Override
+  public java.util.Set<java.lang.Class<?>> getClasses() {
+    Set<Class<?>> resources = new HashSet<Class<?>>();
+    resources.add(Resource.class);
+    return resources;
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/servlet3/rs/core/streamingoutput/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/servlet3/rs/core/streamingoutput/JAXRSClientIT.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2011, 2018, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.servlet3.rs.core.streamingoutput;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JAXRSClientIT extends JAXRSCommonClient {
+  private static final long serialVersionUID = 1L;
+
+  public static final String _root = "/jaxrs_ee_core_streamoutput/StreamOutputTest";
+
+  public JAXRSClientIT() {
+    setup();
+    setContextRoot(_root);
+  }
+
+  @Deployment(testable = false)
+  public static WebArchive createDeployment() throws IOException {
+    
+    InputStream inStream = JAXRSClientIT.class.getClassLoader().getResourceAsStream("jakarta/ws/rs/tck/servlet3/rs/core/streamingoutput/web.xml.template");
+    // Replace the servlet_adaptor in web.xml.template with the System variable set as servlet adaptor
+    String webXml = editWebXmlString(inStream);
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_ee_core_streamoutput.war");
+    archive.addClasses(TSAppConfig.class, StreamOutputTest.class);
+    archive.setWebXML(new StringAsset(webXml));
+    //archive.addAsWebInfResource(JAXRSClientIT.class.getPackage(), "web.xml.template", "web.xml"); //can use if the web.xml.template doesn't need to be modified.    
+    
+    return archive;
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  /*
+   * @testName: writeTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:173;
+   * 
+   * @test_Strategy: Client send a request. Verify that
+   * StreamingOutput.write(OutputStream) works.
+   */
+  @Test
+  public void writeTest() throws Fault {
+    setProperty(REQUEST, buildRequest(GET, "Test1"));
+    setProperty(SEARCH_STRING, "StreamingOutputTest1");
+    invoke();
+  }
+
+  /*
+   * @testName: writeIOExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:174; JAXRS:JAVADOC:132;
+   * 
+   * @test_Strategy: Client send a request. Verify that
+   * StreamingOutput.write(OutputStream) throws IOException (Servlet container
+   * shall return 500 - ResponseBuilder responsibility).
+   */
+  @Test
+  public void writeIOExceptionTest() throws Fault {
+    setProperty(REQUEST, buildRequest(GET, "IOExceptionTest"));
+    setProperty(STATUS_CODE, getStatusCode(Status.INTERNAL_SERVER_ERROR));
+    invoke();
+  }
+
+  /*
+   * @testName: writeWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:175;
+   * 
+   * @test_Strategy: Client send a request. Verify that
+   * StreamingOutput.write(OutputStream) throws WebApplicationException works.
+   */
+  @Test
+  public void writeWebApplicationExceptionTest() throws Fault {
+    setProperty(REQUEST, buildRequest(GET, "Test2"));
+    setProperty(STATUS_CODE, getStatusCode(Status.NOT_FOUND));
+    invoke();
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/servlet3/rs/core/streamingoutput/StreamOutputTest.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/servlet3/rs/core/streamingoutput/StreamOutputTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2011, 2018, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.servlet3.rs.core.streamingoutput;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.StreamingOutput;
+
+@Path(value = "/StreamOutputTest")
+public class StreamOutputTest {
+
+  @GET
+  @Path("/Test1")
+  public StreamingOutput streamingOutput() {
+    return new StreamingOutput() {
+      public void write(OutputStream output) throws IOException {
+        output.write("StreamingOutputTest1".getBytes());
+      }
+    };
+  }
+
+  @GET
+  @Path("/Test2")
+  public StreamingOutput test2() {
+    return new StreamingOutput() {
+      public void write(OutputStream output) throws IOException {
+        throw new WebApplicationException(404);
+      }
+    };
+  }
+
+  @GET
+  @Path("IOExceptionTest")
+  public Response testIOException() {
+    StreamingOutput so = new StreamingOutput() {
+      public void write(OutputStream output) throws IOException {
+        throw new IOException("TckIOExceptionTest");
+      }
+    };
+    Response response = Response.ok(so).build();
+    return response;
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/servlet3/rs/core/streamingoutput/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/servlet3/rs/core/streamingoutput/TSAppConfig.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2011, 2018, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.servlet3.rs.core.streamingoutput;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.ws.rs.core.Application;
+
+public class TSAppConfig extends Application {
+
+  @Override
+  public java.util.Set<java.lang.Class<?>> getClasses() {
+    Set<Class<?>> resources = new HashSet<Class<?>>();
+    resources.add(StreamOutputTest.class);
+    return resources;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/servlet3/rs/ext/paramconverter/autodiscovery/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/servlet3/rs/ext/paramconverter/autodiscovery/JAXRSClientIT.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2012, 2018, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.servlet3.rs.ext.paramconverter.autodiscovery;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import jakarta.ws.rs.tck.common.client.JaxrsCommonClient;
+import jakarta.ws.rs.tck.common.provider.PrintingErrorHandler;
+import jakarta.ws.rs.tck.common.provider.StringBean;
+import jakarta.ws.rs.tck.common.provider.StringBeanParamConverter;
+import jakarta.ws.rs.tck.common.provider.StringBeanParamConverterProvider;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JAXRSClientIT extends JaxrsCommonClient {
+
+  /**
+   * 
+   */
+  private static final long serialVersionUID = 8764917394183731977L;
+
+  public JAXRSClientIT() {
+    setup();
+    setContextRoot(
+        "/jaxrs_servlet3_rs_ext_paramconverter_autodiscovery/resource");
+  }
+
+  @Deployment(testable = false)
+  public static WebArchive createDeployment() throws IOException {
+
+    InputStream inStream = JAXRSClientIT.class.getClassLoader().getResourceAsStream("jakarta/ws/rs/tck/servlet3/rs/ext/paramconverter/autodiscovery/web.xml.template");
+    // Replace the servlet_adaptor in web.xml.template with the System variable set as servlet adaptor
+    String webXml = editWebXmlString(inStream);
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_servlet3_rs_ext_paramconverter_autodiscovery.war");
+    archive.addClasses(
+      TSAppConfig.class, 
+      Resource.class,
+      StringBeanParamConverter.class,
+      StringBeanParamConverterProvider.class,
+      PrintingErrorHandler.class,
+      StringBean.class
+    );
+    archive.setWebXML(new StringAsset(webXml));
+    //archive.addAsWebInfResource(JAXRSClientIT.class.getPackage(), "web.xml.template", "web.xml"); //can use if the web.xml.template doesn't need to be modified.    
+    
+    return archive;
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  /*
+   * @testName: isParamCoverterFoundByAutodiscoveryUsedTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:919; JAXRS:SPEC:59;
+   * 
+   * @test_Strategy: Providers implementing ParamConverterProvider contract must
+   * be annotated with @Provider annotation to be automatically discovered by
+   * the JAX-RS runtime during a provider scanning phase.
+   * 
+   * 2.3.2 When an Application subclass is present in the archive, if both
+   * Application.getClasses and Application.getSingletons return an empty list
+   * then all root resource classes and providers packaged in the web
+   * application MUST be included and the JAX-RS implementation is REQUIRED to
+   * discover them automatically.
+   */
+  @Test
+  public void isParamCoverterFoundByAutodiscoveryUsedTest() throws Fault {
+    String query = "ABCDEFGH";
+    setPropertyRequest(Request.GET, "sbquery?query=", query);
+    setProperty(Property.SEARCH_STRING, StringBeanParamConverter.VALUE);
+    setProperty(Property.SEARCH_STRING, query);
+    invoke();
+  }
+
+  /*
+   * @assertion_ids: JAXRS:JAVADOC:919; JAXRS:SPEC:59;
+   * 
+   * @test_Strategy: Providers implementing ParamConverterProvider contract must
+   * be annotated with @Provider annotation to be automatically discovered by
+   * the JAX-RS runtime during a provider scanning phase.
+   * 
+   * 2.3.2 When an Application subclass is present in the archive, if both
+   * Application.getClasses and Application.getSingletons return an empty list
+   * then all root resource classes and providers packaged in the web
+   * application MUST be included and the JAX-RS implementation is REQUIRED to
+   * discover them automatically.
+   * 
+   * check whether it pass in a case of writer only TODO: IN MR public void
+   * isParamCoverterUsedForWritingTest() throws Fault { String query = "OK";
+   * setPropertyRequest(Request.GET, ""); setProperty(Property.EXPECTED_HEADERS,
+   * Resource.HEADER_NAME + ":" + query); invoke(); }
+   */
+
+  // ////////////////////////////////////////////////////////////////////
+  private void setPropertyRequest(Request request, String... resource) {
+    StringBuilder sb = new StringBuilder();
+    for (String r : resource)
+      sb.append(r);
+    setProperty(Property.REQUEST, buildRequest(request, sb.toString()));
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/servlet3/rs/ext/paramconverter/autodiscovery/Resource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/servlet3/rs/ext/paramconverter/autodiscovery/Resource.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2012, 2018, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.servlet3.rs.ext.paramconverter.autodiscovery;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.tck.common.provider.StringBean;
+
+@Path("resource")
+public class Resource {
+  public static final String HEADER_NAME = "Converter";
+
+  @Path("sbquery")
+  @GET
+  public String stringBeanQuery(@QueryParam("query") StringBean param) {
+    return param.get();
+  }
+
+  @GET
+  public Response get() {
+    return Response.ok().header(HEADER_NAME, new StringBean("OK")).build();
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/servlet3/rs/ext/paramconverter/autodiscovery/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/servlet3/rs/ext/paramconverter/autodiscovery/TSAppConfig.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2012, 2018, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.servlet3.rs.ext.paramconverter.autodiscovery;
+
+import jakarta.ws.rs.core.Application;
+
+public class TSAppConfig extends Application {
+}

--- a/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/servlet3/rs/core/streamingoutput/web.xml.template
+++ b/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/servlet3/rs/core/streamingoutput/web.xml.template
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2011, 2018, 2021 Oracle and/or its affiliates. All rights reserved.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+    <servlet>
+        <servlet-name>jakarta.ws.rs.tck.servlet3.rs.core.streamingoutput.TSAppConfig</servlet-name>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>jakarta.ws.rs.tck.servlet3.rs.core.streamingoutput.TSAppConfig</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+    <session-config>
+        <session-timeout>30</session-timeout>
+    </session-config>
+</web-app>

--- a/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/servlet3/rs/ext/paramconverter/autodiscovery/web.xml.template
+++ b/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/servlet3/rs/ext/paramconverter/autodiscovery/web.xml.template
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2012, 2018, 2021 Oracle and/or its affiliates. All rights reserved.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+    <servlet>
+        <servlet-name>jakarta.ws.rs.tck.servlet3.rs.ext.paramconverter.autodiscovery.TSAppConfig</servlet-name>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>jakarta.ws.rs.tck.servlet3.rs.ext.paramconverter.autodiscovery.TSAppConfig</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+    <session-config>
+        <session-timeout>30</session-timeout>
+    </session-config>
+</web-app>


### PR DESCRIPTION
This PR migrates all tests from `jakartaee-tck/src/com/sun/ts/tests/jaxrs/servlet3` in https://github.com/eclipse-ee4j/jakartaee-tck.

Linked issues: #1015 

To test the changes :

```
export JAVA_HOME=<JDK11_HOME>
export M2_HOME=<MAVEN_HOME>
export PATH=$M2_HOME/bin:$JAVA_HOME/bin:$PATH
```

In `jaxrs-tck/`:
`mvn clean install`

In `jersey-tck/`:
run migrated tests : `mvn clean verify -Parq-glassfish-managed -Dit.test=jakarta.ws.rs.tck.servlet3.**`

All tests should succeed.