### PR TITLE
TCK Migration: Move jaxrs21/ tests from jakartaee-tck

### DIFF
--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/common/impl/JaxbKeyValueBean.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/common/impl/JaxbKeyValueBean.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.common.impl;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+public class JaxbKeyValueBean {
+  @XmlElement
+  public String key;
+  @XmlElement
+  public String value;
+
+  public String getKey() {
+    return key;
+  }
+
+  public void setKey(String key) {
+    this.key = key;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(String value) {
+    this.value = value;
+  }
+
+  public JaxbKeyValueBean set(String key, String value) {
+    setKey(key);
+    setValue(value);
+    return this;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/client/asyncinvoker/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/client/asyncinvoker/JAXRSClientIT.java
@@ -2703,7 +2703,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * @test_Strategy: Invoke HTTP trace method for the current request
    * asynchronously.
    */
-  //@Test
+  @Test
   public void traceTest() throws Fault {
     AsyncInvoker async = startAsyncInvokerForMethod("trace");
     Future<Response> future = async.trace();
@@ -2719,7 +2719,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * @test_Strategy: Invoke HTTP trace method for the current request
    * asynchronously.
    */
-  //@Test
+  @Test
   public void traceWhileServerWaitTest() throws Fault {
     AsyncInvoker async = startAsyncInvokerForMethod("traceandwait");
     Future<Response> future = async.trace();
@@ -2753,7 +2753,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * @test_Strategy: Invoke HTTP trace method for the current request
    * asynchronously.
    */
-  //@Test
+  @Test
   public void traceWithStringClassWhileServerWaitTest() throws Fault {
     AsyncInvoker async = startAsyncInvokerForMethod("traceandwait");
     Future<String> future = async.trace(String.class);
@@ -2769,7 +2769,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * @test_Strategy: Invoke HTTP trace method for the current request
    * asynchronously.
    */
-  //@Test
+  @Test
   public void traceWithResponseClassWhileServerWaitTest()
       throws Fault {
     AsyncInvoker async = startAsyncInvokerForMethod("traceandwait");
@@ -2825,7 +2825,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * received response status code is not successful and the specified response
    * type is not Response.
    */
-  //@Test
+  @Test
   public void traceWithClassThrowsNoWebApplicationExceptionForResponseTest()
       throws Fault {
     AsyncInvoker async = startAsyncInvokerForMethod("tracenotok");
@@ -2841,7 +2841,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * @test_Strategy: Invoke HTTP trace method for the current request
    * asynchronously.
    */
-  //@Test
+  @Test
   public void traceWithGenericTypeStringWhileServerWaitTest()
       throws Fault {
     GenericType<String> generic = createGeneric(String.class);
@@ -2859,7 +2859,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * @test_Strategy: Invoke HTTP trace method for the current request
    * asynchronously.
    */
-  //@Test
+  @Test
   public void traceWithGenericTypeResponseWhileServerWaitTest()
       throws Fault {
     GenericType<Response> generic = createGeneric(Response.class);
@@ -2920,7 +2920,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * received response status code is not successful and the specified response
    * type is not Response.
    */
-  //@Test
+  @Test
   public void traceWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest()
       throws Fault {
     AsyncInvoker async = startAsyncInvokerForMethod("tracenotok");
@@ -2937,7 +2937,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * @test_Strategy: Invoke HTTP trace method for the current request
    * asynchronously.
    */
-  //@Test
+  @Test
   public void traceWithCallbackWhileServerWaitTest() throws Fault {
     InvocationCallback<Response> callback = createCallback(true);
     AsyncInvoker async = startAsyncInvokerForMethod("traceandwait");
@@ -2955,7 +2955,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * @test_Strategy: Invoke HTTP trace method for the current request
    * asynchronously.
    */
-  //@Test
+  @Test
   public void traceWithStringCallbackWhileServerWaitTest()
       throws Fault {
     InvocationCallback<String> callback = createStringCallback(true);
@@ -3016,7 +3016,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * received response status code is not successful and the specified response
    * type is not Response.
    */
-  //@Test
+  @Test
   public void traceWithCallbackThrowsNoWebApplicationExceptionForResponseTest()
       throws Fault {
     AsyncInvoker async = startAsyncInvokerForMethod("tracenotok");

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/client/asyncinvoker/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/client/asyncinvoker/JAXRSClientIT.java
@@ -86,7 +86,9 @@ public class JAXRSClientIT extends JaxrsCommonClient {
     String webXml = editWebXmlString(inStream);
 
     WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_ee_rs_client_asyncinvoker_web.war");
-    archive.addClasses(TSAppConfig.class, Resource.class);
+    archive.addClasses(TSAppConfig.class, Resource.class,
+      jakarta.ws.rs.tck.common.provider.StringBean.class,
+      jakarta.ws.rs.tck.common.impl.TRACE.class);
     archive.setWebXML(new StringAsset(webXml));
     return archive;
 

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/client/syncinvoker/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/client/syncinvoker/JAXRSClientIT.java
@@ -106,11 +106,10 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * synchronously.
    */
   @Test
-  public Response deleteTest() throws Fault {
+  public void deleteTest() throws Fault {
     SyncInvoker sync = createSyncInvokerForMethod("delete");
     Response response = sync.delete();
     assertResponseOk(response);
-    return response;
   }
 
   /*
@@ -142,11 +141,10 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * synchronously.
    */
   @Test
-  public String deleteWithStringClassTest() throws Fault {
+  public void deleteWithStringClassTest() throws Fault {
     SyncInvoker sync = createSyncInvokerForMethod("delete");
     String response = sync.delete(String.class);
     assertResponseString(response, "delete");
-    return response;
   }
 
   /*
@@ -158,11 +156,10 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * synchronously.
    */
   @Test
-  public Response deleteWithResponseClassTest() throws Fault {
+  public void deleteWithResponseClassTest() throws Fault {
     SyncInvoker sync = createSyncInvokerForMethod("delete");
     Response response = sync.delete(Response.class);
     assertResponseOk(response);
-    return response;
   }
 
   /*
@@ -236,12 +233,11 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * synchronously.
    */
   @Test
-  public String deleteWithGenericTypeStringTest() throws Fault {
+  public void deleteWithGenericTypeStringTest() throws Fault {
     SyncInvoker sync = createSyncInvokerForMethod("delete");
     GenericType<String> generic = createGeneric(String.class);
     String response = sync.delete(generic);
     assertResponseString(response, "delete");
-    return response;
   }
 
   /*
@@ -253,12 +249,11 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * synchronously.
    */
   @Test
-  public Response deleteWithGenericTypeResponseTest() throws Fault {
+  public void deleteWithGenericTypeResponseTest() throws Fault {
     SyncInvoker sync = createSyncInvokerForMethod("delete");
     GenericType<Response> generic = createGeneric(Response.class);
     Response response = sync.delete(generic);
     assertResponseOk(response);
-    return response;
   }
 
   /*
@@ -338,11 +333,10 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * synchronously.
    */
   @Test
-  public Response getTest() throws Fault {
+  public void getTest() throws Fault {
     SyncInvoker sync = createSyncInvokerForMethod("get");
     Response response = sync.get();
     assertResponseOk(response);
-    return response;
   }
 
   /*
@@ -374,11 +368,10 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * synchronously.
    */
   @Test
-  public String getWithStringClassTest() throws Fault {
+  public void getWithStringClassTest() throws Fault {
     SyncInvoker sync = createSyncInvokerForMethod("get");
     String response = sync.get(String.class);
     assertResponseString(response, "get");
-    return response;
   }
 
   /*
@@ -390,11 +383,10 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * synchronously.
    */
   @Test
-  public Response getWithResponseClassTest() throws Fault {
+  public void getWithResponseClassTest() throws Fault {
     SyncInvoker sync = createSyncInvokerForMethod("get");
     Response response = sync.get(Response.class);
     assertResponseOk(response);
-    return response;
   }
 
   /*
@@ -467,12 +459,11 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * synchronously.
    */
   @Test
-  public String getWithGenericTypeStringTest() throws Fault {
+  public void getWithGenericTypeStringTest() throws Fault {
     SyncInvoker sync = createSyncInvokerForMethod("get");
     GenericType<String> generic = createGeneric(String.class);
     String response = sync.get(generic);
     assertResponseString(response, "get");
-    return response;
   }
 
   /*
@@ -484,12 +475,11 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * synchronously.
    */
   @Test
-  public Response getWithGenericTypeResponseTest() throws Fault {
+  public void getWithGenericTypeResponseTest() throws Fault {
     SyncInvoker sync = createSyncInvokerForMethod("get");
     GenericType<Response> generic = createGeneric(Response.class);
     Response response = sync.get(generic);
     assertResponseOk(response);
-    return response;
   }
 
   /*
@@ -570,13 +560,12 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * synchronously.
    */
   @Test
-  public Response headTest() throws Fault {
+  public void headTest() throws Fault {
     SyncInvoker sync = createSyncInvokerForMethod("head");
     Response response = sync.head();
     Status status = Status.fromStatusCode(response.getStatus());
     assertTrue(status == Status.OK || status == Status.NO_CONTENT,
         "Incorrect status for head received");
-    return response;
   }
 
   /*
@@ -871,7 +860,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * synchronously.
    */
   @Test
-  public Response methodWithEntityTest() throws Fault {
+  public void methodWithEntityTest() throws Fault {
     Response response = null;
     for (String method : ENTITY_METHODS) {
       SyncInvoker sync = createSyncInvokerForMethod(method.toLowerCase());
@@ -879,7 +868,6 @@ public class JAXRSClientIT extends JaxrsCommonClient {
       response = sync.method(method, entity);
       assertResponseOk(response);
     }
-    return response;
   }
 
   /*
@@ -914,7 +902,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * synchronously.
    */
   @Test
-  public String methodWithStringClassWithEntityTest() throws Fault {
+  public void methodWithStringClassWithEntityTest() throws Fault {
     String response = null;
     for (String method : ENTITY_METHODS) {
       SyncInvoker sync = createSyncInvokerForMethod(method.toLowerCase());
@@ -922,7 +910,6 @@ public class JAXRSClientIT extends JaxrsCommonClient {
       response = sync.method(method, entity, String.class);
       assertResponseString(response, method.toLowerCase());
     }
-    return response;
   }
 
   /*
@@ -934,7 +921,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * synchronously.
    */
   @Test
-  public String methodWithResponseClassWithEntityTest() throws Fault {
+  public void methodWithResponseClassWithEntityTest() throws Fault {
     String response = null;
     for (String method : ENTITY_METHODS) {
       SyncInvoker sync = createSyncInvokerForMethod(method.toLowerCase());
@@ -942,7 +929,6 @@ public class JAXRSClientIT extends JaxrsCommonClient {
       response = sync.method(method, entity, String.class);
       assertResponseString(response, method.toLowerCase());
     }
-    return response;
   }
 
   /*
@@ -1151,11 +1137,10 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * synchronously.
    */
   @Test
-  public Response optionsTest() throws Fault {
+  public void optionsTest() throws Fault {
     SyncInvoker sync = createSyncInvokerForMethod("options");
     Response response = sync.options();
     assertResponseOk(response);
-    return response;
   }
 
   /*
@@ -1187,11 +1172,10 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * synchronously.
    */
   @Test
-  public String optionsWithStringClassTest() throws Fault {
+  public void optionsWithStringClassTest() throws Fault {
     SyncInvoker sync = createSyncInvokerForMethod("options");
     String response = sync.options(String.class);
     assertResponseString(response, "options");
-    return response;
   }
 
   /*
@@ -1203,11 +1187,10 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * synchronously.
    */
   @Test
-  public Response optionsWithResponseClassTest() throws Fault {
+  public void optionsWithResponseClassTest() throws Fault {
     SyncInvoker sync = createSyncInvokerForMethod("options");
     Response response = sync.options(Response.class);
     assertResponseOk(response);
-    return response;
   }
 
   /*
@@ -1280,12 +1263,11 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * synchronously.
    */
   @Test
-  public String optionsWithGenericTypeStringTest() throws Fault {
+  public void optionsWithGenericTypeStringTest() throws Fault {
     SyncInvoker sync = createSyncInvokerForMethod("options");
     GenericType<String> generic = createGeneric(String.class);
     String response = sync.options(generic);
     assertResponseString(response, "options");
-    return response;
   }
 
   /*
@@ -1297,12 +1279,11 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * synchronously.
    */
   @Test
-  public Response optionsWithGenericTypeResponseTest() throws Fault {
+  public void optionsWithGenericTypeResponseTest() throws Fault {
     SyncInvoker sync = createSyncInvokerForMethod("options");
     GenericType<Response> generic = createGeneric(Response.class);
     Response response = sync.options(generic);
     assertResponseOk(response);
-    return response;
   }
 
   /*
@@ -1384,12 +1365,11 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * synchronously.
    */
   @Test
-  public Response postTest() throws Fault {
+  public void postTest() throws Fault {
     SyncInvoker sync = createSyncInvokerForMethod("post");
     Entity<String> entity = createEntity("post");
     Response response = sync.post(entity);
     assertResponseOk(response);
-    return response;
   }
 
   /*
@@ -1422,12 +1402,11 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * synchronously.
    */
   @Test
-  public String postWithStringClassTest() throws Fault {
+  public void postWithStringClassTest() throws Fault {
     Entity<String> entity = createEntity("post");
     SyncInvoker sync = createSyncInvokerForMethod("post");
     String response = sync.post(entity, String.class);
     assertResponseString(response, "post");
-    return response;
   }
 
   /*
@@ -1439,12 +1418,11 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * synchronously.
    */
   @Test
-  public Response postWithResponseClassTest() throws Fault {
+  public void postWithResponseClassTest() throws Fault {
     Entity<String> entity = createEntity("post");
     SyncInvoker sync = createSyncInvokerForMethod("post");
     Response response = sync.post(entity, Response.class);
     assertResponseOk(response);
-    return response;
   }
 
   /*
@@ -1520,13 +1498,12 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * synchronously.
    */
   @Test
-  public String postWithGenericTypeStringTest() throws Fault {
+  public void postWithGenericTypeStringTest() throws Fault {
     GenericType<String> generic = createGeneric(String.class);
     Entity<String> entity = createEntity("post");
     SyncInvoker sync = createSyncInvokerForMethod("post");
     String response = sync.post(entity, generic);
     assertResponseString(response, "post");
-    return response;
   }
 
   /*
@@ -1538,13 +1515,12 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * synchronously.
    */
   @Test
-  public Response postWithGenericTypeResponseTest() throws Fault {
+  public void postWithGenericTypeResponseTest() throws Fault {
     GenericType<Response> generic = createGeneric(Response.class);
     Entity<String> entity = createEntity("post");
     SyncInvoker sync = createSyncInvokerForMethod("post");
     Response response = sync.post(entity, generic);
     assertResponseOk(response);
-    return response;
   }
 
   /*
@@ -1628,12 +1604,11 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * synchronously.
    */
   @Test
-  public Response putTest() throws Fault {
+  public void putTest() throws Fault {
     SyncInvoker sync = createSyncInvokerForMethod("put");
     Entity<String> entity = createEntity("put");
     Response response = sync.put(entity);
     assertResponseOk(response);
-    return response;
   }
 
   /*
@@ -1666,12 +1641,11 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * synchronously.
    */
   @Test
-  public String putWithStringClassTest() throws Fault {
+  public void putWithStringClassTest() throws Fault {
     Entity<String> entity = createEntity("put");
     SyncInvoker sync = createSyncInvokerForMethod("put");
     String response = sync.put(entity, String.class);
     assertResponseString(response, "put");
-    return response;
   }
 
   /*
@@ -1683,12 +1657,11 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * synchronously.
    */
   @Test
-  public Response putWithResponseClassTest() throws Fault {
+  public void putWithResponseClassTest() throws Fault {
     Entity<String> entity = createEntity("put");
     SyncInvoker sync = createSyncInvokerForMethod("put");
     Response response = sync.put(entity, Response.class);
     assertResponseOk(response);
-    return response;
   }
 
   /*
@@ -1764,13 +1737,12 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * synchronously.
    */
   @Test
-  public String putWithGenericTypeStringTest() throws Fault {
+  public void putWithGenericTypeStringTest() throws Fault {
     GenericType<String> generic = createGeneric(String.class);
     Entity<String> entity = createEntity("put");
     SyncInvoker sync = createSyncInvokerForMethod("put");
     String response = sync.put(entity, generic);
     assertResponseString(response, "put");
-    return response;
   }
 
   /*
@@ -1782,13 +1754,12 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * synchronously.
    */
   @Test
-  public Response putWithGenericTypeResponseTest() throws Fault {
+  public void putWithGenericTypeResponseTest() throws Fault {
     GenericType<Response> generic = createGeneric(Response.class);
     Entity<String> entity = createEntity("put");
     SyncInvoker sync = createSyncInvokerForMethod("put");
     Response response = sync.put(entity, generic);
     assertResponseOk(response);
-    return response;
   }
 
   /*
@@ -1871,11 +1842,10 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * synchronously.
    */
   @Test
-  public Response traceTest() throws Fault {
+  public void traceTest() throws Fault {
     SyncInvoker sync = createSyncInvokerForMethod("trace");
     Response response = sync.trace();
     assertResponseOk(response);
-    return response;
   }
 
   /*
@@ -1907,11 +1877,10 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * synchronously.
    */
   @Test
-  public String traceWithStringClassTest() throws Fault {
+  public void traceWithStringClassTest() throws Fault {
     SyncInvoker sync = createSyncInvokerForMethod("trace");
     String response = sync.trace(String.class);
     assertResponseString(response, "trace");
-    return response;
   }
 
   /*
@@ -1923,11 +1892,10 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * synchronously.
    */
   @Test
-  public Response traceWithResponseClassTest() throws Fault {
+  public void traceWithResponseClassTest() throws Fault {
     SyncInvoker sync = createSyncInvokerForMethod("trace");
     Response response = sync.trace(Response.class);
     assertResponseOk(response);
-    return response;
   }
 
   /*
@@ -2000,12 +1968,11 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * synchronously.
    */
   @Test
-  public String traceWithGenericTypeStringTest() throws Fault {
+  public void traceWithGenericTypeStringTest() throws Fault {
     GenericType<String> generic = createGeneric(String.class);
     SyncInvoker sync = createSyncInvokerForMethod("trace");
     String response = sync.trace(generic);
     assertResponseString(response, "trace");
-    return response;
   }
 
   /*
@@ -2017,12 +1984,11 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * synchronously.
    */
   @Test
-  public Response traceWithGenericTypeResponseTest() throws Fault {
+  public void traceWithGenericTypeResponseTest() throws Fault {
     GenericType<Response> generic = createGeneric(Response.class);
     SyncInvoker sync = createSyncInvokerForMethod("trace");
     Response response = sync.trace(generic);
     assertResponseOk(response);
-    return response;
   }
 
   /*

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/client/syncinvoker/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/client/syncinvoker/JAXRSClientIT.java
@@ -1951,7 +1951,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * response returned by the server is not successful and the specified
    * response type is not Response.
    */
-  //@Test
+  @Test
   public void traceWithResponseClassThrowsNoWebApplicationExceptionTest()
       throws Fault {
     SyncInvoker sync = createSyncInvokerForMethod("tracenotok");
@@ -2047,7 +2047,7 @@ public class JAXRSClientIT extends JaxrsCommonClient {
    * response returned by the server is not successful and the specified
    * response type is not Response.
    */
-  //@Test
+  @Test
   public void traceWithGenericTypeResponseThrowsNoWebApplicationExceptionTest()
       throws Fault {
     SyncInvoker sync = createSyncInvokerForMethod("tracenotok");

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/api/client/invocationbuilder/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/api/client/invocationbuilder/JAXRSClientIT.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.api.client.invocationbuilder;
+
+import java.io.IOException;
+import java.io.InputStream;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+import jakarta.ws.rs.client.ClientBuilder;
+
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ */
+/**
+ * @since 2.1
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = 21L;
+
+  public JAXRSClientIT() {
+    setup();
+    setContextRoot("/jaxrs21_api_client_invocationbuilder_web/resource");
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  @Deployment(testable = false)
+  public static WebArchive createDeployment() throws IOException {
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs21_api_client_invocationbuilder_web.war");
+    archive.addClasses(TCKRxInvoker.class, TCKRxInvokerProvider.class, 
+      jakarta.ws.rs.tck.common.JAXRSCommonClient.class,
+      jakarta.ws.rs.tck.common.webclient.TestFailureException.class);
+    return archive;
+
+  }
+
+
+  /*
+   * @testName: testRxClassGetsClassInstance
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1163; JAXRS:JAVADOC:1189;
+   * 
+   * @test_Strategy: Access a reactive invoker based on provider RxInvoker
+   * subclass. Note that corresponding RxInvokerProvider must be registered to
+   * client runtime.
+   */
+  @Test
+  public void testRxClassGetsClassInstance() throws Fault {
+    TCKRxInvoker invoker = ClientBuilder.newClient()
+        .register(TCKRxInvokerProvider.class).target("somewhere").request()
+        .rx(TCKRxInvoker.class);
+    assertNotNull(invoker, "rx did not instantiated the invoker");
+    assertEquals(invoker.getClass(), TCKRxInvoker.class,
+        "Custom rxInvoker has not been created");
+
+    invoker = ClientBuilder.newClient().target("somewhere")
+        .register(TCKRxInvokerProvider.class).request().rx(TCKRxInvoker.class);
+    assertNotNull(invoker, "rx did not instantiated the invoker");
+    assertEquals(invoker.getClass(), TCKRxInvoker.class,
+        "Custom rxInvoker has not been created");
+
+    System.out.println("Custom rxInvoker has been created as expected");
+  }
+
+  /*
+   * @testName: testRxClassThrowsWhenNotRegistered
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1163; JAXRS:JAVADOC:1189;
+   * 
+   * @test_Strategy: Access a reactive invoker based on provider RxInvoker
+   * subclass. Note that corresponding RxInvokerProvider must be registered to
+   * client runtime.
+   */
+  @Test
+  public void testRxClassThrowsWhenNotRegistered() throws Fault {
+    try {
+      ClientBuilder.newClient().target("somewhere").request()
+          .rx(TCKRxInvoker.class);
+      System.out.println(
+          "Illegal state exception has not been thrown when no provider is registered");
+    } catch (IllegalStateException e) {
+      System.out.println(
+          "Illegal state exception has been thrown when no provider is registered as expected");
+    }
+  }
+
+  /*
+   * @testName: testRxClassExceutorServiceGetsClassInstance
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1163; JAXRS:JAVADOC:1189;
+   * 
+   * @test_Strategy: Access a reactive invoker based on provider RxInvoker
+   * subclass. Note that corresponding RxInvokerProvider must be registered to
+   * client runtime.
+   */
+  @Test
+  public void testRxClassExceutorServiceGetsClassInstance() throws Fault {
+    TCKRxInvoker invoker = ClientBuilder.newClient()
+        .register(TCKRxInvokerProvider.class).target("somewhere").request()
+        .rx(TCKRxInvoker.class);
+    assertNotNull(invoker, "rx did not instantiated the invoker");
+    assertEquals(invoker.getClass(), TCKRxInvoker.class,
+        "Custom rxInvoker has not been created");
+
+    invoker = ClientBuilder.newClient().target("somewhere")
+        .register(TCKRxInvokerProvider.class).request().rx(TCKRxInvoker.class);
+    assertNotNull(invoker, "rx did not instantiated the invoker");
+    assertEquals(invoker.getClass(), TCKRxInvoker.class,
+        "Custom rxInvoker has not been created");
+
+    System.out.println("Custom rxInvoker has been created as expected");
+  }
+
+  /*
+   * @testName: testRxClassExecutorServiceThrowsWhenNotRegistered
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1163; JAXRS:JAVADOC:1189;
+   * 
+   * @test_Strategy: Access a reactive invoker based on provider RxInvoker
+   * subclass. Note that corresponding RxInvokerProvider must be registered to
+   * client runtime.
+   */
+  @Test
+  public void testRxClassExecutorServiceThrowsWhenNotRegistered() throws Fault {
+    try {
+      ClientBuilder.newClient().target("somewhere").request()
+          .rx(TCKRxInvoker.class);
+      System.out.println(
+          "Illegal state exception has not been thrown when no provider is registered");
+    } catch (IllegalStateException e) {
+      System.out.println(
+          "Illegal state exception has been thrown when no provider is registered as expected");
+    }
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/api/client/invocationbuilder/TCKRxInvoker.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/api/client/invocationbuilder/TCKRxInvoker.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.api.client.invocationbuilder;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.RxInvoker;
+import jakarta.ws.rs.core.GenericType;
+
+public class TCKRxInvoker implements RxInvoker<CompletionStage<String>> {
+
+  private static final String RESULT = "Some string that to initialize the completable future";
+
+  private CompletableFuture<String> future = new CompletableFuture<>();
+
+  {
+    future.complete(RESULT);
+  }
+
+  @Override
+  public CompletionStage<String> get() {
+    return future;
+  }
+
+  @Override
+  public <R> CompletionStage<String> get(Class<R> responseType) {
+    return future;
+  }
+
+  @Override
+  public <R> CompletionStage<String> get(GenericType<R> responseType) {
+    return future;
+  }
+
+  @Override
+  public CompletionStage<String> put(Entity<?> entity) {
+    return future;
+  }
+
+  @Override
+  public <R> CompletionStage<String> put(Entity<?> entity,
+      Class<R> responseType) {
+    return future;
+  }
+
+  @Override
+  public <R> CompletionStage<String> put(Entity<?> entity,
+      GenericType<R> responseType) {
+    return future;
+  }
+
+  @Override
+  public CompletionStage<String> post(Entity<?> entity) {
+    return future;
+  }
+
+  @Override
+  public <R> CompletionStage<String> post(Entity<?> entity,
+      Class<R> responseType) {
+    return future;
+  }
+
+  @Override
+  public <R> CompletionStage<String> post(Entity<?> entity,
+      GenericType<R> responseType) {
+    return future;
+  }
+
+  @Override
+  public CompletionStage<String> delete() {
+    return future;
+  }
+
+  @Override
+  public <R> CompletionStage<String> delete(Class<R> responseType) {
+    return future;
+  }
+
+  @Override
+  public <R> CompletionStage<String> delete(GenericType<R> responseType) {
+    return future;
+  }
+
+  @Override
+  public CompletionStage<String> head() {
+    return future;
+  }
+
+  @Override
+  public CompletionStage<String> options() {
+    return future;
+  }
+
+  @Override
+  public <R> CompletionStage<String> options(Class<R> responseType) {
+    return future;
+  }
+
+  @Override
+  public <R> CompletionStage<String> options(GenericType<R> responseType) {
+    return future;
+  }
+
+  @Override
+  public CompletionStage<String> trace() {
+    return future;
+  }
+
+  @Override
+  public <R> CompletionStage<String> trace(Class<R> responseType) {
+    return future;
+  }
+
+  @Override
+  public <R> CompletionStage<String> trace(GenericType<R> responseType) {
+    return future;
+  }
+
+  @Override
+  public CompletionStage<String> method(String name) {
+    return future;
+  }
+
+  @Override
+  public <R> CompletionStage<String> method(String name,
+      Class<R> responseType) {
+    return future;
+  }
+
+  @Override
+  public <R> CompletionStage<String> method(String name,
+      GenericType<R> responseType) {
+    return future;
+  }
+
+  @Override
+  public CompletionStage<String> method(String name, Entity<?> entity) {
+    return future;
+  }
+
+  @Override
+  public <R> CompletionStage<String> method(String name, Entity<?> entity,
+      Class<R> responseType) {
+    return future;
+  }
+
+  @Override
+  public <R> CompletionStage<String> method(String name, Entity<?> entity,
+      GenericType<R> responseType) {
+    return future;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/api/client/invocationbuilder/TCKRxInvokerProvider.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/api/client/invocationbuilder/TCKRxInvokerProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.api.client.invocationbuilder;
+
+import java.util.concurrent.ExecutorService;
+
+import jakarta.ws.rs.client.RxInvokerProvider;
+import jakarta.ws.rs.client.SyncInvoker;
+
+public class TCKRxInvokerProvider implements RxInvokerProvider<TCKRxInvoker> {
+
+  @Override
+  public boolean isProviderFor(Class<?> clazz) {
+    return clazz == TCKRxInvoker.class;
+  }
+
+  @Override
+  public TCKRxInvoker getRxInvoker(SyncInvoker syncInvoker,
+      ExecutorService executorService) {
+    return new TCKRxInvoker();
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/client/executor/ExecutorServiceChecker.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/client/executor/ExecutorServiceChecker.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.client.executor;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientRequestFilter;
+import jakarta.ws.rs.core.Response;
+
+import jakarta.ws.rs.tck.ee.rs.core.request.JAXRSClientIT;
+
+public interface ExecutorServiceChecker extends Closeable {
+  final static String THREADPREFIX = "JAXRS_TCK_THREAD";
+
+  static final ThreadFactory THREAD_FACTORY = new ThreadFactory() {
+    AtomicInteger ai = new AtomicInteger();
+
+    @Override
+    public Thread newThread(Runnable r) {
+      return new Thread(r, THREADPREFIX + ai.incrementAndGet());
+    }
+  };
+
+  final static ExecutorService EXECUTOR_SERVICE = Executors
+      .newFixedThreadPool(5, THREAD_FACTORY);
+
+  default Client createClient() {
+    Client c = ClientBuilder.newBuilder().executorService(EXECUTOR_SERVICE)
+        .build();
+    c.register(threadNameChecker());
+    return c;
+  }
+
+  default ClientRequestFilter threadNameChecker() {
+    return new ClientRequestFilter() {
+      @Override
+      public void filter(ClientRequestContext requestContext)
+          throws IOException {
+        Thread t = Thread.currentThread();
+        if (!t.getName().startsWith(THREADPREFIX))
+          requestContext.abortWith(Response.notAcceptable(null)
+              .entity("ThreadExecutor check failed").build());
+        JAXRSClientIT.logMsg(
+            "[Client EXECUTOR SERVICE check]: running from thread",
+            t.getName());
+      }
+    };
+  }
+
+  default void close() throws IOException {
+    EXECUTOR_SERVICE.shutdown();
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/client/executor/async/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/client/executor/async/JAXRSClientIT.java
@@ -1,0 +1,1372 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.client.executor.async;
+
+import java.io.IOException;
+import java.util.concurrent.Future;
+import java.io.InputStream;
+
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+import jakarta.ws.rs.tck.common.client.JdkLoggingFilter;
+import jakarta.ws.rs.tck.jaxrs21.ee.client.executor.ExecutorServiceChecker;
+
+import jakarta.ws.rs.client.AsyncInvoker;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Response;
+
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JAXRSClientIT
+    extends jakarta.ws.rs.tck.ee.rs.client.asyncinvoker.JAXRSClientIT
+    implements ExecutorServiceChecker {
+
+  private static final long serialVersionUID = 21L;
+
+  public JAXRSClientIT() {
+    setup();
+    setContextRoot("/jaxrs_jaxrs21_ee_client_executor_async_web/resource");
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  @Deployment(testable = false, name = "jaxrs21_ee_client_executor_async_deployment")
+  public static WebArchive createDeployment() throws IOException{
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_jaxrs21_ee_client_executor_async_web.war");
+    archive.addClasses(TSAppConfig.class, jakarta.ws.rs.tck.common.impl.TRACE.class,
+      jakarta.ws.rs.tck.ee.rs.client.asyncinvoker.Resource.class);
+    return archive;
+
+  }
+
+
+  /* Run test */
+  // --------------------------------------------------------------------
+  // ---------------------- DELETE --------------------------------------
+  // --------------------------------------------------------------------
+  /*
+   * @testName: deleteTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP DELETE method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void deleteTest() throws Fault {
+    super.deleteTest();
+  }
+
+  @Override
+  public void deleteWhileServerWaitTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void deleteThrowsExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  /*
+   * @testName: deleteWithStringClassWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP DELETE method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void deleteWithStringClassWhileServerWaitTest()
+      throws Fault {
+    super.deleteWithStringClassWhileServerWaitTest();
+  }
+
+  /*
+   * @testName: deleteWithResponseClassWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP DELETE method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void deleteWithResponseClassWhileServerWaitTest()
+      throws Fault {
+    super.deleteWithResponseClassWhileServerWaitTest();
+  }
+
+  @Override
+  public void deleteWithClassThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void deleteWithClassThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void deleteWithClassThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+
+  /*
+   * @testName: deleteWithGenericTypeStringWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP DELETE method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void deleteWithGenericTypeStringWhileServerWaitTest()
+      throws Fault {
+    super.deleteWithGenericTypeStringWhileServerWaitTest();
+  }
+
+  /*
+   * @testName: deleteWithGenericTypeResponseWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP DELETE method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void deleteWithGenericTypeResponseWhileServerWaitTest()
+      throws Fault {
+    super.deleteWithGenericTypeResponseWhileServerWaitTest();
+  }
+
+  @Override
+  public void deleteWithGenericTypeThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void deleteWithGenericTypeThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void deleteWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+
+  /*
+   * @testName: deleteWithCallbackWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP DELETE method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void deleteWithCallbackWhileServerWaitTest() throws Fault {
+    super.deleteWithCallbackWhileServerWaitTest();
+  }
+
+  /*
+   * @testName: deleteWithCallbackStringWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP DELETE method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void deleteWithCallbackStringWhileServerWaitTest()
+      throws Fault {
+    super.deleteWithCallbackStringWhileServerWaitTest();
+  }
+
+  @Override
+  public void deleteWithCallbackStringThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+  
+  @Override
+  public void deleteWithCallbackStringThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void deleteWithCallbackThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+
+  // ------------------------------------------------------------------
+  // ---------------------------GET------------------------------------
+  // ------------------------------------------------------------------
+  /*
+   * @testName: getTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP GET method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void getTest() throws Fault {
+    super.getTest();
+  }
+  
+  @Override
+  public void getWhileServerWaitTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void getThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  /*
+   * @testName: getWithStringClassWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP GET method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void getWithStringClassWhileServerWaitTest() throws Fault {
+    super.getWithStringClassWhileServerWaitTest();
+  }
+
+  /*
+   * @testName: getWithResponseClassWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP GET method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void getWithResponseClassWhileServerWaitTest()
+      throws Fault {
+    super.deleteWithResponseClassWhileServerWaitTest();
+  }
+
+  @Override
+  public void getWithClassThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void getWithClassThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void getWithClassThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+  
+
+  /*
+   * @testName: getWithGenericTypeStringWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP GET method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void getWithGenericTypeStringWhileServerWaitTest()
+      throws Fault {
+    super.getWithGenericTypeStringWhileServerWaitTest();
+  }
+
+  /*
+   * @testName: getWithGenericTypeResponseWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP GET method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void getWithGenericTypeResponseWhileServerWaitTest()
+      throws Fault {
+    super.getWithGenericTypeResponseWhileServerWaitTest();
+  }
+
+  @Override
+  public void getWithGenericTypeThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void getWithGenericTypeThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void getWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+
+  /*
+   * @testName: getWithCallbackWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP GET method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void getWithCallbackWhileServerWaitTest() throws Fault {
+    super.getWithCallbackWhileServerWaitTest();
+  }
+
+  /*
+   * @testName: getWithCallbackStringWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP GET method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void getWithCallbackStringWhileServerWaitTest()
+      throws Fault {
+    super.getWithCallbackStringWhileServerWaitTest();
+  }
+
+  @Override
+  public void getWithCallbackStringThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void getWithCallbackStringThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void getWithCallbackThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+  
+
+  // ------------------------------------------------------------------
+  // ---------------------------HEAD-----------------------------------
+  // ------------------------------------------------------------------
+
+  /*
+   * @testName: headTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP HEAD method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void headTest() throws Fault {
+    super.headTest();
+  }
+  
+  @Override
+  public void headWhileServerWaitTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void headThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  /*
+   * @testName: headWithCallbackWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP HEAD method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void headWithCallbackWhileServerWaitTest() throws Fault {
+    super.headWithCallbackWhileServerWaitTest();
+  }
+
+  @Override
+  public void headWithCallbackStringThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  // ------------------------------------------------------------------
+  // ---------------------------METHOD-----------------------------------
+  // ------------------------------------------------------------------
+
+  /*
+   * @testName: methodTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke an arbitrary method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void methodTest() throws Fault {
+    super.methodTest();
+  }
+
+  @Override
+  public void methodWhileServerWaitTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void methodThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  /*
+   * @testName: methodWithStringClassWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke an arbitrary method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void methodWithStringClassWhileServerWaitTest()
+      throws Fault {
+    super.methodWithStringClassWhileServerWaitTest();
+  }
+
+  /*
+   * @testName: methodWithResponseClassWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke an arbitrary method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void methodWithResponseClassWhileServerWaitTest()
+      throws Fault {
+    super.methodWithResponseClassWhileServerWaitTest();
+  }
+  
+  @Override
+  public void methodWithClassThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void methodWithClassThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+  
+  @Override
+  public void methodWithClassThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+
+  /*
+   * @testName: methodWithGenericTypeStringWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke an arbitrary method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void methodWithGenericTypeStringWhileServerWaitTest()
+      throws Fault {
+    super.methodWithGenericTypeStringWhileServerWaitTest();
+  }
+
+  /*
+   * @testName: methodWithGenericTypeResponseWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke an arbitrary method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void methodWithGenericTypeResponseWhileServerWaitTest()
+      throws Fault {
+    super.methodWithGenericTypeResponseWhileServerWaitTest();
+  }
+
+  @Override
+  public void methodWithGenericTypeThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void methodWithGenericTypeThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void methodWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+  
+
+  /*
+   * @testName: methodWithCallbackWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke an arbitrary method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void methodWithCallbackWhileServerWaitTest() throws Fault {
+    super.methodWithCallbackWhileServerWaitTest();
+  }
+
+  /*
+   * @testName: methodWithCallbackStringWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke an arbitrary method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void methodWithCallbackStringWhileServerWaitTest()
+      throws Fault {
+    super.methodWithCallbackStringWhileServerWaitTest();
+  }
+
+  @Override
+  public void methodWithCallbackThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void methodWithCallbackThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void methodWithCallbackThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+  
+
+  /*
+   * @testName: methodWithEntityWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke an arbitrary method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void methodWithEntityWhileServerWaitTest() throws Fault {
+    super.methodWithEntityWhileServerWaitTest();
+  }
+
+  @Override
+  public void methodWithEntityThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+  
+
+  /*
+   * @testName: methodWithStringClassWithEntityWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke an arbitrary method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void methodWithStringClassWithEntityWhileServerWaitTest()
+      throws Fault {
+    super.methodWithStringClassWithEntityWhileServerWaitTest();
+  }
+
+  /*
+   * @testName: methodWithResponseClassWithEntityWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke an arbitrary method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void methodWithResponseClassWithEntityWhileServerWaitTest()
+      throws Fault {
+    super.methodWithResponseClassWithEntityWhileServerWaitTest();
+  }
+
+  /*
+   * @testName: methodWithGenericTypeStringWithEntityWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke an arbitrary method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void methodWithGenericTypeStringWithEntityWhileServerWaitTest()
+      throws Fault {
+    super.methodWithGenericTypeStringWithEntityWhileServerWaitTest();
+  }
+
+  @Override
+  public void methodWithClassWithEntityThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void methodWithClassWithEntityThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void methodWithClassWithEntityThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+  
+  /*
+   * @testName: methodWithGenericTypeResponseWithEntityWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke an arbitrary method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void methodWithGenericTypeResponseWithEntityWhileServerWaitTest()
+      throws Fault {
+    super.methodWithGenericTypeResponseWithEntityWhileServerWaitTest();
+  }
+
+  @Override
+  public void methodWithGenericTypeWithEntityThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void methodWithGenericTypeWithEntityThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+  
+  @Override
+  public void methodWithGenericTypeWithEntityThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+
+  /*
+   * @testName: methodWithCallbackWithEntityWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke an arbitrary method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void methodWithCallbackWithEntityWhileServerWaitTest()
+      throws Fault {
+    super.methodWithCallbackWithEntityWhileServerWaitTest();
+  }
+
+  /*
+   * @testName: methodWithCallbackStringWithEntityWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke an arbitrary method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void methodWithCallbackStringWithEntityWhileServerWaitTest()
+      throws Fault {
+    super.methodWithCallbackStringWithEntityWhileServerWaitTest();
+  }
+
+  @Override
+  public void methodWithCallbackWithEntityThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void methodWithCallbackWithEntityThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void methodWithCallbackWithEntityThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+  
+
+  // ------------------------------------------------------------------
+  // ---------------------------OPTIONS--------------------------------
+  // ------------------------------------------------------------------
+
+  /*
+   * @testName: optionsTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP options method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void optionsTest() throws Fault {
+    super.optionsTest();
+  }
+
+  @Override
+  public void optionsWhileServerWaitTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void optionsThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+  
+
+  /*
+   * @testName: optionsWithStringClassWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP options method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void optionsWithStringClassWhileServerWaitTest()
+      throws Fault {
+    super.optionsWithStringClassWhileServerWaitTest();
+  }
+
+  /*
+   * @testName: optionsWithResponseClassWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP options method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void optionsWithResponseClassWhileServerWaitTest()
+      throws Fault {
+    super.optionsWithResponseClassWhileServerWaitTest();
+  }
+
+  @Override
+  public void optionsWithClassThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void optionsWithClassThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void optionsWithClassThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+  
+  /*
+   * @testName: optionsWithGenericTypeStringWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP options method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void optionsWithGenericTypeStringWhileServerWaitTest()
+      throws Fault {
+    super.optionsWithGenericTypeStringWhileServerWaitTest();
+  }
+
+  /*
+   * @testName: optionsWithGenericTypeResponseWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP options method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void optionsWithGenericTypeResponseWhileServerWaitTest()
+      throws Fault {
+    super.optionsWithGenericTypeResponseWhileServerWaitTest();
+  }
+
+  @Override
+  public void optionsWithGenericTypeThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+  
+  @Override
+  public void optionsWithGenericTypeThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+  
+  @Override
+  public void optionsWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+
+  /*
+   * @testName: optionsWithCallbackWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP options method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void optionsWithCallbackWhileServerWaitTest()
+      throws Fault {
+    super.optionsWithCallbackWhileServerWaitTest();
+  }
+
+  /*
+   * @testName: optionsWithStringCallbackWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP options method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void optionsWithStringCallbackWhileServerWaitTest()
+      throws Fault {
+    super.optionsWithStringCallbackWhileServerWaitTest();
+  }
+
+  @Override
+  public void optionsWithCallbackThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void optionsWithCallbackThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void optionsWithCallbackThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+
+  // ------------------------------------------------------------------
+  // ---------------------------POST-----------------------------------
+  // ------------------------------------------------------------------
+
+  /*
+   * @testName: postTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP post method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void postTest() throws Fault {
+    super.postTest();
+  }
+
+  @Override
+  public void postWhileServerWaitTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void postThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  /*
+   * @testName: postWithStringClassWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP post method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void postWithStringClassWhileServerWaitTest() throws Fault {
+    super.postWithStringClassWhileServerWaitTest();
+  }
+
+  /*
+   * @testName: postWithResponseClassWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP post method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void postWithResponseClassWhileServerWaitTest()
+      throws Fault {
+    super.postWithResponseClassWhileServerWaitTest();
+  }
+
+  @Override
+  public void postWithClassThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+  
+  @Override
+  public void postWithClassThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void postWithClassThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+
+  /*
+   * @testName: postWithGenericTypeStringWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP post method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void postWithGenericTypeStringWhileServerWaitTest()
+      throws Fault {
+    super.postWithGenericTypeStringWhileServerWaitTest();
+  }
+
+  /*
+   * @testName: postWithGenericTypeResponseWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP post method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void postWithGenericTypeResponseWhileServerWaitTest()
+      throws Fault {
+    super.postWithGenericTypeResponseWhileServerWaitTest();
+  }
+  
+  @Override
+  public void postWithGenericTypeThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void postWithGenericTypeThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void postWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+
+  /*
+   * @testName: postWithCallbackWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP post method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void postWithCallbackWhileServerWaitTest() throws Fault {
+    super.postWithCallbackWhileServerWaitTest();
+  }
+
+  @Override
+  public void postWithCallbackThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void postWithCallbackThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void postWithCallbackThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+  
+
+  // ------------------------------------------------------------------
+  // ---------------------------PUT -----------------------------------
+  // ------------------------------------------------------------------
+
+  /*
+   * @testName: putTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP PUT method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void putTest() throws Fault {
+    super.putTest();
+  }
+
+  @Override
+  public void putWhileServerWaitTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void putThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void putWithClassThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void putWithClassThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void putWithClassThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+
+  /*
+   * @testName: putWithStringClassWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP put method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void putWithStringClassWhileServerWaitTest() throws Fault {
+    super.putWithStringClassWhileServerWaitTest();
+  }
+
+  @Override
+  public void putWithGenericTypeThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void putWithGenericTypeThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void putWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+  
+
+  /*
+   * @testName: putWithResponseClassWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP put method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void putWithResponseClassWhileServerWaitTest()
+      throws Fault {
+    super.putWithResponseClassWhileServerWaitTest();
+  }
+
+  /*
+   * @testName: putWithGenericTypeStringWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP put method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void putWithGenericTypeStringWhileServerWaitTest()
+      throws Fault {
+    super.putWithGenericTypeStringWhileServerWaitTest();
+  }
+
+  /*
+   * @testName: putWithGenericTypeResponseWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP put method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void putWithGenericTypeResponseWhileServerWaitTest()
+      throws Fault {
+    super.putWithGenericTypeResponseWhileServerWaitTest();
+  }
+
+  /*
+   * @testName: putWithCallbackWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP put method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void putWithCallbackWhileServerWaitTest() throws Fault {
+    super.putWithCallbackWhileServerWaitTest();
+  }
+
+  /*
+   * @testName: putWithStringCallbackWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP put method for the current request
+   * asynchronously.
+   */
+  @Test
+  public void putWithStringCallbackWhileServerWaitTest()
+      throws Fault {
+    super.putWithStringCallbackWhileServerWaitTest();
+  }
+
+  @Override
+  public void putWithCallbackThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void putWithCallbackThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+  
+  @Override
+  public void putWithCallbackThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+
+  // ------------------------------------------------------------------
+  // ---------------------------TRACE -----------------------------------
+  // ------------------------------------------------------------------
+
+  /*
+   * @testName: traceTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP trace method for the current request
+   * asynchronously.
+   */
+  //@Test
+  public void traceTest() throws Fault {
+    super.traceTest();
+  }
+
+  @Override
+  public void traceWhileServerWaitTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void traceThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+  
+  
+  /*
+   * @testName: traceWithStringClassWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP trace method for the current request
+   * asynchronously.
+   */
+  //@Test
+  public void traceWithStringClassWhileServerWaitTest() throws Fault {
+    super.traceWithStringClassWhileServerWaitTest();
+  }
+
+  /*
+   * @testName: traceWithResponseClassWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP trace method for the current request
+   * asynchronously.
+   */
+  //@Test
+  public void traceWithResponseClassWhileServerWaitTest()
+      throws Fault {
+    super.traceWithResponseClassWhileServerWaitTest();
+  }
+
+  @Override
+  public void traceWithClassThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void traceWithClassThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void traceWithClassThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+  
+
+  /*
+   * @testName: traceWithGenericTypeStringWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP trace method for the current request
+   * asynchronously.
+   */
+  //@Test
+  public void traceWithGenericTypeStringWhileServerWaitTest()
+      throws Fault {
+    super.traceWithGenericTypeStringWhileServerWaitTest();
+  }
+
+  /*
+   * @testName: traceWithGenericTypeResponseWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP trace method for the current request
+   * asynchronously.
+   */
+  //@Test
+  public void traceWithGenericTypeResponseWhileServerWaitTest()
+      throws Fault {
+    super.traceWithGenericTypeResponseWhileServerWaitTest();
+  }
+
+  @Override
+  public void traceWithGenericTypeThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void traceWithGenericTypeThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void traceWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+  
+
+  /*
+   * @testName: traceWithCallbackWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP trace method for the current request
+   * asynchronously.
+   */
+  //@Test
+  public void traceWithCallbackWhileServerWaitTest() throws Fault {
+    super.traceWithCallbackWhileServerWaitTest();
+  }
+
+  @Override
+  public void traceWithCallbackThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void traceWithCallbackThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void traceWithCallbackThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+  
+  
+  
+  /*
+   * @testName: traceWithStringCallbackWhileServerWaitTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP trace method for the current request
+   * asynchronously.
+   */
+  //@Test
+  public void traceWithStringCallbackWhileServerWaitTest()
+      throws Fault {
+    super.traceWithStringCallbackWhileServerWaitTest();
+  }
+
+  // ///////////////////////////////////////////////////////////////////////
+  // utility methods
+
+  /**
+   * Create AsyncInvoker for given resource method and start time
+   */
+  protected AsyncInvoker startAsyncInvokerForMethod(String methodName) {
+    Client client = createClient();
+    client.register(new JdkLoggingFilter(false));
+    WebTarget target = client.target(getAbsoluteUrl(methodName));
+    AsyncInvoker async = target.request().async();
+    setStartTime();
+    return async;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/client/executor/async/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/client/executor/async/TSAppConfig.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.client.executor.async;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class TSAppConfig extends Application {
+  public java.util.Set<java.lang.Class<?>> getClasses() {
+    Set<Class<?>> resources = new HashSet<Class<?>>();
+    resources
+        .add(jakarta.ws.rs.tck.ee.rs.client.asyncinvoker.Resource.class);
+    return resources;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/client/executor/rx/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/client/executor/rx/JAXRSClientIT.java
@@ -1,0 +1,772 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.client.executor.rx;
+
+import java.io.IOException;
+import java.util.Properties;
+import java.util.concurrent.Future;
+import java.io.InputStream;
+
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+import jakarta.ws.rs.tck.common.client.JdkLoggingFilter;
+import jakarta.ws.rs.tck.jaxrs21.ee.client.executor.ExecutorServiceChecker;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Response;
+
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ */
+/**
+ * @since 2.1
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JAXRSClientIT
+    extends jakarta.ws.rs.tck.jaxrs21.ee.client.rxinvoker.JAXRSClientIT
+    implements ExecutorServiceChecker {
+
+  private static final long serialVersionUID = 21L;
+
+  public JAXRSClientIT() {
+    setup();
+    setContextRoot("/jaxrs_jaxrs21_ee_client_executor_rx_web/resource");
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  @Deployment(testable = false, name = "jaxrs21_ee_client_executor_rx_deployment")
+  public static WebArchive createDeployment() throws IOException{
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_jaxrs21_ee_client_executor_rx_web.war");
+    archive.addClasses(TSAppConfig.class, jakarta.ws.rs.tck.common.impl.TRACE.class,
+      jakarta.ws.rs.tck.jaxrs21.ee.client.rxinvoker.Resource.class);
+    return archive;
+
+  }
+
+  /* Run test */
+  // --------------------------------------------------------------------
+  // ---------------------- DELETE --------------------------------------
+  // --------------------------------------------------------------------
+  /*
+   * @testName: deleteTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP DELETE method for the current request.
+   */
+  @Test
+  public void deleteTest() throws Fault {
+    super.deleteTest();
+  }
+
+  /*
+   * @testName: deleteWithStringClassTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP DELETE method for the current request
+   * 
+   */
+  @Test
+  public void deleteWithStringClassTest() throws Fault {
+    super.deleteWithStringClassTest();
+  }
+
+  /*
+   * @testName: deleteWithResponseClassTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP DELETE method for the current request
+   * 
+   */
+  @Test
+  public void deleteWithResponseClassTest() throws Fault {
+    super.deleteWithResponseClassTest();
+  }
+
+  /*
+   * @testName: deleteWithGenericTypeStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP DELETE method for the current request
+   */
+  @Test
+  public void deleteWithGenericTypeStringTest() throws Fault {
+    super.deleteWithGenericTypeStringTest();
+  }
+
+  /*
+   * @testName: deleteWithGenericTypeResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP DELETE method for the current request
+   */
+  @Test
+  public void deleteWithGenericTypeResponseTest() throws Fault {
+    super.deleteWithGenericTypeResponseTest();
+  }
+
+  // ------------------------------------------------------------------
+  // ---------------------------GET------------------------------------
+  // ------------------------------------------------------------------
+
+  /*
+   * @testName: getTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP GET method for the current request
+   */
+  @Test
+  public void getTest() throws Fault {
+    super.getTest();
+  }
+
+  /*
+   * @testName: getWithStringClassTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP GET method for the current request
+   */
+  @Test
+  public void getWithStringClassTest() throws Fault {
+    super.getWithStringClassTest();
+  }
+
+  /*
+   * @testName: getWithResponseClassTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP GET method for the current request
+   */
+  @Test
+  public void getWithResponseClassTest() throws Fault {
+    super.getWithResponseClassTest();
+  }
+
+  /*
+   * @testName: getWithGenericTypeStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP GET method for the current request
+   */
+  @Test
+  public void getWithGenericTypeStringTest() throws Fault {
+    super.getWithGenericTypeStringTest();
+  }
+
+  /*
+   * @testName: getWithGenericTypeResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP GET method for the current request
+   */
+  @Test
+  public void getWithGenericTypeResponseTest() throws Fault {
+    super.getWithGenericTypeResponseTest();
+  }
+
+  // ------------------------------------------------------------------
+  // ---------------------------HEAD-----------------------------------
+  // ------------------------------------------------------------------
+
+  /*
+   * @testName: headTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP HEAD method for the current request
+   */
+  @Test
+  public void headTest() throws Fault {
+    super.headTest();
+  }
+
+  // ------------------------------------------------------------------
+  // ---------------------------OPTIONS--------------------------------
+  // ------------------------------------------------------------------
+
+  /*
+   * @testName: optionsTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP options method for the current request
+   */
+  @Test
+  public void optionsTest() throws Fault {
+    super.optionsTest();
+  }
+
+  /*
+   * @testName: optionsWithStringClassTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP options method for the current request
+   */
+  @Test
+  public void optionsWithStringClassTest() throws Fault {
+    super.optionsWithStringClassTest();
+  }
+
+  /*
+   * @testName: optionsWithResponseClassTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP options method for the current request
+   */
+  @Test
+  public void optionsWithResponseClassTest() throws Fault {
+    super.optionsWithResponseClassTest();
+  }
+
+  /*
+   * @testName: optionsWithGenericTypeStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP options method for the current request
+   */
+  @Test
+  public void optionsWithGenericTypeStringTest() throws Fault {
+    super.optionsWithGenericTypeStringTest();
+  }
+
+  /*
+   * @testName: optionsWithGenericTypeResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP options method for the current request
+   */
+  @Test
+  public void optionsWithGenericTypeResponseTest() throws Fault {
+    super.optionsWithGenericTypeResponseTest();
+  }
+
+  // ------------------------------------------------------------------
+  // ---------------------------POST-----------------------------------
+  // ------------------------------------------------------------------
+
+  /*
+   * @testName: postTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP post method for the current request
+   */
+  @Test
+  public void postTest() throws Fault {
+    super.postTest();
+  }
+
+  /*
+   * @testName: postWithStringClassTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP post method for the current request
+   */
+  @Test
+  public void postWithStringClassTest() throws Fault {
+    super.postWithStringClassTest();
+  }
+
+  /*
+   * @testName: postWithResponseClassTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP post method for the current request
+   */
+  @Test
+  public void postWithResponseClassTest() throws Fault {
+    super.postWithResponseClassTest();
+  }
+
+  /*
+   * @testName: postWithGenericTypeStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP post method for the current request
+   */
+  @Test
+  public void postWithGenericTypeStringTest() throws Fault {
+    super.postWithGenericTypeStringTest();
+  }
+
+  /*
+   * @testName: postWithGenericTypeResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP post method for the current request
+   */
+  @Test
+  public void postWithGenericTypeResponseTest() throws Fault {
+    super.postWithGenericTypeResponseTest();
+  }
+
+  // ------------------------------------------------------------------
+  // ---------------------------PUT -----------------------------------
+  // ------------------------------------------------------------------
+
+  /*
+   * @testName: putTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP PUT method for the current request
+   */
+  @Test
+  public void putTest() throws Fault {
+    super.putTest();
+  }
+
+  /*
+   * @testName: putWithStringClassTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP put method for the current request
+   */
+  @Test
+  public void putWithStringClassTest() throws Fault {
+    super.putWithStringClassTest();
+  }
+
+  /*
+   * @testName: putWithResponseClassTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP put method for the current request
+   */
+  @Test
+  public void putWithResponseClassTest() throws Fault {
+    super.putWithResponseClassTest();
+  }
+
+  /*
+   * @testName: putWithGenericTypeStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP put method for the current request
+   */
+  @Test
+  public void putWithGenericTypeStringTest() throws Fault {
+    super.putWithGenericTypeStringTest();
+  }
+
+  /*
+   * @testName: putWithGenericTypeResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP put method for the current request
+   */
+  @Test
+  public void putWithGenericTypeResponseTest() throws Fault {
+    super.putWithGenericTypeResponseTest();
+  }
+
+  // ------------------------------------------------------------------
+  // ---------------------------TRACE -----------------------------------
+  // ------------------------------------------------------------------
+
+  /*
+   * @testName: traceTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP trace method for the current request
+   */
+  //@Test
+  public void traceTest() throws Fault {
+    super.traceTest();
+  }
+
+  /*
+   * @testName: traceWithStringClassTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP trace method for the current request
+   */
+  //@Test
+  public void traceWithStringClassTest() throws Fault {
+    super.traceWithStringClassTest();
+  }
+
+  /*
+   * @testName: traceWithResponseClassTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP trace method for the current request
+   */
+  //@Test
+  public void traceWithResponseClassTest() throws Fault {
+    super.traceWithResponseClassTest();
+  }
+
+  /*
+   * @testName: traceWithGenericTypeStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP trace method for the current request
+   */
+  //@Test
+  public void traceWithGenericTypeStringTest() throws Fault {
+    super.traceWithGenericTypeStringTest();
+  }
+
+  /*
+   * @testName: traceWithGenericTypeResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1131;
+   * 
+   * @test_Strategy: Invoke HTTP trace method for the current request
+   */
+  //@Test
+  public void traceWithGenericTypeResponseTest() throws Fault {
+    super.traceWithGenericTypeResponseTest();
+  }
+
+  @Override
+  public void deleteThrowsExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void deleteWithClassThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void deleteWithClassThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void deleteWithClassThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void deleteWithGenericTypeThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void deleteWithGenericTypeThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void deleteWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void getThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void getWithClassThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void getWithClassThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void getWithClassThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void getWithGenericTypeThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void getWithGenericTypeThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void getWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void headThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void methodTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void methodThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void methodWithStringClassTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void methodWithResponseClassTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void methodWithClassThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void methodWithClassThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void methodWithClassThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void methodWithGenericTypeStringTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void methodWithGenericTypeResponseTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void methodWithGenericTypeThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void methodWithGenericTypeThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void methodWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void methodWithEntityTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void methodWithEntityThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void methodWithStringClassWithEntityTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void methodWithResponseClassWithEntityTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void methodWithClassWithEntityThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void methodWithClassWithEntityThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void methodWithClassWithEntityThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void methodWithGenericTypeStringWithEntityTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void methodWithGenericTypeResponseWithEntityTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void methodWithGenericTypeWithEntityThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void methodWithGenericTypeWithEntityThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void methodWithGenericTypeWithEntityThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void optionsThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void optionsWithClassThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void optionsWithClassThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void optionsWithClassThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void optionsWithGenericTypeThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void optionsWithGenericTypeThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+
+  @Override
+  public void optionsWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void postThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void postWithClassThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void postWithClassThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void postWithClassThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void postWithGenericTypeThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void postWithGenericTypeThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void postWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void putThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void putWithClassThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void putWithClassThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void putWithClassThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void putWithGenericTypeThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void putWithGenericTypeThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void putWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void traceThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void traceWithClassThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void traceWithClassThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void traceWithClassThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void traceWithGenericTypeThrowsProcessingExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void traceWithGenericTypeThrowsWebApplicationExceptionTest() throws Fault {
+    //do nothing
+  }
+  @Override
+  public void traceWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest() throws Fault {
+    //do nothing
+  }
+  
+
+  // ///////////////////////////////////////////////////////////////////////
+  // utility methods
+
+  protected Invocation.Builder startBuilderForMethod(String methodName) {
+    Client client = createClient();
+    client.register(new JdkLoggingFilter(false));
+    WebTarget target = client.target(getAbsoluteUrl(methodName));
+    Invocation.Builder ib = target.request();
+    return ib;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/client/executor/rx/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/client/executor/rx/JAXRSClientIT.java
@@ -434,7 +434,7 @@ public class JAXRSClientIT
    * 
    * @test_Strategy: Invoke HTTP trace method for the current request
    */
-  //@Test
+  @Test
   public void traceTest() throws Fault {
     super.traceTest();
   }
@@ -446,7 +446,7 @@ public class JAXRSClientIT
    * 
    * @test_Strategy: Invoke HTTP trace method for the current request
    */
-  //@Test
+  @Test
   public void traceWithStringClassTest() throws Fault {
     super.traceWithStringClassTest();
   }
@@ -458,7 +458,7 @@ public class JAXRSClientIT
    * 
    * @test_Strategy: Invoke HTTP trace method for the current request
    */
-  //@Test
+  @Test
   public void traceWithResponseClassTest() throws Fault {
     super.traceWithResponseClassTest();
   }
@@ -470,7 +470,7 @@ public class JAXRSClientIT
    * 
    * @test_Strategy: Invoke HTTP trace method for the current request
    */
-  //@Test
+  @Test
   public void traceWithGenericTypeStringTest() throws Fault {
     super.traceWithGenericTypeStringTest();
   }
@@ -482,7 +482,7 @@ public class JAXRSClientIT
    * 
    * @test_Strategy: Invoke HTTP trace method for the current request
    */
-  //@Test
+  @Test
   public void traceWithGenericTypeResponseTest() throws Fault {
     super.traceWithGenericTypeResponseTest();
   }

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/client/executor/rx/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/client/executor/rx/TSAppConfig.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.client.executor.rx;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class TSAppConfig extends Application {
+  public java.util.Set<java.lang.Class<?>> getClasses() {
+    Set<Class<?>> resources = new HashSet<Class<?>>();
+    resources
+        .add(jakarta.ws.rs.tck.jaxrs21.ee.client.rxinvoker.Resource.class);
+    return resources;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/client/rxinvoker/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/client/rxinvoker/JAXRSClientIT.java
@@ -1,0 +1,1975 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.client.rxinvoker;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import java.io.InputStream;
+import java.io.IOException;
+
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import jakarta.ws.rs.tck.common.client.JdkLoggingFilter;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.CompletionStageRxInvoker;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+/**
+ * @since 2.1
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = 21L;
+
+  protected long millis;
+
+  protected int callbackResult = 0;
+
+  protected Throwable callbackException = null;
+
+  private final static String NONEXISTING_SITE = "somenonexisting.domain-site";
+
+  public JAXRSClientIT() {
+    setup();
+    setContextRoot("/jaxrs_jaxrs21_ee_client_rxinvoker_web/resource");
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  @Deployment(testable = false)
+  public static WebArchive createDeployment() throws IOException{
+
+    InputStream inStream = JAXRSClientIT.class.getClassLoader().getResourceAsStream("jakarta/ws/rs/tck/jaxrs21/ee/client/rxinvoker/web.xml.template");
+    String webXml = editWebXmlString(inStream);
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_jaxrs21_ee_client_rxinvoker_web.war");
+    archive.addClasses(TSAppConfig.class, Resource.class, jakarta.ws.rs.tck.common.impl.TRACE.class);
+    archive.setWebXML(new StringAsset(webXml));
+    return archive;
+
+  }
+
+  static final String[] METHODS = { "DELETE", "GET", "OPTIONS" };
+
+  static final String[] ENTITY_METHODS = { "PUT", "POST" };
+
+  /* Run test */
+  // --------------------------------------------------------------------
+  // ---------------------- DELETE --------------------------------------
+  // --------------------------------------------------------------------
+  /*
+   * @testName: deleteTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1134; JAXRS:JAVADOC:1162;
+   * 
+   * @test_Strategy: Invoke HTTP DELETE method for the current request.
+   */
+  @Test
+  public void deleteTest() throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("delete");
+    Future<Response> future = rx.delete().toCompletableFuture();
+    checkFutureResponseStatus(future, Status.OK);
+  }
+
+  /*
+   * @testName: deleteThrowsExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1134; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1164;
+   * 
+   * @test_Strategy: ResponseProcessingException - in case processing of a
+   * received HTTP response fails (e.g. in a filter or during conversion of the
+   * response entity data to an instance of a particular Java type).
+   */
+  @Test
+  public void deleteThrowsExceptionTest() throws Fault {
+    _hostname = NONEXISTING_SITE;
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("delete");
+    Future<Response> future = rx.delete().toCompletableFuture();
+    assertExceptionWithProcessingExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName: deleteWithStringClassTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1135; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1164;
+   * 
+   * @test_Strategy: Invoke HTTP DELETE method for the current request
+   * 
+   */
+  @Test
+  public void deleteWithStringClassTest() throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("delete");
+    Future<String> future = rx.delete(String.class).toCompletableFuture();
+    checkFutureString(future, "delete");
+  }
+
+  /*
+   * @testName: deleteWithResponseClassTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1135; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1165;
+   * 
+   * @test_Strategy: Invoke HTTP DELETE method for the current request
+   * 
+   */
+  @Test
+  public void deleteWithResponseClassTest() throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("delete");
+    Future<Response> future = rx.delete(Response.class).toCompletableFuture();
+    checkFutureOkResponse(future);
+  }
+
+  /*
+   * @testName: deleteWithClassThrowsProcessingExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1135; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1165;
+   * 
+   * @test_Strategy: ResponseProcessingException - in case processing of a
+   * received HTTP response fails (e.g. in a filter or during conversion of the
+   * response entity data to an instance of a particular Java type).
+   */
+  @Test
+  public void deleteWithClassThrowsProcessingExceptionTest() throws Fault {
+    _hostname = NONEXISTING_SITE;
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("delete");
+    Future<String> future = rx.delete(String.class).toCompletableFuture();
+    assertExceptionWithProcessingExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName: deleteWithClassThrowsWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1135; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1165;
+   * 
+   * @test_Strategy: WebApplicationException - in case the response status code
+   * of the response returned by the server is not successful and the specified
+   * response type is not Response.
+   */
+  @Test
+  public void deleteWithClassThrowsWebApplicationExceptionTest() throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("deletenotok");
+    Future<String> future = rx.delete(String.class).toCompletableFuture();
+    assertExceptionWithWebApplicationExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName: deleteWithClassThrowsNoWebApplicationExceptionForResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1135; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1165;
+   * 
+   * @test_Strategy: WebApplicationException - in case the response status code
+   * of the response returned by the server is not successful and the specified
+   * response type is not Response.
+   */
+  @Test
+  public void deleteWithClassThrowsNoWebApplicationExceptionForResponseTest()
+      throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("deletenotok");
+    Future<Response> future = rx.delete(Response.class).toCompletableFuture();
+    checkFutureResponseStatus(future, Status.NOT_ACCEPTABLE);
+  }
+
+  /*
+   * @testName: deleteWithGenericTypeStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1136; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1166;
+   * 
+   * @test_Strategy: Invoke HTTP DELETE method for the current request
+   */
+  @Test
+  public void deleteWithGenericTypeStringTest() throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("delete");
+    GenericType<String> generic = createGeneric(String.class);
+    Future<String> future = rx.delete(generic).toCompletableFuture();
+    checkFutureString(future, "delete");
+  }
+
+  /*
+   * @testName: deleteWithGenericTypeResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1136; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1166;
+   * 
+   * @test_Strategy: Invoke HTTP DELETE method for the current request
+   */
+  @Test
+  public void deleteWithGenericTypeResponseTest() throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("delete");
+    GenericType<Response> generic = createGeneric(Response.class);
+    Future<Response> future = rx.delete(generic).toCompletableFuture();
+    checkFutureOkResponse(future);
+  }
+
+  /*
+   * @testName: deleteWithGenericTypeThrowsProcessingExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1136; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1166;
+   * 
+   * @test_Strategy: ResponseProcessingException - in case processing of a
+   * received HTTP response fails (e.g. in a filter or during conversion of the
+   * response entity data to an instance of a particular Java type).
+   */
+  @Test
+  public void deleteWithGenericTypeThrowsProcessingExceptionTest()
+      throws Fault {
+    _hostname = NONEXISTING_SITE;
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("delete");
+    GenericType<String> generic = createGeneric(String.class);
+    Future<String> future = rx.delete(generic).toCompletableFuture();
+    assertExceptionWithProcessingExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName: deleteWithGenericTypeThrowsWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1136; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1166;
+   * 
+   * @test_Strategy: WebApplicationException - in case the response status code
+   * of the response returned by the server is not successful and the specified
+   * response type is not Response.
+   */
+  @Test
+  public void deleteWithGenericTypeThrowsWebApplicationExceptionTest()
+      throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("deletenotok");
+    GenericType<String> generic = createGeneric(String.class);
+    Future<String> future = rx.delete(generic).toCompletableFuture();
+    assertExceptionWithWebApplicationExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName:
+   * deleteWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1136; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1166;
+   * 
+   * @test_Strategy: WebApplicationException - in case the response status code
+   * of the response returned by the server is not successful and the specified
+   * response type is not Response.
+   */
+  @Test
+  public void deleteWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest()
+      throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("deletenotok");
+    GenericType<Response> generic = createGeneric(Response.class);
+    Future<Response> future = rx.delete(generic).toCompletableFuture();
+    checkFutureResponseStatus(future, Status.NOT_ACCEPTABLE);
+  }
+
+  // ------------------------------------------------------------------
+  // ---------------------------GET------------------------------------
+  // ------------------------------------------------------------------
+
+  /*
+   * @testName: getTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1137; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1167;
+   * 
+   * @test_Strategy: Invoke HTTP GET method for the current request
+   */
+  @Test
+  public void getTest() throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("get");
+    Future<Response> future = rx.get().toCompletableFuture();
+    checkFutureOkResponse(future);
+  }
+
+  /*
+   * @testName: getThrowsProcessingExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1137; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1167;
+   * 
+   * @test_Strategy: ResponseProcessingException - in case processing of a
+   * received HTTP response fails (e.g. in a filter or during conversion of the
+   * response entity data to an instance of a particular Java type).
+   */
+  @Test
+  public void getThrowsProcessingExceptionTest() throws Fault {
+    _hostname = NONEXISTING_SITE;
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("get");
+    Future<Response> future = rx.get().toCompletableFuture();
+    assertExceptionWithProcessingExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName: getWithStringClassTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1138; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1168;
+   * 
+   * @test_Strategy: Invoke HTTP GET method for the current request
+   */
+  @Test
+  public void getWithStringClassTest() throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("get");
+    Future<String> future = rx.get(String.class).toCompletableFuture();
+    checkFutureString(future, "get");
+  }
+
+  /*
+   * @testName: getWithResponseClassTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1138; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1168;
+   * 
+   * @test_Strategy: Invoke HTTP GET method for the current request
+   */
+  @Test
+  public void getWithResponseClassTest() throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("get");
+    Future<Response> future = rx.get(Response.class).toCompletableFuture();
+    checkFutureOkResponse(future);
+  }
+
+  /*
+   * @testName: getWithClassThrowsProcessingExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1138; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1168;
+   * 
+   * @test_Strategy: ResponseProcessingException - in case processing of a
+   * received HTTP response fails (e.g. in a filter or during conversion of the
+   * response entity data to an instance of a particular Java type).
+   */
+  @Test
+  public void getWithClassThrowsProcessingExceptionTest() throws Fault {
+    _hostname = NONEXISTING_SITE;
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("get");
+    Future<String> future = rx.get(String.class).toCompletableFuture();
+    assertExceptionWithProcessingExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName: getWithClassThrowsWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1138; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1168;
+   * 
+   * @test_Strategy: WebApplicationException - in case the response status code
+   * of the response returned by the server is not successful and the specified
+   * response type is not Response.
+   */
+  @Test
+  public void getWithClassThrowsWebApplicationExceptionTest() throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("getnotok");
+    Future<String> future = rx.get(String.class).toCompletableFuture();
+    assertExceptionWithWebApplicationExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName: getWithClassThrowsNoWebApplicationExceptionForResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1138; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1168;
+   * 
+   * @test_Strategy: WebApplicationException - in case the response status code
+   * of the response returned by the server is not successful and the specified
+   * response type is not Response.
+   */
+  @Test
+  public void getWithClassThrowsNoWebApplicationExceptionForResponseTest()
+      throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("getnotok");
+    Future<Response> future = rx.get(Response.class).toCompletableFuture();
+    checkFutureResponseStatus(future, Status.NOT_ACCEPTABLE);
+  }
+
+  /*
+   * @testName: getWithGenericTypeStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1139; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1169;
+   * 
+   * @test_Strategy: Invoke HTTP GET method for the current request
+   */
+  @Test
+  public void getWithGenericTypeStringTest() throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("get");
+    GenericType<String> generic = createGeneric(String.class);
+    Future<String> future = rx.get(generic).toCompletableFuture();
+    checkFutureString(future, "get");
+  }
+
+  /*
+   * @testName: getWithGenericTypeResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1139; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1169;
+   * 
+   * @test_Strategy: Invoke HTTP GET method for the current request
+   */
+  @Test
+  public void getWithGenericTypeResponseTest() throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("get");
+    GenericType<Response> generic = createGeneric(Response.class);
+    Future<Response> future = rx.get(generic).toCompletableFuture();
+    checkFutureOkResponse(future);
+  }
+
+  /*
+   * @testName: getWithGenericTypeThrowsProcessingExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1139; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1169;
+   * 
+   * @test_Strategy: ResponseProcessingException - in case processing of a
+   * received HTTP response fails (e.g. in a filter or during conversion of the
+   * response entity data to an instance of a particular Java type).
+   */
+  @Test
+  public void getWithGenericTypeThrowsProcessingExceptionTest() throws Fault {
+    _hostname = NONEXISTING_SITE;
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("get");
+    GenericType<String> generic = createGeneric(String.class);
+    Future<String> future = rx.get(generic).toCompletableFuture();
+    assertExceptionWithProcessingExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName: getWithGenericTypeThrowsWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1139; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1169;
+   * 
+   * @test_Strategy: WebApplicationException - in case the response status code
+   * of the response returned by the server is not successful and the specified
+   * response type is not Response.
+   */
+  @Test
+  public void getWithGenericTypeThrowsWebApplicationExceptionTest()
+      throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("getnotok");
+    GenericType<String> generic = createGeneric(String.class);
+    Future<String> future = rx.get(generic).toCompletableFuture();
+    assertExceptionWithWebApplicationExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName: getWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1139; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1169;
+   * 
+   * @test_Strategy: WebApplicationException - in case the response status code
+   * of the response returned by the server is not successful and the specified
+   * response type is not Response.
+   */
+  @Test
+  public void getWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest()
+      throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("getnotok");
+    GenericType<Response> generic = createGeneric(Response.class);
+    Future<Response> future = rx.get(generic).toCompletableFuture();
+    checkFutureResponseStatus(future, Status.NOT_ACCEPTABLE);
+  }
+
+  // ------------------------------------------------------------------
+  // ---------------------------HEAD-----------------------------------
+  // ------------------------------------------------------------------
+
+  /*
+   * @testName: headTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1140; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1170;
+   * 
+   * @test_Strategy: Invoke HTTP HEAD method for the current request
+   */
+  @Test
+  public void headTest() throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("head");
+    Future<Response> future = rx.head().toCompletableFuture();
+    checkFutureOkResponse(future);
+  }
+
+  /*
+   * @testName: headThrowsProcessingExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1140; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1170;
+   * 
+   * @test_Strategy: ResponseProcessingException - in case processing of a
+   * received HTTP response fails (e.g. in a filter or during conversion of the
+   * response entity data to an instance of a particular Java type).
+   */
+  @Test
+  public void headThrowsProcessingExceptionTest() throws Fault {
+    _hostname = NONEXISTING_SITE;
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("head");
+    Future<Response> future = rx.head().toCompletableFuture();
+    assertExceptionWithProcessingExceptionIsThrownAndLog(future);
+  }
+
+  // ------------------------------------------------------------------
+  // ---------------------------METHOD-----------------------------------
+  // ------------------------------------------------------------------
+
+  /*
+   * @testName: methodTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1141; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1171;
+   * 
+   * @test_Strategy: Invoke an arbitrary method for the current request
+   */
+  @Test
+  public void methodTest() throws Fault {
+    Future<Response> future = null;
+    for (String method : METHODS) {
+      CompletionStageRxInvoker rx = startRxInvokerForMethod(
+          method.toLowerCase() + "");
+      future = rx.method(method).toCompletableFuture();
+      checkFutureOkResponse(future);
+    }
+  }
+
+  /*
+   * @testName: methodThrowsProcessingExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1141; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1171;
+   * 
+   * @test_Strategy: ResponseProcessingException - in case processing of a
+   * received HTTP response fails (e.g. in a filter or during conversion of the
+   * response entity data to an instance of a particular Java type).
+   */
+  @Test
+  public void methodThrowsProcessingExceptionTest() throws Fault {
+    _hostname = NONEXISTING_SITE;
+    Future<Response> future = null;
+    for (String method : METHODS) {
+      CompletionStageRxInvoker rx = startRxInvokerForMethod(
+          method.toLowerCase());
+      future = rx.method(method).toCompletableFuture();
+      assertExceptionWithProcessingExceptionIsThrownAndLog(future);
+    }
+  }
+
+  /*
+   * @testName: methodWithStringClassTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1142; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1172;
+   * 
+   * @test_Strategy: Invoke an arbitrary method for the current request
+   */
+  @Test
+  public void methodWithStringClassTest() throws Fault {
+    Future<String> future = null;
+    for (String method : METHODS) {
+      CompletionStageRxInvoker rx = startRxInvokerForMethod(
+          method.toLowerCase() + "");
+      future = rx.method(method, String.class).toCompletableFuture();
+      checkFutureString(future, method);
+    }
+  }
+
+  /*
+   * @testName: methodWithResponseClassTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1142; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1172;
+   * 
+   * @test_Strategy: Invoke an arbitrary method for the current request
+   */
+  @Test
+  public void methodWithResponseClassTest() throws Fault {
+    Future<Response> future = null;
+    for (String method : METHODS) {
+      CompletionStageRxInvoker rx = startRxInvokerForMethod(
+          method.toLowerCase() + "");
+      future = rx.method(method, Response.class).toCompletableFuture();
+      checkFutureOkResponse(future);
+    }
+  }
+
+  /*
+   * @testName: methodWithClassThrowsProcessingExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1142; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1172;
+   * 
+   * @test_Strategy: ResponseProcessingException - in case processing of a
+   * received HTTP response fails (e.g. in a filter or during conversion of the
+   * response entity data to an instance of a particular Java type).
+   */
+  @Test
+  public void methodWithClassThrowsProcessingExceptionTest() throws Fault {
+    _hostname = NONEXISTING_SITE;
+    Future<String> future = null;
+    for (String method : METHODS) {
+      CompletionStageRxInvoker rx = startRxInvokerForMethod(
+          method.toLowerCase());
+      future = rx.method(method, String.class).toCompletableFuture();
+      assertExceptionWithProcessingExceptionIsThrownAndLog(future);
+    }
+  }
+
+  /*
+   * @testName: methodWithClassThrowsWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1142; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1172;
+   * 
+   * @test_Strategy: WebApplicationException - in case the response status code
+   * of the response returned by the server is not successful and the specified
+   * response type is not Response.
+   */
+  @Test
+  public void methodWithClassThrowsWebApplicationExceptionTest() throws Fault {
+    Future<String> future = null;
+    for (String method : METHODS) {
+      CompletionStageRxInvoker rx = startRxInvokerForMethod(
+          method.toLowerCase() + "notok");
+      future = rx.method(method, String.class).toCompletableFuture();
+      assertExceptionWithWebApplicationExceptionIsThrownAndLog(future);
+    }
+  }
+
+  /*
+   * @testName: methodWithClassThrowsNoWebApplicationExceptionForResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1142; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1172;
+   * 
+   * @test_Strategy: WebApplicationException - in case the response status code
+   * of the response returned by the server is not successful and the specified
+   * response type is not Response.
+   */
+  @Test
+  public void methodWithClassThrowsNoWebApplicationExceptionForResponseTest()
+      throws Fault {
+    Future<Response> future = null;
+    for (String method : METHODS) {
+      CompletionStageRxInvoker rx = startRxInvokerForMethod(
+          method.toLowerCase() + "notok");
+      future = rx.method(method, Response.class).toCompletableFuture();
+      checkFutureResponseStatus(future, Status.NOT_ACCEPTABLE);
+    }
+  }
+
+  /*
+   * @testName: methodWithGenericTypeStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1143; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1173;
+   * 
+   * @test_Strategy: Invoke an arbitrary method for the current request
+   */
+  @Test
+  public void methodWithGenericTypeStringTest() throws Fault {
+    GenericType<String> generic = createGeneric(String.class);
+    Future<String> future = null;
+    for (String method : METHODS) {
+      CompletionStageRxInvoker rx = startRxInvokerForMethod(
+          method.toLowerCase() + "");
+      future = rx.method(method, generic).toCompletableFuture();
+      checkFutureString(future, method);
+    }
+  }
+
+  /*
+   * @testName: methodWithGenericTypeResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1143; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1173;
+   * 
+   * @test_Strategy: Invoke an arbitrary method for the current request
+   */
+  @Test
+  public void methodWithGenericTypeResponseTest() throws Fault {
+    GenericType<Response> generic = createGeneric(Response.class);
+    Future<Response> future = null;
+    for (String method : METHODS) {
+      CompletionStageRxInvoker rx = startRxInvokerForMethod(
+          method.toLowerCase() + "");
+      future = rx.method(method, generic).toCompletableFuture();
+      checkFutureOkResponse(future);
+    }
+  }
+
+  /*
+   * @testName: methodWithGenericTypeThrowsProcessingExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1143; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1173;
+   * 
+   * @test_Strategy: ResponseProcessingException - in case processing of a
+   * received HTTP response fails (e.g. in a filter or during conversion of the
+   * response entity data to an instance of a particular Java type).
+   */
+  @Test
+  public void methodWithGenericTypeThrowsProcessingExceptionTest()
+      throws Fault {
+    _hostname = NONEXISTING_SITE;
+    Future<Response> future = null;
+    GenericType<Response> generic = createGeneric(Response.class);
+    for (String method : METHODS) {
+      CompletionStageRxInvoker rx = startRxInvokerForMethod(
+          method.toLowerCase());
+      future = rx.method(method, generic).toCompletableFuture();
+      assertExceptionWithProcessingExceptionIsThrownAndLog(future);
+    }
+  }
+
+  /*
+   * @testName: methodWithGenericTypeThrowsWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1143; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1173;
+   * 
+   * @test_Strategy: WebApplicationException - in case the response status code
+   * of the response returned by the server is not successful and the specified
+   * response type is not Response.
+   */
+  @Test
+  public void methodWithGenericTypeThrowsWebApplicationExceptionTest()
+      throws Fault {
+    Future<String> future = null;
+    GenericType<String> generic = createGeneric(String.class);
+    for (String method : METHODS) {
+      CompletionStageRxInvoker rx = startRxInvokerForMethod(
+          method.toLowerCase() + "notok");
+      future = rx.method(method, generic).toCompletableFuture();
+      assertExceptionWithWebApplicationExceptionIsThrownAndLog(future);
+    }
+  }
+
+  /*
+   * @testName:
+   * methodWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1143; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1173;
+   * 
+   * @test_Strategy: WebApplicationException - in case the response status code
+   * of the response returned by the server is not successful and the specified
+   * response type is not Response.
+   */
+  @Test
+  public void methodWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest()
+      throws Fault {
+    Future<Response> future = null;
+    GenericType<Response> generic = createGeneric(Response.class);
+    for (String method : METHODS) {
+      CompletionStageRxInvoker rx = startRxInvokerForMethod(
+          method.toLowerCase() + "notok");
+      future = rx.method(method, generic).toCompletableFuture();
+      checkFutureResponseStatus(future, Status.NOT_ACCEPTABLE);
+    }
+  }
+
+  /*
+   * @testName: methodWithEntityTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1144; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1174;
+   * 
+   * @test_Strategy: Invoke an arbitrary method for the current request
+   */
+  @Test
+  public void methodWithEntityTest() throws Fault {
+    Future<Response> future = null;
+    for (String method : ENTITY_METHODS) {
+      CompletionStageRxInvoker rx = startRxInvokerForMethod(
+          method.toLowerCase() + "");
+      Entity<String> entity = Entity.entity(method, MediaType.WILDCARD_TYPE);
+      future = rx.method(method, entity).toCompletableFuture();
+      checkFutureOkResponse(future);
+    }
+  }
+
+  /*
+   * @testName: methodWithEntityThrowsProcessingExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1144; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1174;
+   * 
+   * @test_Strategy: ResponseProcessingException - in case processing of a
+   * received HTTP response fails (e.g. in a filter or during conversion of the
+   * response entity data to an instance of a particular Java type).
+   */
+  @Test
+  public void methodWithEntityThrowsProcessingExceptionTest() throws Fault {
+    _hostname = NONEXISTING_SITE;
+    Future<Response> future = null;
+    for (String method : ENTITY_METHODS) {
+      Entity<String> entity = Entity.entity(method, MediaType.WILDCARD_TYPE);
+      CompletionStageRxInvoker rx = startRxInvokerForMethod(
+          method.toLowerCase());
+      future = rx.method(method, entity).toCompletableFuture();
+      assertExceptionWithProcessingExceptionIsThrownAndLog(future);
+    }
+  }
+
+  /*
+   * @testName: methodWithStringClassWithEntityTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1145; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1175;
+   * 
+   * @test_Strategy: Invoke an arbitrary method for the current request
+   */
+  @Test
+  public void methodWithStringClassWithEntityTest() throws Fault {
+    Future<String> future = null;
+    for (String method : ENTITY_METHODS) {
+      CompletionStageRxInvoker rx = startRxInvokerForMethod(
+          method.toLowerCase() + "");
+      Entity<String> entity = Entity.entity(method, MediaType.WILDCARD_TYPE);
+      future = rx.method(method, entity, String.class).toCompletableFuture();
+      checkFutureString(future, method);
+    }
+  }
+
+  /*
+   * @testName: methodWithResponseClassWithEntityTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1145; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1175;
+   * 
+   * @test_Strategy: Invoke an arbitrary method for the current request
+   */
+  @Test
+  public void methodWithResponseClassWithEntityTest() throws Fault {
+    Future<Response> future = null;
+    for (String method : ENTITY_METHODS) {
+      CompletionStageRxInvoker rx = startRxInvokerForMethod(
+          method.toLowerCase() + "");
+      Entity<String> entity = Entity.entity(method, MediaType.WILDCARD_TYPE);
+      future = rx.method(method, entity, Response.class).toCompletableFuture();
+      checkFutureOkResponse(future);
+    }
+  }
+
+  /*
+   * @testName: methodWithClassWithEntityThrowsProcessingExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1145; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1175;
+   * 
+   * @test_Strategy: ResponseProcessingException - in case processing of a
+   * received HTTP response fails (e.g. in a filter or during conversion of the
+   * response entity data to an instance of a particular Java type).
+   */
+  @Test
+  public void methodWithClassWithEntityThrowsProcessingExceptionTest()
+      throws Fault {
+    _hostname = NONEXISTING_SITE;
+    Future<String> future = null;
+    for (String method : ENTITY_METHODS) {
+      CompletionStageRxInvoker rx = startRxInvokerForMethod(
+          method.toLowerCase());
+      Entity<String> entity = Entity.entity(method, MediaType.WILDCARD_TYPE);
+      future = rx.method(method, entity, String.class).toCompletableFuture();
+      assertExceptionWithProcessingExceptionIsThrownAndLog(future);
+    }
+  }
+
+  /*
+   * @testName: methodWithClassWithEntityThrowsWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1145; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1175;
+   * 
+   * @test_Strategy: WebApplicationException - in case the response status code
+   * of the response returned by the server is not successful and the specified
+   * response type is not Response.
+   */
+  @Test
+  public void methodWithClassWithEntityThrowsWebApplicationExceptionTest()
+      throws Fault {
+    Future<String> future = null;
+    for (String method : ENTITY_METHODS) {
+      CompletionStageRxInvoker rx = startRxInvokerForMethod(
+          method.toLowerCase() + "notok");
+      Entity<String> entity = Entity.entity(method, MediaType.WILDCARD_TYPE);
+      future = rx.method(method, entity, String.class).toCompletableFuture();
+      assertExceptionWithWebApplicationExceptionIsThrownAndLog(future);
+    }
+  }
+
+  /*
+   * @testName:
+   * methodWithClassWithEntityThrowsNoWebApplicationExceptionForResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1145; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1175;
+   * 
+   * @test_Strategy: WebApplicationException - in case the response status code
+   * of the response returned by the server is not successful and the specified
+   * response type is not Response.
+   */
+  @Test
+  public void methodWithClassWithEntityThrowsNoWebApplicationExceptionForResponseTest()
+      throws Fault {
+    Future<Response> future = null;
+    for (String method : ENTITY_METHODS) {
+      CompletionStageRxInvoker rx = startRxInvokerForMethod(
+          method.toLowerCase() + "notok");
+      Entity<String> entity = Entity.entity(method, MediaType.WILDCARD_TYPE);
+      future = rx.method(method, entity, Response.class).toCompletableFuture();
+      checkFutureResponseStatus(future, Status.NOT_ACCEPTABLE);
+    }
+  }
+
+  /*
+   * @testName: methodWithGenericTypeStringWithEntityTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1146; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1176;
+   * 
+   * @test_Strategy: Invoke an arbitrary method for the current request
+   */
+  @Test
+  public void methodWithGenericTypeStringWithEntityTest()
+      throws Fault {
+    Future<String> future = null;
+    GenericType<String> generic = createGeneric(String.class);
+    for (String method : ENTITY_METHODS) {
+      CompletionStageRxInvoker rx = startRxInvokerForMethod(
+          method.toLowerCase() + "");
+      Entity<String> entity = Entity.entity(method, MediaType.WILDCARD_TYPE);
+      future = rx.method(method, entity, generic).toCompletableFuture();
+      checkFutureString(future, method);
+    }
+  }
+
+  /*
+   * @testName: methodWithGenericTypeResponseWithEntityTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1146; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1176;
+   * 
+   * @test_Strategy: Invoke an arbitrary method for the current request
+   */
+  @Test
+  public void methodWithGenericTypeResponseWithEntityTest()
+      throws Fault {
+    Future<Response> future = null;
+    GenericType<Response> generic = createGeneric(Response.class);
+    for (String method : ENTITY_METHODS) {
+      CompletionStageRxInvoker rx = startRxInvokerForMethod(
+          method.toLowerCase() + "");
+      Entity<String> entity = Entity.entity(method, MediaType.WILDCARD_TYPE);
+      future = rx.method(method, entity, generic).toCompletableFuture();
+      checkFutureOkResponse(future);
+    }
+  }
+
+  /*
+   * @testName: methodWithGenericTypeWithEntityThrowsProcessingExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1146; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1176;
+   * 
+   * @test_Strategy: ResponseProcessingException - in case processing of a
+   * received HTTP response fails (e.g. in a filter or during conversion of the
+   * response entity data to an instance of a particular Java type).
+   */
+  @Test
+  public void methodWithGenericTypeWithEntityThrowsProcessingExceptionTest()
+      throws Fault {
+    _hostname = NONEXISTING_SITE;
+    GenericType<String> generic = createGeneric(String.class);
+    Future<String> future = null;
+    for (String method : ENTITY_METHODS) {
+      CompletionStageRxInvoker rx = startRxInvokerForMethod(
+          method.toLowerCase());
+      Entity<String> entity = Entity.entity(method, MediaType.WILDCARD_TYPE);
+      future = rx.method(method, entity, generic).toCompletableFuture();
+      assertExceptionWithProcessingExceptionIsThrownAndLog(future);
+    }
+  }
+
+  /*
+   * @testName: methodWithGenericTypeWithEntityThrowsWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1146; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1176;
+   * 
+   * @test_Strategy: WebApplicationException - in case the response status code
+   * of the response returned by the server is not successful and the specified
+   * response type is not Response.
+   */
+  @Test
+  public void methodWithGenericTypeWithEntityThrowsWebApplicationExceptionTest()
+      throws Fault {
+    Future<String> future = null;
+    GenericType<String> generic = createGeneric(String.class);
+    for (String method : ENTITY_METHODS) {
+      CompletionStageRxInvoker rx = startRxInvokerForMethod(
+          method.toLowerCase() + "notok");
+      Entity<String> entity = Entity.entity(method, MediaType.WILDCARD_TYPE);
+      future = rx.method(method, entity, generic).toCompletableFuture();
+      assertExceptionWithWebApplicationExceptionIsThrownAndLog(future);
+    }
+  }
+
+  /*
+   * @testName:
+   * methodWithGenericTypeWithEntityThrowsNoWebApplicationExceptionForResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1146; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1176;
+   * 
+   * @test_Strategy: WebApplicationException - in case the response status code
+   * of the response returned by the server is not successful and the specified
+   * response type is not Response.
+   */
+  @Test
+  public void methodWithGenericTypeWithEntityThrowsNoWebApplicationExceptionForResponseTest()
+      throws Fault {
+    Future<Response> future = null;
+    GenericType<Response> generic = createGeneric(Response.class);
+    for (String method : ENTITY_METHODS) {
+      CompletionStageRxInvoker rx = startRxInvokerForMethod(
+          method.toLowerCase() + "notok");
+      Entity<String> entity = Entity.entity(method, MediaType.WILDCARD_TYPE);
+      future = rx.method(method, entity, generic).toCompletableFuture();
+      checkFutureResponseStatus(future, Status.NOT_ACCEPTABLE);
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // ---------------------------OPTIONS--------------------------------
+  // ------------------------------------------------------------------
+
+  /*
+   * @testName: optionsTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1147; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1177;
+   * 
+   * @test_Strategy: Invoke HTTP options method for the current request
+   */
+  @Test
+  public void optionsTest() throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("options");
+    Future<Response> future = rx.options().toCompletableFuture();
+    checkFutureResponseStatus(future, Status.OK);
+  }
+
+  /*
+   * @testName: optionsThrowsProcessingExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1147; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1177;
+   * 
+   * @test_Strategy: ResponseProcessingException - in case processing of a
+   * received HTTP response fails (e.g. in a filter or during conversion of the
+   * response entity data to an instance of a particular Java type).
+   */
+  @Test
+  public void optionsThrowsProcessingExceptionTest() throws Fault {
+    _hostname = NONEXISTING_SITE;
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("options");
+    Future<Response> future = rx.options().toCompletableFuture();
+    assertExceptionWithProcessingExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName: optionsWithStringClassTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1148; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1178;
+   * 
+   * @test_Strategy: Invoke HTTP options method for the current request
+   */
+  @Test
+  public void optionsWithStringClassTest() throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("options");
+    Future<String> future = rx.options(String.class).toCompletableFuture();
+    checkFutureString(future, "options");
+  }
+
+  /*
+   * @testName: optionsWithResponseClassTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1148; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1178;
+   * 
+   * @test_Strategy: Invoke HTTP options method for the current request
+   */
+  @Test
+  public void optionsWithResponseClassTest() throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("options");
+    Future<Response> future = rx.options(Response.class).toCompletableFuture();
+    checkFutureOkResponse(future);
+  }
+
+  /*
+   * @testName: optionsWithClassThrowsProcessingExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1148; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1178;
+   * 
+   * @test_Strategy: ResponseProcessingException - in case processing of a
+   * received HTTP response fails (e.g. in a filter or during conversion of the
+   * response entity data to an instance of a particular Java type).
+   */
+  @Test
+  public void optionsWithClassThrowsProcessingExceptionTest() throws Fault {
+    _hostname = NONEXISTING_SITE;
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("options");
+    Future<String> future = rx.options(String.class).toCompletableFuture();
+    assertExceptionWithProcessingExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName: optionsWithClassThrowsWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1148; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1178;
+   * 
+   * @test_Strategy: WebApplicationException - in case the response status code
+   * of the response returned by the server is not successful and the specified
+   * response type is not Response.
+   */
+  @Test
+  public void optionsWithClassThrowsWebApplicationExceptionTest() throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("optionsnotok");
+    Future<String> future = rx.options(String.class).toCompletableFuture();
+    assertExceptionWithWebApplicationExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName: optionsWithClassThrowsNoWebApplicationExceptionForResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1148; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1178;
+   * 
+   * @test_Strategy: WebApplicationException - in case the response status code
+   * of the response returned by the server is not successful and the specified
+   * response type is not Response.
+   */
+  @Test
+  public void optionsWithClassThrowsNoWebApplicationExceptionForResponseTest()
+      throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("optionsnotok");
+    Future<Response> future = rx.options(Response.class).toCompletableFuture();
+    checkFutureResponseStatus(future, Status.NOT_ACCEPTABLE);
+  }
+
+  /*
+   * @testName: optionsWithGenericTypeStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1149; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1179;
+   * 
+   * @test_Strategy: Invoke HTTP options method for the current request
+   */
+  @Test
+  public void optionsWithGenericTypeStringTest() throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("options");
+    GenericType<String> generic = createGeneric(String.class);
+    Future<String> future = rx.options(generic).toCompletableFuture();
+    checkFutureString(future, "options");
+  }
+
+  /*
+   * @testName: optionsWithGenericTypeResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1149; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1179;
+   * 
+   * @test_Strategy: Invoke HTTP options method for the current request
+   */
+  @Test
+  public void optionsWithGenericTypeResponseTest() throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("options");
+    GenericType<Response> generic = createGeneric(Response.class);
+    Future<Response> future = rx.options(generic).toCompletableFuture();
+    checkFutureOkResponse(future);
+  }
+
+  /*
+   * @testName: optionsWithGenericTypeThrowsProcessingExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1149; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1179;
+   * 
+   * @test_Strategy: ResponseProcessingException - in case processing of a
+   * received HTTP response fails (e.g. in a filter or during conversion of the
+   * response entity data to an instance of a particular Java type).
+   */
+  @Test
+  public void optionsWithGenericTypeThrowsProcessingExceptionTest()
+      throws Fault {
+    _hostname = NONEXISTING_SITE;
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("options");
+    GenericType<String> generic = createGeneric(String.class);
+    Future<String> future = rx.options(generic).toCompletableFuture();
+    assertExceptionWithProcessingExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName: optionsWithGenericTypeThrowsWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1149; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1179;
+   * 
+   * @test_Strategy: WebApplicationException - in case the response status code
+   * of the response returned by the server is not successful and the specified
+   * response type is not Response.
+   */
+  @Test
+  public void optionsWithGenericTypeThrowsWebApplicationExceptionTest()
+      throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("optionsnotok");
+    GenericType<String> generic = createGeneric(String.class);
+    Future<String> future = rx.options(generic).toCompletableFuture();
+    assertExceptionWithWebApplicationExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName:
+   * optionsWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1149; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1179;
+   * 
+   * @test_Strategy: WebApplicationException - in case the response status code
+   * of the response returned by the server is not successful and the specified
+   * response type is not Response.
+   */
+  @Test
+  public void optionsWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest()
+      throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("optionsnotok");
+    GenericType<Response> generic = createGeneric(Response.class);
+    Future<Response> future = rx.options(generic).toCompletableFuture();
+    checkFutureResponseStatus(future, Status.NOT_ACCEPTABLE);
+  }
+
+  // ------------------------------------------------------------------
+  // ---------------------------POST-----------------------------------
+  // ------------------------------------------------------------------
+
+  /*
+   * @testName: postTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1150; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1180;
+   * 
+   * @test_Strategy: Invoke HTTP post method for the current request
+   */
+  @Test
+  public void postTest() throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("post");
+    Entity<String> entity = Entity.entity("post", MediaType.WILDCARD_TYPE);
+    Future<Response> future = rx.post(entity).toCompletableFuture();
+    checkFutureOkResponse(future);
+  }
+
+  /*
+   * @testName: postThrowsProcessingExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1150; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1180;
+   * 
+   * @test_Strategy: ResponseProcessingException - in case processing of a
+   * received HTTP response fails (e.g. in a filter or during conversion of the
+   * response entity data to an instance of a particular Java type).
+   */
+  @Test
+  public void postThrowsProcessingExceptionTest() throws Fault {
+    _hostname = NONEXISTING_SITE;
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("post");
+    Entity<String> entity = Entity.entity("post", MediaType.WILDCARD_TYPE);
+    Future<Response> future = rx.post(entity).toCompletableFuture();
+    assertExceptionWithProcessingExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName: postWithStringClassTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1151; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1181;
+   * 
+   * @test_Strategy: Invoke HTTP post method for the current request
+   */
+  @Test
+  public void postWithStringClassTest() throws Fault {
+    Entity<String> entity = Entity.entity("post", MediaType.WILDCARD_TYPE);
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("post");
+    Future<String> future = rx.post(entity, String.class).toCompletableFuture();
+    checkFutureString(future, "post");
+  }
+
+  /*
+   * @testName: postWithResponseClassTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1151; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1181;
+   * 
+   * @test_Strategy: Invoke HTTP post method for the current request
+   */
+  @Test
+  public void postWithResponseClassTest() throws Fault {
+    Entity<String> entity = Entity.entity("post", MediaType.WILDCARD_TYPE);
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("post");
+    Future<Response> future = rx.post(entity, Response.class)
+        .toCompletableFuture();
+    checkFutureOkResponse(future);
+  }
+
+  /*
+   * @testName: postWithClassThrowsProcessingExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1151; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1181;
+   * 
+   * @test_Strategy: ResponseProcessingException - in case processing of a
+   * received HTTP response fails (e.g. in a filter or during conversion of the
+   * response entity data to an instance of a particular Java type).
+   */
+  @Test
+  public void postWithClassThrowsProcessingExceptionTest() throws Fault {
+    _hostname = NONEXISTING_SITE;
+    Entity<String> entity = Entity.entity("post", MediaType.WILDCARD_TYPE);
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("post");
+    Future<String> future = rx.post(entity, String.class).toCompletableFuture();
+    assertExceptionWithProcessingExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName: postWithClassThrowsWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1151; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1181;
+   * 
+   * @test_Strategy: WebApplicationException - in case the response status code
+   * of the response returned by the server is not successful and the specified
+   * response type is not Response.
+   */
+  @Test
+  public void postWithClassThrowsWebApplicationExceptionTest() throws Fault {
+    Entity<String> entity = Entity.entity("post", MediaType.WILDCARD_TYPE);
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("postnotok");
+    Future<String> future = rx.post(entity, String.class).toCompletableFuture();
+    assertExceptionWithWebApplicationExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName: postWithClassThrowsNoWebApplicationExceptionForResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1151; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1181;
+   * 
+   * @test_Strategy: WebApplicationException - in case the response status code
+   * of the response returned by the server is not successful and the specified
+   * response type is not Response.
+   */
+  @Test
+  public void postWithClassThrowsNoWebApplicationExceptionForResponseTest()
+      throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("postnotok");
+    Entity<String> entity = Entity.entity("post", MediaType.WILDCARD_TYPE);
+    Future<Response> future = rx.post(entity, Response.class)
+        .toCompletableFuture();
+    checkFutureResponseStatus(future, Status.NOT_ACCEPTABLE);
+  }
+
+  /*
+   * @testName: postWithGenericTypeStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1152; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1182;
+   * 
+   * @test_Strategy: Invoke HTTP post method for the current request
+   */
+  @Test
+  public void postWithGenericTypeStringTest() throws Fault {
+    GenericType<String> generic = createGeneric(String.class);
+    Entity<String> entity = Entity.entity("post", MediaType.WILDCARD_TYPE);
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("post");
+    Future<String> future = rx.post(entity, generic).toCompletableFuture();
+    checkFutureString(future, "post");
+  }
+
+  /*
+   * @testName: postWithGenericTypeResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1152; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1182;
+   * 
+   * @test_Strategy: Invoke HTTP post method for the current request
+   */
+  @Test
+  public void postWithGenericTypeResponseTest() throws Fault {
+    GenericType<Response> generic = createGeneric(Response.class);
+    Entity<String> entity = Entity.entity("post", MediaType.WILDCARD_TYPE);
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("post");
+    Future<Response> future = rx.post(entity, generic).toCompletableFuture();
+    checkFutureOkResponse(future);
+  }
+
+  /*
+   * @testName: postWithGenericTypeThrowsProcessingExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1152; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1182;
+   * 
+   * @test_Strategy: ResponseProcessingException - in case processing of a
+   * received HTTP response fails (e.g. in a filter or during conversion of the
+   * response entity data to an instance of a particular Java type).
+   */
+  @Test
+  public void postWithGenericTypeThrowsProcessingExceptionTest() throws Fault {
+    _hostname = NONEXISTING_SITE;
+    Entity<String> entity = Entity.entity("post", MediaType.WILDCARD_TYPE);
+    GenericType<String> generic = createGeneric(String.class);
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("post");
+    Future<String> future = rx.post(entity, generic).toCompletableFuture();
+    assertExceptionWithProcessingExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName: postWithGenericTypeThrowsWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1152; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1182;
+   * 
+   * @test_Strategy: WebApplicationException - in case the response status code
+   * of the response returned by the server is not successful and the specified
+   * response type is not Response.
+   */
+  @Test
+  public void postWithGenericTypeThrowsWebApplicationExceptionTest()
+      throws Fault {
+    Entity<String> entity = Entity.entity("post", MediaType.WILDCARD_TYPE);
+    GenericType<String> generic = createGeneric(String.class);
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("postnotok");
+    Future<String> future = rx.post(entity, generic).toCompletableFuture();
+    assertExceptionWithWebApplicationExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName:
+   * postWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1152; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1182;
+   * 
+   * @test_Strategy: WebApplicationException - in case the response status code
+   * of the response returned by the server is not successful and the specified
+   * response type is not Response.
+   */
+  @Test
+  public void postWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest()
+      throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("postnotok");
+    GenericType<Response> generic = createGeneric(Response.class);
+    Entity<String> entity = Entity.entity("post", MediaType.WILDCARD_TYPE);
+    Future<Response> future = rx.post(entity, generic).toCompletableFuture();
+    checkFutureResponseStatus(future, Status.NOT_ACCEPTABLE);
+  }
+
+  // ------------------------------------------------------------------
+  // ---------------------------PUT -----------------------------------
+  // ------------------------------------------------------------------
+
+  /*
+   * @testName: putTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1153; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1183;
+   * 
+   * @test_Strategy: Invoke HTTP PUT method for the current request
+   */
+  @Test
+  public void putTest() throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("put");
+    Entity<String> entity = Entity.entity("put", MediaType.WILDCARD_TYPE);
+    Future<Response> future = rx.put(entity).toCompletableFuture();
+    checkFutureOkResponse(future);
+  }
+
+  /*
+   * @testName: putThrowsProcessingExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1153; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1183;
+   * 
+   * @test_Strategy: ResponseProcessingException - in case processing of a
+   * received HTTP response fails (e.g. in a filter or during conversion of the
+   * response entity data to an instance of a particular Java type).
+   */
+  @Test
+  public void putThrowsProcessingExceptionTest() throws Fault {
+    _hostname = NONEXISTING_SITE;
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("put");
+    Entity<String> entity = Entity.entity("put", MediaType.WILDCARD_TYPE);
+    Future<Response> future = rx.put(entity).toCompletableFuture();
+    assertExceptionWithProcessingExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName: putWithStringClassTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1154; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1184;
+   * 
+   * @test_Strategy: Invoke HTTP put method for the current request
+   */
+  @Test
+  public void putWithStringClassTest() throws Fault {
+    Entity<String> entity = Entity.entity("put", MediaType.WILDCARD_TYPE);
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("put");
+    Future<String> future = rx.put(entity, String.class).toCompletableFuture();
+    checkFutureString(future, "put");
+  }
+
+  /*
+   * @testName: putWithResponseClassTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1154; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1184;
+   * 
+   * @test_Strategy: Invoke HTTP put method for the current request
+   */
+  @Test
+  public void putWithResponseClassTest() throws Fault {
+    Entity<String> entity = Entity.entity("put", MediaType.WILDCARD_TYPE);
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("put");
+    Future<Response> future = rx.put(entity, Response.class)
+        .toCompletableFuture();
+    checkFutureOkResponse(future);
+  }
+
+  /*
+   * @testName: putWithClassThrowsProcessingExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1154; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1184;
+   * 
+   * @test_Strategy: ResponseProcessingException - in case processing of a
+   * received HTTP response fails (e.g. in a filter or during conversion of the
+   * response entity data to an instance of a particular Java type).
+   */
+  @Test
+  public void putWithClassThrowsProcessingExceptionTest() throws Fault {
+    _hostname = NONEXISTING_SITE;
+    Entity<String> entity = Entity.entity("put", MediaType.WILDCARD_TYPE);
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("put");
+    Future<String> future = rx.put(entity, String.class).toCompletableFuture();
+    assertExceptionWithProcessingExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName: putWithClassThrowsWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1154; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1184;
+   * 
+   * @test_Strategy: WebApplicationException - in case the response status code
+   * of the response returned by the server is not successful and the specified
+   * response type is not Response.
+   */
+  @Test
+  public void putWithClassThrowsWebApplicationExceptionTest() throws Fault {
+    Entity<String> entity = Entity.entity("put", MediaType.WILDCARD_TYPE);
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("putnotok");
+    Future<String> future = rx.put(entity, String.class).toCompletableFuture();
+    assertExceptionWithWebApplicationExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName: putWithClassThrowsNoWebApplicationExceptionForResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1154; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1184;
+   * 
+   * @test_Strategy: WebApplicationException - in case the response status code
+   * of the response returned by the server is not successful and the specified
+   * response type is not Response.
+   */
+  @Test
+  public void putWithClassThrowsNoWebApplicationExceptionForResponseTest()
+      throws Fault {
+    Entity<String> entity = Entity.entity("put", MediaType.WILDCARD_TYPE);
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("putnotok");
+    Future<Response> future = rx.put(entity, Response.class)
+        .toCompletableFuture();
+    checkFutureResponseStatus(future, Status.NOT_ACCEPTABLE);
+  }
+
+  /*
+   * @testName: putWithGenericTypeStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1155; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1185;
+   * 
+   * @test_Strategy: Invoke HTTP put method for the current request
+   */
+  @Test
+  public void putWithGenericTypeStringTest() throws Fault {
+    GenericType<String> generic = createGeneric(String.class);
+    Entity<String> entity = Entity.entity("put", MediaType.WILDCARD_TYPE);
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("put");
+    Future<String> future = rx.put(entity, generic).toCompletableFuture();
+    checkFutureString(future, "put");
+  }
+
+  /*
+   * @testName: putWithGenericTypeResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1155; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1185;
+   * 
+   * @test_Strategy: Invoke HTTP put method for the current request
+   */
+  @Test
+  public void putWithGenericTypeResponseTest() throws Fault {
+    GenericType<Response> generic = createGeneric(Response.class);
+    Entity<String> entity = Entity.entity("put", MediaType.WILDCARD_TYPE);
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("put");
+    Future<Response> future = rx.put(entity, generic).toCompletableFuture();
+    checkFutureOkResponse(future);
+  }
+
+  /*
+   * @testName: putWithGenericTypeThrowsProcessingExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1155; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1185;
+   * 
+   * @test_Strategy: ResponseProcessingException - in case processing of a
+   * received HTTP response fails (e.g. in a filter or during conversion of the
+   * response entity data to an instance of a particular Java type).
+   */
+  @Test
+  public void putWithGenericTypeThrowsProcessingExceptionTest() throws Fault {
+    _hostname = NONEXISTING_SITE;
+    GenericType<String> generic = createGeneric(String.class);
+    Entity<String> entity = Entity.entity("put", MediaType.WILDCARD_TYPE);
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("put");
+    Future<String> future = rx.put(entity, generic).toCompletableFuture();
+    assertExceptionWithProcessingExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName: putWithGenericTypeThrowsWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1155; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1185;
+   * 
+   * @test_Strategy: WebApplicationException - in case the response status code
+   * of the response returned by the server is not successful and the specified
+   * response type is not Response.
+   */
+  @Test
+  public void putWithGenericTypeThrowsWebApplicationExceptionTest()
+      throws Fault {
+    GenericType<String> generic = createGeneric(String.class);
+    Entity<String> entity = Entity.entity("put", MediaType.WILDCARD_TYPE);
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("putnotok");
+    Future<String> future = rx.put(entity, generic).toCompletableFuture();
+    assertExceptionWithWebApplicationExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName: putWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1155; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1185;
+   * 
+   * @test_Strategy: WebApplicationException - in case the response status code
+   * of the response returned by the server is not successful and the specified
+   * response type is not Response.
+   */
+  @Test
+  public void putWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest()
+      throws Fault {
+    Entity<String> entity = Entity.entity("put", MediaType.WILDCARD_TYPE);
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("putnotok");
+    GenericType<Response> generic = createGeneric(Response.class);
+    Future<Response> future = rx.put(entity, generic).toCompletableFuture();
+    checkFutureResponseStatus(future, Status.NOT_ACCEPTABLE);
+  }
+
+  // ------------------------------------------------------------------
+  // ---------------------------TRACE -----------------------------------
+  // ------------------------------------------------------------------
+
+  /*
+   * @testName: traceTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1156; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1186;
+   * 
+   * @test_Strategy: Invoke HTTP trace method for the current request
+   */
+  //@Test
+  public void traceTest() throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("trace");
+    Future<Response> future = rx.trace().toCompletableFuture();
+    checkFutureOkResponse(future);
+  }
+
+  /*
+   * @testName: traceThrowsProcessingExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1156; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1186;
+   * 
+   * @test_Strategy: ResponseProcessingException - in case processing of a
+   * received HTTP response fails (e.g. in a filter or during conversion of the
+   * response entity data to an instance of a particular Java type).
+   */
+  @Test
+  public void traceThrowsProcessingExceptionTest() throws Fault {
+    _hostname = NONEXISTING_SITE;
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("trace");
+    Future<Response> future = rx.trace().toCompletableFuture();
+    assertExceptionWithProcessingExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName: traceWithStringClassTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1157; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1187;
+   * 
+   * @test_Strategy: Invoke HTTP trace method for the current request
+   */
+  //@Test
+  public void traceWithStringClassTest() throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("trace");
+    Future<String> future = rx.trace(String.class).toCompletableFuture();
+    checkFutureString(future, "trace");
+  }
+
+  /*
+   * @testName: traceWithResponseClassTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1157; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1187;
+   * 
+   * @test_Strategy: Invoke HTTP trace method for the current request
+   */
+  //@Test
+  public void traceWithResponseClassTest() throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("trace");
+    Future<Response> future = rx.trace(Response.class).toCompletableFuture();
+    checkFutureOkResponse(future);
+  }
+
+  /*
+   * @testName: traceWithClassThrowsProcessingExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1157; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1187;
+   * 
+   * @test_Strategy: ResponseProcessingException - in case processing of a
+   * received HTTP response fails (e.g. in a filter or during conversion of the
+   * response entity data to an instance of a particular Java type).
+   */
+  @Test
+  public void traceWithClassThrowsProcessingExceptionTest() throws Fault {
+    _hostname = NONEXISTING_SITE;
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("trace");
+    Future<String> future = rx.trace(String.class).toCompletableFuture();
+    assertExceptionWithProcessingExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName: traceWithClassThrowsWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1157; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1187;
+   * 
+   * @test_Strategy: WebApplicationException - in case the response status code
+   * of the response returned by the server is not successful and the specified
+   * response type is not Response.
+   */
+  @Test
+  public void traceWithClassThrowsWebApplicationExceptionTest() throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("tracenotok");
+    Future<String> future = rx.trace(String.class).toCompletableFuture();
+    assertExceptionWithWebApplicationExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName: traceWithClassThrowsNoWebApplicationExceptionForResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1157; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1187;
+   * 
+   * @test_Strategy: WebApplicationException - in case the response status code
+   * of the response returned by the server is not successful and the specified
+   * response type is not Response.
+   */
+  //@Test
+  public void traceWithClassThrowsNoWebApplicationExceptionForResponseTest()
+      throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("tracenotok");
+    Future<Response> future = rx.trace(Response.class).toCompletableFuture();
+    checkFutureResponseStatus(future, Status.NOT_ACCEPTABLE);
+  }
+
+  /*
+   * @testName: traceWithGenericTypeStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1158; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1188;
+   * 
+   * @test_Strategy: Invoke HTTP trace method for the current request
+   */
+  //@Test
+  public void traceWithGenericTypeStringTest() throws Fault {
+    GenericType<String> generic = createGeneric(String.class);
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("trace");
+    Future<String> future = rx.trace(generic).toCompletableFuture();
+    checkFutureString(future, "trace");
+  }
+
+  /*
+   * @testName: traceWithGenericTypeResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1158; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1188;
+   * 
+   * @test_Strategy: Invoke HTTP trace method for the current request
+   */
+  //@Test
+  public void traceWithGenericTypeResponseTest() throws Fault {
+    GenericType<Response> generic = createGeneric(Response.class);
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("trace");
+    Future<Response> future = rx.trace(generic).toCompletableFuture();
+    checkFutureOkResponse(future);
+  }
+
+  /*
+   * @testName: traceWithGenericTypeThrowsProcessingExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1158; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1188;
+   * 
+   * @test_Strategy: ResponseProcessingException - in case processing of a
+   * received HTTP response fails (e.g. in a filter or during conversion of the
+   * response entity data to an instance of a particular Java type).
+   */
+  @Test
+  public void traceWithGenericTypeThrowsProcessingExceptionTest() throws Fault {
+    _hostname = NONEXISTING_SITE;
+    GenericType<String> generic = createGeneric(String.class);
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("trace");
+    Future<String> future = rx.trace(generic).toCompletableFuture();
+    assertExceptionWithProcessingExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName: traceWithGenericTypeThrowsWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1158; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1188;
+   * 
+   * @test_Strategy: WebApplicationException - in case the response status code
+   * of the response returned by the server is not successful and the specified
+   * response type is not Response.
+   */
+  @Test
+  public void traceWithGenericTypeThrowsWebApplicationExceptionTest()
+      throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("tracenotok");
+    GenericType<String> generic = createGeneric(String.class);
+    Future<String> future = rx.trace(generic).toCompletableFuture();
+    assertExceptionWithWebApplicationExceptionIsThrownAndLog(future);
+  }
+
+  /*
+   * @testName:
+   * traceWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1158; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1188;
+   * 
+   * @test_Strategy: WebApplicationException - in case the response status code
+   * of the response returned by the server is not successful and the specified
+   * response type is not Response.
+   */
+  //@Test
+  public void traceWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest()
+      throws Fault {
+    CompletionStageRxInvoker rx = startRxInvokerForMethod("tracenotok");
+    GenericType<Response> generic = createGeneric(Response.class);
+    Future<Response> future = rx.trace(generic).toCompletableFuture();
+    checkFutureResponseStatus(future, Status.NOT_ACCEPTABLE);
+  }
+
+  // ///////////////////////////////////////////////////////////////////////
+  // utility methods
+
+  /**
+   * Create CompletionStageRxInvoker for given resource method and start time
+   */
+  protected CompletionStageRxInvoker startRxInvokerForMethod(
+      String methodName) {
+    return startBuilderForMethod(methodName).rx();
+  }
+
+  protected Invocation.Builder startBuilderForMethod(String methodName) {
+    Client client = ClientBuilder.newClient();
+    client.register(new JdkLoggingFilter(false));
+    WebTarget target = client.target(getAbsoluteUrl(methodName));
+    Invocation.Builder ib = target.request();
+    return ib;
+  }
+
+  protected void assertOkAndLog(Response response, Status status) throws Fault {
+    assertTrue(response.getStatus() == status.getStatusCode(),
+        "Returned unexpected status"+ response.getStatus());
+    String msg = new StringBuilder().append("Returned status ")
+        .append(status.getStatusCode()).append(" (").append(status.name())
+        .append(")").toString();
+    TestUtil.logMsg(msg);
+  }
+
+  protected void checkFutureResponseStatus(Future<Response> future,
+      Status status) throws Fault {
+    Response response = null;
+    try {
+      response = future.get();
+    } catch (Exception e) {
+      throw new Fault(e);
+    }
+    assertOkAndLog(response, status);
+  }
+
+  protected void checkFutureOkResponse(Future<Response> future) throws Fault {
+    assertTrue(!future.isDone(), "Future cannot be done, yet!");
+    checkFutureResponseStatus(future, Status.OK);
+  }
+
+  protected void checkFutureString(Future<String> future, String expectedValue)
+      throws Fault {
+    assertTrue(!future.isDone(), "Future cannot be done, yet!");
+    String value = null;
+    try {
+      value = future.get();
+    } catch (Exception e) {
+      throw new Fault(e);
+    }
+    assertTrue(expectedValue.equalsIgnoreCase(value), "expected value"+
+        expectedValue+ "differes from acquired value"+ value);
+  }
+
+  protected void //
+      assertExceptionWithWebApplicationExceptionIsThrownAndLog(Future<?> future)
+          throws Fault {
+    try {
+      future.get();
+      throw new Fault("ExecutionException has not been thrown");
+    } catch (ExecutionException e) {
+      assertWebApplicationExceptionIsCauseAndLog(e);
+    } catch (InterruptedException e) {
+      throw new Fault("Unexpected exception thrown", e);
+    }
+  }
+
+  protected void assertExceptionWithProcessingExceptionIsThrownAndLog(
+      Future<?> future) throws Fault {
+    try {
+      future.get();
+      throw new Fault("ExecutionException has not been thrown");
+    } catch (ExecutionException e) {
+      assertProcessingExceptionIsCauseAndLog(e);
+    } catch (InterruptedException e) {
+      throw new Fault("Unexpected exception thrown", e);
+    }
+  }
+
+  protected void //
+      assertProcessingExceptionIsCauseAndLog(ExecutionException e)
+          throws Fault {
+    logMsg("ExecutionException has been thrown as expected", e);
+    assertCause(e, jakarta.ws.rs.ProcessingException.class,
+        "ExecutionException wrapped", e.getCause(),
+        "rather then ProcessingException");
+    logMsg("ExecutionException.getCause is ProcessingException as expected");
+  }
+
+  protected void //
+      assertWebApplicationExceptionIsCauseAndLog(ExecutionException e)
+          throws Fault {
+    logMsg("ExecutionException has been thrown as expected", e);
+    assertCause(e, WebApplicationException.class, "ExecutionException wrapped",
+        e.getCause(), "rather then WebApplicationException");
+    logMsg(
+        "ExecutionException.getCause is WebApplicationException as expected");
+  }
+
+  protected <T> GenericType<T> createGeneric(Class<T> clazz) {
+    return new GenericType<T>(clazz);
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/client/rxinvoker/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/client/rxinvoker/JAXRSClientIT.java
@@ -1679,7 +1679,7 @@ public class JAXRSClientIT extends JAXRSCommonClient {
    * 
    * @test_Strategy: Invoke HTTP trace method for the current request
    */
-  //@Test
+  @Test
   public void traceTest() throws Fault {
     CompletionStageRxInvoker rx = startRxInvokerForMethod("trace");
     Future<Response> future = rx.trace().toCompletableFuture();
@@ -1710,7 +1710,7 @@ public class JAXRSClientIT extends JAXRSCommonClient {
    * 
    * @test_Strategy: Invoke HTTP trace method for the current request
    */
-  //@Test
+  @Test
   public void traceWithStringClassTest() throws Fault {
     CompletionStageRxInvoker rx = startRxInvokerForMethod("trace");
     Future<String> future = rx.trace(String.class).toCompletableFuture();
@@ -1724,7 +1724,7 @@ public class JAXRSClientIT extends JAXRSCommonClient {
    * 
    * @test_Strategy: Invoke HTTP trace method for the current request
    */
-  //@Test
+  @Test
   public void traceWithResponseClassTest() throws Fault {
     CompletionStageRxInvoker rx = startRxInvokerForMethod("trace");
     Future<Response> future = rx.trace(Response.class).toCompletableFuture();
@@ -1773,7 +1773,7 @@ public class JAXRSClientIT extends JAXRSCommonClient {
    * of the response returned by the server is not successful and the specified
    * response type is not Response.
    */
-  //@Test
+  @Test
   public void traceWithClassThrowsNoWebApplicationExceptionForResponseTest()
       throws Fault {
     CompletionStageRxInvoker rx = startRxInvokerForMethod("tracenotok");
@@ -1788,7 +1788,7 @@ public class JAXRSClientIT extends JAXRSCommonClient {
    * 
    * @test_Strategy: Invoke HTTP trace method for the current request
    */
-  //@Test
+  @Test
   public void traceWithGenericTypeStringTest() throws Fault {
     GenericType<String> generic = createGeneric(String.class);
     CompletionStageRxInvoker rx = startRxInvokerForMethod("trace");
@@ -1803,7 +1803,7 @@ public class JAXRSClientIT extends JAXRSCommonClient {
    * 
    * @test_Strategy: Invoke HTTP trace method for the current request
    */
-  //@Test
+  @Test
   public void traceWithGenericTypeResponseTest() throws Fault {
     GenericType<Response> generic = createGeneric(Response.class);
     CompletionStageRxInvoker rx = startRxInvokerForMethod("trace");
@@ -1857,7 +1857,7 @@ public class JAXRSClientIT extends JAXRSCommonClient {
    * of the response returned by the server is not successful and the specified
    * response type is not Response.
    */
-  //@Test
+  @Test
   public void traceWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest()
       throws Fault {
     CompletionStageRxInvoker rx = startRxInvokerForMethod("tracenotok");

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/client/rxinvoker/Resource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/client/rxinvoker/Resource.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.client.rxinvoker;
+
+import jakarta.ws.rs.tck.common.impl.TRACE;
+
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HEAD;
+import jakarta.ws.rs.OPTIONS;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+
+@Path("resource")
+public class Resource {
+
+  @GET
+  @Path("get")
+  public String get() {
+    return "get";
+  }
+
+  @GET
+  @Path("getnotok")
+  public Response getNotOk() {
+    return Response.status(Status.NOT_ACCEPTABLE).build();
+  }
+
+  @HEAD
+  @Path("head")
+  public String head() {
+    return "head";
+  }
+
+  @HEAD
+  @Path("headnotok")
+  public Response headNotOk() {
+    return Response.status(Status.NOT_ACCEPTABLE).build();
+  }
+
+  @PUT
+  @Path("put")
+  public String put(String value) {
+    return value;
+  }
+
+  @PUT
+  @Path("putnotok")
+  public Response putNotOk(String value) {
+    return Response.status(Status.NOT_ACCEPTABLE).build();
+  }
+
+  @POST
+  @Path("post")
+  public String post(String value) {
+    return value;
+  }
+
+  @POST
+  @Path("postnotok")
+  public Response postNotOk(String value) {
+    return Response.status(Status.NOT_ACCEPTABLE).build();
+  }
+
+  @DELETE
+  @Path("delete")
+  public String delete() {
+    return "delete";
+  }
+
+  @DELETE
+  @Path("deletenotok")
+  public Response deleteNotOk() {
+    return Response.status(Status.NOT_ACCEPTABLE).build();
+  }
+
+  @OPTIONS
+  @Path("options")
+  public String options() {
+    return "options";
+  }
+
+  @OPTIONS
+  @Path("optionsnotok")
+  public Response optionsNotOk() {
+    return Response.status(Status.NOT_ACCEPTABLE).build();
+  }
+
+  @TRACE
+  @Path("trace")
+  public String trace() {
+    return "trace";
+  }
+
+  @TRACE
+  @Path("tracenotok")
+  public Response traceNotOk() {
+    return Response.status(Status.NOT_ACCEPTABLE).build();
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/client/rxinvoker/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/client/rxinvoker/TSAppConfig.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.client.rxinvoker;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.ws.rs.core.Application;
+
+public class TSAppConfig extends Application {
+
+  public java.util.Set<java.lang.Class<?>> getClasses() {
+    Set<Class<?>> resources = new HashSet<Class<?>>();
+    resources.add(Resource.class);
+    return resources;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/patch/Resource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/patch/Resource.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.patch;
+
+import jakarta.ws.rs.PATCH;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+
+@Path("resource")
+public class Resource {
+  public static final long SLEEP_TIME = 1500L;
+
+  @PATCH
+  @Path("patch")
+  public String patch(String in) {
+    return in;
+  }
+
+  @PATCH
+  @Path("patchnotok")
+  public Response patchNotOk(String value) {
+    return Response.status(Status.NOT_ACCEPTABLE).build();
+  }
+
+  @PATCH
+  @Path("patchandwait")
+  public String postAndWait(String value) throws InterruptedException {
+    Thread.sleep(SLEEP_TIME);
+    return value;
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/patch/server/AdaptiveHttpRequest.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/patch/server/AdaptiveHttpRequest.java
@@ -1,0 +1,547 @@
+/*
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.patch.server;
+
+import java.io.IOException;
+import java.util.StringTokenizer;
+
+import org.apache.commons.httpclient.Cookie;
+import org.apache.commons.httpclient.Header;
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpConnection;
+import org.apache.commons.httpclient.HttpException;
+import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.HttpState;
+import org.apache.commons.httpclient.UsernamePasswordCredentials;
+import org.apache.commons.httpclient.auth.AuthScope;
+import org.apache.commons.httpclient.cookie.CookiePolicy;
+import org.apache.commons.httpclient.methods.EntityEnclosingMethod;
+import org.apache.commons.httpclient.methods.StringRequestEntity;
+import org.apache.commons.httpclient.protocol.DefaultProtocolSocketFactory;
+import org.apache.commons.httpclient.protocol.Protocol;
+import org.apache.commons.httpclient.protocol.ProtocolSocketFactory;
+import org.apache.commons.httpclient.protocol.SSLProtocolSocketFactory;
+
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+import jakarta.ws.rs.tck.common.webclient.Util;
+import jakarta.ws.rs.tck.common.webclient.http.HttpRequest;
+import jakarta.ws.rs.tck.common.webclient.http.HttpResponse;
+
+/**
+ * Represents an HTTP client Request
+ */
+
+public class AdaptiveHttpRequest extends HttpRequest {
+  /**
+   * Method representation of request.
+   */
+  private HttpMethod _method = null;
+
+  /**
+   * Target web container host
+   */
+  private String _host = null;
+
+  /**
+   * Target web container port
+   */
+  private int _port = DEFAULT_HTTP_PORT;
+
+  /**
+   * Is the request going over SSL
+   */
+  private boolean _isSecure = false;
+
+  /**
+   * HTTP state
+   */
+  private HttpState _state = null;
+
+  /**
+   * Original request line for this request.
+   */
+  private String _requestLine = null;
+
+  /**
+   * Authentication type for current request
+   */
+  private int _authType = NO_AUTHENTICATION;
+
+  /**
+   * Flag to determine if session tracking will be used or not.
+   */
+  private boolean _useCookies = false;
+
+  /**
+   * Content length of request body.
+   */
+  private int _contentLength = 0;
+
+  Header[] _headers = null;
+
+  /**
+   * Creates new HttpRequest based of the passed request line. The request line
+   * provied must be in the form of:<br>
+   * 
+   * <pre>
+   *     METHOD PATH HTTP-VERSION
+   *     Ex.  GET /index.html HTTP/1.0
+   * </pre>
+   */
+  public AdaptiveHttpRequest(String requestLine, String host, int port) {
+    super("GET /fake.jsp HTTP/1.1", host, port);
+    _method = AdaptiveMethodFactory.getInstance(requestLine);
+    _method.setFollowRedirects(false);
+    _host = host;
+    _port = port;
+
+    if (port == DEFAULT_SSL_PORT) {
+      _isSecure = true;
+    }
+
+    // If we got this far, the request line is in the proper
+    // format
+    _requestLine = requestLine;
+  }
+
+  /*
+   * public methods
+   * ========================================================================
+   */
+
+  /**
+   * <code>getRequestPath</code> returns the request path for this particular
+   * request.
+   *
+   * @return String request path
+   */
+  public String getRequestPath() {
+    return _method.getPath();
+  }
+
+  /**
+   * <code>getRequestMethod</code> returns the request type, i.e., GET, POST,
+   * etc.
+   *
+   * @return String request type
+   */
+  public String getRequestMethod() {
+    return _method.getName();
+  }
+
+  /**
+   * <code>isSecureConnection()</code> indicates if the Request is secure or
+   * not.
+   *
+   * @return boolean whether Request is using SSL or not.
+   */
+  public boolean isSecureRequest() {
+    return _isSecure;
+  }
+
+  /**
+   * <code>setSecureRequest</code> configures this request to use SSL.
+   *
+   * @param secure
+   *          - whether the Request uses SSL or not.
+   */
+  public void setSecureRequest(boolean secure) {
+    _isSecure = secure;
+  }
+
+  /**
+   * <code>setContent</code> will set the body for this request. Note, this is
+   * only valid for POST and PUT operations, however, if called and the request
+   * represents some other HTTP method, it will be no-op'd.
+   *
+   * @param content
+   *          request content
+   */
+  @SuppressWarnings("deprecation")
+  public void setContent(String content) {
+    if (_method instanceof EntityEnclosingMethod) {
+      ((EntityEnclosingMethod) _method)
+          .setRequestEntity(new StringRequestEntity(content));
+    }
+    _contentLength = content.length();
+  }
+
+  /**
+   * <code>setAuthenticationCredentials configures the request to
+   * perform authentication.
+   *
+   * <p><code>username</code> and <code>password</code> cannot be null.
+   * </p>
+   *
+   * <p>
+   * It is legal for <code>realm</code> to be null.
+   * </p>
+   *
+   * @param username
+   *          the user
+   * @param password
+   *          the user's password
+   * @param authType
+   *          authentication type
+   * @param realm
+   *          authentication realm
+   */
+  public void setAuthenticationCredentials(String username, String password,
+      int authType, String realm) {
+    if (username == null) {
+      throw new IllegalArgumentException("Username cannot be null");
+    }
+
+    if (password == null) {
+      throw new IllegalArgumentException("Password cannot be null");
+    }
+
+    UsernamePasswordCredentials cred = new UsernamePasswordCredentials(username,
+        password);
+    AuthScope scope = new AuthScope(_host, _port, realm);
+    getState().setCredentials(scope, cred);
+    TestUtil.logTrace("[HttpRequest] Added credentials for '" + username
+        + "' with password '" + password + "' in realm '" + realm + "'");
+
+    _authType = authType;
+  }
+
+  /**
+   * <code>addRequestHeader</code> adds a request header to this request. If a
+   * request header of the same name already exists, the new value, will be
+   * added to the set of already existing values.
+   *
+   * <strong>NOTE:</strong> that header names are not case-sensitive.
+   *
+   * @param headerName
+   *          request header name
+   * @param headerValue
+   *          request header value
+   */
+  public void addRequestHeader(String headerName, String headerValue) {
+    _method.addRequestHeader(headerName, headerValue);
+    TestUtil.logTrace("[HttpRequest] Added request header: "
+        + _method.getRequestHeader(headerName).toExternalForm());
+  }
+
+  public void addRequestHeader(String header) {
+    StringTokenizer st = new StringTokenizer(header, "|");
+    while (st.hasMoreTokens()) {
+      String h = st.nextToken();
+      if (h.toLowerCase().startsWith("cookie")) {
+        createCookie(h);
+        continue;
+      }
+      int col = h.indexOf(':');
+      addRequestHeader(h.substring(0, col).trim(), h.substring(col + 1).trim());
+    }
+  }
+
+  /**
+   * <code>setRequestHeader</code> sets a request header for this request
+   * overwritting any previously existing header/values with the same name.
+   *
+   * <strong>NOTE:</strong> Header names are not case-sensitive.
+   *
+   * @param headerName
+   *          request header name
+   * @param headerValue
+   *          request header value
+   */
+  public void setRequestHeader(String headerName, String headerValue) {
+    _method.setRequestHeader(headerName, headerValue);
+    TestUtil.logTrace("[HttpRequest] Set request header: "
+        + _method.getRequestHeader(headerName).toExternalForm());
+
+  }
+
+  /**
+   * <code>setFollowRedirects</code> indicates whether HTTP redirects are
+   * followed. By default, redirects are not followed.
+   */
+  public void setFollowRedirects(boolean followRedirects) {
+    _method.setFollowRedirects(followRedirects);
+  }
+
+  /**
+   * <code>getFollowRedirects</code> indicates whether HTTP redirects are
+   * followed.
+   */
+  public boolean getFollowRedirects() {
+    return _method.getFollowRedirects();
+  }
+
+  /**
+   * <code>setState</code> will set the HTTP state for the current request (i.e.
+   * session tracking). This has the side affect
+   */
+  public void setState(HttpState state) {
+    _state = state;
+    _useCookies = true;
+  }
+
+  /**
+   * <code>execute</code> will dispatch the current request to the target
+   * server.
+   *
+   * @return HttpResponse the server's response.
+   * @throws IOException
+   *           if an I/O error occurs during dispatch.
+   */
+  public HttpResponse execute() throws IOException, HttpException {
+    String method;
+    int defaultPort;
+    ProtocolSocketFactory factory;
+
+    if (_method.getFollowRedirects()) {
+      client = new HttpClient();
+
+      if (_isSecure) {
+        method = "https";
+        defaultPort = DEFAULT_SSL_PORT;
+        factory = new SSLProtocolSocketFactory();
+      } else {
+        method = "http";
+        defaultPort = DEFAULT_HTTP_PORT;
+        factory = new DefaultProtocolSocketFactory();
+      }
+
+      Protocol protocol = new Protocol(method, factory, defaultPort);
+      HttpConnection conn = new HttpConnection(_host, _port, protocol);
+
+      if (conn.isOpen()) {
+        throw new IllegalStateException("Connection incorrectly opened");
+      }
+
+      conn.open();
+
+      TestUtil.logMsg("[HttpRequest] Dispatching request: '" + _requestLine
+          + "' to target server at '" + _host + ":" + _port + "'");
+
+      addSupportHeaders();
+      _headers = _method.getRequestHeaders();
+
+      TestUtil.logTrace(
+          "########## The real value set: " + _method.getFollowRedirects());
+
+      client.getHostConfiguration().setHost(_host, _port, protocol);
+
+      client.executeMethod(_method);
+
+      return new HttpResponse(_host, _port, _isSecure, _method, getState());
+    } else {
+      if (_isSecure) {
+        method = "https";
+        defaultPort = DEFAULT_SSL_PORT;
+        factory = new SSLProtocolSocketFactory();
+      } else {
+        method = "http";
+        defaultPort = DEFAULT_HTTP_PORT;
+        factory = new DefaultProtocolSocketFactory();
+      }
+
+      Protocol protocol = new Protocol(method, factory, defaultPort);
+      HttpConnection conn = new HttpConnection(_host, _port, protocol);
+
+      if (conn.isOpen()) {
+        throw new IllegalStateException("Connection incorrectly opened");
+      }
+
+      conn.open();
+
+      TestUtil.logMsg("[HttpRequest] Dispatching request: '" + _requestLine
+          + "' to target server at '" + _host + ":" + _port + "'");
+
+      addSupportHeaders();
+      _headers = _method.getRequestHeaders();
+
+      TestUtil.logTrace(
+          "########## The real value set: " + _method.getFollowRedirects());
+
+      _method.execute(getState(), conn);
+
+      return new HttpResponse(_host, _port, _isSecure, _method, getState());
+    }
+  }
+
+  /**
+   * Returns the current state for this request.
+   *
+   * @return HttpState current state
+   */
+  public HttpState getState() {
+    if (_state == null) {
+      _state = new HttpState();
+    }
+    return _state;
+  }
+
+  public String toString() {
+    StringBuffer sb = new StringBuffer(255);
+    sb.append("[REQUEST LINE] -> ").append(_requestLine).append('\n');
+
+    if (_headers != null && _headers.length != 0) {
+
+      for (Header _header : _headers) {
+        sb.append("       [REQUEST HEADER] -> ");
+        sb.append(_header.toExternalForm()).append('\n');
+      }
+    }
+
+    if (_contentLength != 0) {
+      sb.append("       [REQUEST BODY LENGTH] -> ").append(_contentLength);
+      sb.append('\n');
+    }
+
+    return sb.toString();
+
+  }
+
+  /*
+   * private methods
+   * ========================================================================
+   */
+
+  private void createCookie(String cookieHeader) {
+    String cookieLine = cookieHeader.substring(cookieHeader.indexOf(':') + 1)
+        .trim();
+    StringTokenizer st = new StringTokenizer(cookieLine, " ;");
+    Cookie cookie = new Cookie();
+    cookie.setVersion(1);
+
+    getState();
+
+    if (cookieLine.indexOf("$Version") == -1) {
+      cookie.setVersion(0);
+      _method.getParams().setCookiePolicy(CookiePolicy.NETSCAPE);
+    }
+
+    while (st.hasMoreTokens()) {
+      String token = st.nextToken();
+
+      if (token.charAt(0) != '$' && !token.startsWith("Domain")
+          && !token.startsWith("Path")) {
+        cookie.setName(token.substring(0, token.indexOf('=')));
+        cookie.setValue(token.substring(token.indexOf('=') + 1));
+      } else if (token.indexOf("Domain") > -1) {
+        cookie.setDomainAttributeSpecified(true);
+        cookie.setDomain(token.substring(token.indexOf('=') + 1));
+      } else if (token.indexOf("Path") > -1) {
+        cookie.setPathAttributeSpecified(true);
+        cookie.setPath(token.substring(token.indexOf('=') + 1));
+      }
+    }
+    _state.addCookie(cookie);
+
+  }
+
+  /**
+   * Adds any support request headers necessary for this request. These headers
+   * will be added based on the state of the request.
+   */
+  private void addSupportHeaders() {
+
+    // Authentication headers
+    // NOTE: Possibly move logic to generic method
+    switch (_authType) {
+    case NO_AUTHENTICATION:
+      break;
+    case BASIC_AUTHENTICATION:
+      setBasicAuthorizationHeader();
+      break;
+    case DIGEST_AUTHENTICATION:
+      throw new UnsupportedOperationException(
+          "Digest Authentication is not currently " + "supported");
+    }
+
+    // A Host header will be added to each request to handle
+    // cases where virtual hosts are used, or there is no DNS
+    // available on the system where the container is running.
+    setHostHeader();
+
+    // Content length header
+    setContentLengthHeader();
+
+    // Cookies
+    setCookieHeader();
+  }
+
+  /**
+   * Sets a basic authentication header in the request is Request is configured
+   * to use basic authentication
+   */
+  private void setBasicAuthorizationHeader() {
+    UsernamePasswordCredentials cred = (UsernamePasswordCredentials) getState()
+        .getCredentials(new AuthScope(_host, _port, null));
+    String authString = null;
+    if (cred != null) {
+      authString = "Basic " + Util.getBase64EncodedString(
+          cred.getUserName() + ":" + cred.getPassword());
+    } else {
+      TestUtil.logTrace("[HttpRequest] NULL CREDENTIALS");
+    }
+    _method.setRequestHeader("Authorization", authString);
+  }
+
+  /**
+   * Sets a Content-Length header in the request if content is present
+   */
+  private void setContentLengthHeader() {
+    if (_contentLength > 0) {
+      _method.setRequestHeader("Content-Length",
+          Integer.toString(_contentLength));
+    }
+  }
+
+  /**
+   * Sets a host header in the request. If the configured host value is an IP
+   * address, the Host header will be sent, but without any value.
+   *
+   * If we adhered to the HTTP/1.1 spec, the Host header must be empty of the
+   * target server is identified via IP address. However, no user agents I've
+   * tested follow this. And if a custom client library does this, it may not
+   * work properly with the target server. For now, the Host request-header will
+   * always have a value.
+   */
+  private void setHostHeader() {
+    if (_port == DEFAULT_HTTP_PORT || _port == DEFAULT_SSL_PORT) {
+      _method.setRequestHeader("Host", _host);
+    } else {
+      _method.setRequestHeader("Host", _host + ":" + _port);
+    }
+  }
+
+  /**
+   * Sets a Cookie header if this request is using cookies.
+   */
+  private void setCookieHeader() {
+    if (_useCookies) {
+      Cookie[] cookies = _state.getCookies();
+      if (cookies != null && cookies.length > 0) {
+        Header cHeader = CookiePolicy.getCookieSpec(CookiePolicy.RFC_2109)
+            .formatCookieHeader(_state.getCookies());
+        if (cHeader != null) {
+          _method.setRequestHeader(cHeader);
+        }
+      }
+    }
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/patch/server/AdaptiveMethodFactory.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/patch/server/AdaptiveMethodFactory.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.patch.server;
+
+import java.lang.reflect.Constructor;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.StringTokenizer;
+
+import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.HttpMethodBase;
+import org.apache.commons.httpclient.HttpVersion;
+import org.apache.commons.httpclient.methods.DeleteMethod;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.commons.httpclient.methods.HeadMethod;
+import org.apache.commons.httpclient.methods.OptionsMethod;
+import org.apache.commons.httpclient.methods.PostMethod;
+import org.apache.commons.httpclient.methods.PutMethod;
+
+import jakarta.ws.rs.tck.lib.porting.TSURL;
+
+/**
+ * Simple factory class which returns HttpMethod implementations based on a
+ * request line.
+ * <p>
+ * For example, a request line of <tt>GET /index.jsp HTTP/1.0</tt> would return
+ * an HttpMethod implementation that handles GET requests using HTTP/1.0.
+ * </p>
+ */
+
+public class AdaptiveMethodFactory {
+
+  /**
+   * HTTP GET
+   */
+  private static final String GET_METHOD = "GET";
+
+  /**
+   * HTTP POST
+   */
+  private static final String POST_METHOD = "POST";
+
+  /**
+   * HTTP HEAD
+   */
+  private static final String HEAD_METHOD = "HEAD";
+
+  /**
+   * HTTP PUT
+   */
+  private static final String PUT_METHOD = "PUT";
+
+  /**
+   * HTTP DELETE
+   */
+  private static final String DELETE_METHOD = "DELETE";
+
+  /**
+   * HTTP OPTIONS
+   */
+  private static final String OPTIONS_METHOD = "OPTIONS";
+
+  private static final Map<String, Class<? extends HttpMethodBase>> METHOD_MAP = new HashMap<>();
+  static {
+    METHOD_MAP.put(GET_METHOD, GetMethod.class);
+    METHOD_MAP.put(POST_METHOD, PostMethod.class);
+    METHOD_MAP.put(PUT_METHOD, PutMethod.class);
+    METHOD_MAP.put(DELETE_METHOD, DeleteMethod.class);
+    METHOD_MAP.put(HEAD_METHOD, HeadMethod.class);
+    METHOD_MAP.put(OPTIONS_METHOD, OptionsMethod.class);
+  }
+
+  /**
+   * TSURL implementation
+   */
+  private static final TSURL TS_URL = new TSURL();
+
+  /**
+   * Private constructor as all interaction with this class is through the
+   * getInstance() method.
+   */
+  private AdaptiveMethodFactory() {
+  }
+
+  /*
+   * public methods
+   * ========================================================================
+   */
+
+  public static final Map<String, Class<? extends HttpMethodBase>> getMethodMap() {
+    return METHOD_MAP;
+  }
+
+  /**
+   * Returns the approriate request method based on the provided request string.
+   * The request must be in the format of METHOD URI_PATH HTTP_VERSION, i.e. GET
+   * /index.jsp HTTP/1.1.
+   *
+   * @return HttpMethod based in request.
+   */
+  public static HttpMethod getInstance(String request) {
+    StringTokenizer st = new StringTokenizer(request);
+    String method;
+    String query = null;
+    String uri;
+    String version;
+    try {
+      method = st.nextToken();
+      uri = TS_URL.getRequest(st.nextToken());
+      version = st.nextToken();
+    } catch (NoSuchElementException nsee) {
+      throw new IllegalArgumentException(
+          "Request provided: " + request + " is malformed.");
+    }
+
+    // check to see if there is a query string appended
+    // to the URI
+    int queryStart = uri.indexOf('?');
+    if (queryStart != -1) {
+      query = uri.substring(queryStart + 1);
+      uri = uri.substring(0, queryStart);
+    }
+
+    HttpMethodBase req;
+    Class<? extends HttpMethodBase> methodClass = METHOD_MAP.get(method);
+    if (methodClass == null) {
+      throw new IllegalArgumentException("Invalid method: " + method);
+    }
+
+    Constructor<? extends HttpMethodBase> constructor;
+    try {
+      constructor = methodClass.getDeclaredConstructor(String.class);
+      req = constructor.newInstance(uri);
+    } catch (Exception e) {
+      throw new IllegalStateException(e);
+    }
+
+    setHttpVersion(version, req);
+
+    if (query != null) {
+      req.setQueryString(query);
+    }
+
+    return req;
+  }
+
+  /*
+   * private methods
+   * ========================================================================
+   */
+
+  /**
+   * Sets the HTTP version for the method in question.
+   *
+   * @param version
+   *          HTTP version to use for this request
+   * @param method
+   *          method to adjust HTTP version
+   */
+  private static void setHttpVersion(String version, HttpMethodBase method) {
+    final String oneOne = "HTTP/1.1";
+    method.getParams().setVersion(
+        (version.equals(oneOne) ? HttpVersion.HTTP_1_1 : HttpVersion.HTTP_1_0));
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/patch/server/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/patch/server/JAXRSClientIT.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.patch.server;
+
+import jakarta.ws.rs.tck.common.webclient.http.HttpRequest;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import java.io.InputStream;
+import java.io.IOException;
+
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+import jakarta.ws.rs.core.MediaType;
+
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+/**
+ * @since 2.1
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = 21L;
+
+  public JAXRSClientIT() {
+    setup();
+    setContextRoot("/jaxrs_jaxrs21_ee_patch_server_web/resource");
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  @Deployment(testable = false)
+  public static WebArchive createDeployment() throws IOException{
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_jaxrs21_ee_patch_server_web.war");
+    archive.addClasses(TSAppConfig.class, jakarta.ws.rs.tck.jaxrs21.ee.patch.Resource.class);
+    return archive;
+
+  }
+
+
+  /*
+   * @testName: patchTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:124;
+   * 
+   */
+  @Test
+  public void patchTest() throws Fault {
+    AdaptiveMethodFactory.getMethodMap().put("PATCH", PatchMethod.class);
+    setProperty(Property.REQUEST, buildRequest("PATCH", "patch"));
+    setProperty(Property.CONTENT, "patch");
+    setProperty(Property.SEARCH_STRING, "patch");
+    setProperty(Property.REQUEST_HEADERS,
+        buildAccept(MediaType.TEXT_PLAIN_TYPE));
+    invoke();
+  }
+
+  @Override
+  protected HttpRequest createHttpRequest(String requestLine, String host,
+      int port) {
+    return new AdaptiveHttpRequest(requestLine, host, port);
+  };
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/patch/server/PatchMethod.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/patch/server/PatchMethod.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.patch.server;
+
+import org.apache.commons.httpclient.methods.EntityEnclosingMethod;
+
+public class PatchMethod extends EntityEnclosingMethod {
+  public PatchMethod() {
+    super();
+  }
+
+  public PatchMethod(String uri) {
+    super(uri);
+  }
+
+  @Override
+  public String getName() {
+    return "PATCH";
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/patch/server/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/patch/server/TSAppConfig.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.patch.server;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class TSAppConfig extends Application {
+
+  public java.util.Set<java.lang.Class<?>> getClasses() {
+    Set<Class<?>> resources = new HashSet<Class<?>>();
+    resources.add(jakarta.ws.rs.tck.jaxrs21.ee.patch.Resource.class);
+    return resources;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/priority/ExceptionMapperOne.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/priority/ExceptionMapperOne.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.priority;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+@Provider
+@Priority(10)
+public class ExceptionMapperOne
+    implements ExceptionMapper<TckPriorityException> {
+
+  @Override
+  public Response toResponse(TckPriorityException exception) {
+    return Response.ok().entity(getClass().getName()).build();
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/priority/ExceptionMapperThree.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/priority/ExceptionMapperThree.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.priority;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+@Provider
+@Priority(11)
+public class ExceptionMapperThree
+    implements ExceptionMapper<TckPriorityException> {
+
+  @Override
+  public Response toResponse(TckPriorityException exception) {
+    return Response.ok().entity(getClass().getName()).build();
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/priority/ExceptionMapperTwo.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/priority/ExceptionMapperTwo.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.priority;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+@Provider
+@Priority(20)
+public class ExceptionMapperTwo
+    implements ExceptionMapper<TckPriorityException> {
+
+  @Override
+  public Response toResponse(TckPriorityException exception) {
+    return Response.ok().entity(getClass().getName()).build();
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/priority/ExceptionResource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/priority/ExceptionResource.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.priority;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("exception")
+public class ExceptionResource {
+  @GET
+  @Produces(MediaType.TEXT_PLAIN)
+  public String get() {
+    throw new TckPriorityException();
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/priority/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/priority/JAXRSClientIT.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.priority;
+
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+import java.io.InputStream;
+import java.io.IOException;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = 21L;
+
+  public JAXRSClientIT() {
+    setup();
+    setContextRoot("/jaxrs_jaxrs21_ee_priority_web");
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  @Deployment(testable = false)
+  public static WebArchive createDeployment() throws IOException {
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_jaxrs21_ee_priority_web.war");
+    archive.addClasses(TSAppConfig.class, ExceptionMapperOne.class,
+      ExceptionMapperThree.class, ExceptionMapperTwo.class, ExceptionResource.class,
+      ParamConverterProviderAnother.class, ParamConverterProviderOne.class, ParamConverterProviderTwo.class,
+      ParamConverterResource.class, TckPriorityException.class);
+    return archive;
+
+  }
+
+
+  /* Run test */
+
+  /*
+   * @testName: exceptionMapperPriorityTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:127;
+   * 
+   * @test_Strategy:
+   */
+  @Test
+  public void exceptionMapperPriorityTest() throws Fault {
+    setProperty(Property.REQUEST, buildRequest(Request.GET, "exception"));
+    setProperty(Property.SEARCH_STRING, ExceptionMapperOne.class.getName());
+    invoke();
+  }
+
+  /*
+   * @testName: paramConverterPriorityTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:127;
+   * 
+   * @test_Strategy:
+   */
+  @Test
+  public void paramConverterPriorityTest() throws Fault {
+    setProperty(Property.REQUEST,
+        buildRequest(Request.GET, "converter?id=something"));
+    setProperty(Property.SEARCH_STRING,
+        ParamConverterProviderOne.class.getName());
+    invoke();
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/priority/ParamConverterProviderAnother.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/priority/ParamConverterProviderAnother.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.priority;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.ext.ParamConverter;
+import jakarta.ws.rs.ext.ParamConverterProvider;
+import jakarta.ws.rs.ext.Provider;
+
+@Provider
+@Priority(98)
+/*
+ * The name is to start with A
+ */
+public class ParamConverterProviderAnother implements ParamConverterProvider {
+
+  @Override
+  public <T> ParamConverter<T> getConverter(Class<T> rawType, Type genericType,
+      Annotation[] annotations) {
+    return new ParamConverter<T>() {
+
+      @Override
+      public T fromString(String value) {
+        return null;
+      }
+
+      @Override
+      public String toString(T value) {
+        return getClass().getName();
+      }
+
+    };
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/priority/ParamConverterProviderOne.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/priority/ParamConverterProviderOne.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.priority;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.ext.ParamConverter;
+import jakarta.ws.rs.ext.ParamConverterProvider;
+import jakarta.ws.rs.ext.Provider;
+
+@Provider
+@Priority(88)
+public class ParamConverterProviderOne implements ParamConverterProvider {
+
+  @Override
+  public <T> ParamConverter<T> getConverter(Class<T> rawType, Type genericType,
+      Annotation[] annotations) {
+    return new ParamConverter<T>() {
+
+      @SuppressWarnings("unchecked")
+      @Override
+      public T fromString(String value) {
+        if (String.class == rawType)
+          return (T) getClass().getName();
+        return null;
+      }
+
+      @Override
+      public String toString(T value) {
+        return getClass().getName();
+      }
+
+    };
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/priority/ParamConverterProviderTwo.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/priority/ParamConverterProviderTwo.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.priority;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.ext.ParamConverter;
+import jakarta.ws.rs.ext.ParamConverterProvider;
+import jakarta.ws.rs.ext.Provider;
+
+@Provider
+@Priority(99)
+public class ParamConverterProviderTwo implements ParamConverterProvider {
+
+  @Override
+  public <T> ParamConverter<T> getConverter(Class<T> rawType, Type genericType,
+      Annotation[] annotations) {
+    return new ParamConverter<T>() {
+
+      @Override
+      public T fromString(String value) {
+        return null;
+      }
+
+      @Override
+      public String toString(T value) {
+        return getClass().getName();
+      }
+
+    };
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/priority/ParamConverterResource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/priority/ParamConverterResource.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.priority;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+
+@Path("converter")
+public class ParamConverterResource {
+  @GET
+  public String get(@QueryParam("id") String id) {
+    return id;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/priority/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/priority/TSAppConfig.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.priority;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class TSAppConfig extends Application {
+
+  public java.util.Set<java.lang.Class<?>> getClasses() {
+    Set<Class<?>> resources = new HashSet<Class<?>>();
+    resources.add(ExceptionMapperTwo.class);
+    resources.add(ExceptionMapperOne.class);
+    resources.add(ExceptionMapperThree.class);
+    resources.add(ExceptionResource.class);
+    resources.add(ParamConverterResource.class);
+    resources.add(ParamConverterProviderTwo.class);
+    return resources;
+  }
+
+  @Override
+  public Set<Object> getSingletons() {
+    Set<Object> resources = new HashSet<Object>();
+    resources.add(new ParamConverterProviderAnother());
+    resources.add(new ParamConverterProviderOne());
+    return resources;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/priority/TckPriorityException.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/priority/TckPriorityException.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.priority;
+
+public class TckPriorityException extends RuntimeException {
+  private static final long serialVersionUID = 21L;
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/sse/OutboundSSEEventImpl.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/sse/OutboundSSEEventImpl.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.sse;
+
+import java.lang.reflect.Type;
+
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.sse.OutboundSseEvent;
+
+public class OutboundSSEEventImpl extends SSEEventImpl
+    implements OutboundSseEvent {
+  public Class<?> type = String.class;
+
+  public Type genericType = new GenericType<String>(type) {
+  }.getType();
+
+  public Object data = null;
+
+  public MediaType media = MediaType.TEXT_PLAIN_TYPE;
+
+  public OutboundSSEEventImpl(Object data) {
+    setData(data);
+  }
+
+  public OutboundSSEEventImpl(Object data, String comment, String id,
+      String name, int delay) {
+    super(comment, id, name, delay);
+    setData(data);
+  }
+
+  @Override
+  public boolean isReconnectDelaySet() {
+    return delay != 0;
+  }
+
+  @Override
+  public Class<?> getType() {
+    return type;
+  }
+
+  @Override
+  public Type getGenericType() {
+    return type;
+  }
+
+  @Override
+  public MediaType getMediaType() {
+    return media;
+  }
+
+  @Override
+  public Object getData() {
+    return data;
+  }
+
+  public OutboundSSEEventImpl setType(Class<?> type) {
+    this.type = type;
+    return this;
+  }
+
+  public OutboundSSEEventImpl setGenericType(Type genericType) {
+    this.genericType = genericType;
+    return this;
+  }
+
+  public OutboundSSEEventImpl setData(Object data) {
+    this.data = data;
+    return this;
+  }
+
+  public OutboundSSEEventImpl setData(Object data, MediaType type) {
+    this.data = data;
+    return this;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/sse/SSEEventImpl.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/sse/SSEEventImpl.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.sse;
+
+import jakarta.ws.rs.sse.SseEvent;
+
+public abstract class SSEEventImpl implements SseEvent {
+
+  public SSEEventImpl(String comment, String id, String name, int delay) {
+    super();
+    this.comment = comment;
+    this.id = id;
+    this.name = name;
+    this.delay = delay;
+  }
+
+  public SSEEventImpl() {
+    super();
+  }
+
+  public int getDelay() {
+    return delay;
+  }
+
+  public SSEEventImpl setDelay(int delay) {
+    this.delay = delay;
+    return this;
+  }
+
+  public SSEEventImpl setId(String id) {
+    this.id = id;
+    return this;
+  }
+
+  public SSEEventImpl setName(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public SSEEventImpl setComment(String comment) {
+    this.comment = comment;
+    return this;
+  }
+
+  public String id;
+
+  public String name;
+
+  public int delay = 0;
+
+  public String comment;
+
+  @Override
+  public String getComment() {
+    return comment;
+  }
+
+  @Override
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public long getReconnectDelay() {
+    return delay;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/sse/SSEJAXRSClient.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/sse/SSEJAXRSClient.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.sse;
+
+import java.util.function.BiConsumer;
+
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.sse.InboundSseEvent;
+import jakarta.ws.rs.sse.SseEventSource;
+
+import jakarta.ws.rs.tck.common.client.JaxrsCommonClient;
+import jakarta.ws.rs.tck.common.util.Holder;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+/**
+ * @since 2.1
+ */
+public abstract class SSEJAXRSClient extends JaxrsCommonClient {
+
+  private static final long serialVersionUID = 21L;
+
+  protected long millis = 550L;
+
+  protected int sleep = -1;
+
+  public static final String MESSAGE = SSEMessage.MESSAGE;
+
+  protected Holder<InboundSseEvent> querySSEEndpoint(String endpoint)
+      throws Fault {
+    return querySSEEndpoint(endpoint, (a, b) -> a.register(b::set));
+  }
+
+  protected Holder<InboundSseEvent> querySSEEndpoint(String endpoint,
+      BiConsumer<SseEventSource, Holder<InboundSseEvent>> registrator)
+      throws Fault {
+    Holder<InboundSseEvent> holder = new Holder<>();
+    WebTarget target = ClientBuilder.newClient()
+        .target(getAbsoluteUrl(endpoint));
+
+    try (SseEventSource source = SseEventSource.target(target).build()) {
+      registrator.accept(source, holder);
+      source.open();
+      sleep = sleepUntilHolderGetsFilled(holder);
+      assertTrue(source.isOpen(), "SseEventSource#isOpen returns false");
+    // } catch (Fault f) {
+    //   throw f;
+    } catch (Exception e) {
+      throw new Fault(e);
+    }
+    assertNotNull(holder.get(), "The message was not received");
+    return holder;
+  }
+
+  protected void querySSEEndpointAndAssert(String endpoint) throws Fault {
+    Holder<InboundSseEvent> holder = querySSEEndpoint(endpoint);
+    assertEquals(MESSAGE, holder.get().readData(),
+        "Unexpected message received", holder.get().readData());
+  }
+
+  protected <T> int sleepUntilHolderGetsFilled(Holder<T> holder) {
+    try {
+      for (int i = 0; i != 7; i++) {
+        Thread.sleep(millis);
+        if (holder.get() != null)
+          return i + 1;
+      }
+    } catch (InterruptedException ie) {
+      // ignore
+    }
+    return 7;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/sse/SSEMessage.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/sse/SSEMessage.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.sse;
+
+public interface SSEMessage {
+  public static final String MESSAGE = "some_ServiceUnavailableEndpoint_message";
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/sse/ssebroadcaster/BroadcastResource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/sse/ssebroadcaster/BroadcastResource.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.sse.ssebroadcaster;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.sse.Sse;
+import jakarta.ws.rs.sse.SseBroadcaster;
+import jakarta.ws.rs.sse.SseEventSink;
+
+import jakarta.ws.rs.tck.common.util.Holder;
+
+@Path("broadcast")
+public class BroadcastResource {
+  private static final List<SseEventSink> sinkList = Collections
+      .synchronizedList(new LinkedList<>());
+
+  private volatile static Holder<SseBroadcaster> broadcaster = new Holder<>();
+
+  private final static Holder<SseEventSink> onCloseSink = new Holder<>();
+
+  private static int cnt;
+
+  @GET
+  @Path("clear")
+  public String clear() {
+    sinkList.clear();
+    onCloseSink.set(null);
+    broadcaster.set(null);
+    cnt = 0;
+    return "CLEAR";
+  }
+
+  @GET
+  @Path("register")
+  @Produces(MediaType.SERVER_SENT_EVENTS)
+  public void register(@Context SseEventSink sink, @Context Sse sse) {
+    synchronized (broadcaster) {
+      if (broadcaster.get() == null)
+        broadcaster.set(sse.newBroadcaster());
+      onCloseSink.set(null);
+      broadcaster.get().register(sink);
+      broadcaster.get().onClose(onCloseSink::set);
+      sinkList.add(sink);
+    }
+    sink.send(sse.newEvent("WELCOME" + cnt++));
+  }
+
+  @POST
+  @Path("broadcast")
+  public String broadcast(@Context Sse sse, String message) {
+    synchronized (broadcaster) {
+      broadcaster.get().broadcast(sse.newEvent(message));
+    }
+    return message;
+  }
+
+  @GET
+  @Path("close")
+  public String close() {
+    synchronized (broadcaster) {
+      broadcaster.get().close();
+    }
+    return "CLOSE";
+  }
+
+  @GET
+  @Path("check")
+  public String check() {
+    StringBuffer sb = new StringBuffer();
+    synchronized (broadcaster) {
+      Iterator<SseEventSink> si = sinkList.iterator();
+      for (int i = 0; i != sinkList.size(); i++) {
+        sb.append("SseEventSink number ").append(i).append(" is closed:")
+            .append(si.next().isClosed());
+      }
+      sb.append("OnCloseSink has been called:")
+          .append(onCloseSink.get() != null);
+    }
+    return sb.toString();
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/sse/ssebroadcaster/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/sse/ssebroadcaster/JAXRSClientIT.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.sse.ssebroadcaster;
+
+import java.util.List;
+import java.util.Properties;
+import java.io.InputStream;
+import java.io.IOException;
+
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.sse.InboundSseEvent;
+import jakarta.ws.rs.sse.SseEventSource;
+
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+import jakarta.ws.rs.tck.common.util.LinkedHolder;
+import jakarta.ws.rs.tck.jaxrs21.ee.sse.SSEJAXRSClient;
+import jakarta.ws.rs.tck.jaxrs21.ee.sse.SSEMessage;
+
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ */
+/**
+ * @since 2.1
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JAXRSClientIT extends SSEJAXRSClient {
+
+  private static final long serialVersionUID = 21L;
+
+  private static final int CLIENTS = 5;
+
+  public JAXRSClientIT() {
+    setup();
+    setContextRoot("/jaxrs_jaxrs21_ee_sse_ssebroadcaster_web");
+  }
+
+  @Override
+  public void setup() {
+    super.setup();
+    target = ClientBuilder.newClient()
+        .target(getAbsoluteUrl("broadcast/register"));
+    clients = new BroadCasterClient[CLIENTS];
+  }
+
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  @Deployment(testable = false)
+  public static WebArchive createDeployment() throws IOException {
+
+    InputStream inStream = JAXRSClientIT.class.getClassLoader().getResourceAsStream("jakarta/ws/rs/tck/jaxrs21/ee/sse/ssebroadcaster/web.xml.template");
+    String webXml = editWebXmlString(inStream);
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_jaxrs21_ee_sse_ssebroadcaster_web.war");
+    archive.addClasses(TSAppConfig.class, BroadcastResource.class,
+        jakarta.ws.rs.tck.common.util.Holder.class,
+        jakarta.ws.rs.tck.jaxrs21.ee.sse.SSEMessage.class,
+        jakarta.ws.rs.tck.common.impl.TRACE.class,
+        jakarta.ws.rs.tck.common.impl.StringSource.class,
+        jakarta.ws.rs.tck.common.impl.StringStreamingOutput.class,
+        jakarta.ws.rs.tck.common.impl.StringDataSource.class,
+        jakarta.ws.rs.tck.common.impl.SinglevaluedMap.class,
+        jakarta.ws.rs.tck.common.impl.SecurityContextImpl.class,
+        jakarta.ws.rs.tck.common.impl.ReplacingOutputStream.class,
+        jakarta.ws.rs.tck.common.impl.JaxbKeyValueBean.class);
+    archive.setWebXML(new StringAsset(webXml));
+    return archive;
+
+  }
+
+
+
+  @Override
+  public void cleanup() throws Fault {
+    super.cleanup();
+    try {
+      for (int i = 0; i != clients.length; i++) {
+        System.out.println("cleanup" + i);
+        clients[i].close();
+      }
+    } catch (Exception e) {
+      throw new Fault(e);
+    }
+  }
+
+  private BroadCasterClient[] clients;
+
+  /* Run test */
+  ///////////////////////////////////////////////////////////////////////////////////////////
+
+  /*
+   * @testName: sseBroadcastTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1216; JAXRS:JAVADOC:1220; JAXRS:JAVADOC:1221;
+   * JAXRS:JAVADOC:1222; JAXRS:JAVADOC:1224;
+   * 
+   * @test_Strategy:
+   */
+  //@Test
+  public void sseBroadcastTest() throws Fault {
+    int MSG_MAX = 7;
+    int wait = 25;
+
+    setProperty(Property.REQUEST, buildRequest(Request.GET, "broadcast/clear"));
+    setProperty(Property.SEARCH_STRING, "CLEAR");
+    invoke();
+
+    clients = new BroadCasterClient[CLIENTS];
+    for (int i = 0; i != CLIENTS; i++) {
+      clients[i] = new BroadCasterClient();
+      Thread t = new Thread(clients[i]);
+      t.start();
+    }
+
+    for (int i = 0; i != CLIENTS; i++) {
+      while (clients[i].getEvents().size() == 0 && wait-- > 0)
+        TestUtil.sleep(100);
+    }
+
+    for (int i = 0; i != MSG_MAX; i++) {
+      setProperty(Property.CONTENT, SSEMessage.MESSAGE + i);
+      setProperty(Property.REQUEST,
+          buildRequest(Request.POST, "broadcast/broadcast"));
+      setProperty(Property.SEARCH_STRING, TEST_PROPS.get(Property.CONTENT));
+      invoke();
+    }
+
+    wait = 25;
+    while (clients[0].holder.size() <= MSG_MAX && wait > 0) {
+      TestUtil.sleep(200);
+      wait--;
+    }
+
+    setProperty(Property.REQUEST, buildRequest(Request.GET, "broadcast/close"));
+    setProperty(Property.SEARCH_STRING, "CLOSE");
+    invoke();
+
+    for (int i = 0; i != CLIENTS; i++) {
+      List<String> events = clients[i].getEvents();
+      for (String e : events) {
+        logMsg("Client", i, "Received message", e);
+      }
+    }
+
+    for (int i = 0; i != CLIENTS; i++) {
+      List<String> events = clients[i].getEvents();
+      assertEquals(events.size(), MSG_MAX + 1,
+          "Received unexpected number of events", events.size());
+      assertTrue(events.get(0).contains("WELCOME"),
+          "Received unexpected message"+ events.get(0));
+      for (int j = 0; j != MSG_MAX; j++)
+        assertEquals(events.get(j + 1), SSEMessage.MESSAGE + j,
+            "Received unexpected message", events.get(j + 1));
+    }
+
+    setProperty(Property.REQUEST, buildRequest(Request.GET, "broadcast/check"));
+    invoke();
+    String response = getResponseBody();
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i != CLIENTS; i++) {
+      sb.append("SseEventSink number ").append(i).append(" is closed:true");
+    }
+    sb.append("OnCloseSink has been called:true");
+    assertEquals(response, sb.toString(), "Unexpected check message received",
+        response);
+  }
+
+  private WebTarget target;
+
+  class BroadCasterClient implements Runnable, AutoCloseable {
+    MsgHolder holder = new MsgHolder();
+
+    volatile boolean isClosed = false;
+
+    @Override
+    public void run() {
+      try (SseEventSource source = SseEventSource.target(target).build()) {
+        source.register(holder::add);
+        source.open();
+        while (!isClosed) {
+          sleepUntilHolderGetsFilled(holder);
+          System.out.append("WAITING:").println(toString());
+        }
+      }
+    }
+
+    @Override
+    public void close() throws Exception {
+      isClosed = true;
+    }
+
+    public List<String> getEvents() {
+      return holder.asList();
+    }
+  }
+
+  static class MsgHolder extends LinkedHolder<String> {
+    public void add(InboundSseEvent value) {
+      String data = value.readData();
+      super.add(data);
+      System.out.println("Received" + data);
+    }
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/sse/ssebroadcaster/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/sse/ssebroadcaster/TSAppConfig.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.sse.ssebroadcaster;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.ws.rs.core.Application;
+
+public class TSAppConfig extends Application {
+
+  public java.util.Set<java.lang.Class<?>> getClasses() {
+    Set<Class<?>> resources = new HashSet<Class<?>>();
+    resources.add(BroadcastResource.class);
+    return resources;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/sse/sseeventsink/CloseResource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/sse/sseeventsink/CloseResource.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.sse.sseeventsink;
+
+import jakarta.ws.rs.tck.jaxrs21.ee.sse.SSEMessage;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.sse.Sse;
+import jakarta.ws.rs.sse.SseEventSink;
+
+@Path("close")
+public class CloseResource {
+
+  private static volatile boolean exception = false;
+
+  private static volatile boolean isClosed = false;
+
+  @GET
+  @Path("reset")
+  @Produces(MediaType.SERVER_SENT_EVENTS)
+  public void reset(@Context SseEventSink sink, @Context Sse sse) {
+    exception = false;
+    isClosed = false;
+    try (SseEventSink s = sink) {
+      s.send(sse.newEvent("RESET"));
+    }
+  }
+
+  @GET
+  @Path("send")
+  @Produces(MediaType.SERVER_SENT_EVENTS)
+  public void send(@Context SseEventSink sink, @Context Sse sse) {
+    Thread t = new Thread(new Runnable() {
+      public void run() {
+        SseEventSink s = sink;
+        s.send(sse.newEvent(SSEMessage.MESSAGE));
+        s.close();
+        isClosed = s.isClosed();
+        if (!isClosed)
+          return;
+        s.close();
+        isClosed = s.isClosed();
+        if (!isClosed)
+          return;
+        s.close();
+        isClosed = s.isClosed();
+        if (!isClosed)
+          return;
+        try {
+          s.send(sse.newEvent("SOMETHING"));
+        } catch (IllegalStateException ise) {
+          exception = true;
+        }
+      }
+    });
+    t.start();
+  }
+
+  @GET
+  @Path("check")
+  @Produces(MediaType.SERVER_SENT_EVENTS)
+  public void check(@Context SseEventSink sink, @Context Sse sse) {
+    try (SseEventSink s = sink) {
+      if (!isClosed) {
+        s.send(sse.newEvent("Not closed"));
+        return;
+      }
+      if (!exception) {
+        s.send(sse.newEvent("No IllegalStateException is thrown"));
+        return;
+      }
+      s.send(sse.newEvent("CHECK"));
+    }
+  }
+
+  @GET
+  @Path("closed")
+  @Produces(MediaType.TEXT_PLAIN)
+  public boolean isClosed() {
+    return isClosed;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/sse/sseeventsink/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/sse/sseeventsink/JAXRSClientIT.java
@@ -1,0 +1,386 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.sse.sseeventsink;
+
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.sse.InboundSseEvent;
+import jakarta.ws.rs.sse.SseEventSource;
+import java.io.InputStream;
+import java.io.IOException;
+
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+import jakarta.ws.rs.tck.common.util.Holder;
+import jakarta.ws.rs.tck.common.util.LinkedHolder;
+import jakarta.ws.rs.tck.jaxrs21.ee.sse.SSEJAXRSClient;
+import jakarta.ws.rs.tck.jaxrs21.ee.sse.SSEMessage;
+
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ */
+/**
+ * @since 2.1
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JAXRSClientIT extends SSEJAXRSClient {
+
+  private static final long serialVersionUID = 21L;
+
+  protected long millis = 550L;
+
+  protected int callbackResult = 0;
+
+  protected Throwable callbackException = null;
+
+  protected int sleep = -1;
+
+  public JAXRSClientIT() {
+    setup();
+    setContextRoot("/jaxrs_jaxrs21_ee_sse_sseeventsink_web");
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  @Deployment(testable = false)
+  public static WebArchive createDeployment() throws IOException{
+
+    InputStream inStream = JAXRSClientIT.class.getClassLoader().getResourceAsStream("jakarta/ws/rs/tck/jaxrs21/ee/sse/sseeventsink/web.xml.template");
+    String webXml = editWebXmlString(inStream);
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_jaxrs21_ee_sse_sseeventsink_web.war");
+    archive.addClasses(TSAppConfig.class, CloseResource.class, MBWCheckResource.class, StageCheckerResource.class,
+      jakarta.ws.rs.tck.common.impl.TRACE.class,
+      jakarta.ws.rs.tck.common.impl.StringSource.class,
+      jakarta.ws.rs.tck.common.impl.StringStreamingOutput.class,
+      jakarta.ws.rs.tck.common.impl.StringDataSource.class,
+      jakarta.ws.rs.tck.common.impl.SinglevaluedMap.class,
+      jakarta.ws.rs.tck.common.impl.SecurityContextImpl.class,
+      jakarta.ws.rs.tck.common.impl.ReplacingOutputStream.class,
+      jakarta.ws.rs.tck.common.impl.JaxbKeyValueBean.class);
+    archive.setWebXML(new StringAsset(webXml));
+    return archive;
+
+  }
+
+
+  /* Run test */
+  ///////////////////////////////////////////////////////////////////////////////////////////
+  // Default MBW
+
+  /*
+   * @testName: stringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1207; JAXRS:JAVADOC:1211; JAXRS:JAVADOC:1207;
+   * JAXRS:JAVADOC:1235; JAXRS:JAVADOC:1236; JAXRS:JAVADOC:1232;
+   * JAXRS:JAVADOC:1219; JAXRS:JAVADOC:1213; JAXRS:JAVADOC:1211;
+   * JAXRS:JAVADOC:1207;
+   * 
+   * @test_Strategy:
+   */
+  @Test
+  public void stringTest() throws Fault {
+    querySSEEndpointAndAssert("mbw/string");
+  }
+
+  /*
+   * @testName: charTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1207; JAXRS:JAVADOC:1211; JAXRS:JAVADOC:1207;
+   * JAXRS:JAVADOC:1235; JAXRS:JAVADOC:1236; JAXRS:JAVADOC:1232;
+   * JAXRS:JAVADOC:1219; JAXRS:JAVADOC:1213; JAXRS:JAVADOC:1211;
+   * JAXRS:JAVADOC:1207;
+   * 
+   * @test_Strategy:
+   */
+  @Test
+  public void charTest() throws Fault {
+    Holder<InboundSseEvent> holder = querySSEEndpoint("mbw/char");
+    assertEquals(String.valueOf(SSEMessage.MESSAGE.charAt(0)),
+        holder.get().readData(), "Unexpected message received",
+        holder.get().readData());
+  }
+
+  /*
+   * @testName: intTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1207; JAXRS:JAVADOC:1211; JAXRS:JAVADOC:1207;
+   * JAXRS:JAVADOC:1235; JAXRS:JAVADOC:1236; JAXRS:JAVADOC:1232;
+   * JAXRS:JAVADOC:1219; JAXRS:JAVADOC:1213; JAXRS:JAVADOC:1211;
+   * JAXRS:JAVADOC:1207;
+   * 
+   * @test_Strategy:
+   */
+  @Test
+  public void intTest() throws Fault {
+    Holder<InboundSseEvent> holder = querySSEEndpoint("mbw/int");
+    assertEquals(Integer.MIN_VALUE, holder.get().readData(Integer.class),
+        "Unexpected message received", holder.get().readData());
+  }
+
+  /*
+   * @testName: doubleTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1207; JAXRS:JAVADOC:1211; JAXRS:JAVADOC:1207;
+   * JAXRS:JAVADOC:1235; JAXRS:JAVADOC:1236; JAXRS:JAVADOC:1232;
+   * JAXRS:JAVADOC:1219; JAXRS:JAVADOC:1213; JAXRS:JAVADOC:1211;
+   * JAXRS:JAVADOC:1207;
+   * 
+   * @test_Strategy:
+   */
+  @Test
+  public void doubleTest() throws Fault {
+    Holder<InboundSseEvent> holder = querySSEEndpoint("mbw/double");
+    assertEquals(Double.MAX_VALUE, holder.get().readData(Double.class),
+        "Unexpected message received", holder.get().readData());
+  }
+
+  /*
+   * @testName: bytearrayTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1207; JAXRS:JAVADOC:1211; JAXRS:JAVADOC:1207;
+   * JAXRS:JAVADOC:1235; JAXRS:JAVADOC:1236; JAXRS:JAVADOC:1232;
+   * JAXRS:JAVADOC:1219; JAXRS:JAVADOC:1213; JAXRS:JAVADOC:1211;
+   * JAXRS:JAVADOC:1207;
+   * 
+   * @test_Strategy:
+   */
+  @Test
+  public void bytearrayTest() throws Fault {
+    querySSEEndpointAndAssert("mbw/bytearray");
+  }
+
+  /*
+   * @testName: readerTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1207; JAXRS:JAVADOC:1211; JAXRS:JAVADOC:1207;
+   * JAXRS:JAVADOC:1235; JAXRS:JAVADOC:1236; JAXRS:JAVADOC:1232;
+   * JAXRS:JAVADOC:1219; JAXRS:JAVADOC:1213; JAXRS:JAVADOC:1211;
+   * JAXRS:JAVADOC:1207;
+   * 
+   * @test_Strategy:
+   */
+  @Test
+  public void readerTest() throws Fault {
+    querySSEEndpointAndAssert("mbw/reader");
+  }
+
+  /*
+   * @testName: inputstreamTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1207; JAXRS:JAVADOC:1211; JAXRS:JAVADOC:1207;
+   * JAXRS:JAVADOC:1235; JAXRS:JAVADOC:1236; JAXRS:JAVADOC:1232;
+   * JAXRS:JAVADOC:1219; JAXRS:JAVADOC:1213; JAXRS:JAVADOC:1211;
+   * JAXRS:JAVADOC:1207;
+   * 
+   * @test_Strategy:
+   */
+  @Test
+  public void inputstreamTest() throws Fault {
+    querySSEEndpointAndAssert("mbw/inputstream");
+  }
+
+  /*
+   * @testName: fileTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1207; JAXRS:JAVADOC:1211; JAXRS:JAVADOC:1207;
+   * JAXRS:JAVADOC:1235; JAXRS:JAVADOC:1236; JAXRS:JAVADOC:1232;
+   * JAXRS:JAVADOC:1219; JAXRS:JAVADOC:1213; JAXRS:JAVADOC:1211;
+   * JAXRS:JAVADOC:1207;
+   * 
+   * @test_Strategy:
+   */
+  @Test
+  public void fileTest() throws Fault {
+    querySSEEndpointAndAssert("mbw/file");
+  }
+
+  /*
+   * @testName: datasourceTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1207; JAXRS:JAVADOC:1211; JAXRS:JAVADOC:1207;
+   * JAXRS:JAVADOC:1235; JAXRS:JAVADOC:1236; JAXRS:JAVADOC:1232;
+   * JAXRS:JAVADOC:1219; JAXRS:JAVADOC:1213; JAXRS:JAVADOC:1211;
+   * JAXRS:JAVADOC:1207;
+   * 
+   * @test_Strategy:
+   */
+  @Test
+  public void datasourceTest() throws Fault {
+    querySSEEndpointAndAssert("mbw/datasource");
+  }
+
+  /*
+   * @testName: transformSourceTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1207; JAXRS:JAVADOC:1211; JAXRS:JAVADOC:1207;
+   * JAXRS:JAVADOC:1235; JAXRS:JAVADOC:1236; JAXRS:JAVADOC:1232;
+   * JAXRS:JAVADOC:1219; JAXRS:JAVADOC:1213; JAXRS:JAVADOC:1211;
+   * JAXRS:JAVADOC:1207;
+   * 
+   * @test_Strategy:
+   */
+  @Test
+  public void transformSourceTest() throws Fault {
+    Holder<InboundSseEvent> holder = querySSEEndpoint("mbw/transformsource");
+    logTrace("Received", holder.get());
+    assertTrue(holder.get().readData().contains(SSEMessage.MESSAGE),
+        "Unexpected message received"+ holder.get().readData());
+  }
+
+  /*
+   * @testName: jaxbElementTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1207; JAXRS:JAVADOC:1211; JAXRS:JAVADOC:1207;
+   * JAXRS:JAVADOC:1235; JAXRS:JAVADOC:1236; JAXRS:JAVADOC:1232;
+   * JAXRS:JAVADOC:1219; JAXRS:JAVADOC:1213; JAXRS:JAVADOC:1211;
+   * JAXRS:JAVADOC:1207;
+   * 
+   * @test_Strategy:
+   */
+  @Test
+  public void jaxbElementTest() throws Fault {
+    Holder<InboundSseEvent> holder = querySSEEndpoint("mbw/jaxbelement");
+    logTrace("Received", holder.get());
+    assertTrue(holder.get().readData().contains(SSEMessage.MESSAGE),
+        "Unexpected message received"+ holder.get().readData());
+  }
+
+  /*
+   * @testName: multivaluedMapTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1207; JAXRS:JAVADOC:1211; JAXRS:JAVADOC:1207;
+   * JAXRS:JAVADOC:1235; JAXRS:JAVADOC:1236; JAXRS:JAVADOC:1232;
+   * JAXRS:JAVADOC:1219; JAXRS:JAVADOC:1213; JAXRS:JAVADOC:1211;
+   * JAXRS:JAVADOC:1207;
+   * 
+   * @test_Strategy:
+   */
+  @Test
+  public void multivaluedMapTest() throws Fault {
+    Holder<InboundSseEvent> holder = querySSEEndpoint("mbw/multivaluedmap");
+    logTrace("Received", holder.get());
+    assertTrue(holder.get().readData().contains(SSEMessage.MESSAGE),
+        "Unexpected message received"+ holder.get().readData());
+  }
+
+  /*
+   * @testName: streamingOutputTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1207; JAXRS:JAVADOC:1211; JAXRS:JAVADOC:1207;
+   * JAXRS:JAVADOC:1235; JAXRS:JAVADOC:1236; JAXRS:JAVADOC:1232;
+   * JAXRS:JAVADOC:1219; JAXRS:JAVADOC:1213; JAXRS:JAVADOC:1211;
+   * JAXRS:JAVADOC:1207;
+   * 
+   * @test_Strategy:
+   */
+  @Test
+  public void streamingOutputTest() throws Fault {
+    querySSEEndpointAndAssert("mbw/streamingoutput");
+  }
+
+  /*
+   * @testName: closeTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1230; JAXRS:JAVADOC:1231; JAXRS:JAVADOC:1235;
+   * JAXRS:JAVADOC:1236; JAXRS:JAVADOC:1232;
+   * 
+   * @test_Strategy: Subsequent calls have no effect and are ignored. Once the
+   * SseEventSink is closed, invoking any method other than this one and
+   * isClosed() would result in an IllegalStateException being thrown.
+   */
+  @Test
+  public void closeTest() throws Fault {
+    Holder<InboundSseEvent> holder = querySSEEndpoint("close/reset");
+    assertEquals(holder.get().readData(), "RESET", "Reset unsuccessful");
+
+    querySSEEndpointAndAssert("close/send");
+
+    boolean closed = false;
+    int cnt = 0;
+    while (!closed && cnt < 20) {
+      setProperty(Property.REQUEST, buildRequest(Request.GET, "close/closed"));
+      setProperty(Property.REQUEST_HEADERS,
+          buildAccept(MediaType.TEXT_PLAIN_TYPE));
+      setProperty(Property.EXPECTED_HEADERS,
+          buildContentType(MediaType.TEXT_PLAIN_TYPE));
+      invoke();
+      closed = getResponse().readEntity(Boolean.class);
+      TestUtil.sleepMsec(200);
+      cnt++;
+    }
+
+    holder = querySSEEndpoint("close/check");
+    String msg = holder.get().readData();
+    assertEquals(msg, "CHECK", "check unsuccessful:", msg);
+  }
+
+  /*
+   * @testName: sseStageCheckTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1232; JAXRS:JAVADOC:1217;
+   * 
+   * @test_Strategy: check the stage is ever done
+   */
+  @Test
+  public void sseStageCheckTest() throws Fault {
+    LinkedHolder<InboundSseEvent> holder = new LinkedHolder<>();
+    WebTarget target = ClientBuilder.newClient()
+        .target(getAbsoluteUrl("stage"));
+
+    try (SseEventSource source = SseEventSource.target(target).build()) {
+      source.register(holder::add);
+      source.open();
+      sleepUntilHolderGetsFilled(holder);
+      assertNotNull(holder.get(), "No message received");
+      assertTrue(holder.get(0).readData().contains(SSEJAXRSClient.MESSAGE),
+          holder.get(0)+ "does not contain expected"+ SSEJAXRSClient.MESSAGE);
+      if (!holder.get(1).readData().contains(StageCheckerResource.DONE)) {
+        sleepUntilHolderGetsFilled(holder);
+      }
+    }
+    assertNotNull(holder.get(1), "No message received");
+    assertEquals(holder.get(1).readData(), StageCheckerResource.DONE,
+        "The stage has not ever been done, message is",
+        holder.get().readData());
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/sse/sseeventsink/MBWCheckResource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/sse/sseeventsink/MBWCheckResource.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.sse.sseeventsink;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+
+import javax.xml.namespace.QName;
+
+import jakarta.ws.rs.tck.common.impl.SinglevaluedMap;
+import jakarta.ws.rs.tck.common.impl.StringDataSource;
+import jakarta.ws.rs.tck.common.impl.StringSource;
+import jakarta.ws.rs.tck.common.impl.StringStreamingOutput;
+import jakarta.ws.rs.tck.jaxrs21.ee.sse.SSEMessage;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.sse.Sse;
+import jakarta.ws.rs.sse.SseEventSink;
+import jakarta.xml.bind.JAXBElement;
+
+/**
+ * Defined in Spec., Section 4.2.4
+ */
+@Path("mbw")
+public class MBWCheckResource {
+  static final String MESSAGE = SSEMessage.MESSAGE;
+
+  @GET
+  @Path("boolean")
+  @Produces(MediaType.SERVER_SENT_EVENTS)
+  public void sendBoolean(@Context SseEventSink sink, @Context Sse sse) {
+    try (SseEventSink s = sink) {
+      s.send(sse.newEventBuilder().data(true)
+          .mediaType(MediaType.TEXT_PLAIN_TYPE).build());
+    }
+  }
+
+  @GET
+  @Path("bytearray")
+  @Produces(MediaType.SERVER_SENT_EVENTS)
+  public void sendByteArray(@Context SseEventSink sink, @Context Sse sse) {
+    try (SseEventSink s = sink) {
+      s.send(sse.newEventBuilder().data(MESSAGE.getBytes())
+          .mediaType(MediaType.WILDCARD_TYPE).build());
+    }
+  }
+
+  @GET
+  @Path("char")
+  @Produces(MediaType.SERVER_SENT_EVENTS)
+  public void sendChar(@Context SseEventSink sink, @Context Sse sse) {
+    try (SseEventSink s = sink) {
+      s.send(sse.newEventBuilder().data(MESSAGE.charAt(0))
+          .mediaType(MediaType.TEXT_PLAIN_TYPE).build());
+    }
+  }
+
+  @GET
+  @Path("datasource")
+  @Produces(MediaType.SERVER_SENT_EVENTS)
+  public void sendDatasource(@Context SseEventSink sink, @Context Sse sse) {
+    try (SseEventSink s = sink) {
+      s.send(sse.newEventBuilder()
+          .data(new StringDataSource(MESSAGE, MediaType.TEXT_PLAIN_TYPE))
+          .mediaType(MediaType.WILDCARD_TYPE).build());
+    }
+  }
+
+  @GET
+  @Path("double")
+  @Produces(MediaType.SERVER_SENT_EVENTS)
+  public void sendDouble(@Context SseEventSink sink, @Context Sse sse) {
+    try (SseEventSink s = sink) {
+      s.send(sse.newEventBuilder().data(Double.MAX_VALUE)
+          .mediaType(MediaType.TEXT_PLAIN_TYPE).build());
+    }
+  }
+
+  @GET
+  @Path("file")
+  @Produces(MediaType.SERVER_SENT_EVENTS)
+  public void sendFile(@Context SseEventSink sink, @Context Sse sse) {
+    File f;
+    try (SseEventSink s = sink) {
+      try {
+        f = File.createTempFile("tck", "tempfile");
+        Files.write(f.toPath(), MESSAGE.getBytes(), StandardOpenOption.CREATE,
+            StandardOpenOption.APPEND);
+        f.deleteOnExit();
+        s.send(sse.newEventBuilder().data(f).mediaType(MediaType.WILDCARD_TYPE)
+            .build());
+      } catch (IOException e) {
+        s.send(sse.newEvent(e.getMessage()));
+        throw new RuntimeException(e); // log to server log
+      }
+    }
+  }
+
+  @GET
+  @Path("inputstream")
+  @Produces(MediaType.SERVER_SENT_EVENTS)
+  public void sendInputStream(@Context SseEventSink sink, @Context Sse sse) {
+    try (SseEventSink s = sink) {
+      s.send(sse.newEventBuilder()
+          .data(new ByteArrayInputStream(MESSAGE.getBytes()))
+          .mediaType(MediaType.WILDCARD_TYPE).build());
+    }
+  }
+
+  @GET
+  @Path("int")
+  @Produces(MediaType.SERVER_SENT_EVENTS)
+  public void sendInt(@Context SseEventSink sink, @Context Sse sse) {
+    try (SseEventSink s = sink) {
+      s.send(sse.newEventBuilder().data(Integer.MIN_VALUE)
+          .mediaType(MediaType.TEXT_PLAIN_TYPE).build());
+    }
+  }
+
+  @GET
+  @Path("jaxbelement")
+  @Produces(MediaType.SERVER_SENT_EVENTS)
+  public void sendJAXBElement(@Context SseEventSink sink, @Context Sse sse) {
+    try (SseEventSink s = sink) {
+      JAXBElement<String> element = new JAXBElement<String>(new QName("name"),
+          String.class, MESSAGE);
+      s.send(sse.newEventBuilder().data(element)
+          .mediaType(MediaType.APPLICATION_XML_TYPE).build());
+    }
+  }
+
+  @GET
+  @Path("multivaluedmap")
+  @Produces(MediaType.SERVER_SENT_EVENTS)
+  public void sendMultivaluedMap(@Context SseEventSink sink, @Context Sse sse) {
+    try (SseEventSink s = sink) {
+      SinglevaluedMap<String, String> map = new SinglevaluedMap<>();
+      map.add("name", MESSAGE);
+      s.send(sse.newEventBuilder().data(map)
+          .mediaType(MediaType.APPLICATION_FORM_URLENCODED_TYPE).build());
+    }
+  }
+
+  @GET
+  @Path("reader")
+  @Produces(MediaType.SERVER_SENT_EVENTS)
+  public void sendReader(@Context SseEventSink sink, @Context Sse sse) {
+    try (SseEventSink s = sink) {
+      s.send(sse.newEventBuilder()
+          .data(new InputStreamReader(
+              new ByteArrayInputStream(MESSAGE.getBytes())))
+          .mediaType(MediaType.WILDCARD_TYPE).build());
+    }
+  }
+
+  @GET
+  @Path("streamingoutput")
+  @Produces(MediaType.SERVER_SENT_EVENTS)
+  public void sendStreamingOutput(@Context SseEventSink sink,
+      @Context Sse sse) {
+    try (SseEventSink s = sink) {
+      StringStreamingOutput output = new StringStreamingOutput(MESSAGE);
+      s.send(sse.newEventBuilder().data(output)
+          .mediaType(MediaType.WILDCARD_TYPE).build());
+    }
+  }
+
+  @GET
+  @Path("string")
+  @Produces(MediaType.SERVER_SENT_EVENTS)
+  public void sendString(@Context SseEventSink sink, @Context Sse sse) {
+    try (SseEventSink s = sink) {
+      s.send(sse.newEventBuilder().data(MESSAGE)
+          .mediaType(MediaType.WILDCARD_TYPE).build());
+    }
+  }
+
+  @GET
+  @Path("transformsource")
+  @Produces(MediaType.SERVER_SENT_EVENTS)
+  public void sendTransformSource(@Context SseEventSink sink,
+      @Context Sse sse) {
+    try (SseEventSink s = sink) {
+      s.send(sse.newEventBuilder().data(new StringSource(MESSAGE))
+          .mediaType(MediaType.TEXT_XML_TYPE).build());
+    }
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/sse/sseeventsink/StageCheckerResource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/sse/sseeventsink/StageCheckerResource.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.sse.sseeventsink;
+
+import static jakarta.ws.rs.tck.jaxrs21.ee.sse.SSEJAXRSClient.MESSAGE;
+
+import java.util.concurrent.CompletableFuture;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.sse.Sse;
+import jakarta.ws.rs.sse.SseEventSink;
+
+@Path("stage")
+public class StageCheckerResource {
+  public static final String DONE = "CompletionStage has been done";
+
+  @GET
+  @Produces(MediaType.SERVER_SENT_EVENTS)
+  public void send(@Context SseEventSink sink, @Context Sse sse) {
+    try (SseEventSink s = sink) {
+      CompletableFuture<?> stage = s.send(sse.newEvent(MESSAGE))
+          .toCompletableFuture();
+      while (!stage.isDone()) {
+        try {
+          Thread.sleep(200L);
+        } catch (InterruptedException e) {
+          e.printStackTrace();
+          sse.newEvent(e.getMessage());
+          return;
+        }
+      }
+      s.send(sse.newEvent(DONE));
+    }
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/sse/sseeventsink/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/sse/sseeventsink/TSAppConfig.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.sse.sseeventsink;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.ws.rs.core.Application;
+
+public class TSAppConfig extends Application {
+
+  public java.util.Set<java.lang.Class<?>> getClasses() {
+    Set<Class<?>> resources = new HashSet<Class<?>>();
+    resources.add(MBWCheckResource.class);
+    resources.add(CloseResource.class);
+    resources.add(StageCheckerResource.class);
+    return resources;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/sse/sseeventsource/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/sse/sseeventsource/JAXRSClientIT.java
@@ -1,0 +1,765 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.sse.sseeventsource;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiPredicate;
+
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+import jakarta.activation.DataSource;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.sse.InboundSseEvent;
+import jakarta.ws.rs.sse.SseEventSource;
+import jakarta.xml.bind.JAXBElement;
+import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamSource;
+
+import jakarta.ws.rs.tck.common.impl.JaxbKeyValueBean;
+import jakarta.ws.rs.tck.common.util.Holder;
+import jakarta.ws.rs.tck.common.util.JaxrsUtil;
+import jakarta.ws.rs.tck.common.util.LinkedHolder;
+import jakarta.ws.rs.tck.jaxrs21.ee.sse.SSEJAXRSClient;
+import jakarta.ws.rs.tck.jaxrs21.ee.sse.SSEMessage;
+
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ */
+/**
+ * @since 2.1
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JAXRSClientIT extends SSEJAXRSClient {
+
+  private static final long serialVersionUID = 21L;
+
+  private int mediaTestLevel = 0;
+
+  public JAXRSClientIT() {
+    setup();
+    mediaTestLevel = 0;
+    setContextRoot("/jaxrs_jaxrs21_ee_sse_sseeventsource_web");
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  @Deployment(testable = false)
+  public static WebArchive createDeployment() throws IOException{
+
+    InputStream inStream = JAXRSClientIT.class.getClassLoader().getResourceAsStream("jakarta/ws/rs/tck/jaxrs21/ee/sse/sseeventsource/web.xml.template");
+    String webXml = editWebXmlString(inStream);
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_jaxrs21_ee_sse_sseeventsource_web.war");
+    archive.addClasses(TSAppConfig.class, MediaTypeResource.class,
+      RepeatedCasterResource.class, ServiceUnavailableResource.class,
+      jakarta.ws.rs.tck.common.util.JaxrsUtil.class,
+      jakarta.ws.rs.tck.jaxrs21.ee.sse.SSEEventImpl.class,
+      jakarta.ws.rs.tck.jaxrs21.ee.sse.SSEMessage.class,
+      jakarta.ws.rs.tck.jaxrs21.ee.sse.OutboundSSEEventImpl.class,
+      jakarta.ws.rs.tck.common.impl.TRACE.class,
+      jakarta.ws.rs.tck.common.impl.StringSource.class,
+      jakarta.ws.rs.tck.common.impl.StringStreamingOutput.class,
+      jakarta.ws.rs.tck.common.impl.StringDataSource.class,
+      jakarta.ws.rs.tck.common.impl.SinglevaluedMap.class,
+      jakarta.ws.rs.tck.common.impl.SecurityContextImpl.class,
+      jakarta.ws.rs.tck.common.impl.ReplacingOutputStream.class,
+      jakarta.ws.rs.tck.common.impl.JaxbKeyValueBean.class
+      );
+    archive.setWebXML(new StringAsset(webXml));
+    return archive;
+
+  }
+
+
+  /* Run test */
+  /*
+   * @testName: defaultWaiting1s
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1197; JAXRS:JAVADOC:1198; JAXRS:JAVADOC:1199;
+   * JAXRS:JAVADOC:1200; JAXRS:JAVADOC:1201; JAXRS:JAVADOC:1202;
+   * JAXRS:JAVADOC:1241; JAXRS:JAVADOC:1240; JAXRS:JAVADOC:1236;
+   * 
+   * @test_Strategy: In addition to handling the standard connection loss
+   * failures, JAX-RS SseEventSource automatically deals with any HTTP 503
+   * Service Unavailable responses from an SSE endpoint, that contain a
+   * "Retry-After" HTTP header with a valid value. The HTTP 503 + "Retry-After"
+   * technique is often used by HTTP endpoints as a means of connection and
+   * traffic throttling. In case a HTTP 503 + "Retry-After" response is received
+   * in return to a connection request, JAX-RS SSE event source will
+   * automatically schedule a new reconnect attempt and use the received
+   * "Retry-After" HTTP header value as a one-time override of the reconnect
+   * delay.
+   */
+  @Test
+  public void defaultWaiting1s() throws Fault {
+    // define
+    Holder<InboundSseEvent> holder = new Holder<>();
+    WebTarget target = ClientBuilder.newClient()
+        .target(getAbsoluteUrl("su/sse"));
+
+    // check its working
+    try (SseEventSource source = SseEventSource.target(target).build()) {
+      source.register(holder::set);
+      source.open();
+      sleepUntilHolderGetsFilled(holder);
+    } catch (Exception e) {
+      throw new Fault(e);
+    }
+    assertNotNull(holder.get(), "Holder was not filled");
+    logTrace("Received message", holder.get().readData());
+    holder.set(null);
+
+    // set to return 503
+    setProperty(Property.REQUEST, buildRequest(Request.GET, "su/available"));
+    setProperty(Property.SEARCH_STRING, "OK");
+    invoke();
+
+    try (SseEventSource source = SseEventSource.target(target).build()) {
+      source.register(holder::set);
+      source.open();
+    } catch (Exception e) {
+      throw new Fault(e);
+    }
+    assertNull(holder.get(),
+        "The event should be sent after default 1s in retry, not sooner");
+    // SseEventSource.close() has been called
+
+    // set to return 503
+    setProperty(Property.REQUEST, buildRequest(Request.GET, "su/available"));
+    setProperty(Property.SEARCH_STRING, "OK");
+    invoke();
+
+    holder = querySSEEndpoint("su/sse");
+    logTrace("Received message", holder.get().readData());
+    logTrace("Slept for", sleep * millis, "ms");
+    assertTrue(sleep < 4,
+        "The message has been sent unexpectedly late, after 2000ms");
+  }
+
+  /*
+   * @testName: wait2Seconds
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1197; JAXRS:JAVADOC:1198; JAXRS:JAVADOC:1199;
+   * JAXRS:JAVADOC:1200; JAXRS:JAVADOC:1201; JAXRS:JAVADOC:1202;
+   * JAXRS:JAVADOC:1241; JAXRS:JAVADOC:1240; JAXRS:JAVADOC:1236;
+   * 
+   * @test_Strategy: In addition to handling the standard connection loss
+   * failures, JAX-RS SseEventSource automatically deals with any HTTP 503
+   * Service Unavailable responses from an SSE endpoint, that contain a
+   * "Retry-After" HTTP header with a valid value. The HTTP 503 + "Retry-After"
+   * technique is often used by HTTP endpoints as a means of connection and
+   * traffic throttling. In case a HTTP 503 + "Retry-After" response is received
+   * in return to a connection request, JAX-RS SSE event source will
+   * automatically schedule a new reconnect attempt and use the received
+   * "Retry-After" HTTP header value as a one-time override of the reconnect
+   * delay.
+   */
+  @Test
+  public void wait2Seconds() throws Fault {
+    // set to return 503
+    setProperty(Property.REQUEST, buildRequest(Request.GET, "su/available"));
+    setProperty(Property.SEARCH_STRING, "OK");
+    invoke();
+    // set to wait 2 seconds
+    setRequestContentEntity("2");
+    setProperty(Property.REQUEST_HEADERS,
+        buildContentType(MediaType.TEXT_PLAIN_TYPE));
+    setProperty(Property.REQUEST, buildRequest(Request.POST, "su/retry"));
+    setProperty(Property.SEARCH_STRING, "2");
+    invoke();
+
+    Holder<InboundSseEvent> holder = querySSEEndpoint("su/sse");
+    logTrace("Received message", holder.get().readData());
+    logTrace("Slept for", sleep * millis, "ms");
+    assertTrue(sleep > 3,
+        "The message has been sent unexpectedly soon, sooner then 2000ms");
+    assertTrue(sleep < 6,
+        "The message has been sent unexpectedly late, after 3000ms");
+    assertEquals(SSEMessage.MESSAGE, holder.get().readData(),
+        "Unexpected message received", holder.get().readData());
+  }
+
+  /*
+   * @testName: connectionLostForDefault500msTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1197; JAXRS:JAVADOC:1198; JAXRS:JAVADOC:1199;
+   * JAXRS:JAVADOC:1200; JAXRS:JAVADOC:1201; JAXRS:JAVADOC:1202;
+   * JAXRS:JAVADOC:1241; JAXRS:JAVADOC:1240; JAXRS:JAVADOC:1236;
+   * 
+   * @test_Strategy: By default, when a connection the the SSE endpoint is lost,
+   * the event source will wait 500 ms before attempting to reconnect to the SSE
+   * endpoint.
+   */
+  @Test
+  public void connectionLostForDefault500msTest() throws Fault {
+    resetUnavailableServer();
+
+    // wait for 3 reconnections
+    setRequestContentEntity("3");
+    setProperty(Property.REQUEST, buildRequest(Request.POST, "su/lost"));
+    setProperty(Property.REQUEST_HEADERS,
+        buildContentType(MediaType.TEXT_PLAIN_TYPE));
+    setProperty(Property.SEARCH_STRING, "3");
+    invoke();
+
+    Holder<InboundSseEvent> holder = querySSEEndpoint("su/sselost");
+    logTrace("Received message", holder.get().readData());
+    logTrace("Slept for", sleep * millis, "ms");
+    assertTrue(sleep > 2,
+        "The message has been sent unexpectedly soon, sooner then 1500ms");
+    assertTrue(sleep < 5,
+        "The message has been sent unexpectedly late, after 3000ms");
+    assertEquals(SSEMessage.MESSAGE, holder.get().readData(),
+        "Unexpected message received", holder.get().readData());
+
+    int cnt = getServerCount();
+    logTrace("Received count:", cnt);
+    assertTrue(cnt > 3 && cnt < 7,
+        "The client tried to reconnected unexpectedly"+ cnt+ "times!");
+  }
+
+  /*
+   * @testName: reconnectByEventMethodTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1215; JAXRS:JAVADOC:1228; JAXRS:JAVADOC:1197;
+   * JAXRS:JAVADOC:1198; JAXRS:JAVADOC:1199; JAXRS:JAVADOC:1200;
+   * JAXRS:JAVADOC:1201; JAXRS:JAVADOC:1202; JAXRS:JAVADOC:1241;
+   * JAXRS:JAVADOC:1240; JAXRS:JAVADOC:1236;
+   * 
+   * @test_Strategy: The SSE endpoint can however control the client-side retry
+   * delay by including a special retry field value in the any send event.
+   * JAX-RS SseEventSource tracks any received SSE event retry field values set
+   * by the endpoint and adjusts the reconnect delay accordingly, using the last
+   * received retry field value as the reconnect delay.
+   */
+  @Test
+  public void reconnectByEventMethodTest() throws Fault {
+    Holder<InboundSseEvent> holder = querySSEEndpoint("su/reconnectdelay");
+    assertTrue(holder.get().isReconnectDelaySet(),
+        "ReconnectDelay was not set");
+    long delay = holder.get().getReconnectDelay();
+    assertEquals(delay, 3000L, "Received unexepcted ReconnectDelay", delay);
+    assertEquals(SSEMessage.MESSAGE, holder.get().readData(),
+        "Unexpected message received", holder.get().readData());
+  }
+
+  /*
+   * @testName: userReconnectByEventMethodTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1197; JAXRS:JAVADOC:1198; JAXRS:JAVADOC:1199;
+   * JAXRS:JAVADOC:1200; JAXRS:JAVADOC:1201; JAXRS:JAVADOC:1202;
+   * JAXRS:JAVADOC:1241; JAXRS:JAVADOC:1240; JAXRS:JAVADOC:1236;
+   * 
+   * @test_Strategy: The SSE endpoint can however control the client-side retry
+   * delay by including a special retry field value in the any send event.
+   * JAX-RS SseEventSource tracks any received SSE event retry field values set
+   * by the endpoint and adjusts the reconnect delay accordingly, using the last
+   * received retry field value as the reconnect delay.
+   */
+  @Test
+  public void userReconnectByEventMethodTest() throws Fault {
+    Holder<InboundSseEvent> holder = querySSEEndpoint("su/userreconnectdelay");
+    assertTrue(holder.get().isReconnectDelaySet(),
+        "ReconnectDelay was not set");
+    long delay = holder.get().getReconnectDelay();
+    assertEquals(delay, 20000L, "Received unexepcted ReconnectDelay", delay);
+    assertEquals(SSEMessage.MESSAGE, holder.get().readData(),
+        "Unexpected message received", holder.get().readData());
+  }
+
+  /*
+   * @testName: stringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1241; JAXRS:JAVADOC:1240; JAXRS:JAVADOC:1236;
+   * JAXRS:JAVADOC:1237; JAXRS:JAVADOC:1238; JAXRS:JAVADOC:1239;
+   * JAXRS:JAVADOC:1240;
+   * 
+   * @test_Strategy: JAXRS:JAVADOC:1197; JAXRS:JAVADOC:1198; JAXRS:JAVADOC:1199;
+   * JAXRS:JAVADOC:1200; JAXRS:JAVADOC:1201; JAXRS:JAVADOC:1202;
+   */
+  @Test
+  public void stringTest() throws Fault {
+    mediaTest(String.class, SSEMessage.MESSAGE, MediaType.TEXT_PLAIN,
+        MediaType.TEXT_PLAIN_TYPE, MediaType.TEXT_HTML_TYPE);
+  }
+
+  /*
+   * @testName: byteArrayTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1241; JAXRS:JAVADOC:1240; JAXRS:JAVADOC:1236;
+   * JAXRS:JAVADOC:1237; JAXRS:JAVADOC:1238; JAXRS:JAVADOC:1239;
+   * JAXRS:JAVADOC:1240;
+   * 
+   * @test_Strategy:
+   */
+  @Test
+  public void byteArrayTest() throws Fault {
+    BiPredicate<Object, Object> p = (a, b) -> a.equals(new String((byte[]) b));
+    mediaTest(byte[].class, SSEMessage.MESSAGE, p, MediaType.TEXT_PLAIN,
+        MediaType.TEXT_PLAIN_TYPE, MediaType.TEXT_HTML_TYPE);
+  }
+
+  /*
+   * @testName: inputStreamTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1197; JAXRS:JAVADOC:1198; JAXRS:JAVADOC:1199;
+   * JAXRS:JAVADOC:1200; JAXRS:JAVADOC:1201; JAXRS:JAVADOC:1202;
+   * JAXRS:JAVADOC:1241; JAXRS:JAVADOC:1240; JAXRS:JAVADOC:1236;
+   * JAXRS:JAVADOC:1237; JAXRS:JAVADOC:1238; JAXRS:JAVADOC:1239;
+   * JAXRS:JAVADOC:1240;
+   * 
+   * @test_Strategy:
+   */
+  @Test
+  public void inputStreamTest() throws Fault {
+    BiPredicate<Object, Object> p = (a, b) -> {
+      try {
+        return JaxrsUtil.readFromStream((InputStream) b).equals(a);
+      } catch (IOException e) {
+        return false;
+      }
+    };
+    mediaTest(InputStream.class, SSEMessage.MESSAGE, p, MediaType.TEXT_PLAIN,
+        MediaType.TEXT_PLAIN_TYPE, MediaType.TEXT_HTML_TYPE);
+  }
+
+  /*
+   * @testName: readerTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1197; JAXRS:JAVADOC:1198; JAXRS:JAVADOC:1199;
+   * JAXRS:JAVADOC:1200; JAXRS:JAVADOC:1201; JAXRS:JAVADOC:1202;
+   * JAXRS:JAVADOC:1241; JAXRS:JAVADOC:1240; JAXRS:JAVADOC:1236;
+   * JAXRS:JAVADOC:1237; JAXRS:JAVADOC:1238; JAXRS:JAVADOC:1239;
+   * JAXRS:JAVADOC:1240;
+   * 
+   * @test_Strategy:
+   */
+  @Test
+  public void readerTest() throws Fault {
+    BiPredicate<Object, Object> p = (a, b) -> {
+      try {
+        return JaxrsUtil.readFromReader((Reader) b).equals(a);
+      } catch (IOException e) {
+        return false;
+      }
+    };
+    mediaTest(Reader.class, SSEMessage.MESSAGE, p, MediaType.TEXT_PLAIN,
+        MediaType.TEXT_PLAIN_TYPE, MediaType.TEXT_HTML_TYPE);
+  }
+
+  /*
+   * @testName: fileTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1197; JAXRS:JAVADOC:1198; JAXRS:JAVADOC:1199;
+   * JAXRS:JAVADOC:1200; JAXRS:JAVADOC:1201; JAXRS:JAVADOC:1202;
+   * JAXRS:JAVADOC:1241; JAXRS:JAVADOC:1240; JAXRS:JAVADOC:1236;
+   * JAXRS:JAVADOC:1237; JAXRS:JAVADOC:1238; JAXRS:JAVADOC:1239;
+   * JAXRS:JAVADOC:1240;
+   * 
+   * @test_Strategy:
+   */
+  @Test
+  public void fileTest() throws Fault {
+    BiPredicate<Object, Object> p = (a, b) -> {
+      try {
+        return JaxrsUtil.readFromFile((File) b).equals(a);
+      } catch (IOException e) {
+        return false;
+      }
+    };
+    mediaTest(File.class, SSEMessage.MESSAGE, p, MediaType.TEXT_PLAIN,
+        MediaType.TEXT_PLAIN_TYPE, MediaType.TEXT_HTML_TYPE);
+  }
+
+  /*
+   * @testName: dataSourceTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1197; JAXRS:JAVADOC:1198; JAXRS:JAVADOC:1199;
+   * JAXRS:JAVADOC:1200; JAXRS:JAVADOC:1201; JAXRS:JAVADOC:1202;
+   * JAXRS:JAVADOC:1241; JAXRS:JAVADOC:1240; JAXRS:JAVADOC:1236;
+   * JAXRS:JAVADOC:1237; JAXRS:JAVADOC:1238; JAXRS:JAVADOC:1239;
+   * JAXRS:JAVADOC:1240;
+   * 
+   * @test_Strategy:
+   */
+  @Test
+  public void dataSourceTest() throws Fault {
+    BiPredicate<Object, Object> p = (a, b) -> {
+      try {
+        return JaxrsUtil.readFromStream(((DataSource) b).getInputStream())
+            .equals(a);
+      } catch (IOException e) {
+        return false;
+      }
+    };
+    mediaTest(DataSource.class, SSEMessage.MESSAGE, p, MediaType.TEXT_PLAIN,
+        MediaType.TEXT_PLAIN_TYPE, MediaType.TEXT_HTML_TYPE);
+  }
+
+  /*
+   * @testName: transformSourceTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1197; JAXRS:JAVADOC:1198; JAXRS:JAVADOC:1199;
+   * JAXRS:JAVADOC:1200; JAXRS:JAVADOC:1201; JAXRS:JAVADOC:1202;
+   * JAXRS:JAVADOC:1241; JAXRS:JAVADOC:1240; JAXRS:JAVADOC:1236;
+   * JAXRS:JAVADOC:1237; JAXRS:JAVADOC:1238; JAXRS:JAVADOC:1239;
+   * JAXRS:JAVADOC:1240;
+   * 
+   * @test_Strategy:
+   */
+  @Test
+  public void transformSourceTest() throws Fault {
+    mediaTestLevel = 2;
+    BiPredicate<Object, Object> p = (a, b) -> {
+      try {
+        Source s = (Source) b;
+        if (StreamSource.class.isInstance(s)) {
+          return JaxrsUtil.readFromStream(((StreamSource) b).getInputStream())
+              .equals(a);
+        } else {
+          return true;
+        }
+      } catch (IOException e) {
+        return false;
+      }
+    };
+    mediaTest(Source.class, SSEMessage.MESSAGE, p, MediaType.TEXT_XML,
+        MediaType.TEXT_XML_TYPE, MediaType.APPLICATION_ATOM_XML_TYPE);
+  }
+
+  /*
+   * @testName: jaxbElementTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1197; JAXRS:JAVADOC:1198; JAXRS:JAVADOC:1199;
+   * JAXRS:JAVADOC:1200; JAXRS:JAVADOC:1201; JAXRS:JAVADOC:1202;
+   * JAXRS:JAVADOC:1241; JAXRS:JAVADOC:1240; JAXRS:JAVADOC:1236;
+   * JAXRS:JAVADOC:1237; JAXRS:JAVADOC:1238; JAXRS:JAVADOC:1239;
+   * JAXRS:JAVADOC:1240;
+   * 
+   * @test_Strategy:
+   */
+  @Test
+  public void jaxbElementTest() throws Fault {
+    mediaTestLevel = 3;
+    @SuppressWarnings("unchecked")
+    BiPredicate<Object, Object> p = (a, b) -> ((JAXBElement<String>) b)
+        .getValue().equals(a);
+    mediaTest(JAXBElement.class, SSEMessage.MESSAGE, p, MediaType.TEXT_XML,
+        MediaType.TEXT_XML_TYPE, MediaType.APPLICATION_XML_TYPE,
+        new GenericType<JAXBElement<String>>() {
+        }, "media/jaxb");
+  }
+
+  /*
+   * @testName: xmlTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1197; JAXRS:JAVADOC:1198; JAXRS:JAVADOC:1199;
+   * JAXRS:JAVADOC:1200; JAXRS:JAVADOC:1201; JAXRS:JAVADOC:1202;
+   * JAXRS:JAVADOC:1241; JAXRS:JAVADOC:1240; JAXRS:JAVADOC:1236;
+   * JAXRS:JAVADOC:1237; JAXRS:JAVADOC:1238; JAXRS:JAVADOC:1239;
+   * JAXRS:JAVADOC:1240;
+   * 
+   * @test_Strategy:
+   */
+  @Test
+  public void xmlTest() throws Fault {
+    mediaTestLevel = 2;
+    BiPredicate<Object, Object> p = (a, b) -> ((JaxbKeyValueBean) b).getValue().equals(a);
+    mediaTest(JaxbKeyValueBean.class, SSEMessage.MESSAGE, p, MediaType.TEXT_XML, MediaType.TEXT_XML_TYPE,
+        MediaType.APPLICATION_XML_TYPE, createGenericType(JaxbKeyValueBean.class), "media/xml");
+  }
+
+  /*
+   * @testName: multivaluedMapTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1197; JAXRS:JAVADOC:1198; JAXRS:JAVADOC:1199;
+   * JAXRS:JAVADOC:1200; JAXRS:JAVADOC:1201; JAXRS:JAVADOC:1202;
+   * JAXRS:JAVADOC:1241; JAXRS:JAVADOC:1240; JAXRS:JAVADOC:1236;
+   * JAXRS:JAVADOC:1237; JAXRS:JAVADOC:1238; JAXRS:JAVADOC:1239;
+   * JAXRS:JAVADOC:1240;
+   * 
+   * @test_Strategy:
+   */
+  @Test
+  public void multivaluedMapTest() throws Fault {
+    mediaTestLevel = 3;
+    @SuppressWarnings("unchecked")
+    BiPredicate<Object, Object> p = (a,
+        b) -> ((MultivaluedMap<String, String>) b).getFirst("key").equals(a);
+    mediaTest(MultivaluedMap.class, SSEMessage.MESSAGE, p,
+        MediaType.APPLICATION_FORM_URLENCODED,
+        MediaType.APPLICATION_FORM_URLENCODED_TYPE,
+        MediaType.APPLICATION_FORM_URLENCODED_TYPE,
+        new GenericType<MultivaluedMap<String, String>>() {
+        }, "media/map");
+  }
+
+  /*
+   * @testName: connectionLostFor1500msTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1242; JAXRS:JAVADOC:1197; JAXRS:JAVADOC:1198;
+   * JAXRS:JAVADOC:1199; JAXRS:JAVADOC:1200; JAXRS:JAVADOC:1201;
+   * JAXRS:JAVADOC:1202; JAXRS:JAVADOC:1241; JAXRS:JAVADOC:1240;
+   * JAXRS:JAVADOC:1236;
+   * 
+   * @test_Strategy: reconnectingEvery should send request to the server just
+   * twice, once without response, once after reconnect timeout with a response
+   */
+  @Test
+  public void connectionLostFor1500msTest() throws Fault {
+    resetUnavailableServer();
+
+    // set to wait 3 seconds
+    setRequestContentEntity("1");
+    setProperty(Property.REQUEST, buildRequest(Request.POST, "su/lost"));
+    setProperty(Property.REQUEST_HEADERS,
+        buildContentType(MediaType.TEXT_PLAIN_TYPE));
+    setProperty(Property.SEARCH_STRING, "1");
+    invoke();
+
+    Holder<InboundSseEvent> holder = new Holder<>();
+    WebTarget target = ClientBuilder.newClient()
+        .target(getAbsoluteUrl("su/sselost"));
+    try (SseEventSource source = SseEventSource.target(target)
+        .reconnectingEvery(2000L, TimeUnit.MILLISECONDS).build()) {
+      source.register(holder::set);
+      source.open();
+      sleep = sleepUntilHolderGetsFilled(holder);
+    }
+    int cnt = getServerCount();
+    logTrace("Slept for", sleep * millis, "ms");
+    assertNotNull(holder.get(), "Message not received, reconnect was done",
+        cnt - 1, "times.");
+    logTrace("Received message", holder.get().readData());
+    assertTrue(sleep > 3,
+        "The message has been sent unexpectedly soon, sooner then 2000ms");
+    assertTrue(sleep < 5,
+        "The message has been sent unexpectedly late, after 3000ms");
+    assertEquals(SSEMessage.MESSAGE, holder.get().readData(),
+        "Unexpected message received", holder.get().readData());
+
+    assertEquals(cnt, 2, "Server was reconnected", cnt, "times, unexpectedly");
+  }
+
+  /*
+   * @testName: closeTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:1233; JAXRS:JAVADOC:1197; JAXRS:JAVADOC:1198;
+   * JAXRS:JAVADOC:1199; JAXRS:JAVADOC:1200; JAXRS:JAVADOC:1201;
+   * JAXRS:JAVADOC:1202; JAXRS:JAVADOC:1241; JAXRS:JAVADOC:1240;
+   * JAXRS:JAVADOC:1236;
+   * 
+   * @test_Strategy:
+   */
+  @Test
+  public void closeTest() throws Fault {
+    boolean isOpen = true;
+    LinkedHolder<InboundSseEvent> holder = new LinkedHolder<>();
+    WebTarget target = ClientBuilder.newClient()
+        .target(getAbsoluteUrl("repeat/cast"));
+
+    // set clear
+    setRequestContentEntity(Boolean.TRUE);
+    setProperty(Property.REQUEST, buildRequest(Request.POST, "repeat/set"));
+    setProperty(Property.REQUEST_HEADERS,
+        buildContentType(MediaType.TEXT_PLAIN_TYPE));
+    invoke();
+    assertTrue(getResponse().readEntity(Boolean.class),
+        "Cast has not been set");
+
+    // ask for a message
+    SseEventSource source = SseEventSource.target(target).build();
+    source.register(holder::add);
+    source.open();
+    sleepUntilHolderGetsFilled(holder);
+    assertNotNull(holder.get(), "Message was not received");
+    for (InboundSseEvent e : holder)
+      logMsg("Received message no", e.readData());
+
+    // check the session is opened
+    setProperty(Property.REQUEST, buildRequest(Request.GET, "repeat/isopen"));
+    invoke();
+    isOpen = getResponseBody(Boolean.class);
+    assertTrue(isOpen, "SseEventSource is closed");
+
+    // Wait 3 times
+    for (int i = 0; i != 3; i++) {
+      holder.clear();
+      sleepUntilHolderGetsFilled(holder);
+      for (InboundSseEvent e : holder)
+        logMsg("Received message no", e.readData());
+    }
+    // close
+    source.close();
+    assertFalse(source.isOpen(), "SseEventSource was not closed");
+
+    // check it was closed
+    int cnt = 0;
+    int size = holder.size();
+    try {
+      while (isOpen && cnt < 20) { // check the server sends events
+        holder.clear();
+        cnt++;
+        setProperty(Property.REQUEST,
+            buildRequest(Request.GET, "repeat/isopen"));
+        invoke();
+        isOpen = getResponseBody(Boolean.class);
+
+        assertFalse(size == 0 && isOpen,
+            "Message was not received and SseEventSink is open");
+        sleepUntilHolderGetsFilled(holder);
+        for (InboundSseEvent e : holder)
+          logMsg("Received message no", e.readData());
+        size = holder.size();
+      }
+    } finally {
+      System.out.println("Sending false");
+      setRequestContentEntity(Boolean.FALSE);
+      setProperty(Property.REQUEST, buildRequest(Request.POST, "repeat/set"));
+      setProperty(Property.REQUEST_HEADERS,
+          buildContentType(MediaType.TEXT_PLAIN_TYPE));
+      invoke();
+      System.out.println("Sent false");
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  private <T> void mediaTest(Class<T> queryClass, Object compare,
+      String queryMedia, MediaType classMedia, MediaType genericTypeMedia)
+      throws Fault {
+    mediaTest(queryClass, compare, (a, b) -> a.equals(b), queryMedia,
+        classMedia, genericTypeMedia);
+  }
+
+  private <T> void mediaTest(Class<T> queryClass, Object compare,
+      BiPredicate<Object, Object> comparator, String queryMedia,
+      MediaType classMedia, MediaType genericTypeMedia) throws Fault {
+    mediaTest(queryClass, compare, comparator, queryMedia, classMedia,
+        genericTypeMedia, createGenericType(queryClass), "media/data");
+  }
+
+  private <T> void mediaTest(Class<T> queryClass, Object compare,
+      BiPredicate<Object, Object> comparator, String queryMedia,
+      MediaType classMedia, MediaType genericTypeMedia, GenericType<?> type,
+      String path) throws Fault {
+    setRequestContentEntity(queryMedia);
+    setProperty(Property.REQUEST, buildRequest(Request.POST, "media/set"));
+    setProperty(Property.REQUEST_HEADERS,
+        buildContentType(MediaType.TEXT_PLAIN_TYPE));
+    setProperty(Property.SEARCH_STRING, queryMedia);
+    invoke();
+
+    Holder<InboundSseEvent> holder = querySSEEndpoint(path);
+    assertHolder(queryClass, compare, comparator, classMedia, genericTypeMedia,
+        type, holder);
+    logTrace("readData(", queryClass,
+        ") returned message as expected when register(Consumer<InboundSseEvent>)");
+
+    Holder<Throwable> exception = new Holder<>();
+    holder = querySSEEndpoint(path,
+        (a, b) -> a.register(b::set, exception::set));
+    assertHolder(queryClass, compare, comparator, classMedia, genericTypeMedia,
+        type, holder);
+    logTrace("readData(", queryClass,
+        ") returned message as expected when register(Consumer<InboundSseEvent>, Consumer<Throwable>)");
+
+    final Holder<Boolean> finished = new Holder<>(false);
+    Runnable r = () -> finished.set(true);
+    holder = querySSEEndpoint(path,
+        (a, b) -> a.register(b::set, exception::set, r));
+    assertHolder(queryClass, compare, comparator, classMedia, genericTypeMedia,
+        type, holder);
+    logTrace("readData(", queryClass,
+        ") returned message as expected register(Consumer<InboundSseEvent>, Consumer<Throwable>, Runnable)");
+  }
+
+  private <T> void assertHolder(Class<T> queryClass, Object compare,
+      BiPredicate<Object, Object> comparator, MediaType classMedia,
+      MediaType genericTypeMedia, GenericType<?> type,
+      Holder<InboundSseEvent> holder) throws Fault {
+    switch (mediaTestLevel) {
+    case 0:
+      assertTrue(comparator.test(compare, holder.get().readData(queryClass)),
+          "Unexpected message received"+ holder.get().readData());
+    case 1:
+      assertTrue(comparator.test(compare, holder.get().readData(type)),
+          "Unexpected message received"+ holder.get().readData());
+    case 2:
+      assertTrue(
+          comparator.test(compare,
+              holder.get().readData(queryClass, classMedia)),
+          "Unexpected message received"+ holder.get().readData());
+    case 3:
+      assertTrue(
+          comparator.test(compare,
+              holder.get().readData(type, genericTypeMedia)),
+          "Unexpected message received"+ holder.get().readData());
+    }
+  }
+
+  private <T> GenericType<T> createGenericType(Class<T> clazz) {
+    GenericType<T> type = new GenericType<>(clazz);
+    return type;
+  }
+
+  private int getServerCount() throws Fault {
+    setProperty(Property.REQUEST, buildRequest(Request.GET, "su/count"));
+    invoke();
+    return Integer.parseInt(getResponseBody());
+  }
+
+  private void resetUnavailableServer() throws Fault {
+    setProperty(Property.REQUEST, buildRequest(Request.GET, "su/reset"));
+    setProperty(Property.SEARCH_STRING, "RESET");
+    invoke();
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/sse/sseeventsource/MediaTypeResource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/sse/sseeventsource/MediaTypeResource.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.sse.sseeventsource;
+
+import javax.xml.namespace.QName;
+
+import jakarta.ws.rs.tck.common.impl.JaxbKeyValueBean;
+import jakarta.ws.rs.tck.common.impl.SinglevaluedMap;
+import jakarta.ws.rs.tck.jaxrs21.ee.sse.SSEMessage;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.sse.Sse;
+import jakarta.ws.rs.sse.SseEventSink;
+import jakarta.xml.bind.JAXBElement;
+
+@Path("media")
+public class MediaTypeResource {
+  private static MediaType mediaType = MediaType.WILDCARD_TYPE;
+
+  @POST
+  @Path("set")
+  public String setMediaType(String media) {
+    String[] split = media.split("/", 2);
+    mediaType = new MediaType(split[0], split[1]);
+    return media;
+  }
+
+  @GET
+  @Path("data")
+  @Produces(MediaType.SERVER_SENT_EVENTS)
+  public void sendData(@Context SseEventSink sink, @Context Sse sse) {
+    try (SseEventSink s = sink) {
+      s.send(sse.newEventBuilder().data(SSEMessage.MESSAGE).mediaType(mediaType)
+          .build());
+    }
+  }
+
+  @GET
+  @Path("jaxb")
+  @Produces(MediaType.SERVER_SENT_EVENTS)
+  public void sendJAXB(@Context SseEventSink sink, @Context Sse sse) {
+    try (SseEventSink s = sink) {
+      JAXBElement<String> element = new JAXBElement<String>(new QName("name"),
+          String.class, SSEMessage.MESSAGE);
+      s.send(sse.newEventBuilder().data(element).mediaType(mediaType).build());
+    }
+  }
+
+  @GET
+  @Path("xml")
+  @Produces(MediaType.SERVER_SENT_EVENTS)
+  public void sendXML(@Context SseEventSink sink, @Context Sse sse) {
+    try (SseEventSink s = sink) {
+      JaxbKeyValueBean bean = new JaxbKeyValueBean();
+      bean.set("key", SSEMessage.MESSAGE);
+      s.send(sse.newEventBuilder().data(bean).mediaType(mediaType).build());
+    }
+  }
+
+  @GET
+  @Path("map")
+  @Produces(MediaType.SERVER_SENT_EVENTS)
+  public void sendMap(@Context SseEventSink sink, @Context Sse sse) {
+    try (SseEventSink s = sink) {
+      SinglevaluedMap<String, String> map = new SinglevaluedMap<>();
+      map.add("key", SSEMessage.MESSAGE);
+      s.send(sse.newEventBuilder().data(map).mediaType(mediaType).build());
+    }
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/sse/sseeventsource/RepeatedCasterResource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/sse/sseeventsource/RepeatedCasterResource.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.sse.sseeventsource;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.sse.Sse;
+import jakarta.ws.rs.sse.SseEventSink;
+
+@Path("repeat")
+public class RepeatedCasterResource {
+
+  private static boolean cast = false;
+
+  private static volatile Boolean isOpen = false;
+
+  private static int cnt = 0;
+
+  @POST
+  @Path("set")
+  @Produces(MediaType.TEXT_PLAIN)
+  public boolean set(boolean b) {
+    isOpen = false;
+    cast = b;
+    cnt = 0;
+    return cast;
+  }
+
+  @GET
+  @Path("cast")
+  @Produces(MediaType.SERVER_SENT_EVENTS)
+  public void send(@Context SseEventSink sink, @Context Sse sse) {
+    new Thread() {
+      public void run() {
+        synchronized (isOpen) {
+          isOpen = !sink.isClosed();
+        }
+        while (!sink.isClosed() && cast) {
+          sink.send(sse.newEvent(String.valueOf(cnt++)));
+          try {
+            Thread.sleep(500L);
+          } catch (InterruptedException e1) {
+            cast = false;
+          }
+          synchronized (isOpen) {
+            isOpen = !sink.isClosed();
+            System.out.println("ISOPEN " + isOpen);
+          }
+        }
+        cast = false;
+      };
+    }.start();
+  }
+
+  @GET
+  @Path("isopen")
+  public boolean isOpen() {
+    synchronized (isOpen) {
+      System.out.println("ASKED ISOPEN " + isOpen);
+      return isOpen;
+    }
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/sse/sseeventsource/ServiceUnavailableResource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/sse/sseeventsource/ServiceUnavailableResource.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.sse.sseeventsource;
+
+import jakarta.ws.rs.tck.jaxrs21.ee.sse.OutboundSSEEventImpl;
+import jakarta.ws.rs.tck.jaxrs21.ee.sse.SSEMessage;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.sse.OutboundSseEvent;
+import jakarta.ws.rs.sse.Sse;
+import jakarta.ws.rs.sse.SseEventSink;
+
+@Path("su")
+public class ServiceUnavailableResource {
+  private static volatile Boolean isServiceUnavailable = false;
+
+  private static volatile int isConnectionLost = 0;
+
+  private static volatile int retry = 1;
+
+  private static int count = 0;
+
+  static final String MESSAGE = SSEMessage.MESSAGE;
+
+  @GET
+  @Path("reset")
+  public String reset() {
+    retry = 0;
+    isServiceUnavailable = false;
+    isConnectionLost = 0;
+    count = 0;
+    return "RESET";
+  }
+
+  @GET
+  @Path("count")
+  public int count() {
+    return count;
+  }
+
+  @GET
+  @Path("available")
+  @Produces(MediaType.TEXT_PLAIN)
+  public String setUnavailable() {
+    synchronized (isServiceUnavailable) {
+      isServiceUnavailable = true;
+      retry = 1;
+    }
+    return "OK";
+  }
+
+  @POST
+  @Path("lost")
+  @Produces(MediaType.TEXT_PLAIN)
+  public int setConnectionLost(int count) {
+    synchronized (isServiceUnavailable) {
+      isConnectionLost = count;
+      isServiceUnavailable = false;
+      retry = 1;
+    }
+    return count;
+  }
+
+  @POST
+  @Path("retry")
+  @Produces(MediaType.TEXT_PLAIN)
+  public int retry(int seconds) {
+    synchronized (isServiceUnavailable) {
+      retry = seconds;
+    }
+    return seconds;
+  }
+
+  @GET
+  @Path("sse")
+  @Produces(MediaType.SERVER_SENT_EVENTS)
+  public void sendMessage(@Context SseEventSink sink, @Context Sse sse) {
+    synchronized (isServiceUnavailable) {
+      if (isServiceUnavailable) {
+        isServiceUnavailable = false;
+        throw new WebApplicationException(Response.status(503)
+            .header(HttpHeaders.RETRY_AFTER, String.valueOf(retry)).build());
+      } else {
+        try (SseEventSink s = sink) {
+          s.send(sse.newEvent(MESSAGE));
+        }
+      }
+    }
+  }
+
+  @GET
+  @Path("sselost")
+  @Produces(MediaType.SERVER_SENT_EVENTS)
+  public void sseLost(@Context SseEventSink sink, @Context Sse sse) {
+    synchronized (isServiceUnavailable) {
+      count++;
+      if (isConnectionLost != 0) {
+        isConnectionLost--;
+        sink.close();
+        /*
+         * To cancel a stream from the server, respond with a non
+         * "text/event-stream" Content-Type or return an HTTP status other than
+         * 200 OK and 503 Service Unavailable (e.g. 404 Not Found).
+         */
+      } else {
+        try (SseEventSink s = sink) {
+          s.send(sse.newEvent(MESSAGE));
+        }
+      }
+    }
+  }
+
+  @GET
+  @Path("reconnectdelay")
+  @Produces(MediaType.SERVER_SENT_EVENTS)
+  public void sendRetry(@Context SseEventSink sink, @Context Sse sse) {
+    try (SseEventSink s = sink) {
+      s.send(sse.newEventBuilder().data(MESSAGE).reconnectDelay(3000L).build());
+    }
+  }
+
+  @GET
+  @Path("userreconnectdelay")
+  @Produces(MediaType.SERVER_SENT_EVENTS)
+  public void sendUserRetry(@Context SseEventSink sink, @Context Sse sse) {
+    try (SseEventSink s = sink) {
+      s.send(
+          (OutboundSseEvent) new OutboundSSEEventImpl(MESSAGE).setDelay(20000));
+    }
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/sse/sseeventsource/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/ee/sse/sseeventsource/TSAppConfig.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.ee.sse.sseeventsource;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.ws.rs.core.Application;
+
+public class TSAppConfig extends Application {
+
+  public java.util.Set<java.lang.Class<?>> getClasses() {
+    Set<Class<?>> resources = new HashSet<Class<?>>();
+    resources.add(ServiceUnavailableResource.class);
+    resources.add(MediaTypeResource.class);
+    resources.add(RepeatedCasterResource.class);
+    return resources;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/spec/classsubresourcelocator/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/spec/classsubresourcelocator/JAXRSClientIT.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.spec.classsubresourcelocator;
+
+import jakarta.ws.rs.tck.common.client.JaxrsCommonClient;
+import java.io.InputStream;
+import java.io.IOException;
+
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+/**
+ * @since 2.1
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JAXRSClientIT extends JaxrsCommonClient {
+
+  private static final long serialVersionUID = 21L;
+
+  public JAXRSClientIT() {
+    setup();
+    setContextRoot("/jaxrs_jaxrs21_spec_classsubresourcelocator_web/resource");
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  @Deployment(testable = false)
+  public static WebArchive createDeployment() throws IOException{
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_jaxrs21_spec_classsubresourcelocator_web.war");
+    archive.addClasses(TSAppConfig.class, Resource.class, SubResource.class);
+    return archive;
+
+  }
+
+
+  /* Run test */
+  /*
+   * @testName: subResourceLocatorAsClassTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:125;
+   * 
+   * @test_Strategy:
+   */
+  @Test
+  public void subResourceLocatorAsClassTest() throws Fault {
+    setProperty(Property.REQUEST, buildRequest(Request.GET, "sub"));
+    setProperty(Property.SEARCH_STRING, "OK");
+    invoke();
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/spec/classsubresourcelocator/Resource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/spec/classsubresourcelocator/Resource.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.spec.classsubresourcelocator;
+
+import jakarta.ws.rs.Path;
+
+@Path("resource")
+public class Resource {
+
+  @Path("sub")
+  public Class<SubResource> sub() {
+    return SubResource.class;
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/spec/classsubresourcelocator/SubResource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/spec/classsubresourcelocator/SubResource.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.spec.classsubresourcelocator;
+
+import jakarta.ws.rs.GET;
+
+public class SubResource {
+  @GET
+  public String ok() {
+    return "OK";
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/spec/classsubresourcelocator/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/spec/classsubresourcelocator/TSAppConfig.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.spec.classsubresourcelocator;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class TSAppConfig extends Application {
+  public java.util.Set<java.lang.Class<?>> getClasses() {
+    Set<Class<?>> resources = new HashSet<Class<?>>();
+    resources.add(Resource.class);
+    resources.add(SubResource.class);
+    return resources;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/spec/completionstage/CompletionStageResource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/spec/completionstage/CompletionStageResource.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.spec.completionstage;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executors;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.WebApplicationException;
+
+@Path("/async")
+public class CompletionStageResource {
+
+  public static final String MESSAGE = CompletionStageResource.class.getName();
+
+  @GET
+  public CompletionStage<String> async() {
+    CompletableFuture<String> cs = new CompletableFuture<>();
+    Executors.newSingleThreadExecutor().submit(() -> {
+      try {
+        Thread.sleep(1000L);
+      } catch (InterruptedException e) {
+        throw new WebApplicationException(e);
+      }
+      cs.complete(MESSAGE);
+    });
+    return cs;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/spec/completionstage/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/spec/completionstage/JAXRSClientIT.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.spec.completionstage;
+
+import java.util.concurrent.Future;
+import java.io.InputStream;
+import java.io.IOException;
+
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+import jakarta.ws.rs.tck.common.client.JaxrsCommonClient;
+import jakarta.ws.rs.tck.common.client.JdkLoggingFilter;
+
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Response;
+
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JAXRSClientIT extends JaxrsCommonClient {
+
+  private static final long serialVersionUID = 21L;
+
+  public JAXRSClientIT() {
+    setup();
+    setContextRoot("/jaxrs_jaxrs21_spec_completionstage_web");
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+
+  @Deployment(testable = false)
+  public static WebArchive createDeployment() throws IOException{
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_jaxrs21_spec_completionstage_web.war");
+    archive.addClasses(TSAppConfig.class, CompletionStageResource.class);
+    return archive;
+
+  }
+
+  /* Run test */
+
+  /*
+   * @testName: completionStageReturnedTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:128;
+   * 
+   * @test_Strategy:
+   */
+  @Test
+  public void completionStageReturnedTest() throws Fault {
+    Future<Response> f = ClientBuilder.newClient()
+        .register(new JdkLoggingFilter(false)).target(getAbsoluteUrl("async"))
+        .request().async().get();
+    assertFalse(f.isDone());
+    try (Response r = f.get()) {
+      String msg = r.readEntity(String.class);
+      assertEquals(CompletionStageResource.MESSAGE, msg);
+    } catch (Exception e) {
+      fault(e);
+    }
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/spec/completionstage/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/jaxrs21/spec/completionstage/TSAppConfig.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.jaxrs21.spec.completionstage;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class TSAppConfig extends Application {
+
+  public java.util.Set<java.lang.Class<?>> getClasses() {
+    Set<Class<?>> resources = new HashSet<Class<?>>();
+    resources.add(CompletionStageResource.class);
+    return resources;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/spec/provider/overridestandard/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/spec/provider/overridestandard/JAXRSClientIT.java
@@ -90,7 +90,15 @@ public class JAXRSClientIT extends JAXRSCommonClient {
     InputStream inStream = JAXRSClientIT.class.getClassLoader().getResourceAsStream("jakarta/ws/rs/tck/spec/provider/overridestandard/web.xml.template");
     String webXml = editWebXmlString(inStream);
     WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_spec_provider_overridestandard_web.war");
-    archive.addClasses(TSAppConfig.class, Resource.class, AbstractProvider.class, TckBooleanProvider.class, TckByteArrayProvider.class, TckCharacterProvider.class, TckDataSourceProvider.class, TckDataSourceProvider.class, TckFileProvider.class, TckInputStreamProvider.class, TckJaxbProvider.class, TckMapProvider.class, TckNumberProvider.class, TckReaderProvider.class, TckSourceProvider.class, TckStreamingOutputProvider.class, TckStringProvider.class);
+    archive.addClasses(TSAppConfig.class, Resource.class, 
+      AbstractProvider.class, TckBooleanProvider.class, 
+      TckByteArrayProvider.class, TckCharacterProvider.class, 
+      TckDataSourceProvider.class, TckDataSourceProvider.class, 
+      TckFileProvider.class, TckInputStreamProvider.class, 
+      TckJaxbProvider.class, TckMapProvider.class, 
+      TckNumberProvider.class, TckReaderProvider.class, 
+      TckSourceProvider.class, TckStreamingOutputProvider.class, 
+      TckStringProvider.class, jakarta.ws.rs.tck.common.impl.StringStreamingOutput.class);
     archive.setWebXML(new StringAsset(webXml));
     return archive;
   }
@@ -245,7 +253,7 @@ public class JAXRSClientIT extends JAXRSCommonClient {
    * providers when either could handle the same request.
    * 
    */
-  //@Test
+  @Test
   @Tag("xml_binding")
   public void readWriteStreamingOutputProviderTest() throws Fault {
     setPropertyAndInvoke("streamingoutput", MediaType.APPLICATION_XML_TYPE);

--- a/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/jaxrs21/ee/client/rxinvoker/web.xml.template
+++ b/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/jaxrs21/ee/client/rxinvoker/web.xml.template
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+    <servlet>
+        <servlet-name>CTS_JAXRS21_CLIENT_RXINVOKER</servlet-name>
+        <servlet-class>servlet_adaptor</servlet-class>
+        <init-param>
+            <param-name>jakarta.ws.rs.Application</param-name>
+            <param-value>jakarta.ws.rs.tck.jaxrs21.ee.client.rxinvoker.TSAppConfig</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>CTS_JAXRS21_CLIENT_RXINVOKER</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+    <session-config>
+        <session-timeout>30</session-timeout>
+    </session-config>
+</web-app>

--- a/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/jaxrs21/ee/sse/ssebroadcaster/web.xml.template
+++ b/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/jaxrs21/ee/sse/ssebroadcaster/web.xml.template
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+    <servlet>
+        <servlet-name>jakarta.ws.rs.tck.jaxrs21.ee.sse.ssebroadcaster.TSAppConfig</servlet-name>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>jakarta.ws.rs.tck.jaxrs21.ee.sse.ssebroadcaster.TSAppConfig</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+    <session-config>
+        <session-timeout>30</session-timeout>
+    </session-config>
+</web-app>

--- a/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/jaxrs21/ee/sse/sseeventsink/web.xml.template
+++ b/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/jaxrs21/ee/sse/sseeventsink/web.xml.template
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+    <servlet>
+        <servlet-name>jakarta.ws.rs.tck.jaxrs21.ee.sse.sseeventsink.TSAppConfig</servlet-name>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>jakarta.ws.rs.tck.jaxrs21.ee.sse.sseeventsink.TSAppConfig</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+    <session-config>
+        <session-timeout>30</session-timeout>
+    </session-config>
+</web-app>

--- a/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/jaxrs21/ee/sse/sseeventsource/web.xml.template
+++ b/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/jaxrs21/ee/sse/sseeventsource/web.xml.template
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+    <servlet>
+        <servlet-name>jakarta.ws.rs.tck.jaxrs21.ee.sse.sseeventsource.TSAppConfig</servlet-name>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>jakarta.ws.rs.tck.jaxrs21.ee.sse.sseeventsource.TSAppConfig</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+    <session-config>
+        <session-timeout>30</session-timeout>
+    </session-config>
+</web-app>

--- a/jersey-tck/pom.xml
+++ b/jersey-tck/pom.xml
@@ -106,6 +106,13 @@
             <scope>test</scope>
         </dependency> 
 
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-sse</artifactId>
+            <version>${jersey.version}</version>
+        </dependency>
+
+
     </dependencies>
 
 

--- a/jersey-tck/pom.xml
+++ b/jersey-tck/pom.xml
@@ -154,7 +154,56 @@
                     </execution>
                 </executions>
             </plugin>
-
+	    
+	    <plugin>
+                <artifactId>exec-maven-plugin</artifactId>
+                <groupId>org.codehaus.mojo</groupId>
+                <executions>
+                    <execution>
+                        <id>StartDomain1</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <workingDirectory>${project.build.directory}/glassfish6/glassfish/bin</workingDirectory>
+                            <executable>asadmin</executable>
+                            <arguments>
+                                <argument>start-domain</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>Enable Trace requests</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <workingDirectory>${project.build.directory}/glassfish6/glassfish/bin</workingDirectory>
+                            <executable>asadmin</executable>
+                            <arguments>
+                                <argument>set</argument>
+                                <argument>server-config.network-config.protocols.protocol.http-listener-1.http.trace-enabled=true</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>StopDomain2</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <workingDirectory>${project.build.directory}/glassfish6/glassfish/bin</workingDirectory>
+                            <executable>asadmin</executable>
+                            <arguments>
+                                <argument>stop-domain</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>

--- a/jersey-tck/pom.xml
+++ b/jersey-tck/pom.xml
@@ -123,6 +123,7 @@
     </profiles>
 
     <build>	    
+    <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
@@ -290,7 +291,7 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugins>
+            
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>3.0.0-M5</version>

--- a/jersey-tck/pom.xml
+++ b/jersey-tck/pom.xml
@@ -122,88 +122,7 @@
         </profile>
     </profiles>
 
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M5</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                        <configuration>
-                            <dependenciesToScan>jakarta.ws.rs:jakarta.ws.rs-tck</dependenciesToScan>
-                            <systemPropertyVariables>
-                                <GLASSFISH_HOME>${project.build.directory}/glassfish6</GLASSFISH_HOME>
-                                <servlet_adaptor>org.glassfish.jersey.servlet.ServletContainer</servlet_adaptor>
-                                <webServerHost>localhost</webServerHost>
-                                <webServerPort>8080</webServerPort>
-                                <junit.log.traceflag>true</junit.log.traceflag>
-                                <user>j2ee</user>
-                                <password>j2ee</password>
-                                <authuser>javajoe</authuser>
-                                <authpassword>javajoe</authpassword>
-                                <porting.ts.url.class.1>jakarta.ws.rs.tck.lib.implementation.sun.common.SunRIURL</porting.ts.url.class.1>
-                            </systemPropertyVariables>
-                            <environmentVariables>
-                                <GLASSFISH_HOME>${project.build.directory}/glassfish6</GLASSFISH_HOME>
-                            </environmentVariables>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-	    
-	    <plugin>
-                <artifactId>exec-maven-plugin</artifactId>
-                <groupId>org.codehaus.mojo</groupId>
-                <executions>
-                    <execution>
-                        <id>StartDomain1</id>
-                        <phase>pre-integration-test</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <workingDirectory>${project.build.directory}/glassfish6/glassfish/bin</workingDirectory>
-                            <executable>asadmin</executable>
-                            <arguments>
-                                <argument>start-domain</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>Enable Trace requests</id>
-                        <phase>pre-integration-test</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <workingDirectory>${project.build.directory}/glassfish6/glassfish/bin</workingDirectory>
-                            <executable>asadmin</executable>
-                            <arguments>
-                                <argument>set</argument>
-                                <argument>server-config.network-config.protocols.protocol.http-listener-1.http.trace-enabled=true</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>StopDomain2</id>
-                        <phase>pre-integration-test</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <workingDirectory>${project.build.directory}/glassfish6/glassfish/bin</workingDirectory>
-                            <executable>asadmin</executable>
-                            <arguments>
-                                <argument>stop-domain</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
+    <build>	    
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
@@ -318,6 +237,86 @@
                                     <destFileName>jakarta.ws.rs-api.jar</destFileName>
                                 </artifactItem>
                             </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>exec-maven-plugin</artifactId>
+                <groupId>org.codehaus.mojo</groupId>
+                <executions>
+                    <execution>
+                        <id>StartDomain1</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <workingDirectory>${project.build.directory}/glassfish6/glassfish/bin</workingDirectory>
+                            <executable>asadmin</executable>
+                            <arguments>
+                                <argument>start-domain</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>Enable Trace requests</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <workingDirectory>${project.build.directory}/glassfish6/glassfish/bin</workingDirectory>
+                            <executable>asadmin</executable>
+                            <arguments>
+                                <argument>set</argument>
+                                <argument>server-config.network-config.protocols.protocol.http-listener-1.http.trace-enabled=true</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>StopDomain2</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <workingDirectory>${project.build.directory}/glassfish6/glassfish/bin</workingDirectory>
+                            <executable>asadmin</executable>
+                            <arguments>
+                                <argument>stop-domain</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugins>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.0.0-M5</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <dependenciesToScan>jakarta.ws.rs:jakarta.ws.rs-tck</dependenciesToScan>
+                            <systemPropertyVariables>
+                                <GLASSFISH_HOME>${project.build.directory}/glassfish6</GLASSFISH_HOME>
+                                <servlet_adaptor>org.glassfish.jersey.servlet.ServletContainer</servlet_adaptor>
+                                <webServerHost>localhost</webServerHost>
+                                <webServerPort>8080</webServerPort>
+                                <junit.log.traceflag>true</junit.log.traceflag>
+                                <user>j2ee</user>
+                                <password>j2ee</password>
+                                <authuser>javajoe</authuser>
+                                <authpassword>javajoe</authpassword>
+                                <porting.ts.url.class.1>jakarta.ws.rs.tck.lib.implementation.sun.common.SunRIURL</porting.ts.url.class.1>
+                            </systemPropertyVariables>
+                            <environmentVariables>
+                                <GLASSFISH_HOME>${project.build.directory}/glassfish6</GLASSFISH_HOME>
+                            </environmentVariables>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
This is to migrate the tests from jakartaee-tck jaxrs/jaxrs21 folder (not including jaxrs/jaxrs21/platform)
Also the change includes correction to some tests in ee/rs/client/syncinvoker/JAXRSClientIT.java

To test the changes :

export JAVA_HOME=<JDK11_HOME>
export M2_HOME=<MAVEN_HOME>
export PATH=$M2_HOME/bin:$JAVA_HOME/bin:$PATH
export PATH=<project.build.directory>/glassfish6/glassfish/bin:$PATH

jaxrs-tck/
mvn clean install

jersey-tck/
mvn clean verify -Parq-glassfish-managed -Dit.test=jakarta.ws.rs.tck.jaxrs21.**

The tests migrated :
jakartaee-tck/src/com/sun/ts/tests/jaxrs/jaxrs21 


failing test (1) : will be tracked and fixed using https://github.com/eclipse-ee4j/jaxrs-api/issues/1020 

- jakarta.ws.rs.tck.jaxrs21.ee.sse.ssebroadcaster.JAXRSClientIT.sseBroadcastTest


Below are tests that needs to be disabled as per the ts.jtx file. 
They will be disabled along with other skipped tests.
- jakarta.ws.rs.tck.jaxrs21.ee.client.executor.async.JAXRSClientIT.traceWithGenericTypeResponseWhileServerWaitTest
- jakarta.ws.rs.tck.jaxrs21.ee.client.executor.async.JAXRSClientIT.traceWithGenericTypeStringWhileServerWaitTest
- jakarta.ws.rs.tck.jaxrs21.ee.client.executor.async.JAXRSClientIT.traceWithStringCallbackWhileServerWaitTest
- jakarta.ws.rs.tck.jaxrs21.ee.client.executor.async.JAXRSClientIT.traceWithStringClassWhileServerWaitTest
- jakarta.ws.rs.tck.jaxrs21.ee.client.executor.async.JAXRSClientIT.traceWithResponseClassWhileServerWaitTest
- jakarta.ws.rs.tck.jaxrs21.ee.client.executor.async.JAXRSClientIT.traceWithCallbackWhileServerWaitTest
- jakarta.ws.rs.tck.jaxrs21.ee.client.executor.async.JAXRSClientIT.traceTest



Signed-off-by: alwin-joseph <alwin.joseph@oracle.com>