### PR TITLE
TCK Migration: Move pending tests from jakartaee-tck/src/com/sun/ts/tests/jaxrs/ee/resource

### DIFF
--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/resource/java2entity/CollectionWriter.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/resource/java2entity/CollectionWriter.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2012, 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.resource.java2entity;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.MessageBodyWriter;
+import jakarta.ws.rs.ext.Provider;
+import jakarta.ws.rs.tck.common.AbstractMessageBodyRW;
+
+/**
+ * If isWritable arguments are passed according to the spec, writes OK,
+ * otherwise IncorrectCollectionWriter writes ERROR
+ */
+@Provider
+public class CollectionWriter extends AbstractMessageBodyRW
+    implements MessageBodyWriter<Collection<?>> {
+  @Override
+  public boolean isWriteable(Class<?> type, Type genericType,
+      Annotation[] annotations, MediaType mediaType) {
+    String path = getPathValue(annotations);
+    // Return type : Other
+    if (path.equalsIgnoreCase(type.getSimpleName()))
+      return checkOther(type, genericType);
+    else if (path.equalsIgnoreCase("response/linkedlist"))
+      return checkResponseNongeneric(type, genericType);
+    else if (path.equalsIgnoreCase("response/genericentity/linkedlist"))
+      return checkGeneric(type, genericType);
+    else if (path.equalsIgnoreCase("genericentity/linkedlist"))
+      return checkGeneric(type, genericType);
+    return false;
+  }
+
+  private static boolean checkOther(Class<?> type, Type genericType) {
+    if (!(genericType instanceof ParameterizedType))
+      return false;
+    ParameterizedType pType = (ParameterizedType) genericType;
+    boolean ok = pType.getRawType().equals(LinkedList.class);
+    ok &= pType.getActualTypeArguments()[0].equals(String.class);
+    return ok;
+  }
+
+  private static boolean checkResponseNongeneric(Class<?> type,
+      Type genericType) {
+    boolean ok = genericType.equals(LinkedList.class);
+    ok &= type.equals(LinkedList.class);
+    return ok;
+  }
+
+  private static boolean checkGeneric(Class<?> type, Type genericType) {
+    if (ParameterizedType.class.isInstance(genericType))
+      genericType = ((ParameterizedType) genericType).getRawType();
+    boolean ok = genericType.getClass().equals(List.class)
+        || genericType.equals(LinkedList.class);
+    ok &= type.equals(LinkedList.class);
+    return ok;
+  }
+
+  @Override
+  public long getSize(Collection<?> t, Class<?> type, Type genericType,
+      Annotation[] annotations, MediaType mediaType) {
+    return Response.Status.OK.name().length();
+  }
+
+  @Override
+  public void writeTo(Collection<?> t, Class<?> type, Type genericType,
+      Annotation[] annotations, MediaType mediaType,
+      MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream)
+      throws IOException, WebApplicationException {
+    entityStream.write(Response.Status.OK.name().getBytes());
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/resource/java2entity/IncorrectCollectionWriter.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/resource/java2entity/IncorrectCollectionWriter.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2012, 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.resource.java2entity;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Collection;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyWriter;
+import jakarta.ws.rs.ext.Provider;
+import jakarta.ws.rs.tck.common.AbstractMessageBodyRW;
+
+/**
+ * Complement to CollectionWriter, writes error
+ */
+@Provider
+public class IncorrectCollectionWriter extends AbstractMessageBodyRW
+    implements MessageBodyWriter<Collection<?>> {
+
+  public static final String ERROR = "ERROR ";
+
+  @Override
+  public boolean isWriteable(Class<?> type, Type genericType,
+      Annotation[] annotations, MediaType mediaType) {
+    return !new CollectionWriter().isWriteable(type, genericType, annotations,
+        mediaType);
+  }
+
+  @Override
+  public long getSize(Collection<?> t, Class<?> type, Type genericType,
+      Annotation[] annotations, MediaType mediaType) {
+    String path = getPathValue(annotations);
+    return ERROR.length() + path.length();
+  }
+
+  @Override
+  public void writeTo(Collection<?> t, Class<?> type, Type genericType,
+      Annotation[] annotations, MediaType mediaType,
+      MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream)
+      throws IOException, WebApplicationException {
+    String path = getPathValue(annotations);
+    entityStream.write(ERROR.getBytes());
+    entityStream.write(path.getBytes());
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/resource/java2entity/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/resource/java2entity/JAXRSClientIT.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2012, 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.resource.java2entity;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.tck.common.AbstractMessageBodyRW;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = 1L;
+
+  public JAXRSClientIT() {
+    setup();
+    setContextRoot("/jaxrs_resource_java2entity_web/resource");
+  }
+
+  @Deployment(testable = false)
+  public static WebArchive createDeployment() throws IOException {
+
+    InputStream inStream = JAXRSClientIT.class.getClassLoader().getResourceAsStream("jakarta/ws/rs/tck/ee/resource/java2entity/web.xml.template");
+    // Replace the servlet_adaptor in web.xml.template with the System variable set as servlet adaptor
+    String webXml = editWebXmlString(inStream);
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_resource_java2entity_web.war");
+    archive.addClasses(TSAppConfig.class, AbstractMessageBodyRW.class, Resource.class, CollectionWriter.class, IncorrectCollectionWriter.class);
+    archive.setWebXML(new StringAsset(webXml));
+    //archive.addAsWebInfResource(JAXRSClientIT.class.getPackage(), "web.xml.template", "web.xml"); //can use if the web.xml.template doesn't need to be modified.    
+    
+    return archive;
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  /*
+   * @testName: directClassTypeTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:15; JAXRS:SPEC:15.1; JAXRS:SPEC:15.2;
+   * JAXRS:SPEC:15.3; JAXRS:SPEC:15.4;
+   * 
+   * @test_Strategy: Other | Return type or subclass | Class of instance |
+   * Generic type of return type
+   */
+  @Test
+  public void directClassTypeTest() throws Fault {
+    setProperty(REQUEST, buildRequest(GET, "linkedlist"));
+    setProperty(SEARCH_STRING, Response.Status.OK.name());
+    setProperty(Property.UNEXPECTED_RESPONSE_MATCH,
+        IncorrectCollectionWriter.ERROR);
+    invoke();
+  }
+
+  /*
+   * @testName: responseDirectClassTypeTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:15; JAXRS:SPEC:15.1; JAXRS:SPEC:15.2;
+   * JAXRS:SPEC:15.3; JAXRS:SPEC:15.4;
+   * 
+   * @test_Strategy: Response | Object or subclass | Class of instance | Class
+   * of instance
+   */
+  @Test
+  public void responseDirectClassTypeTest() throws Fault {
+    setProperty(REQUEST, buildRequest(GET, "response/linkedlist"));
+    setProperty(SEARCH_STRING, Response.Status.OK.name());
+    setProperty(Property.UNEXPECTED_RESPONSE_MATCH,
+        IncorrectCollectionWriter.ERROR);
+    invoke();
+  }
+
+  /*
+   * @testName: responseGenericEntityTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:15; JAXRS:SPEC:15.1; JAXRS:SPEC:15.2;
+   * JAXRS:SPEC:15.3; JAXRS:SPEC:15.4;
+   * 
+   * @test_Strategy: Response | GenericEntity or subclass | RawType property |
+   * Type property
+   */
+  @Test
+  public void responseGenericEntityTest() throws Fault {
+    setProperty(REQUEST,
+        buildRequest(GET, "response/genericentity/linkedlist"));
+    setProperty(SEARCH_STRING, Response.Status.OK.name());
+    setProperty(Property.UNEXPECTED_RESPONSE_MATCH,
+        IncorrectCollectionWriter.ERROR);
+    invoke();
+  }
+
+  /*
+   * @testName: genericEntityTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:15; JAXRS:SPEC:15.1; JAXRS:SPEC:15.2;
+   * JAXRS:SPEC:15.3; JAXRS:SPEC:15.4;
+   * 
+   * @test_Strategy: GenericEntity | GenericEntity or subclass | RawType
+   * property | Type property
+   */
+  @Test
+  public void genericEntityTest() throws Fault {
+    setProperty(REQUEST, buildRequest(GET, "genericentity/linkedlist"));
+    setProperty(SEARCH_STRING, Response.Status.OK.name());
+    setProperty(Property.UNEXPECTED_RESPONSE_MATCH,
+        IncorrectCollectionWriter.ERROR);
+    invoke();
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/resource/java2entity/Resource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/resource/java2entity/Resource.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2012, 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.resource.java2entity;
+
+import java.lang.reflect.Method;
+import java.util.LinkedList;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.GenericEntity;
+import jakarta.ws.rs.core.Response;
+
+@Path("resource")
+public class Resource {
+
+  @Path("linkedlist")
+  @GET
+  public LinkedList<String> checkDirect() {
+    LinkedList<String> list = new LinkedList<String>();
+    list.add("linked");
+    list.add("list");
+    return list;
+  }
+
+  @Path("response/linkedlist")
+  @GET
+  public Response checkResponseDirect() {
+    LinkedList<String> list = new LinkedList<String>();
+    list.add("linked");
+    list.add("list");
+    return Response.ok(list).build();
+  }
+
+  @Path("response/genericentity/linkedlist")
+  @GET
+  public Response checkResponseGeneric() {
+    GenericEntity<LinkedList<String>> gells = checkGeneric();
+    return Response.ok(gells).build();
+  }
+
+  @Path("genericentity/linkedlist")
+  @GET
+  public GenericEntity<LinkedList<String>> checkGeneric() {
+    LinkedList<String> list = new LinkedList<String>();
+    list.add("linked");
+    list.add("list");
+    GenericEntity<LinkedList<String>> gells;
+    gells = new GenericEntity<LinkedList<String>>(list,
+        getMethodByName("checkDirect").getGenericReturnType());
+    return gells;
+  }
+
+  private Method getMethodByName(String name) {
+    try {
+      Method method = getClass().getMethod(name);
+      return method;
+    } catch (NoSuchMethodException e) {
+      e.printStackTrace();
+      return null;
+    }
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/resource/java2entity/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/resource/java2entity/TSAppConfig.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2012, 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.resource.java2entity;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.ws.rs.core.Application;
+
+public class TSAppConfig extends Application {
+
+  public java.util.Set<java.lang.Class<?>> getClasses() {
+    Set<Class<?>> resources = new HashSet<Class<?>>();
+    resources.add(Resource.class);
+    resources.add(CollectionWriter.class);
+    resources.add(IncorrectCollectionWriter.class);
+    return resources;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/resource/readme.txt
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/resource/readme.txt
@@ -1,0 +1,4 @@
+The resources package is used for testing assertions specified in the following 
+sections: 
+	o Section 3. : Resources
+	o Section 4. : Providers 

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/resource/webappexception/mapper/DirectResponseUsageResource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/resource/webappexception/mapper/DirectResponseUsageResource.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2014, 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.resource.webappexception.mapper;
+
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.ClientErrorException;
+import jakarta.ws.rs.ForbiddenException;
+import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.NotAcceptableException;
+import jakarta.ws.rs.NotAllowedException;
+import jakarta.ws.rs.NotAuthorizedException;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.NotSupportedException;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.RedirectionException;
+import jakarta.ws.rs.ServerErrorException;
+import jakarta.ws.rs.ServiceUnavailableException;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.ResponseBuilder;
+
+@Path("resource/direct")
+public class DirectResponseUsageResource {
+
+  public static final String ENTITY = "DirectEntity";
+
+  private static Response buildResponse(int status, String entity) {
+    ResponseBuilder rb = Response.status(status);
+    if (entity != null)
+      rb.entity(entity);
+    return rb.build();
+  }
+
+  public static String getReasonPhrase(int status) {
+    return Response.status(status).build().getStatusInfo().getReasonPhrase();
+  }
+
+  private static Response buildResponse(int status, boolean entity) {
+    ResponseBuilder rb = Response.status(status);
+    if (entity)
+      rb.entity(getReasonPhrase(status));
+    return rb.build();
+  }
+
+  @Path("{id}")
+  public Response getException(@PathParam("id") int id) {
+    WebApplicationException wae = null;
+    switch (id) {
+    case 2000:
+      wae = new WebApplicationException(ENTITY, buildResponse(200, ENTITY));
+      break;
+    case 4000:
+      wae = new ClientErrorException(ENTITY, buildResponse(400, ENTITY));
+      break;
+    case 400:
+      wae = new BadRequestException(ENTITY, buildResponse(id, true));
+      break;
+    case 403:
+      wae = new ForbiddenException(ENTITY, buildResponse(id, true));
+      break;
+    case 406:
+      wae = new NotAcceptableException(ENTITY, buildResponse(id, true));
+      break;
+    case 405:
+      wae = new NotAllowedException(ENTITY, buildResponse(id, true));
+      break;
+    case 401:
+      wae = new NotAuthorizedException(ENTITY, buildResponse(id, true));
+      break;
+    case 404:
+      wae = new NotFoundException(ENTITY, buildResponse(id, true));
+      break;
+    case 415:
+      wae = new NotSupportedException(ENTITY, buildResponse(id, true));
+      break;
+    case 3000:
+      wae = new RedirectionException(ENTITY, buildResponse(300, ENTITY));
+      break;
+    case 5000:
+      wae = new ServerErrorException(ENTITY, buildResponse(500, ENTITY));
+      break;
+    case 500:
+      wae = new InternalServerErrorException(ENTITY, buildResponse(id, true));
+      break;
+    case 503:
+      wae = new ServiceUnavailableException(ENTITY, buildResponse(id, true));
+      break;
+    }
+    throw wae;
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/resource/webappexception/mapper/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/resource/webappexception/mapper/JAXRSClientIT.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright (c) 2012, 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.resource.webappexception.mapper;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JAXRSClientIT extends JAXRSCommonClient {
+  private static final long serialVersionUID = 1L;
+
+  public JAXRSClientIT() {
+    setup();
+    setContextRoot("/jaxrs_resource_webappexception_mapper_web/resource");
+  }
+
+  @Deployment(testable = false)
+  public static WebArchive createDeployment() throws IOException {
+
+    InputStream inStream = JAXRSClientIT.class.getClassLoader().getResourceAsStream("jakarta/ws/rs/tck/ee/resource/webappexception/mapper/web.xml.template");
+    // Replace the servlet_adaptor in web.xml.template with the System variable set as servlet adaptor
+    String webXml = editWebXmlString(inStream);
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_resource_webappexception_mapper_web.war");
+    archive.addClasses(
+        TSAppConfig.class, 
+        Resource.class, 
+        RuntimeExceptionMapper.class, 
+        WebAppExceptionMapper.class, 
+        DirectResponseUsageResource.class, 
+        ResponseWithNoEntityUsesMapperResource.class
+    );
+    archive.setWebXML(new StringAsset(webXml));
+    //archive.addAsWebInfResource(JAXRSClientIT.class.getPackage(), "web.xml.template", "web.xml"); //can use if the web.xml.template doesn't need to be modified.    
+    
+    return archive;
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  /*
+   * @testName: noResponseTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:16; JAXRS:SPEC:16.1; JAXRS:SPEC:16.2;
+   * 
+   * @test_Strategy: An implementation MUST catch all exceptions and process
+   * them as follows: Instances of WebApplicationException MUST be mapped to a
+   * response as follows. If the response property of the exception does not
+   * contain an entity and an exception mapping provider (see section 4.4) is
+   * available for WebApplicationException an implementation MUST use the
+   * provider to create a new Response instance, otherwise the response property
+   * is used directly.
+   */
+  @Test
+  public void noResponseTest() throws Fault {
+    setProperty(REQUEST, buildRequest(GET, "noresponse"));
+    setProperty(STATUS_CODE, getStatusCode(Status.ACCEPTED));
+    invoke();
+  }
+
+  /*
+   * @testName: okResponseTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:16; JAXRS:SPEC:16.1; JAXRS:SPEC:16.2;
+   * 
+   * @test_Strategy: An implementation MUST catch all exceptions and process
+   * them as follows: Instances of WebApplicationException MUST be mapped to a
+   * response as follows. If the response property of the exception does not
+   * contain an entity and an exception mapping provider (see section 4.4) is
+   * available for WebApplicationException an implementation MUST use the
+   * provider to create a new Response instance, otherwise the response property
+   * is used directly.
+   */
+  @Test
+  public void okResponseTest() throws Fault {
+    setProperty(REQUEST, buildRequest(GET, "responseok"));
+    setProperty(STATUS_CODE, getStatusCode(Status.ACCEPTED));
+    invoke();
+  }
+
+  /*
+   * @testName: responseEntityTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:16; JAXRS:SPEC:16.1; JAXRS:SPEC:16.2;
+   * 
+   * @test_Strategy: An implementation MUST catch all exceptions and process
+   * them as follows: Instances of WebApplicationException MUST be mapped to a
+   * response as follows. If the response property of the exception does not
+   * contain an entity and an exception mapping provider (see section 4.4) is
+   * available for WebApplicationException an implementation MUST use the
+   * provider to create a new Response instance, otherwise the response property
+   * is used directly.
+   * 
+   * The ExceptionMapper is omitted
+   */
+  @Test
+  public void responseEntityTest() throws Fault {
+    setProperty(REQUEST, buildRequest(GET, "responseentity"));
+    setProperty(Property.SEARCH_STRING, Resource.class.getSimpleName());
+    invoke();
+  }
+
+  /*
+   * @testName: statusOkResponseTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:16; JAXRS:SPEC:16.1; JAXRS:SPEC:16.2;
+   * 
+   * @test_Strategy: An implementation MUST catch all exceptions and process
+   * them as follows: Instances of WebApplicationException MUST be mapped to a
+   * response as follows. If the response property of the exception does not
+   * contain an entity and an exception mapping provider (see section 4.4) is
+   * available for WebApplicationException an implementation MUST use the
+   * provider to create a new Response instance, otherwise the response property
+   * is used directly.
+   */
+  @Test
+  public void statusOkResponseTest() throws Fault {
+    setProperty(REQUEST, buildRequest(GET, "responsestatusok"));
+    setProperty(STATUS_CODE, getStatusCode(Status.ACCEPTED));
+    invoke();
+  }
+
+  /*
+   * @testName: statusIntOkResponseTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:16; JAXRS:SPEC:16.1; JAXRS:SPEC:16.2;
+   * 
+   * @test_Strategy: An implementation MUST catch all exceptions and process
+   * them as follows: Instances of WebApplicationException MUST be mapped to a
+   * response as follows. If the response property of the exception does not
+   * contain an entity and an exception mapping provider (see section 4.4) is
+   * available for WebApplicationException an implementation MUST use the
+   * provider to create a new Response instance, otherwise the response property
+   * is used directly.
+   */
+  @Test
+  public void statusIntOkResponseTest() throws Fault {
+    setProperty(REQUEST, buildRequest(GET, "responsestatusintok"));
+    setProperty(STATUS_CODE, getStatusCode(Status.ACCEPTED));
+    invoke();
+  }
+
+  /*
+   * @testName: throwableResponseTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:16; JAXRS:SPEC:16.1; JAXRS:SPEC:16.2;
+   * 
+   * @test_Strategy: An implementation MUST catch all exceptions and process
+   * them as follows: Instances of WebApplicationException MUST be mapped to a
+   * response as follows. If the response property of the exception does not
+   * contain an entity and an exception mapping provider (see section 4.4) is
+   * available for WebApplicationException an implementation MUST use the
+   * provider to create a new Response instance, otherwise the response property
+   * is used directly.
+   */
+  @Test
+  public void throwableResponseTest() throws Fault {
+    setProperty(REQUEST, buildRequest(GET, "responsethrowable"));
+    setProperty(STATUS_CODE, getStatusCode(Status.ACCEPTED));
+    invoke();
+  }
+
+  /*
+   * @testName: throwableOkResponseTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:16; JAXRS:SPEC:16.1; JAXRS:SPEC:16.2;
+   * 
+   * @test_Strategy: An implementation MUST catch all exceptions and process
+   * them as follows: Instances of WebApplicationException MUST be mapped to a
+   * response as follows. If the response property of the exception does not
+   * contain an entity and an exception mapping provider (see section 4.4) is
+   * available for WebApplicationException an implementation MUST use the
+   * provider to create a new Response instance, otherwise the response property
+   * is used directly.
+   */
+  @Test
+  public void throwableOkResponseTest() throws Fault {
+    setProperty(REQUEST, buildRequest(GET, "responsestatusthrowableok"));
+    setProperty(STATUS_CODE, getStatusCode(Status.ACCEPTED));
+    invoke();
+  }
+
+  /*
+   * @testName: throwableIntOkResponseTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:16; JAXRS:SPEC:16.1; JAXRS:SPEC:16.2;
+   * 
+   * @test_Strategy: An implementation MUST catch all exceptions and process
+   * them as follows: Instances of WebApplicationException MUST be mapped to a
+   * response as follows. If the response property of the exception does not
+   * contain an entity and an exception mapping provider (see section 4.4) is
+   * available for WebApplicationException an implementation MUST use the
+   * provider to create a new Response instance, otherwise the response property
+   * is used directly.
+   */
+  @Test
+  public void throwableIntOkResponseTest() throws Fault {
+    setProperty(REQUEST, buildRequest(GET, "responsestatusthrowableintok"));
+    setProperty(STATUS_CODE, getStatusCode(Status.ACCEPTED));
+    invoke();
+  }
+
+  /*
+   * @testName: throwUncheckedExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:16; JAXRS:SPEC:16.3;
+   * 
+   * @test_Strategy: Unchecked exceptions and errors MUST be re-thrown and
+   * allowed to propagate to the underlying container..
+   */
+  @Test
+  public void throwUncheckedExceptionTest() throws Fault {
+    setProperty(REQUEST, buildRequest(GET, "uncheckedexception"));
+    setProperty(STATUS_CODE, getStatusCode(Status.NOT_ACCEPTABLE));
+    invoke();
+  }
+
+  /*
+   * @testName: webApplicationExceptionHasResponseWithEntityDoesNotUseMapperTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:16; JAXRS:SPEC:16.1;
+   * 
+   * @test_Strategy: An implementation MUST catch all exceptions and process
+   * them as follows: Instances of WebApplicationException MUST be mapped to a
+   * response as follows. If the response property of the exception does not
+   * contain an entity and an exception mapping provider (see section 4.4) is
+   * available for WebApplicationException an implementation MUST use the
+   * provider to create a new Response instance, otherwise the response property
+   * is used directly.
+   */
+  @Test
+  public void webApplicationExceptionHasResponseWithEntityDoesNotUseMapperTest()
+      throws Fault {
+    int[] codes = { 2000, 4000, 400, 401, 403, 404, 405, 406, 415, 3000, 5000,
+        500, 503 };
+    for (int i = 0; i != codes.length; i++) {
+      setProperty(Property.REQUEST,
+          buildRequest(Request.GET, "direct/" + codes[i]));
+      setProperty(Property.STATUS_CODE,
+          String.valueOf(codes[i] > 1000 ? codes[i] / 10 : codes[i]));
+      setProperty(Property.SEARCH_STRING,
+          codes[i] > 1000 ? DirectResponseUsageResource.ENTITY
+              : DirectResponseUsageResource.getReasonPhrase(codes[i]));
+      invoke();
+    }
+  }
+
+  /*
+   * @testName: webApplicationExceptionHasResponseWithoutEntityDoesUseMapperTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:16; JAXRS:SPEC:16.1;
+   * 
+   * @test_Strategy: An implementation MUST catch all exceptions and process
+   * them as follows: Instances of WebApplicationException MUST be mapped to a
+   * response as follows. If the response property of the exception does not
+   * contain an entity and an exception mapping provider (see section 4.4) is
+   * available for WebApplicationException an implementation MUST use the
+   * provider to create a new Response instance, otherwise the response property
+   * is used directly.
+   */
+  @Test
+  public void webApplicationExceptionHasResponseWithoutEntityDoesUseMapperTest()
+      throws Fault {
+    int[] codes = { 4000, 400, 401, 403, 404, 405, 406, 415, 3000, 5000, 500,
+        503 };
+    for (int i = 0; i != codes.length; i++) {
+      setProperty(Property.REQUEST,
+          buildRequest(Request.GET, "noentity/" + codes[i]));
+      setProperty(Property.STATUS_CODE, getStatusCode(Status.FOUND));
+      invoke();
+    }
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/resource/webappexception/mapper/Resource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/resource/webappexception/mapper/Resource.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2012, 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.resource.webappexception.mapper;
+
+import java.io.IOException;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+
+@Path(value = "resource")
+public class Resource {
+
+  @GET
+  @Path("noresponse")
+  public String noresponse() {
+    throw new WebApplicationException();
+  }
+
+  @GET
+  @Path("responseok")
+  public String responseOk() {
+    Response r = Response.ok().build();
+    throw new WebApplicationException(r);
+  }
+
+  @GET
+  @Path("responsestatusok")
+  public String responseStatusOk() {
+    throw new WebApplicationException(Status.OK);
+  }
+
+  @GET
+  @Path("responseentity")
+  public String responseEntity() {
+    Response r = Response.ok(getClass().getSimpleName()).build();
+    throw new WebApplicationException(r);
+  }
+
+  @GET
+  @Path("responsestatusintok")
+  public String responseStatusIntOk() {
+    throw new WebApplicationException(Status.OK.getStatusCode());
+  }
+
+  @GET
+  @Path("responsethrowable")
+  public String responseThrowable() {
+    throw new WebApplicationException(getIOException());
+  }
+
+  @GET
+  @Path("responsethrowableok")
+  public String responseThrowableOk() {
+    Response r = Response.ok().build();
+    throw new WebApplicationException(getIOException(), r);
+  }
+
+  @GET
+  @Path("responsestatusthrowableok")
+  public String responseThrowableStatusOk() {
+    throw new WebApplicationException(getIOException(), Status.OK);
+  }
+
+  @GET
+  @Path("responsestatusthrowableintok")
+  public String responseThrowableStatusIntOk() {
+    throw new WebApplicationException(getIOException(),
+        Status.OK.getStatusCode());
+  }
+
+  @GET
+  @Path("uncheckedexception")
+  public String throwIOExecption() {
+    throw new ClassCastException("ERROR");
+  }
+
+  IOException getIOException() {
+    IOException ioe = new IOException("You should NOT see this message");
+    return ioe;
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/resource/webappexception/mapper/ResponseWithNoEntityUsesMapperResource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/resource/webappexception/mapper/ResponseWithNoEntityUsesMapperResource.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2014, 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.resource.webappexception.mapper;
+
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.ClientErrorException;
+import jakarta.ws.rs.ForbiddenException;
+import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.NotAcceptableException;
+import jakarta.ws.rs.NotAllowedException;
+import jakarta.ws.rs.NotAuthorizedException;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.NotSupportedException;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.RedirectionException;
+import jakarta.ws.rs.ServerErrorException;
+import jakarta.ws.rs.ServiceUnavailableException;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.ResponseBuilder;
+
+@Path("resource/noentity")
+public class ResponseWithNoEntityUsesMapperResource {
+
+  public static final String MESSAGE = "Use mapper";
+
+  private static Response buildResponse(int status) {
+    ResponseBuilder rb = Response.status(status);
+    return rb.build();
+  }
+
+  @Path("{id}")
+  public Response getException(@PathParam("id") int id) {
+    WebApplicationException wae = null;
+    switch (id) {
+    case 4000:
+      wae = new ClientErrorException(MESSAGE, buildResponse(400));
+      break;
+    case 400:
+      wae = new BadRequestException(MESSAGE, buildResponse(id));
+      break;
+    case 403:
+      wae = new ForbiddenException(MESSAGE, buildResponse(id));
+      break;
+    case 406:
+      wae = new NotAcceptableException(MESSAGE, buildResponse(id));
+      break;
+    case 405:
+      wae = new NotAllowedException(MESSAGE, buildResponse(id));
+      break;
+    case 401:
+      wae = new NotAuthorizedException(MESSAGE, buildResponse(id));
+      break;
+    case 404:
+      wae = new NotFoundException(MESSAGE, buildResponse(id));
+      break;
+    case 415:
+      wae = new NotSupportedException(MESSAGE, buildResponse(id));
+      break;
+    case 3000:
+      wae = new RedirectionException(MESSAGE, buildResponse(300));
+      break;
+    case 5000:
+      wae = new ServerErrorException(MESSAGE, buildResponse(500));
+      break;
+    case 500:
+      wae = new InternalServerErrorException(MESSAGE, buildResponse(id));
+      break;
+    case 503:
+      wae = new ServiceUnavailableException(MESSAGE, buildResponse(id));
+      break;
+    }
+    throw wae;
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/resource/webappexception/mapper/RuntimeExceptionMapper.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/resource/webappexception/mapper/RuntimeExceptionMapper.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2012, 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.resource.webappexception.mapper;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+@Provider
+public class RuntimeExceptionMapper
+    implements ExceptionMapper<RuntimeException> {
+
+  @Override
+  public Response toResponse(RuntimeException exception) {
+    return Response.status(Status.NOT_ACCEPTABLE).build();
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/resource/webappexception/mapper/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/resource/webappexception/mapper/TSAppConfig.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2012, 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.resource.webappexception.mapper;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.ws.rs.core.Application;
+
+public class TSAppConfig extends Application {
+
+  public java.util.Set<java.lang.Class<?>> getClasses() {
+    Set<Class<?>> resources = new HashSet<Class<?>>();
+    resources.add(Resource.class);
+    resources.add(DirectResponseUsageResource.class);
+    resources.add(ResponseWithNoEntityUsesMapperResource.class);
+    resources.add(RuntimeExceptionMapper.class);
+    resources.add(WebAppExceptionMapper.class);
+    return resources;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/resource/webappexception/mapper/WebAppExceptionMapper.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/resource/webappexception/mapper/WebAppExceptionMapper.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2012, 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.resource.webappexception.mapper;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+@Provider
+public class WebAppExceptionMapper
+    implements ExceptionMapper<WebApplicationException> {
+
+  @Override
+  public Response toResponse(WebApplicationException exception) {
+    // When not found, i.e. url is wrong, one get also
+    // WebApplicationException
+    if (exception.getClass() != WebApplicationException.class) {
+      // When response has entity, the ExceptionMapper is not used
+      // Let's mark these WebApplicationException with message
+      // DirectResponseUsageResource.ENTITY
+      if (exception.getMessage().equals(DirectResponseUsageResource.ENTITY))
+        return Response.status(400).entity(
+            "WebAppExceptionMapper should not be used when WebApplicationException has an entity")
+            .build();
+      // Lets mark the WebApplicationException without entity by a message
+      // in this case, the WebApplicationException should have been used
+      else if (exception.getMessage()
+          .equals(ResponseWithNoEntityUsesMapperResource.MESSAGE))
+        return Response.status(Status.FOUND).build();
+      // default, not a source by TCK, but vi, possible config issue?
+      else
+        return exception.getResponse();
+    }
+    return Response.status(Status.ACCEPTED).build();
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/resource/webappexception/nomapper/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/resource/webappexception/nomapper/JAXRSClientIT.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright (c) 2011, 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.resource.webappexception.nomapper;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JAXRSClientIT extends JAXRSCommonClient {
+  private static final long serialVersionUID = 1L;
+
+  public JAXRSClientIT() {
+    setup();
+    setContextRoot("/jaxrs_resource_webappexception_nomapper_web/resource");
+  }
+
+  @Deployment(testable = false)
+  public static WebArchive createDeployment() throws IOException {
+
+    InputStream inStream = JAXRSClientIT.class.getClassLoader().getResourceAsStream("jakarta/ws/rs/tck/ee/resource/webappexception/nomapper/web.xml.template");
+    // Replace the servlet_adaptor in web.xml.template with the System variable set as servlet adaptor
+    String webXml = editWebXmlString(inStream);
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_resource_webappexception_nomapper_web.war");
+    archive.addClasses(TSAppConfig.class, Resource.class);
+    archive.setWebXML(new StringAsset(webXml));
+    //archive.addAsWebInfResource(JAXRSClientIT.class.getPackage(), "web.xml.template", "web.xml"); //can use if the web.xml.template doesn't need to be modified.    
+    
+    return archive;
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  /*
+   * @testName: emptyConstructorTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:13;
+   * 
+   * @test_Strategy: Client invokes GET on root resource at /resource; Verify
+   * that WebApplicationException() works.
+   */
+  @Test
+  public void emptyConstructorTest() throws Fault {
+    setProperty(REQUEST, buildRequest(GET, "EmptyConstructor"));
+    setProperty(STATUS_CODE, getStatusCode(Status.INTERNAL_SERVER_ERROR));
+    invoke();
+  }
+
+  /*
+   * @testName: statusCode404Test
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:15;
+   * 
+   * @test_Strategy: Client invokes GET on root resource at /resource; Verify
+   * that WebApplicationException(404) works.
+   */
+  @Test
+  public void statusCode404Test() throws Fault {
+    setProperty(REQUEST, buildRequest(GET, "StatusCode404"));
+    setProperty(STATUS_CODE, getStatusCode(Status.NOT_FOUND));
+    invoke();
+  }
+
+  /*
+   * @testName: statusCode401Test
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:15;
+   * 
+   * @test_Strategy: Client invokes GET on root resource at /resource; Verify
+   * that WebApplicationException(401) works.
+   */
+  @Test
+  public void statusCode401Test() throws Fault {
+    setProperty(REQUEST, buildRequest(GET, "StatusCode401"));
+    setProperty(STATUS_CODE, getStatusCode(Status.UNAUTHORIZED));
+    invoke();
+  }
+
+  /*
+   * @testName: status503Test
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:16;
+   * 
+   * @test_Strategy: Client invokes GET on root resource at /resource; Verify
+   * that WebApplicationException(Status) works.
+   */
+  @Test
+  public void status503Test() throws Fault {
+    setProperty(REQUEST, buildRequest(GET, "Status503"));
+    setProperty(STATUS_CODE, getStatusCode(Status.SERVICE_UNAVAILABLE));
+    invoke();
+  }
+
+  /*
+   * @testName: status415Test
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:16;
+   * 
+   * @test_Strategy: Client invokes GET on root resource at /resource; Verify
+   * that WebApplicationException(Status) works.
+   */
+  @Test
+  public void status415Test() throws Fault {
+    setProperty(REQUEST, buildRequest(GET, "Status415"));
+    setProperty(STATUS_CODE, getStatusCode(Status.UNSUPPORTED_MEDIA_TYPE));
+    invoke();
+  }
+
+  /*
+   * @testName: responseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:14;
+   * 
+   * @test_Strategy: Client invokes GET on root resource at /resource; Verify
+   * that WebApplicationException(Response) works.
+   */
+  @Test
+  public void responseTest() throws Fault {
+    setProperty(REQUEST, buildRequest(GET, "ResponseTest"));
+    setProperty(SEARCH_STRING, Resource.TESTID);
+    setProperty(Property.EXPECTED_HEADERS, "CTS-HEAD: " + Resource.TESTID);
+    invoke();
+  }
+
+  /*
+   * @testName: nullResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:14;
+   * 
+   * @test_Strategy: Client invokes GET on root resource at /resource; Verify
+   * that WebApplicationException(Response null) works.
+   */
+  @Test
+  public void nullResponseTest() throws Fault {
+    setProperty(REQUEST, buildRequest(GET, "NullResponseTest"));
+    setProperty(STATUS_CODE, getStatusCode(Status.INTERNAL_SERVER_ERROR));
+    invoke();
+  }
+
+  /*
+   * @testName: getResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:12;
+   * 
+   * @test_Strategy: Client invokes GET on root resource at /resource; Verify
+   * that WebApplicationException.getResponse works.
+   */
+  @Test
+  public void getResponseTest() throws Fault {
+    setProperty(REQUEST, buildRequest(GET, "getResponseTest"));
+    setProperty(SEARCH_STRING, Resource.TESTID);
+    setProperty(Property.EXPECTED_HEADERS, "CTS-HEAD: " + Resource.TESTID);
+    invoke();
+  }
+
+  /*
+   * @testName: throwableTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:17;
+   * 
+   * @test_Strategy: Client invokes GET on root resource at /resource; Verify
+   * that WebApplicationException(Throwable) works.
+   */
+  @Test
+  public void throwableTest() throws Fault {
+    setProperty(REQUEST, buildRequest(GET, "ThrowableTest"));
+    setProperty(STATUS_CODE, getStatusCode(Status.INTERNAL_SERVER_ERROR));
+    setProperty(Property.UNEXPECTED_RESPONSE_MATCH,
+        Resource.id("-throwableTest"));
+    invoke();
+  }
+
+  /*
+   * @testName: throwableResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:18;
+   * 
+   * @test_Strategy: Client invokes GET on root resource at /resource; Verify
+   * that WebApplicationException(Throwable, Response) works.
+   */
+  @Test
+  public void throwableResponseTest() throws Fault {
+    setProperty(REQUEST, buildRequest(GET, "ThrowableResponseTest"));
+    setProperty(STATUS_CODE, getStatusCode(Status.ACCEPTED));
+    setProperty(Property.EXPECTED_HEADERS, "CTS-HEAD: " + Resource.TESTID);
+    setProperty(SEARCH_STRING, Resource.TESTID);
+    setProperty(SEARCH_STRING, "throwableResponseTest");
+    setProperty(Property.UNEXPECTED_RESPONSE_MATCH, Resource.id("-FAIL"));
+    invoke();
+  }
+
+  /*
+   * @testName: throwableResponseTest1
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:18;
+   * 
+   * @test_Strategy: Client invokes GET on root resource at /resource; Verify
+   * that WebApplicationException(Throwable, Response Null) works.
+   */
+  @Test
+  public void throwableResponseTest1() throws Fault {
+    setProperty(REQUEST, buildRequest(GET, "ThrowableResponseTest1"));
+    setProperty(STATUS_CODE, getStatusCode(Status.INTERNAL_SERVER_ERROR));
+    setProperty(Property.UNEXPECTED_RESPONSE_MATCH,
+        Resource.id("-throwableResponseTest1-FAIL"));
+    invoke();
+  }
+
+  /*
+   * @testName: throwableStatusTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:20;
+   * 
+   * @test_Strategy: Client invokes GET on root resource at /resource; Verify
+   * that WebApplicationException(Throwable, Status) works.
+   */
+  @Test
+  public void throwableStatusTest() throws Fault {
+    setProperty(REQUEST, buildRequest(GET, "ThrowableStatusTest"));
+    setProperty(STATUS_CODE, getStatusCode(Status.SEE_OTHER));
+    setProperty(Property.UNEXPECTED_RESPONSE_MATCH,
+        Resource.id("-throwableStatusTest"));
+    invoke();
+  }
+
+  /*
+   * @testName: throwableStatusTest1
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:20;
+   * 
+   * @test_Strategy: Client invokes GET on root resource at /resource; Verify
+   * that WebApplicationException(Throwable, Status Null) works.
+   */
+  @Test
+  public void throwableStatusTest1() throws Fault {
+    setProperty(REQUEST, buildRequest(GET, "ThrowableNullStatusTest"));
+    setProperty(Property.UNEXPECTED_RESPONSE_MATCH,
+        Resource.id("-throwableNullStatusTest-FAIL"));
+    setProperty(SEARCH_STRING, Resource.id("-throwableNullStatusTest-PASS"));
+    invoke();
+  }
+
+  /*
+   * @testName: throwableStatusCodeTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:19;
+   * 
+   * @test_Strategy: Client invokes GET on root resource at /resource; Verify
+   * that WebApplicationException(Throwable, int) works.
+   */
+  @Test
+  public void throwableStatusCodeTest() throws Fault {
+    setProperty(REQUEST, buildRequest(GET, "ThrowableStatusCodeTest"));
+    setProperty(STATUS_CODE, getStatusCode(Status.NO_CONTENT));
+    invoke();
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/resource/webappexception/nomapper/Resource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/resource/webappexception/nomapper/Resource.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2011, 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.resource.webappexception.nomapper;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+
+@Path(value = "resource")
+public class Resource {
+
+  static String html_content = "<html>"
+      + "<head><title>CTS-get text/html</title></head>"
+      + "<body>CTS-get text/html</body></html>";
+
+  public static final String TESTID = "CTS-WebApplicationExceptionTest";
+
+  @GET
+  @Path("/EmptyConstructor")
+  public Response emptyConstructor() {
+    throw new WebApplicationException();
+  }
+
+  @GET
+  @Path("/StatusCode404")
+  public Response statusCode404() {
+    throw new WebApplicationException(404);
+  }
+
+  @GET
+  @Path("/StatusCode401")
+  public Response statusCode401() {
+    throw new WebApplicationException(401);
+  }
+
+  @GET
+  @Path("/Status503")
+  public Response status503() {
+    throw new WebApplicationException(Response.Status.SERVICE_UNAVAILABLE);
+  }
+
+  @GET
+  @Path("/Status415")
+  public Response status415() {
+    throw new WebApplicationException(Response.Status.UNSUPPORTED_MEDIA_TYPE);
+  }
+
+  @GET
+  @Path("/ResponseTest")
+  public Response responseTest() {
+    throw new WebApplicationException(
+        Response.ok(TESTID).header("CTS-HEAD", TESTID).build());
+  }
+
+  @GET
+  @Path("/NullResponseTest")
+  public Response nullResponseTest() {
+    Response rsp = null;
+    throw new WebApplicationException(rsp);
+  }
+
+  @GET
+  @Path("/getResponseTest")
+  public Response getResponseTest() {
+    Response r = Response.ok(TESTID).header("CTS-HEAD", TESTID).build();
+    WebApplicationException wae = new WebApplicationException(r);
+    return wae.getResponse();
+  }
+
+  @GET
+  @Path("/ThrowableTest")
+  public Response throwableTest() {
+    throw new WebApplicationException(
+        new Throwable("CTS-WebApplicationExceptionTest-throwableTest"));
+  }
+
+  @GET
+  @Path("/ThrowableResponseTest")
+  public Response throwableResponseTest() {
+    throw new WebApplicationException(
+        new Throwable(id("-throwableResponseTest-FAIL")),
+        Response.ok(id("-throwableResponseTest")).status(202)
+            .header("CTS-HEAD", TESTID).build());
+  }
+
+  @GET
+  @Path("/ThrowableResponseTest1")
+  public Response throwableResponseTest1() {
+    Response rsp = null;
+    throw new WebApplicationException(
+        new Throwable(id("-throwableResponseTest1-FAIL")), rsp);
+  }
+
+  @GET
+  @Path("/ThrowableStatusTest")
+  public Response throwableStatusTest() {
+    throw new WebApplicationException(new Throwable(id("-throwableStatusTest")),
+        Response.Status.SEE_OTHER);
+  }
+
+  @GET
+  @Path("/ThrowableNullStatusTest")
+  public Response throwableNullStatusTest() {
+    try {
+      throw new WebApplicationException(
+          new Throwable(id("-throwableNullStatusTest")),
+          (Response.Status) null);
+    } catch (java.lang.IllegalArgumentException iae) {
+      throw new WebApplicationException(
+          new Throwable(id("-throwableNullStatusTest")),
+          Response.ok(id("-throwableNullStatusTest-PASS")).build());
+    } catch (Exception e) {
+      throw new WebApplicationException(
+          new Throwable(id("-throwableNullStatusTest")),
+          Response.Status.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  @GET
+  @Path("/ThrowableStatusCodeTest")
+  public Response throwableStatusCodeTest() {
+    throw new WebApplicationException(
+        new Throwable(id("-throwableStatusCodeTest")), 204);
+  }
+
+  public static String id(String suffix) {
+    return new StringBuilder().append(TESTID).append(suffix).toString();
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/resource/webappexception/nomapper/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/resource/webappexception/nomapper/TSAppConfig.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2011, 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.resource.webappexception.nomapper;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.ws.rs.core.Application;
+
+public class TSAppConfig extends Application {
+
+  public java.util.Set<java.lang.Class<?>> getClasses() {
+    Set<Class<?>> resources = new HashSet<Class<?>>();
+    resources.add(Resource.class);
+    return resources;
+  }
+}

--- a/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/resource/java2entity/web.xml.template
+++ b/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/resource/java2entity/web.xml.template
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2012, 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+    <servlet>
+        <servlet-name>CTS_JAXRS_JAVA2ENTITY</servlet-name>
+        <servlet-class>servlet_adaptor</servlet-class>
+        <init-param>
+            <param-name>jakarta.ws.rs.Application</param-name>
+            <param-value>jakarta.ws.rs.tck.ee.resource.java2entity.TSAppConfig</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>CTS_JAXRS_JAVA2ENTITY</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+    <session-config>
+        <session-timeout>30</session-timeout>
+    </session-config>
+</web-app>

--- a/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/resource/webappexception/mapper/web.xml.template
+++ b/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/resource/webappexception/mapper/web.xml.template
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2012, 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+    <servlet>
+        <servlet-name>CTS_JAXRS_WEBAPPEXCEPTION_MAPPER</servlet-name>
+        <servlet-class>servlet_adaptor</servlet-class>
+        <init-param>
+            <param-name>jakarta.ws.rs.Application</param-name>
+            <param-value>jakarta.ws.rs.tck.ee.resource.webappexception.mapper.TSAppConfig</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>CTS_JAXRS_WEBAPPEXCEPTION_MAPPER</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+    <session-config>
+        <session-timeout>30</session-timeout>
+    </session-config>
+</web-app>

--- a/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/resource/webappexception/nomapper/web.xml.template
+++ b/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/resource/webappexception/nomapper/web.xml.template
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2012, 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+    <servlet>
+        <servlet-name>CTS_JAXRS_WEBAPPEXCEPTION_NOMAPPER</servlet-name>
+        <servlet-class>servlet_adaptor</servlet-class>
+        <init-param>
+            <param-name>jakarta.ws.rs.Application</param-name>
+            <param-value>jakarta.ws.rs.tck.ee.resource.webappexception.nomapper.TSAppConfig</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>CTS_JAXRS_WEBAPPEXCEPTION_NOMAPPER</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+    <session-config>
+        <session-timeout>30</session-timeout>
+    </session-config>
+</web-app>


### PR DESCRIPTION
This PR migrates all tests from [`jakartaee-tck/src/com/sun/ts/tests/jaxrs/servlet3`](https://github.com/eclipse-ee4j/jakartaee-tck/tree/master/src/com/sun/ts/tests/jaxrs/ee/resource).

Linked issues: #1015 

To test the changes :

```
export JAVA_HOME=<JDK11_HOME>
export M2_HOME=<MAVEN_HOME>
export PATH=$M2_HOME/bin:$JAVA_HOME/bin:$PATH
```

In `jaxrs-tck/`:
`mvn clean install`

In `jersey-tck/`:
run migrated tests : `mvn clean verify -Parq-glassfish-managed -Dit.test=jakarta.ws.rs.tck.ee.resource.**`

All tests should succeed.