### PR TITLE
TCK Migration: migrate last set of tests from ee/rs

### DIFF
--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/formparam/FormParamTest.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/formparam/FormParamTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.formparam;
+
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+
+import jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingExceptionGivenByName;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingWebApplicationException;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityWithConstructor;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityWithFromString;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityWithValueOf;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.Encoded;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+@Path(value = "/FormParamTest/")
+public class FormParamTest {
+
+  public static final String response(String argument) {
+    return new StringBuilder().append("CTS_FORMPARAM:").append(argument)
+        .toString();
+  }
+
+  @Path(value = "/PostNonDefParam")
+  @POST
+  @Consumes("application/x-www-form-urlencoded")
+  public Response nonDefault(
+      @FormParam("non_default_argument") String nonDefaultArgument) {
+    return Response.ok(response(nonDefaultArgument)).build();
+  }
+
+  @Path(value = "/PostDefParam")
+  @POST
+  @Consumes("application/x-www-form-urlencoded")
+  public Response defaultValue(
+      @Encoded @DefaultValue("default") @FormParam("default_argument") String defaultArgument) {
+    return Response.ok(response(defaultArgument)).build();
+  }
+
+  @Path(value = "/DefParam")
+  @PUT
+  @Consumes("application/x-www-form-urlencoded")
+  public Response defaultValuePut(
+      @DefaultValue("DefParam") @FormParam("default_argument") String defaultArgument) {
+    return Response.ok(response(defaultArgument)).build();
+  }
+
+  @Path(value = "/ParamEntityWithValueOf")
+  @POST
+  @Consumes("application/x-www-form-urlencoded")
+  public Response defaultValueOf(
+      @DefaultValue("ValueOf") @FormParam("default_argument") ParamEntityWithValueOf defaultArgument) {
+    return Response.ok(response(defaultArgument.getValue())).build();
+  }
+
+  @Path(value = "/Constructor")
+  @POST
+  @Consumes("application/x-www-form-urlencoded")
+  public Response defaultConstructor(
+      @DefaultValue("Constructor") @FormParam("default_argument") ParamEntityWithConstructor defaultArgument) {
+    return Response.ok(response(defaultArgument.getValue())).build();
+  }
+
+  @Path(value = "/ParamEntityWithFromString")
+  @POST
+  @Consumes("application/x-www-form-urlencoded")
+  public Response fromString(
+      @Encoded @DefaultValue("FromString") @FormParam("default_argument") ParamEntityWithFromString defaultArgument) {
+    return Response.ok(response(defaultArgument.getValue())).build();
+  }
+
+  @Path(value = "/ListConstructor")
+  @POST
+  @Consumes("application/x-www-form-urlencoded")
+  public Response defaultListConstructor(
+      @DefaultValue("ListConstructor") @FormParam("default_argument") List<ParamEntityWithConstructor> defaultArgument) {
+    return Response
+        .ok(response(defaultArgument.listIterator().next().getValue())).build();
+  }
+
+  @Path(value = "/SetFromString")
+  @POST
+  @Consumes("application/x-www-form-urlencoded")
+  public Response setFromString(
+      @Encoded @DefaultValue("SetFromString") @FormParam("default_argument") Set<ParamEntityWithFromString> defaultArgument) {
+    return Response.ok(response(defaultArgument.iterator().next().getValue()))
+        .build();
+  }
+
+  @Path(value = "/SortedSetFromString")
+  @POST
+  @Consumes("application/x-www-form-urlencoded")
+  public Response sortedSetFromString(
+      @Encoded @DefaultValue("SortedSetFromString") @FormParam("default_argument") SortedSet<ParamEntityWithFromString> defaultArgument) {
+    return Response.ok(response(defaultArgument.first().getValue())).build();
+  }
+
+  @Path(value = "/ListFromString")
+  @POST
+  @Consumes("application/x-www-form-urlencoded")
+  public Response listFromString(
+      @Encoded @DefaultValue("ListFromString") @FormParam("default_argument") List<ParamEntityWithFromString> defaultArgument) {
+    return Response.ok(response(defaultArgument.iterator().next().getValue()))
+        .build();
+  }
+
+  @Path(value = "/ParamEntityThrowingWebApplicationException")
+  @POST
+  @Consumes("application/x-www-form-urlencoded")
+  public Response throwWebApplicationException(
+      @FormParam("default_argument") ParamEntityThrowingWebApplicationException defaultArgument) {
+    return Response.ok().build();
+  }
+
+  @Path(value = "/ParamEntityThrowingExceptionGivenByName")
+  @POST
+  @Consumes("application/x-www-form-urlencoded")
+  public Response throwWebApplicationException(
+      @FormParam("default_argument") ParamEntityThrowingExceptionGivenByName defaultArgument) {
+    return Response.ok().build();
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/formparam/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/formparam/JAXRSClientIT.java
@@ -1,0 +1,412 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.formparam;
+
+import jakarta.ws.rs.tck.ee.rs.JaxrsParamClient;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response.Status;
+
+import java.io.InputStream;
+import java.io.IOException;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JAXRSClientIT extends JaxrsParamClient {
+  private static final String ENCODED = "_%60%27%24X+Y%40%22a+a%22";
+
+  private static final String DECODED = "_`'$X Y@\"a a\"";
+
+  public JAXRSClientIT() {
+    setup();
+    setContextRoot("/jaxrs_ee_formparam_web/FormParamTest");
+  }
+
+  private static final long serialVersionUID = 1L;
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  @Deployment(testable = false)
+  public static WebArchive createDeployment() throws IOException{
+
+    InputStream inStream = JAXRSClientIT.class.getClassLoader().getResourceAsStream("jakarta/ws/rs/tck/ee/rs/formparam/web.xml.template");
+    String webXml = editWebXmlString(inStream);
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_ee_formparam_web.war");
+    archive.addClasses(TSAppConfig.class, FormParamTest.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityPrototype.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityWithConstructor.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityWithValueOf.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityWithFromString.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingWebApplicationException.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
+      jakarta.ws.rs.tck.ee.rs.RuntimeExceptionMapper.class,
+      jakarta.ws.rs.tck.ee.rs.WebApplicationExceptionMapper.class
+);
+    archive.setWebXML(new StringAsset(webXml));
+    return archive;
+
+  }
+
+
+
+  /*
+   * @testName: nonDefaultFormParamNothingSentTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12;
+   * 
+   * @test_Strategy: Test sending no content;
+   */
+  @Test
+  public void nonDefaultFormParamNothingSentTest() throws Fault {
+    defaultFormParamAndInvoke(Request.POST, "PostNonDefParam", null);
+  }
+
+  /*
+   * @testName: defaultFormParamSentTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12; JAXRS:SPEC:12.1;
+   * 
+   * @test_Strategy: Test sending override of default argument content;
+   */
+  @Test
+  public void defaultFormParamSentTest() throws Fault {
+    setProperty(Property.CONTENT, "default_argument=" + ENCODED);
+    defaultFormParamAndInvoke(Request.POST, "PostDefParam", ENCODED);
+  }
+
+  /*
+   * @testName: defaultFormParamNoArgSentTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12;
+   * 
+   * @test_Strategy: Test sending no argument content, receiving default;
+   */
+  @Test
+  public void defaultFormParamNoArgSentTest() throws Fault {
+    defaultFormParamAndInvoke(Request.POST, "PostDefParam", "default");
+  }
+
+  /*
+   * @testName: defaultFormParamPutNoArgSentTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12; JAXRS:SPEC:12.1;
+   * 
+   * @test_Strategy: Test sending no argument content, PUT, receiving default;
+   */
+  @Test
+  public void defaultFormParamPutNoArgSentTest() throws Fault {
+    defaultFormParamAndInvoke(Request.PUT, "DefParam", "DefParam");
+  }
+
+  /*
+   * @testName: defaultFormParamPutArgSentTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12;
+   * 
+   * @test_Strategy: Test sending argument content, PUT;
+   */
+  @Test
+  public void defaultFormParamPutArgSentTest() throws Fault {
+    setProperty(Property.CONTENT, "default_argument=" + ENCODED);
+    defaultFormParamAndInvoke(Request.PUT, "DefParam", DECODED);
+  }
+
+  /*
+   * @testName: defaultFormParamValueOfTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12; JAXRS:SPEC:12.1;
+   * 
+   * @test_Strategy: Test creating a ParamEntityWithValueOf from default;
+   */
+  @Test
+  public void defaultFormParamValueOfTest() throws Fault {
+    defaultFormParamAndInvoke(Request.POST, "ParamEntityWithValueOf",
+        "ValueOf");
+  }
+
+  /*
+   * @testName: nonDefaultFormParamValueOfTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12;
+   * 
+   * @test_Strategy: Test creating a ParamEntityWithValueOf from sending a
+   * String;
+   */
+  @Test
+  public void nonDefaultFormParamValueOfTest() throws Fault {
+    setProperty(Property.CONTENT, "default_argument=" + ENCODED);
+    defaultFormParamAndInvoke(Request.POST, "ParamEntityWithValueOf", DECODED);
+  }
+
+  /*
+   * @testName: defaultFormParamFromStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12; JAXRS:SPEC:12.1;
+   * 
+   * @test_Strategy: Test creating a ParamEntityWithFromString from default;
+   */
+  @Test
+  public void defaultFormParamFromStringTest() throws Fault {
+    defaultFormParamAndInvoke(Request.POST, "ParamEntityWithFromString",
+        "FromString");
+  }
+
+  /*
+   * @testName: nonDefaultFormParamFromStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12;
+   * 
+   * @test_Strategy: Test creating a ParamEntityWithFromString from sending a
+   * String;
+   */
+  @Test
+  public void nonDefaultFormParamFromStringTest() throws Fault {
+    setProperty(Property.CONTENT, "default_argument=" + ENCODED);
+    defaultFormParamAndInvoke(Request.POST, "ParamEntityWithFromString",
+        ENCODED);
+  }
+
+  /*
+   * @testName: defaultFormParamFromConstructorTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12; JAXRS:SPEC:12.1;
+   * 
+   * @test_Strategy: Test creating a ParamEntityWithFromString from default;
+   */
+  @Test
+  public void defaultFormParamFromConstructorTest() throws Fault {
+    defaultFormParamAndInvoke(Request.POST, "Constructor", "Constructor");
+  }
+
+  /*
+   * @testName: nonDefaultFormParamFromConstructorTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12;
+   * 
+   * @test_Strategy: Test creating a ParamEntityWithConstructor from sending a
+   * String;
+   */
+  @Test
+  public void nonDefaultFormParamFromConstructorTest() throws Fault {
+    setProperty(Property.CONTENT, "default_argument=" + ENCODED);
+    defaultFormParamAndInvoke(Request.POST, "Constructor", DECODED);
+  }
+
+  /*
+   * @testName: defaultFormParamFromListConstructorTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12; JAXRS:SPEC:12.1;
+   * 
+   * @test_Strategy: Test creating a ParamEntityWithConstructor from default;
+   */
+  @Test
+  public void defaultFormParamFromListConstructorTest() throws Fault {
+    defaultFormParamAndInvoke(Request.POST, "ListConstructor",
+        "ListConstructor");
+  }
+
+  /*
+   * @testName: nonDefaultFormParamFromListConstructorTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12;
+   * 
+   * @test_Strategy: Test creating a ParamEntityWithConstructor from sending a
+   * String;
+   */
+  @Test
+  public void nonDefaultFormParamFromListConstructorTest() throws Fault {
+    setProperty(Property.CONTENT, "default_argument=" + ENCODED);
+    defaultFormParamAndInvoke(Request.POST, "ListConstructor", DECODED);
+  }
+
+  /*
+   * @testName: defaultFormParamFromSetFromStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12; JAXRS:SPEC:12.1;
+   * 
+   * @test_Strategy: Test creating a ParamEntityWithFromString from default;
+   */
+  @Test
+  public void defaultFormParamFromSetFromStringTest() throws Fault {
+    defaultFormParamAndInvoke(Request.POST, "SetFromString", "SetFromString");
+  }
+
+  /*
+   * @testName: nonDefaultFormParamFromSetFromStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12;
+   * 
+   * @test_Strategy: Test creating a ParamEntityWithListConstructor from sending
+   * a String;
+   */
+  @Test
+  public void nonDefaultFormParamFromSetFromStringTest() throws Fault {
+    setProperty(Property.CONTENT, "default_argument=" + ENCODED);
+    defaultFormParamAndInvoke(Request.POST, "SetFromString", ENCODED);
+  }
+
+  /*
+   * @testName: defaultFormParamFromSortedSetFromStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12; JAXRS:SPEC:12.1;
+   * 
+   * @test_Strategy: Test creating a ParamEntityWithFromString from default;
+   */
+  @Test
+  public void defaultFormParamFromSortedSetFromStringTest() throws Fault {
+    defaultFormParamAndInvoke(Request.POST, "SortedSetFromString",
+        "SortedSetFromString");
+  }
+
+  /*
+   * @testName: nonDefaultFormParamFromSortedSetFromStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12;
+   * 
+   * @test_Strategy: Test creating a ParamEntityWithListConstructor from sending
+   * a String;
+   */
+  @Test
+  public void nonDefaultFormParamFromSortedSetFromStringTest() throws Fault {
+    setProperty(Property.CONTENT, "default_argument=" + ENCODED);
+    defaultFormParamAndInvoke(Request.POST, "SortedSetFromString", ENCODED);
+  }
+
+  /*
+   * @testName: defaultFormParamFromListFromStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12; JAXRS:SPEC:12.1;
+   * 
+   * @test_Strategy: Test creating a ParamEntityWithFromString from default;
+   */
+  @Test
+  public void defaultFormParamFromListFromStringTest() throws Fault {
+    defaultFormParamAndInvoke(Request.POST, "ListFromString", "ListFromString");
+  }
+
+  /*
+   * @testName: nonDefaultFormParamFromListFromStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12;
+   * 
+   * @test_Strategy: Test creating a ParamEntityWithListConstructor from sending
+   * a String;
+   */
+  @Test
+  public void nonDefaultFormParamFromListFromStringTest() throws Fault {
+    setProperty(Property.CONTENT, "default_argument=" + ENCODED);
+    defaultFormParamAndInvoke(Request.POST, "ListFromString", ENCODED);
+  }
+
+  /*
+   * @testName: formParamEntityWithEncodedTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:7; JAXRS:SPEC:12;JAXRS:SPEC:12.2;
+   * 
+   * @test_Strategy: Verify that named FormParam @Encoded is handled
+   */
+  @Test
+  public void formParamEntityWithEncodedTest() throws Fault {
+    searchEqualsEncoded = true;
+    super.paramEntityWithEncodedTest();
+  }
+
+  /*
+   * @testName: formParamThrowingWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:12.3;
+   * 
+   * @test_Strategy: Exceptions thrown during construction of parameter values
+   * are treated the same as exceptions thrown during construction of field or
+   * bean property values, see Section 3.2.
+   */
+  @Test
+  public void formParamThrowingWebApplicationExceptionTest() throws Fault {
+    super.paramThrowingWebApplicationExceptionTest();
+  }
+
+  /*
+   * @testName: formParamThrowingIllegalArgumentExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:12.3;
+   * 
+   * @test_Strategy: Exceptions thrown during construction of parameter values
+   * are treated the same as exceptions thrown during construction of field or
+   * bean property values, see section 3.2. Exceptions thrown during
+   * construction of @FormParam annotated parameter values are treated the same
+   * as if the parameter were annotated with @HeaderParam.
+   */
+  @Test
+  public void formParamThrowingIllegalArgumentExceptionTest() throws Fault {
+    setProperty(Property.UNORDERED_SEARCH_STRING, Status.BAD_REQUEST.name());
+    super.paramThrowingIllegalArgumentExceptionTest();
+  }
+
+  // ///////////////////////////////////////////////////////////////////////
+
+  private void defaultFormParamAndInvoke(Request request, String method,
+      String arg) throws Fault {
+    setProperty(Property.REQUEST_HEADERS,
+        buildContentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE));
+    setProperty(Property.REQUEST, buildRequest(request, method));
+    setProperty(Property.SEARCH_STRING, FormParamTest.response(arg));
+    invoke();
+  }
+
+  @Override
+  protected String buildRequest(String param) {
+    setProperty(Property.REQUEST_HEADERS,
+        buildContentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE));
+    setProperty(Property.CONTENT,
+        "default_argument=" + param.replace("=", "%3d"));
+    return buildRequest(Request.POST, segmentFromParam(param));
+  }
+
+  // not used at the moment
+  @Override
+  protected String getDefaultValueOfParam(String param) {
+    return null;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/formparam/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/formparam/TSAppConfig.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.formparam;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.ws.rs.tck.ee.rs.RuntimeExceptionMapper;
+import jakarta.ws.rs.tck.ee.rs.WebApplicationExceptionMapper;
+
+import jakarta.ws.rs.core.Application;
+
+public class TSAppConfig extends Application {
+
+  public java.util.Set<java.lang.Class<?>> getClasses() {
+    Set<Class<?>> resources = new HashSet<Class<?>>();
+    resources.add(FormParamTest.class);
+    resources.add(WebApplicationExceptionMapper.class);
+    resources.add(RuntimeExceptionMapper.class);
+    return resources;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/formparam/locator/JAXRSLocatorClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/formparam/locator/JAXRSLocatorClientIT.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.formparam.locator;
+
+import jakarta.ws.rs.tck.ee.rs.formparam.JAXRSClientIT;
+
+import java.io.InputStream;
+import java.io.IOException;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JAXRSLocatorClientIT extends JAXRSClientIT {
+
+  public JAXRSLocatorClientIT() {
+    setup();
+    setContextRoot("/jaxrs_ee_formparam_locator_web/resource/locator");
+  }
+
+  private static final long serialVersionUID = 1L;
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  @Deployment(testable = false, name = "jaxrs_ee_formparam_locator_deployment")
+  public static WebArchive createDeployment() throws IOException{
+
+    InputStream inStream = JAXRSLocatorClientIT.class.getClassLoader().getResourceAsStream("jakarta/ws/rs/tck/ee/rs/formparam/locator/web.xml.template");
+    String webXml = editWebXmlString(inStream);
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_ee_formparam_locator_web.war");
+    archive.addClasses(TSAppConfig.class, MiddleResource.class, LocatorResource.class,
+      jakarta.ws.rs.tck.ee.rs.formparam.FormParamTest.class,
+      jakarta.ws.rs.tck.common.AbstractMessageBodyRW.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityPrototype.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityWithConstructor.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityWithValueOf.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityWithFromString.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingWebApplicationException.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
+      jakarta.ws.rs.tck.ee.rs.RuntimeExceptionMapper.class,
+      jakarta.ws.rs.tck.ee.rs.WebApplicationExceptionMapper.class
+    );
+    archive.setWebXML(new StringAsset(webXml));
+    return archive;
+
+  }
+
+
+
+  /*
+   * @testName: nonDefaultFormParamNothingSentTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3;
+   * 
+   * @test_Strategy: Test sending no content;
+   */
+  @Test
+  public void nonDefaultFormParamNothingSentTest() throws Fault {
+    super.nonDefaultFormParamNothingSentTest();
+  }
+
+  /*
+   * @testName: nonDefaultFormParamValueOfTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3;
+   * 
+   * @test_Strategy: Test creating a ParamEntityWithValueOf from sending a
+   * String;
+   */
+  @Test
+  public void nonDefaultFormParamValueOfTest() throws Fault {
+    super.nonDefaultFormParamValueOfTest();
+  }
+
+  /*
+   * @testName: nonDefaultFormParamFromStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3;
+   * 
+   * @test_Strategy: Test creating a ParamEntityWithFromString from sending a
+   * String;
+   */
+  @Test
+  public void nonDefaultFormParamFromStringTest() throws Fault {
+    _contextRoot += "encoded";
+    super.nonDefaultFormParamFromStringTest();
+  }
+
+  /*
+   * @testName: nonDefaultFormParamFromConstructorTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3;
+   * 
+   * @test_Strategy: Test creating a ParamEntityWithConstructor from sending a
+   * String;
+   */
+  @Test
+  public void nonDefaultFormParamFromConstructorTest() throws Fault {
+    super.nonDefaultFormParamFromConstructorTest();
+  }
+
+  /*
+   * @testName: nonDefaultFormParamFromListConstructorTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3;
+   * 
+   * @test_Strategy: Test creating a ParamEntityWithConstructor from sending a
+   * String;
+   */
+  @Test
+  public void nonDefaultFormParamFromListConstructorTest() throws Fault {
+    super.nonDefaultFormParamFromListConstructorTest();
+  }
+
+  /*
+   * @testName: nonDefaultFormParamFromSetFromStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3;
+   * 
+   * @test_Strategy: Test creating a ParamEntityWithListConstructor from sending
+   * a String;
+   */
+  @Test
+  public void nonDefaultFormParamFromSetFromStringTest() throws Fault {
+    _contextRoot += "encoded";
+    super.nonDefaultFormParamFromSetFromStringTest();
+  }
+
+  /*
+   * @testName: nonDefaultFormParamFromSortedSetFromStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3;
+   * 
+   * @test_Strategy: Test creating a ParamEntityWithListConstructor from sending
+   * a String;
+   */
+  @Test
+  public void nonDefaultFormParamFromSortedSetFromStringTest() throws Fault {
+    _contextRoot += "encoded";
+    super.nonDefaultFormParamFromSortedSetFromStringTest();
+  }
+
+  /*
+   * @testName: nonDefaultFormParamFromListFromStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3;
+   * 
+   * @test_Strategy: Test creating a ParamEntityWithListConstructor from sending
+   * a String;
+   */
+  @Test
+  public void nonDefaultFormParamFromListFromStringTest() throws Fault {
+    _contextRoot += "encoded";
+    super.nonDefaultFormParamFromListFromStringTest();
+  }
+
+  /*
+   * @assertion_ids: JAXRS:SPEC:7; JAXRS:SPEC:12;JAXRS:SPEC:12.2; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3;
+   * 
+   * @test_Strategy: Verify that named FormParam @Encoded is handled
+   */
+  public void formParamEntityWithEncodedTest() throws Fault {
+    _contextRoot += "encoded";
+    super.paramEntityWithEncodedTest();
+  }
+
+  public void defaultFormParamSentTest() throws Fault {
+    //do nothing  
+  }
+  public void defaultFormParamNoArgSentTest() throws Fault {
+    //do nothing  
+  }
+  public void defaultFormParamPutNoArgSentTest() throws Fault {
+    //do nothing  
+  }
+  public void defaultFormParamPutArgSentTest() throws Fault {
+    //do nothing  
+  }
+  public void defaultFormParamValueOfTest() throws Fault {
+    //do nothing  
+  }
+  public void defaultFormParamFromStringTest() throws Fault {
+    //do nothing  
+  }
+  public void defaultFormParamFromConstructorTest() throws Fault {
+    //do nothing  
+  }
+  public void defaultFormParamFromListConstructorTest() throws Fault {
+    //do nothing  
+  }
+  public void defaultFormParamFromSetFromStringTest() throws Fault {
+    //do nothing  
+  }
+  public void defaultFormParamFromSortedSetFromStringTest() throws Fault {
+    //do nothing  
+  }
+  public void defaultFormParamFromListFromStringTest() throws Fault {
+    //do nothing  
+  }
+  public void formParamThrowingWebApplicationExceptionTest() throws Fault {
+    //do nothing  
+  }
+  public void formParamThrowingIllegalArgumentExceptionTest() throws Fault {
+    //do nothing  
+  }
+
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/formparam/locator/LocatorResource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/formparam/locator/LocatorResource.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.formparam.locator;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Encoded;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("resource")
+public class LocatorResource extends MiddleResource {
+
+  @Path("locator/{id1}")
+  @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+  public MiddleResource locatorHasArguments(@PathParam("id1") String id1,
+      @FormParam("default_argument") String arg) throws Exception {
+    return new MiddleResource(id1, arg);
+  }
+
+  @Path("locatorencoded/{id1}")
+  @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+  public MiddleResource locatorHasEncodedArguments(@PathParam("id1") String id1,
+      @Encoded @FormParam("default_argument") String arg) throws Exception {
+    return new MiddleResource(id1, arg);
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/formparam/locator/MiddleResource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/formparam/locator/MiddleResource.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.formparam.locator;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.TreeSet;
+
+import jakarta.ws.rs.tck.common.AbstractMessageBodyRW;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityWithConstructor;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityWithFromString;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityWithValueOf;
+import jakarta.ws.rs.tck.ee.rs.formparam.FormParamTest;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+public class MiddleResource {
+
+  private Response returnValue;
+
+  FormParamTest resource;
+
+  public MiddleResource() {
+    returnValue = null;
+  }
+
+  protected MiddleResource(String path, String arg) {
+    Method m = getMethod(path);
+    Object o = getMethodArgument(path, arg);
+    resource = new FormParamTest();
+    try {
+      returnValue = (Response) m.invoke(resource, o);
+    } catch (Exception e) {
+      returnValue = Response.ok(e).build();
+    }
+  }
+
+  @POST
+  @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+  public Response returnValue() {
+    return returnValue;
+  }
+
+  private static Method getMethod(String id) {
+    Method[] methods = FormParamTest.class.getMethods();
+    for (Method m : methods) {
+      String path = AbstractMessageBodyRW.getPathValue(m.getAnnotations());
+      if (path != null && path.substring(1, path.length()).startsWith(id))
+        return m;
+    }
+    return null;
+  }
+
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  private static Object getMethodArgument(String path, String arg) {
+    Object o;
+    // Choose entity
+    if (path.contains("Constructor"))
+      o = new ParamEntityWithConstructor(arg);
+    else if (path.contains("FromString"))
+      o = ParamEntityWithFromString.fromString(arg);
+    else if (path.contains("ValueOf"))
+      o = ParamEntityWithValueOf.valueOf(arg);
+    else
+      o = arg;
+
+    // Choose collection
+    if (path.contains("SortedSet"))
+      o = new TreeSet(Collections.singleton(o));
+    else if (path.contains("Set"))
+      o = Collections.singleton(o);
+    else if (path.contains("List"))
+      o = Collections.singletonList(o);
+
+    return o;
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/formparam/locator/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/formparam/locator/TSAppConfig.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.formparam.locator;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.ws.rs.tck.ee.rs.RuntimeExceptionMapper;
+import jakarta.ws.rs.tck.ee.rs.WebApplicationExceptionMapper;
+
+import jakarta.ws.rs.core.Application;
+
+public class TSAppConfig extends Application {
+
+  public java.util.Set<java.lang.Class<?>> getClasses() {
+    Set<Class<?>> resources = new HashSet<Class<?>>();
+    resources.add(LocatorResource.class);
+    resources.add(WebApplicationExceptionMapper.class);
+    resources.add(RuntimeExceptionMapper.class);
+    return resources;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/formparam/sub/JAXRSSubClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/formparam/sub/JAXRSSubClientIT.java
@@ -1,0 +1,382 @@
+/*
+ * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.formparam.sub;
+
+import jakarta.ws.rs.tck.ee.rs.formparam.JAXRSClientIT;
+import java.io.InputStream;
+import java.io.IOException;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JAXRSSubClientIT extends JAXRSClientIT {
+
+  public JAXRSSubClientIT() {
+    setup();
+    setContextRoot("/jaxrs_ee_formparam_sub_web/resource/sub");
+  }
+
+  private static final long serialVersionUID = 1L;
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  @Deployment(testable = false, name = "jaxrs_ee_formparam_sub_deployment")
+  public static WebArchive createDeployment() throws IOException{
+
+    InputStream inStream = JAXRSSubClientIT.class.getClassLoader().getResourceAsStream("jakarta/ws/rs/tck/ee/rs/formparam/sub/web.xml.template");
+    String webXml = editWebXmlString(inStream);
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_ee_formparam_sub_web.war");
+    archive.addClasses(TSAppConfig.class, SubResource.class,
+      jakarta.ws.rs.tck.ee.rs.formparam.FormParamTest.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityPrototype.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityWithConstructor.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityWithValueOf.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityWithFromString.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingWebApplicationException.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
+      jakarta.ws.rs.tck.ee.rs.RuntimeExceptionMapper.class,
+      jakarta.ws.rs.tck.ee.rs.WebApplicationExceptionMapper.class
+    );
+    archive.setWebXML(new StringAsset(webXml));
+    return archive;
+
+  }
+
+
+
+  /*
+   * @testName: nonDefaultFormParamNothingSentTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Test sending no content;
+   */
+  @Test
+  public void nonDefaultFormParamNothingSentTest() throws Fault {
+    super.nonDefaultFormParamNothingSentTest();
+  }
+
+  /*
+   * @testName: defaultFormParamSentTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12; JAXRS:SPEC:12.1;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Test sending override of default argument content;
+   */
+  @Test
+  public void defaultFormParamSentTest() throws Fault {
+    super.defaultFormParamSentTest();
+  }
+
+  /*
+   * @testName: defaultFormParamNoArgSentTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Test sending no argument content, receiving default;
+   */
+  @Test
+  public void defaultFormParamNoArgSentTest() throws Fault {
+    super.defaultFormParamNoArgSentTest();
+  }
+
+  /*
+   * @testName: defaultFormParamPutNoArgSentTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12; JAXRS:SPEC:12.1;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Test sending no argument content, PUT, receiving default;
+   */
+  @Test
+  public void defaultFormParamPutNoArgSentTest() throws Fault {
+    super.defaultFormParamPutNoArgSentTest();
+  }
+
+  /*
+   * @testName: defaultFormParamPutArgSentTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Test sending argument content, PUT;
+   */
+  @Test
+  public void defaultFormParamPutArgSentTest() throws Fault {
+    super.defaultFormParamPutArgSentTest();
+  }
+
+  /*
+   * @testName: defaultFormParamValueOfTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12; JAXRS:SPEC:12.1;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Test creating a ParamEntityWithValueOf from default;
+   */
+  @Test
+  public void defaultFormParamValueOfTest() throws Fault {
+    super.defaultFormParamValueOfTest();
+  }
+
+  /*
+   * @testName: nonDefaultFormParamValueOfTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Test creating a ParamEntityWithValueOf from sending a
+   * String;
+   */
+  @Test
+  public void nonDefaultFormParamValueOfTest() throws Fault {
+    super.nonDefaultFormParamValueOfTest();
+  }
+
+  /*
+   * @testName: defaultFormParamFromStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12; JAXRS:SPEC:12.1;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Test creating a ParamEntityWithFromString from default;
+   */
+  @Test
+  public void defaultFormParamFromStringTest() throws Fault {
+    super.defaultFormParamFromStringTest();
+  }
+
+  /*
+   * @testName: nonDefaultFormParamFromStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Test creating a ParamEntityWithFromString from sending a
+   * String;
+   */
+  @Test
+  public void nonDefaultFormParamFromStringTest() throws Fault {
+    super.nonDefaultFormParamFromStringTest();
+  }
+
+  /*
+   * @testName: defaultFormParamFromConstructorTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12; JAXRS:SPEC:12.1;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Test creating a ParamEntityWithFromString from default;
+   */
+  @Test
+  public void defaultFormParamFromConstructorTest() throws Fault {
+    super.defaultFormParamFromConstructorTest();
+  }
+
+  /*
+   * @testName: nonDefaultFormParamFromConstructorTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Test creating a ParamEntityWithConstructor from sending a
+   * String;
+   */
+  @Test
+  public void nonDefaultFormParamFromConstructorTest() throws Fault {
+    super.nonDefaultFormParamFromConstructorTest();
+  }
+
+  /*
+   * @testName: defaultFormParamFromListConstructorTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12; JAXRS:SPEC:12.1;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Test creating a ParamEntityWithConstructor from default;
+   */
+  @Test
+  public void defaultFormParamFromListConstructorTest() throws Fault {
+    super.defaultFormParamFromListConstructorTest();
+  }
+
+  /*
+   * @testName: nonDefaultFormParamFromListConstructorTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Test creating a ParamEntityWithConstructor from sending a
+   * String;
+   */
+  @Test
+  public void nonDefaultFormParamFromListConstructorTest() throws Fault {
+    super.nonDefaultFormParamFromListConstructorTest();
+  }
+
+  /*
+   * @testName: defaultFormParamFromSetFromStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12; JAXRS:SPEC:12.1;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Test creating a ParamEntityWithFromString from default;
+   */
+  @Test
+  public void defaultFormParamFromSetFromStringTest() throws Fault {
+    super.defaultFormParamFromSetFromStringTest();
+  }
+
+  /*
+   * @testName: nonDefaultFormParamFromSetFromStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Test creating a ParamEntityWithListConstructor from sending
+   * a String;
+   */
+  @Test
+  public void nonDefaultFormParamFromSetFromStringTest() throws Fault {
+    super.nonDefaultFormParamFromSetFromStringTest();
+  }
+
+  /*
+   * @testName: defaultFormParamFromSortedSetFromStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12; JAXRS:SPEC:12.1;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Test creating a ParamEntityWithFromString from default;
+   */
+  @Test
+  public void defaultFormParamFromSortedSetFromStringTest() throws Fault {
+    super.defaultFormParamFromSortedSetFromStringTest();
+  }
+
+  /*
+   * @testName: nonDefaultFormParamFromSortedSetFromStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Test creating a ParamEntityWithListConstructor from sending
+   * a String;
+   */
+  @Test
+  public void nonDefaultFormParamFromSortedSetFromStringTest() throws Fault {
+    super.nonDefaultFormParamFromSortedSetFromStringTest();
+  }
+
+  /*
+   * @testName: defaultFormParamFromListFromStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12; JAXRS:SPEC:12.1;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Test creating a ParamEntityWithFromString from default;
+   * 
+   */
+  @Test
+  public void defaultFormParamFromListFromStringTest() throws Fault {
+    super.defaultFormParamFromListFromStringTest();
+  }
+
+  /*
+   * @testName: nonDefaultFormParamFromListFromStringTest
+   * 
+   * @assertion_ids: JAXRS:JAVADOC:4; JAXRS:SPEC:12; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Test creating a ParamEntityWithListConstructor from sending
+   * a String;
+   */
+  @Test
+  public void nonDefaultFormParamFromListFromStringTest() throws Fault {
+    super.nonDefaultFormParamFromListFromStringTest();
+  }
+
+  /*
+   * @assertion_ids: JAXRS:SPEC:7; JAXRS:SPEC:12;JAXRS:SPEC:12.2; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Verify that named FormParam @Encoded is handled
+   */
+  public void formParamEntityWithEncodedTest() throws Fault {
+    super.paramEntityWithEncodedTest();
+  }
+
+  /*
+   * @testName: formParamThrowingWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:12.3; JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Exceptions thrown during construction of parameter values
+   * are treated the same as exceptions thrown during construction of field or
+   * bean property values, see Section 3.2.
+   */
+  @Test
+  public void formParamThrowingWebApplicationExceptionTest() throws Fault {
+    super.formParamThrowingIllegalArgumentExceptionTest();
+  }
+
+  /*
+   * @testName: formParamThrowingIllegalArgumentExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:12.3; JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Exceptions thrown during construction of parameter values
+   * are treated the same as exceptions thrown during construction of field or
+   * bean property values, see section 3.2. Exceptions thrown during
+   * construction of @FormParam annotated parameter values are treated the same
+   * as if the parameter were annotated with @HeaderParam.
+   */
+  @Test
+  public void formParamThrowingIllegalArgumentExceptionTest() throws Fault {
+    super.formParamThrowingIllegalArgumentExceptionTest();
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/formparam/sub/SubResource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/formparam/sub/SubResource.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.formparam.sub;
+
+import jakarta.ws.rs.tck.ee.rs.formparam.FormParamTest;
+
+import jakarta.ws.rs.Path;
+
+@Path("resource")
+public class SubResource extends FormParamTest {
+
+  @Path("sub")
+  public SubResource sub() {
+    return this;
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/formparam/sub/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/formparam/sub/TSAppConfig.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.formparam.sub;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.ws.rs.tck.ee.rs.RuntimeExceptionMapper;
+import jakarta.ws.rs.tck.ee.rs.WebApplicationExceptionMapper;
+
+import jakarta.ws.rs.core.Application;
+
+public class TSAppConfig extends Application {
+
+  public java.util.Set<java.lang.Class<?>> getClasses() {
+    Set<Class<?>> resources = new HashSet<Class<?>>();
+    resources.add(SubResource.class);
+    resources.add(WebApplicationExceptionMapper.class);
+    resources.add(RuntimeExceptionMapper.class);
+    return resources;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/get/HttpMethodGetTest.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/get/HttpMethodGetTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.get;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
+
+@Path(value = "/GetTest")
+public class HttpMethodGetTest {
+
+  static String html_content = "<html>"
+      + "<head><title>CTS-get text/html</title></head>"
+      + "<body>CTS-get text/html</body></html>";
+
+  @GET
+  public Response getPlain() {
+    return Response.ok("CTS-get text/plain").header("CTS-HEAD", "text-plain")
+        .build();
+  }
+
+  @GET
+  @Produces(value = "text/html")
+  public Response getHtml() {
+    return Response.ok(html_content).header("CTS-HEAD", "text-html").build();
+  }
+
+  @GET
+  @Path(value = "/sub")
+  public Response getSub() {
+    return Response.ok("CTS-get text/plain")
+        .header("CTS-HEAD", "sub-text-plain").build();
+  }
+
+  @GET
+  @Path(value = "/sub")
+  @Produces(value = "text/html")
+  public Response headSub() {
+    return Response.ok(html_content).header("CTS-HEAD", "sub-text-html")
+        .build();
+  }
+
+  @Path("{id}")
+  public SubResource getAbstractResource(@PathParam("id") int id) {
+    return new SubResource();
+  }
+
+  @Path("recursive")
+  public RecursiveLocator recursion() {
+    return new RecursiveLocator();
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/get/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/get/JAXRSClientIT.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.get;
+
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+
+import jakarta.ws.rs.core.MediaType;
+
+import java.io.InputStream;
+import java.io.IOException;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JAXRSClientIT extends JAXRSCommonClient {
+  private static final long serialVersionUID = 1L;
+
+  public JAXRSClientIT() {
+    setup();
+    setContextRoot("/jaxrs_ee_rs_get_web/GetTest");
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  @Deployment(testable = false)
+  public static WebArchive createDeployment() throws IOException{
+
+    InputStream inStream = JAXRSClientIT.class.getClassLoader().getResourceAsStream("jakarta/ws/rs/tck/ee/rs/get/web.xml.template");
+    String webXml = editWebXmlString(inStream);
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_ee_rs_get_web.war");
+    archive.addClasses(TSAppConfig.class, HttpMethodGetTest.class, RecursiveLocator.class, SubResource.class);
+    archive.setWebXML(new StringAsset(webXml));
+    return archive;
+
+  }
+
+
+  /* Run test */
+  /*
+   * @testName: getTest1
+   * 
+   * @assertion_ids: JAXRS:SPEC:20.1; JAXRS:JAVADOC:6; JAXRS:JAVADOC:8;
+   * JAXRS:JAVADOC:10;
+   * 
+   * @test_Strategy: Client invokes GET on root resource at /GetTest; Verify
+   * that right Method is invoked.
+   */
+  @Test
+  public void getTest1() throws Fault {
+    setProperty(Property.REQUEST_HEADERS,
+        buildAccept(MediaType.TEXT_PLAIN_TYPE));
+    setProperty(Property.REQUEST, buildRequest(GET, ""));
+    setProperty(Property.SEARCH_STRING, "CTS-get text/plain");
+    invoke();
+  }
+
+  /*
+   * @testName: getTest2
+   * 
+   * @assertion_ids: JAXRS:SPEC:20.1; JAXRS:JAVADOC:6; JAXRS:JAVADOC:8;
+   * JAXRS:JAVADOC:10;
+   * 
+   * @test_Strategy: Client invokes GET on root resource at /GetTest; Verify
+   * that right Method is invoked.
+   */
+  @Test
+  public void getTest2() throws Fault {
+    setProperty(Property.REQUEST_HEADERS,
+        buildAccept(MediaType.TEXT_HTML_TYPE));
+    setProperty(Property.REQUEST, buildRequest(GET, ""));
+    setProperty(Property.SEARCH_STRING, "CTS-get text/html");
+    invoke();
+  }
+
+  /*
+   * @testName: getSubTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:20.1; JAXRS:JAVADOC:6; JAXRS:JAVADOC:8;
+   * JAXRS:JAVADOC:10;
+   * 
+   * @test_Strategy: Client invokes GET on a sub resource at /GetTest/sub;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void getSubTest() throws Fault {
+    setProperty(Property.REQUEST_HEADERS,
+        buildAccept(MediaType.TEXT_PLAIN_TYPE));
+    setProperty(Property.REQUEST, buildRequest(GET, "sub"));
+    setProperty(Property.SEARCH_STRING, "CTS-get text/plain");
+    invoke();
+  }
+
+  /*
+   * @testName: headTest1
+   * 
+   * @assertion_ids: JAXRS:SPEC:17.2; JAXRS:JAVADOC:6; JAXRS:JAVADOC:8;
+   * JAXRS:JAVADOC:10;
+   * 
+   * @test_Strategy: Client invokes Head on root resource at /GetTest; which no
+   * request method designated for HEAD; Verify that corresponding GET Method is
+   * invoked.
+   */
+  @Test
+  public void headTest1() throws Fault {
+    setProperty(Property.REQUEST_HEADERS,
+        buildAccept(MediaType.TEXT_PLAIN_TYPE));
+    setProperty(Property.REQUEST, buildRequest("HEAD", ""));
+    setProperty(Property.EXPECTED_HEADERS, "CTS-HEAD: text-plain");
+    invoke();
+  }
+
+  /*
+   * @testName: headTest2
+   * 
+   * @assertion_ids: JAXRS:SPEC:17.2; JAXRS:JAVADOC:6; JAXRS:JAVADOC:8;
+   * JAXRS:JAVADOC:10;
+   * 
+   * @test_Strategy: Client invokes HEAD on root resource at /GetTest; which no
+   * request method designated for HEAD; Verify that corresponding GET Method is
+   * invoked.
+   */
+  @Test
+  public void headTest2() throws Fault {
+    setProperty(Property.REQUEST_HEADERS,
+        buildAccept(MediaType.TEXT_HTML_TYPE));
+    setProperty(Property.REQUEST, buildRequest("HEAD", ""));
+    setProperty(Property.EXPECTED_HEADERS, "CTS-HEAD: text-html");
+    invoke();
+  }
+
+  /*
+   * @testName: headSubTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:17.2; JAXRS:JAVADOC:6; JAXRS:JAVADOC:8;
+   * JAXRS:JAVADOC:10;
+   * 
+   * @test_Strategy: Client invokes HEAD on sub resource at /GetTest/sub; which
+   * no request method designated for HEAD; Verify that corresponding GET Method
+   * is invoked instead.
+   */
+  @Test
+  public void headSubTest() throws Fault {
+    setProperty(Property.REQUEST_HEADERS,
+        buildAccept(MediaType.TEXT_PLAIN_TYPE));
+    setProperty(Property.REQUEST, buildRequest("HEAD", "sub"));
+    setProperty(Property.EXPECTED_HEADERS, "CTS-HEAD: sub-text-plain");
+    invoke();
+  }
+
+  /*
+   * @testName: optionSubTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:18.2; JAXRS:JAVADOC:6; JAXRS:JAVADOC:8;
+   * JAXRS:JAVADOC:10;
+   * 
+   * @test_Strategy: Client invokes OPTIONS on a sub resource at /GetTest/sub;
+   * which no request method designated for OPTIONS. Verify that an automatic
+   * response is generated.
+   */
+  @Test
+  public void optionSubTest() throws Fault {
+    setProperty(Property.REQUEST_HEADERS,
+        buildAccept(MediaType.TEXT_HTML_TYPE));
+    setProperty(Property.REQUEST, buildRequest("OPTIONS", "sub"));
+    setProperty(Property.EXPECTED_HEADERS, "ALLOW:GET,OPTIONS,HEAD");
+    invoke();
+  }
+
+  /*
+   * @testName: dynamicGetTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: The presence or absence of a request method designator
+   * (e.g. @GET) differentiates between the two: o Absent
+   */
+  @Test
+  public void dynamicGetTest() throws Fault {
+    setProperty(Property.REQUEST, buildRequest(GET, "123"));
+    setProperty(Property.SEARCH_STRING, SubResource.ID);
+    invoke();
+  }
+
+  /*
+   * @testName: recursiveResourceLocatorTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: The presence or absence of a request method designator
+   * (e.g. @GET) differentiates between the two: o Absent
+   *
+   * Any returned object is treated as a resource class instance and used to
+   * either handle the request or to further resolve the object that will handle
+   * the request
+   * 
+   */
+  @Test
+  public void recursiveResourceLocatorTest() throws Fault {
+    StringBuilder sb = new StringBuilder();
+    sb.append("recursive");
+    for (int i = 0; i != 10; i++)
+      sb.append("/lvl");
+    setProperty(Property.REQUEST, buildRequest(GET, sb.toString()));
+    setProperty(Property.SEARCH_STRING, "10");
+    invoke();
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/get/RecursiveLocator.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/get/RecursiveLocator.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.get;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+public class RecursiveLocator {
+  private int level = 0;
+
+  @Path("{id}")
+  public RecursiveLocator recursion() {
+    level++;
+    return this;
+  }
+
+  @GET
+  public String getLevel() {
+    return String.valueOf(level);
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/get/SubResource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/get/SubResource.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.get;
+
+import jakarta.ws.rs.GET;
+
+public class SubResource {
+  public static final String ID = "JAXRS:DIRECT";
+
+  @GET
+  public String reveal() {
+    return ID;
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/get/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/get/TSAppConfig.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.get;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.ws.rs.core.Application;
+
+/**
+ *
+ * @author diannejiao
+ */
+public class TSAppConfig extends Application {
+
+  public java.util.Set<java.lang.Class<?>> getClasses() {
+    Set<Class<?>> resources = new HashSet<Class<?>>();
+    resources.add(HttpMethodGetTest.class);
+    return resources;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/head/HttpMethodHeadTest.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/head/HttpMethodHeadTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.head;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HEAD;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
+
+@Path(value = "/HeadTest")
+public class HttpMethodHeadTest {
+
+  @HEAD
+  @Produces(value = "text/plain")
+  public Response headPlain() {
+    return Response.ok().header("CTS-HEAD", "text-plain").build();
+  }
+
+  @HEAD
+  @Produces(value = "text/html")
+  public Response headHtml() {
+    return Response.ok().header("CTS-HEAD", "text-html").build();
+  }
+
+  @HEAD
+  @Path(value = "/sub")
+  @Produces(value = "text/html")
+  public Response headSub() {
+    return Response.ok().header("CTS-HEAD", "sub-text-html").build();
+  }
+
+  @GET
+  @Path(value = "/get")
+  public Response get() {
+    return Response.ok("HEAD-GET").header("CTS-HEAD", "get").build();
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/head/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/head/JAXRSClientIT.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.head;
+
+
+import jakarta.ws.rs.tck.common.webclient.http.HttpResponse;
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+
+import java.io.InputStream;
+import java.io.IOException;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JAXRSClientIT extends JAXRSCommonClient {
+  private static final long serialVersionUID = 1L;
+
+  public JAXRSClientIT() {
+    setup();
+    setContextRoot("/jaxrs_ee_rs_head_web/HeadTest");
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  @Deployment(testable = false)
+  public static WebArchive createDeployment() throws IOException{
+
+    InputStream inStream = JAXRSClientIT.class.getClassLoader().getResourceAsStream("jakarta/ws/rs/tck/ee/rs/head/web.xml.template");
+    String webXml = editWebXmlString(inStream);
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_ee_rs_head_web.war");
+    archive.addClasses(TSAppConfig.class, HttpMethodHeadTest.class);
+    archive.setWebXML(new StringAsset(webXml));
+    return archive;
+
+  }
+
+
+
+  /* Run test */
+  /*
+   * @testName: headTest1
+   * 
+   * @assertion_ids: JAXRS:SPEC:17.1; JAXRS:SPEC:20.1; JAXRS:JAVADOC:6;
+   * JAXRS:JAVADOC:8; JAXRS:JAVADOC:10; JAXRS:JAVADOC:148;
+   * 
+   * @test_Strategy: Client invokes HEAD on root resource at /HeadTest; Verify
+   * that right Method is invoked.
+   */
+  @Test
+  public void headTest1() throws Fault {
+    setProperty(REQUEST_HEADERS, "Accept:text/plain");
+    setProperty(REQUEST, buildRequest("HEAD", ""));
+    setProperty(Property.EXPECTED_HEADERS, "CTS-HEAD: text-plain");
+    invoke();
+  }
+
+  /*
+   * @testName: headTest2
+   * 
+   * @assertion_ids: JAXRS:SPEC:17.1; JAXRS:SPEC:20.1; JAXRS:JAVADOC:6;
+   * JAXRS:JAVADOC:8; JAXRS:JAVADOC:10; JAXRS:JAVADOC:148;
+   * 
+   * @test_Strategy: Client invokes HEAD on root resource at /HeadTest; Verify
+   * that right Method is invoked.
+   */
+  @Test
+  public void headTest2() throws Fault {
+    setProperty(REQUEST_HEADERS, "Accept:text/html");
+    setProperty(REQUEST, buildRequest("HEAD", ""));
+    setProperty(Property.EXPECTED_HEADERS, "CTS-HEAD: text-html");
+    invoke();
+  }
+
+  /*
+   * @testName: headSubTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:17.1; JAXRS:SPEC:20.1; JAXRS:JAVADOC:6;
+   * JAXRS:JAVADOC:8; JAXRS:JAVADOC:10; JAXRS:JAVADOC:148;
+   * 
+   * @test_Strategy: Client invokes HEAD on a sub resource at /HeadTest/sub;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void headSubTest() throws Fault {
+    setProperty(REQUEST, buildRequest("HEAD", "sub"));
+    setProperty(Property.EXPECTED_HEADERS, "CTS-HEAD:  sub-text-html");
+    invoke();
+  }
+
+  /*
+   * @testName: headGetTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:17.2;
+   * 
+   * @test_Strategy: Call a method annotated with a request method designator
+   * for GET and discard any returned entity
+   */
+  @Test
+  public void headGetTest() throws Fault, IOException {
+    setProperty(REQUEST, buildRequest("HEAD", "get"));
+    setProperty(Property.EXPECTED_HEADERS, "CTS-HEAD: get");
+    invoke();
+    HttpResponse request = _testCase.getResponse();
+    assertTrue(request.getResponseBodyAsRawString() == null,
+        "Unexpected entity in request body");
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/head/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/head/TSAppConfig.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.head;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.ws.rs.core.Application;
+
+/**
+ *
+ * @author diannejiao
+ */
+public class TSAppConfig extends Application {
+
+  public java.util.Set<java.lang.Class<?>> getClasses() {
+    Set<Class<?>> resources = new HashSet<Class<?>>();
+    resources.add(HttpMethodHeadTest.class);
+    return resources;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/headerparam/HeaderParamTest.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/headerparam/HeaderParamTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.headerparam;
+
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+
+import jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingExceptionGivenByName;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingWebApplicationException;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityWithConstructor;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityWithFromString;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityWithValueOf;
+import jakarta.ws.rs.tck.ee.rs.ParamTest;
+
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.Path;
+
+@Path(value = "/HeaderParamTest")
+public class HeaderParamTest extends ParamTest {
+
+  @DefaultValue("HeaderParamTest")
+  @HeaderParam("FieldParamEntityWithConstructor")
+  ParamEntityWithConstructor fieldParamEntityWithConstructor;
+
+  @DefaultValue("HeaderParamTest")
+  @HeaderParam("FieldParamEntityWithFromString")
+  ParamEntityWithFromString fieldParamEntityWithFromString;
+
+  @DefaultValue("HeaderParamTest")
+  @HeaderParam("FieldParamEntityWithValueOf")
+  ParamEntityWithValueOf fieldParamEntityWithValueOf;
+
+  @DefaultValue("HeaderParamTest")
+  @HeaderParam("FieldSetParamEntityWithFromString")
+  Set<ParamEntityWithFromString> fieldSetParamEntityWithFromString;
+
+  @DefaultValue("HeaderParamTest")
+  @HeaderParam("FieldSortedSetParamEntityWithFromString")
+  SortedSet<ParamEntityWithFromString> fieldSortedSetParamEntityWithFromString;
+
+  @DefaultValue("HeaderParamTest")
+  @HeaderParam("FieldListParamEntityWithFromString")
+  List<ParamEntityWithFromString> fieldListParamEntityWithFromString;
+
+  @HeaderParam("FieldParamEntityThrowingWebApplicationException")
+  public ParamEntityThrowingWebApplicationException fieldEntityThrowingWebApplicationException;
+
+  @HeaderParam("FieldParamEntityThrowingExceptionGivenByName")
+  public ParamEntityThrowingExceptionGivenByName fieldEntityThrowingExceptionGivenByName;
+
+  @GET
+  public String stringParamHandling(
+      @HeaderParam("X-CTSTEST-HEADERTEST-STRINGTEST1") @DefaultValue("default") String stringheader1,
+      @HeaderParam("X-CTSTEST-HEADERTEST-stringtest2") @DefaultValue("default") String stringheader2,
+      @HeaderParam("X-CTSTEST-HEADERTEST-inttest1") int intheader1,
+      @HeaderParam("X-CTSTEST-HEADERTEST-inttest2") int intheader2,
+      @HeaderParam("X-CTSTEST-HEADERTEST-bytetest1") byte byteheader1,
+      @HeaderParam("X-CTSTEST-HEADERTEST-bytetest2") byte byteheader2,
+      @HeaderParam("X-CTSTEST-HEADERTEST-doubletest1") double doubleheader1,
+      @HeaderParam("X-CTSTEST-HEADERTEST-doubletest2") double doubleheader2,
+      @HeaderParam("X-CTSTEST-HEADERTEST-floattest1") float floatheader1,
+      @HeaderParam("X-CTSTEST-HEADERTEST-floattest2") float floatheader2,
+      @HeaderParam("X-CTSTEST-HEADERTEST-shorttest1") short shortheader1,
+      @HeaderParam("X-CTSTEST-HEADERTEST-shorttest2") short shortheader2,
+      @HeaderParam("X-CTSTEST-HEADERTEST-longtest1") long longheader1,
+      @HeaderParam("X-CTSTEST-HEADERTEST-longtest2") long longheader2,
+      @HeaderParam("X-CTSTEST-HEADERTEST-booleantest1") boolean booleanheader1,
+      @HeaderParam("X-CTSTEST-HEADERTEST-booleantest2") boolean booleanheader2,
+      @DefaultValue("HeaderParamTest") @HeaderParam("ParamEntityWithConstructor") ParamEntityWithConstructor paramEntityWithConstructor,
+      @DefaultValue("HeaderParamTest") @HeaderParam("ParamEntityWithFromString") ParamEntityWithFromString paramEntityWithFromString,
+      @DefaultValue("HeaderParamTest") @HeaderParam("ParamEntityWithValueOf") ParamEntityWithValueOf paramEntityWithValueOf,
+      @DefaultValue("HeaderParamTest") @HeaderParam("SetParamEntityWithFromString") Set<ParamEntityWithFromString> setParamEntityWithFromString,
+      @DefaultValue("HeaderParamTest") @HeaderParam("SortedSetParamEntityWithFromString") SortedSet<ParamEntityWithFromString> sortedSetParamEntityWithFromString,
+      @DefaultValue("HeaderParamTest") @HeaderParam("ListParamEntityWithFromString") List<ParamEntityWithFromString> listParamEntityWithFromString,
+      @HeaderParam("ParamEntityThrowingWebApplicationException") ParamEntityThrowingWebApplicationException paramEntityThrowingWebApplicationException,
+      @HeaderParam("ParamEntityThrowingExceptionGivenByName") ParamEntityThrowingExceptionGivenByName paramEntityThrowingExceptionGivenByName) {
+
+    noparam = true;
+    sb = new StringBuilder();
+
+    if (stringheader1 == "" || stringheader1 == null
+        || !stringheader1.equals("default"))
+      noparam = false;
+    sb.append("stringtest1=").append(stringheader1);
+
+    if (stringheader2 == "" || stringheader2 == null
+        || !stringheader2.equals("default"))
+      noparam = false;
+    sb.append("stringtest2=").append(stringheader2);
+
+    appendNonNullSetNoParam("inttest1", intheader1);
+    appendNonNullSetNoParam("inttest2", intheader2);
+    appendNonNullSetNoParam("doubletest1", doubleheader1);
+    appendNonNullSetNoParam("doubletest2", doubleheader2);
+    appendNonNullSetNoParam("floattest1", floatheader1);
+    appendNonNullSetNoParam("floattest2", floatheader2);
+    appendNonNullSetNoParam("longtest1", longheader1);
+    appendNonNullSetNoParam("longtest2", longheader2);
+    appendNonNullSetNoParam("shorttest1", shortheader1);
+    appendNonNullSetNoParam("shorttest2", shortheader2);
+    appendNonNullSetNoParam("bytetest1", byteheader1);
+    appendNonNullSetNoParam("bytetest2", byteheader2);
+    appendTrueSetNoParam("booleantest1", booleanheader1);
+    appendTrueSetNoParam("booleantest2", booleanheader2);
+
+    setReturnValues(paramEntityWithConstructor, paramEntityWithFromString,
+        paramEntityWithValueOf, setParamEntityWithFromString,
+        sortedSetParamEntityWithFromString, listParamEntityWithFromString, "");
+
+    setReturnValues(fieldParamEntityWithConstructor,
+        fieldParamEntityWithFromString, fieldParamEntityWithValueOf,
+        fieldSetParamEntityWithFromString,
+        fieldSortedSetParamEntityWithFromString,
+        fieldListParamEntityWithFromString, FIELD);
+
+    if (noparam)
+      sb.append("No HeaderParam");
+    return sb.toString();
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/headerparam/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/headerparam/JAXRSClientIT.java
@@ -1,0 +1,685 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+package jakarta.ws.rs.tck.ee.rs.headerparam;
+
+import jakarta.ws.rs.tck.ee.rs.JaxrsParamClient;
+
+import jakarta.ws.rs.core.Response.Status;
+import java.io.InputStream;
+import java.io.IOException;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JAXRSClientIT extends JaxrsParamClient {
+  private static final long serialVersionUID = 1L;
+
+  public JAXRSClientIT() {
+    setup();
+    setContextRoot("/jaxrs_ee_rs_headerparam_web/HeaderParamTest");
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  @Deployment(testable = false)
+  public static WebArchive createDeployment() throws IOException{
+
+    InputStream inStream = JAXRSClientIT.class.getClassLoader().getResourceAsStream("jakarta/ws/rs/tck/ee/rs/headerparam/web.xml.template");
+    String webXml = editWebXmlString(inStream);
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_ee_rs_headerparam_web.war");
+    archive.addClasses(TSAppConfig.class, HeaderParamTest.class,
+        jakarta.ws.rs.tck.ee.rs.ParamEntityPrototype.class,
+        jakarta.ws.rs.tck.ee.rs.ParamEntityWithConstructor.class,
+        jakarta.ws.rs.tck.ee.rs.ParamEntityWithValueOf.class,
+        jakarta.ws.rs.tck.ee.rs.ParamEntityWithFromString.class,
+        jakarta.ws.rs.tck.ee.rs.ParamTest.class,
+        jakarta.ws.rs.tck.ee.rs.JaxrsParamClient.CollectionName.class,
+        jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingWebApplicationException.class,
+        jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
+        jakarta.ws.rs.tck.ee.rs.RuntimeExceptionMapper.class,
+        jakarta.ws.rs.tck.ee.rs.WebApplicationExceptionMapper.class
+);
+    archive.setWebXML(new StringAsset(webXml));
+    return archive;
+
+  }
+
+
+
+  /* Run test */
+  /*
+   * @testName: headerParamStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.1; JAXRS:JAVADOC:3;
+   * JAXRS:JAVADOC:5;
+   * 
+   * @test_Strategy: Client invokes HEAD on root resource at /HeaderParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void headerParamStringTest() throws Fault {
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-STRINGTEST1: cts");
+    setProperty(Property.REQUEST, buildRequest(Request.GET, ""));
+    setProperty(Property.SEARCH_STRING, "stringtest1=cts");
+    invoke();
+
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-STRINGTEST1: cts1");
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-STRINGTEST1: cts2");
+    setProperty(Property.REQUEST, buildRequest(Request.GET, ""));
+    setProperty(Property.SEARCH_STRING, "stringtest1=cts1");
+    invoke();
+
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-STRINGTEST1: cts1");
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-STRINGTEST2: cts2");
+    setProperty(Property.REQUEST, buildRequest(Request.GET, ""));
+    setProperty(Property.SEARCH_STRING, "stringtest1=cts|stringtest2=cts2");
+    invoke();
+
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-STRINGTEST1: cts1");
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-STRINGTEST2: cts2");
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-STRINGTEST1: newone");
+    setProperty(Property.REQUEST, buildRequest(Request.GET, ""));
+    setProperty(Property.SEARCH_STRING, "stringtest1=cts1|stringtest2=cts2");
+
+    invoke();
+  }
+
+  /*
+   * @testName: headerParamNoQueryTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.1; JAXRS:JAVADOC:5;
+   * 
+   * @test_Strategy: Client invokes Request.GET on a resource at
+   * /HeaderParamTest; Verify that right Method is invoked.
+   */
+  @Test
+  public void headerParamNoQueryTest() throws Fault {
+    setProperty(Property.REQUEST, buildRequest(Request.GET, ""));
+    setProperty(Property.SEARCH_STRING, "No HeaderParam");
+    invoke();
+  }
+
+  /*
+   * @testName: headerParamIntTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.1; JAXRS:JAVADOC:5;
+   * 
+   * @test_Strategy: Client invokes Request.GET on a resource at
+   * /HeaderParamTest; Verify that right Method is invoked.
+   */
+  @Test
+  public void headerParamIntTest() throws Fault {
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-INTTEST1: 2147483647");
+    setProperty(Property.REQUEST, buildRequest(Request.GET, ""));
+    setProperty(Property.SEARCH_STRING, "inttest1=2147483647");
+    invoke();
+
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-INTTEST1: -2147483648");
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-INTTEST1: 2147483647");
+    setProperty(Property.REQUEST, buildRequest(Request.GET, ""));
+    setProperty(Property.SEARCH_STRING, "inttest1=-2147483648");
+    invoke();
+
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-INTTEST1: -2147483648");
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-INTTEST2: 2147483647");
+    setProperty(Property.REQUEST, buildRequest(Request.GET, ""));
+    setProperty(Property.SEARCH_STRING,
+        "inttest1=-2147483648|inttest2=2147483647");
+    invoke();
+
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-INTTEST1: -2147483648");
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-INTTEST2: 2147483647");
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-INTTEST1: 1234");
+    setProperty(Property.REQUEST, buildRequest(Request.GET, ""));
+    setProperty(Property.SEARCH_STRING,
+        "inttest1=-2147483648|inttest2=2147483647");
+    invoke();
+  }
+
+  /*
+   * @testName: headerParamDoubleTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.1; JAXRS:JAVADOC:5;
+   * 
+   * @test_Strategy: Client invokes Request.GET on a resource at
+   * /HeaderParamTest; Verify that right Method is invoked.
+   */
+  @Test
+  public void headerParamDoubleTest() throws Fault {
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-DOUBLETEST1: 123");
+    setProperty(Property.REQUEST, buildRequest(Request.GET, ""));
+    setProperty(Property.SEARCH_STRING, "doubletest1=123.0");
+    invoke();
+
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-DOUBLETEST1: 123.1");
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-DOUBLETEST1: 345");
+    setProperty(Property.REQUEST, buildRequest(Request.GET, ""));
+    setProperty(Property.SEARCH_STRING, "doubletest1=123.1");
+    invoke();
+
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-DOUBLETEST1: 12.345");
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-DOUBLETEST2: 34.567");
+    setProperty(Property.REQUEST, buildRequest(Request.GET, ""));
+    setProperty(Property.SEARCH_STRING,
+        "doubletest1=12.345|doubletest2=34.567");
+    invoke();
+
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-DOUBLETEST1: 23.456");
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-DOUBLETEST2: 0.56789");
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-DOUBLETEST1: 1.234");
+    setProperty(Property.REQUEST, buildRequest(Request.GET, ""));
+    setProperty(Property.SEARCH_STRING,
+        "doubletest1=23.456|doubletest2=0.56789");
+    invoke();
+  }
+
+  /*
+   * @testName: headerParamFloatTest
+   *
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.1; JAXRS:JAVADOC:5;
+   *
+   * @test_Strategy: Client invokes Request.GET on a resource at
+   * /HeaderParamTest; Verify that right Method is invoked.
+   */
+  @Test
+  public void headerParamFloatTest() throws Fault {
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-FLOATTEST1: 123");
+    setProperty(Property.REQUEST, buildRequest(Request.GET, ""));
+    setProperty(Property.SEARCH_STRING, "floattest1=123.0");
+    invoke();
+
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-FLOATTEST1: 123.1");
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-FLOATTEST1: 345");
+    setProperty(Property.REQUEST, buildRequest(Request.GET, ""));
+    setProperty(Property.SEARCH_STRING, "floattest1=123.1");
+    invoke();
+
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-FLOATTEST1: 12.345");
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-FLOATTEST2: 34.567");
+    setProperty(Property.REQUEST, buildRequest(Request.GET, ""));
+    setProperty(Property.SEARCH_STRING, "floattest1=12.345|floattest2=34.567");
+    invoke();
+
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-FLOATTEST1: 23.456");
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-FLOATTEST2: 0.56789");
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-FLOATTEST1: 1.234");
+    setProperty(Property.REQUEST, buildRequest(Request.GET, ""));
+    setProperty(Property.SEARCH_STRING, "floattest1=23.456|floattest2=0.56789");
+    invoke();
+  }
+
+  /*
+   * @testName: headerParamLongTest
+   *
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.1; JAXRS:JAVADOC:5;
+   *
+   * @test_Strategy: Client invokes Request.GET on a sub resource at
+   * /HeaderParamTest; Verify that right Method is invoked.
+   */
+  @Test
+  public void headerParamLongTest() throws Fault {
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-LONGTEST1: -9223372036854775808");
+    setProperty(Property.REQUEST, buildRequest(Request.GET, ""));
+    setProperty(Property.SEARCH_STRING, "longtest1=-9223372036854775808");
+    invoke();
+
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-LONGTEST1: 9223372036854775807");
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-LONGTEST1: -9223372036854775808");
+    setProperty(Property.REQUEST, buildRequest(Request.GET, ""));
+    setProperty(Property.SEARCH_STRING, "longtest1=9223372036854775807");
+    invoke();
+
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-LONGTEST1: -9223372036854775808");
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-LONGTEST2: 9223372036854775807");
+    setProperty(Property.REQUEST, buildRequest(Request.GET, ""));
+    setProperty(Property.SEARCH_STRING,
+        "longtest1=-9223372036854775808|longtest2=9223372036854775807");
+    invoke();
+
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-LONGTEST1: -9223372036854775808");
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-LONGTEST2: 9223372036854775807");
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-LONGTEST1: 1234");
+    setProperty(Property.REQUEST, buildRequest(Request.GET, ""));
+    setProperty(Property.SEARCH_STRING,
+        "longtest1=-9223372036854775808|longtest2=9223372036854775807");
+    invoke();
+  }
+
+  /*
+   * @testName: headerParamShortTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.1; JAXRS:JAVADOC:5;
+   * 
+   * @test_Strategy: Client invokes Request.GET on a sub resource at
+   * /HeaderParamTest; Verify that right Method is invoked.
+   */
+  @Test
+  public void headerParamShortTest() throws Fault {
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-SHORTTEST1: -32768");
+    setProperty(Property.REQUEST, buildRequest(Request.GET, ""));
+    setProperty(Property.SEARCH_STRING, "shorttest1=-32768");
+    invoke();
+
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-SHORTTEST1: 32767");
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-SHORTTEST1: -32768");
+    setProperty(Property.REQUEST, buildRequest(Request.GET, ""));
+    setProperty(Property.SEARCH_STRING, "shorttest1=32767");
+    invoke();
+
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-SHORTTEST1: 32767");
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-SHORTTEST2: -32768");
+    setProperty(Property.REQUEST, buildRequest(Request.GET, ""));
+    setProperty(Property.SEARCH_STRING, "shorttest1=32767|shorttest2=-32768");
+    invoke();
+
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-SHORTTEST1: 32767");
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-SHORTTEST2: -32768");
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-SHORTTEST1: 1234");
+    setProperty(Property.REQUEST, buildRequest(Request.GET, ""));
+    setProperty(Property.SEARCH_STRING, "shorttest1=32767|shorttest2=-32768");
+    invoke();
+  }
+
+  /*
+   * @testName: headerParamByteTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.1; JAXRS:JAVADOC:5;
+   * 
+   * @test_Strategy: Client invokes Request.GET on a sub resource at
+   * /HeaderParamTest; Verify that right Method is invoked.
+   */
+  @Test
+  public void headerParamByteTest() throws Fault {
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-BYTETEST1: 127");
+    setProperty(Property.REQUEST, buildRequest(Request.GET, ""));
+    setProperty(Property.SEARCH_STRING, "bytetest1=127");
+    invoke();
+
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-BYTETEST1: -128");
+    setProperty(Property.REQUEST_HEADERS, "X-CTSTEST-HEADERTEST-BYTETEST1: 26");
+    setProperty(Property.REQUEST, buildRequest(Request.GET, ""));
+    setProperty(Property.SEARCH_STRING, "bytetest1=-128");
+    invoke();
+
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-BYTETEST1: 127");
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-BYTETEST2: -128");
+    setProperty(Property.REQUEST, buildRequest(Request.GET, ""));
+    setProperty(Property.SEARCH_STRING, "bytetest1=127|bytetest2=-128");
+    invoke();
+
+    setProperty(Property.REQUEST_HEADERS, "X-CTSTEST-HEADERTEST-BYTETEST1: 0");
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-BYTETEST2: -128");
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-BYTETEST1: 127");
+    setProperty(Property.REQUEST, buildRequest(Request.GET, ""));
+    setProperty(Property.SEARCH_STRING, "bytetest2=-128");
+    setProperty(Property.UNEXPECTED_RESPONSE_MATCH, "bytetest1");
+    invoke();
+  }
+
+  /*
+   * @testName: headerParamBooleanTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.1; JAXRS:JAVADOC:5;
+   * 
+   * @test_Strategy: Client invokes Request.GET on a sub resource at
+   * /HeaderParamTest; Verify that right Method is invoked.
+   */
+  @Test
+  public void headerParamBooleanTest() throws Fault {
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-BOOLEANTEST1: true");
+    setProperty(Property.REQUEST, buildRequest(Request.GET, ""));
+    setProperty(Property.SEARCH_STRING, "booleantest1=true");
+    invoke();
+
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-BOOLEANTEST1: true");
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-BOOLEANTEST1: false");
+    setProperty(Property.REQUEST, buildRequest(Request.GET, ""));
+    setProperty(Property.SEARCH_STRING, "booleantest1=true");
+    invoke();
+
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-BOOLEANTEST1: false");
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-BOOLEANTEST2: true");
+    setProperty(Property.REQUEST, buildRequest(Request.GET, ""));
+    setProperty(Property.SEARCH_STRING, "booleantest2=true");
+    invoke();
+
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-BOOLEANTEST1: true");
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-BOOLEANTEST2: false");
+    setProperty(Property.REQUEST_HEADERS,
+        "X-CTSTEST-HEADERTEST-BOOLEANTEST1: false");
+    setProperty(Property.REQUEST, buildRequest(Request.GET, ""));
+    setProperty(Property.SEARCH_STRING, "booleantest1=true");
+    invoke();
+  }
+
+  /*
+   * @testName: headerParamEntityWithConstructorTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.2; JAXRS:JAVADOC:6;
+   * JAXRS:JAVADOC:12; JAXRS:JAVADOC:12.1;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void headerParamEntityWithConstructorTest() throws Fault {
+    super.paramEntityWithConstructorTest();
+  }
+
+  /*
+   * @testName: headerParamEntityWithValueOfTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.3; JAXRS:JAVADOC:6;
+   * JAXRS:JAVADOC:12; JAXRS:JAVADOC:12.1;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void headerParamEntityWithValueOfTest() throws Fault {
+    super.paramEntityWithValueOfTest();
+  }
+
+  /*
+   * @testName: headerParamEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.3; JAXRS:JAVADOC:6;
+   * JAXRS:JAVADOC:12; JAXRS:JAVADOC:12.1;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void headerParamEntityWithFromStringTest() throws Fault {
+    super.paramEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: headerParamSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.4; JAXRS:JAVADOC:6;
+   * JAXRS:JAVADOC:12; JAXRS:JAVADOC:12.1;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void headerParamSetEntityWithFromStringTest() throws Fault {
+    super.paramCollectionEntityWithFromStringTest(CollectionName.SET);
+  }
+
+  /*
+   * @testName: headerParamSortedSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.4; JAXRS:JAVADOC:6;
+   * JAXRS:JAVADOC:12; JAXRS:JAVADOC:12.1;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void headerParamSortedSetEntityWithFromStringTest() throws Fault {
+    super.paramCollectionEntityWithFromStringTest(CollectionName.SORTED_SET);
+  }
+
+  /*
+   * @testName: headerParamListEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.4; JAXRS:JAVADOC:6;
+   * JAXRS:JAVADOC:12; JAXRS:JAVADOC:12.1;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void headerParamListEntityWithFromStringTest() throws Fault {
+    super.paramCollectionEntityWithFromStringTest(CollectionName.LIST);
+  }
+
+  /*
+   * @testName: headerFieldParamEntityWithConstructorTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.2; JAXRS:JAVADOC:6;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void headerFieldParamEntityWithConstructorTest() throws Fault {
+    super.fieldEntityWithConstructorTest();
+  }
+
+  /*
+   * @testName: headerFieldParamEntityWithValueOfTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.3; JAXRS:JAVADOC:6;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void headerFieldParamEntityWithValueOfTest() throws Fault {
+    super.fieldEntityWithValueOfTest();
+  }
+
+  /*
+   * @testName: headerFieldParamEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.3; JAXRS:JAVADOC:6;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void headerFieldParamEntityWithFromStringTest() throws Fault {
+    super.fieldEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: headerFieldParamSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.4; JAXRS:JAVADOC:6;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void headerFieldParamSetEntityWithFromStringTest() throws Fault {
+    super.fieldCollectionEntityWithFromStringTest(CollectionName.SET);
+  }
+
+  /*
+   * @testName: headerFieldParamSortedSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.4; JAXRS:JAVADOC:6;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void headerFieldParamSortedSetEntityWithFromStringTest() throws Fault {
+    super.fieldCollectionEntityWithFromStringTest(CollectionName.SORTED_SET);
+  }
+
+  /*
+   * @testName: headerFieldParamListEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.4; JAXRS:JAVADOC:6;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void headerFieldParamListEntityWithFromStringTest() throws Fault {
+    super.fieldCollectionEntityWithFromStringTest(CollectionName.LIST);
+  }
+
+  /*
+   * @testName: headerParamThrowingWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:12.3;
+   * 
+   * @test_Strategy: Exceptions thrown during construction of parameter values
+   * are treated the same as exceptions thrown during construction of field or
+   * bean property values, see Section 3.2.
+   */
+  @Test
+  public void headerParamThrowingWebApplicationExceptionTest() throws Fault {
+    super.paramThrowingWebApplicationExceptionTest();
+  }
+
+  /*
+   * @testName: headerFieldThrowingWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:8;
+   * 
+   * @test_Strategy: A WebApplicationException thrown during construction of
+   * field or property values using 2 or 3 above is processed directly as
+   * described in section 3.3.4.
+   */
+  @Test
+  public void headerFieldThrowingWebApplicationExceptionTest() throws Fault {
+    super.fieldThrowingWebApplicationExceptionTest();
+  }
+
+  /*
+   * @testName: headerParamThrowingIllegalArgumentExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:12.3;
+   * 
+   * @test_Strategy: Exceptions thrown during construction of parameter values
+   * are treated the same as exceptions thrown during construction of field or
+   * bean property values, see section 3.2.
+   */
+  @Test
+  public void headerParamThrowingIllegalArgumentExceptionTest() throws Fault {
+    setProperty(Property.UNORDERED_SEARCH_STRING, Status.BAD_REQUEST.name());
+    super.paramThrowingIllegalArgumentExceptionTest();
+  }
+
+  /*
+   * @testName: headerFieldThrowingIllegalArgumentExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:9; JAXRS:SPEC:9.2; JAXRS:SPEC:10;
+   * 
+   * @test_Strategy: Other exceptions thrown during construction of field or
+   * property values using 2 or 3 above are treated as client errors:
+   *
+   * if the field or property is annotated with @HeaderParam or @CookieParam
+   * then an implementation MUST generate a WebApplicationException that wraps
+   * the thrown exception with a client error response (400 status) and no
+   * entity.
+   */
+  @Test
+  public void headerFieldThrowingIllegalArgumentExceptionTest() throws Fault {
+    setProperty(Property.UNORDERED_SEARCH_STRING, Status.BAD_REQUEST.name());
+    super.fieldThrowingIllegalArgumentExceptionTest();
+  }
+
+  @Override
+  protected String buildRequest(String param) {
+    setProperty(Property.REQUEST_HEADERS, param.replace("=", ":"));
+    return buildRequest(Request.GET, "");
+  }
+
+  @Override
+  protected String getDefaultValueOfParam(String param) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(param).append("=");
+    sb.append(HeaderParamTest.class.getSimpleName());
+    return sb.toString();
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/headerparam/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/headerparam/TSAppConfig.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.headerparam;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.ws.rs.tck.ee.rs.RuntimeExceptionMapper;
+import jakarta.ws.rs.tck.ee.rs.WebApplicationExceptionMapper;
+
+import jakarta.ws.rs.core.Application;
+
+/**
+ *
+ * @author diannejiao
+ */
+public class TSAppConfig extends Application {
+
+  public java.util.Set<java.lang.Class<?>> getClasses() {
+    Set<Class<?>> resources = new HashSet<Class<?>>();
+    resources.add(HeaderParamTest.class);
+    resources.add(RuntimeExceptionMapper.class);
+    resources.add(WebApplicationExceptionMapper.class);
+    return resources;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/headerparam/locator/JAXRSLocatorClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/headerparam/locator/JAXRSLocatorClientIT.java
@@ -1,0 +1,356 @@
+/*
+ * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.headerparam.locator;
+
+import java.io.InputStream;
+import java.io.IOException;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JAXRSLocatorClientIT
+    extends jakarta.ws.rs.tck.ee.rs.headerparam.JAXRSClientIT {
+  private static final long serialVersionUID = 1L;
+
+  public JAXRSLocatorClientIT() {
+    setup();
+    setContextRoot("/jaxrs_ee_rs_headerparam_locator_web/resource/locator");
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  @Deployment(testable = false, name = "jaxrs_ee_rs_headerparam_locator_deployment")
+  public static WebArchive createDeployment() throws IOException{
+
+    InputStream inStream = JAXRSLocatorClientIT.class.getClassLoader().getResourceAsStream("jakarta/ws/rs/tck/ee/rs/headerparam/locator/web.xml.template");
+    String webXml = editWebXmlString(inStream);
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_ee_rs_headerparam_locator_web.war");
+    archive.addClasses(TSAppConfig.class, LocatorResource.class, MiddleResource.class,
+      jakarta.ws.rs.tck.ee.rs.headerparam.HeaderParamTest.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityPrototype.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityWithConstructor.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityWithValueOf.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityWithFromString.class,
+      jakarta.ws.rs.tck.ee.rs.ParamTest.class,
+      jakarta.ws.rs.tck.ee.rs.JaxrsParamClient.CollectionName.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingWebApplicationException.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
+      jakarta.ws.rs.tck.ee.rs.RuntimeExceptionMapper.class,
+      jakarta.ws.rs.tck.ee.rs.WebApplicationExceptionMapper.class
+    );
+    archive.setWebXML(new StringAsset(webXml));
+    return archive;
+
+  }
+
+
+
+  /* Run test */
+  /*
+   * @testName: headerParamStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.1; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3; JAXRS:JAVADOC:3; JAXRS:JAVADOC:5;
+   * 
+   * @test_Strategy: Client invokes HEAD on root resource at /HeaderParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void headerParamStringTest() throws Fault {
+    super.headerParamStringTest();
+  }
+
+  /*
+   * @testName: headerParamNoQueryTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.1; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3; JAXRS:JAVADOC:5;
+   * 
+   * @test_Strategy: Client invokes GET on a resource at /HeaderParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void headerParamNoQueryTest() throws Fault {
+    super.headerParamNoQueryTest();
+  }
+
+  /*
+   * @testName: headerParamIntTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.1; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3; JAXRS:JAVADOC:5;
+   * 
+   * @test_Strategy: Client invokes GET on a resource at /HeaderParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void headerParamIntTest() throws Fault {
+    super.headerParamIntTest();
+  }
+
+  /*
+   * @testName: headerParamDoubleTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.1; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3; JAXRS:JAVADOC:5;
+   * 
+   * @test_Strategy: Client invokes GET on a resource at /HeaderParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void headerParamDoubleTest() throws Fault {
+    super.headerParamDoubleTest();
+  }
+
+  /*
+   * @testName: headerParamFloatTest
+   *
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.1; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3; JAXRS:JAVADOC:5;
+   *
+   * @test_Strategy: Client invokes GET on a resource at /HeaderParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void headerParamFloatTest() throws Fault {
+    super.headerParamFloatTest();
+  }
+
+  /*
+   * @testName: headerParamLongTest
+   *
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.1; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3; JAXRS:JAVADOC:5;
+   *
+   * @test_Strategy: Client invokes GET on a sub resource at /HeaderParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void headerParamLongTest() throws Fault {
+    super.headerParamLongTest();
+  }
+
+  /*
+   * @testName: headerParamShortTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.1; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3; JAXRS:JAVADOC:5;
+   * 
+   * @test_Strategy: Client invokes GET on a sub resource at /HeaderParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void headerParamShortTest() throws Fault {
+    super.headerParamShortTest();
+  }
+
+  /*
+   * @testName: headerParamByteTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.1; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3; JAXRS:JAVADOC:5;
+   * 
+   * @test_Strategy: Client invokes GET on a sub resource at /HeaderParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void headerParamByteTest() throws Fault {
+    super.headerParamByteTest();
+  }
+
+  /*
+   * @testName: headerParamBooleanTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.1; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3; JAXRS:JAVADOC:5;
+   * 
+   * @test_Strategy: Client invokes GET on a sub resource at /HeaderParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void headerParamBooleanTest() throws Fault {
+    super.headerParamBooleanTest();
+  }
+
+  /*
+   * @testName: headerParamEntityWithConstructorTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.2; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3; JAXRS:JAVADOC:6; JAXRS:JAVADOC:12; JAXRS:JAVADOC:12.1;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void headerParamEntityWithConstructorTest() throws Fault {
+    super.headerParamEntityWithConstructorTest();
+  }
+
+  /*
+   * @testName: headerParamEntityWithValueOfTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.3; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3; JAXRS:JAVADOC:6; JAXRS:JAVADOC:12; JAXRS:JAVADOC:12.1;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void headerParamEntityWithValueOfTest() throws Fault {
+    super.headerParamEntityWithValueOfTest();
+  }
+
+  /*
+   * @testName: headerParamEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.3; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3; JAXRS:JAVADOC:6; JAXRS:JAVADOC:12; JAXRS:JAVADOC:12.1;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void headerParamEntityWithFromStringTest() throws Fault {
+    super.headerParamEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: headerParamSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.4; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3; JAXRS:JAVADOC:6; JAXRS:JAVADOC:12; JAXRS:JAVADOC:12.1;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void headerParamSetEntityWithFromStringTest() throws Fault {
+    super.headerParamSetEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: headerParamSortedSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.4; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3; JAXRS:JAVADOC:6; JAXRS:JAVADOC:12; JAXRS:JAVADOC:12.1;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void headerParamSortedSetEntityWithFromStringTest() throws Fault {
+    super.headerParamSortedSetEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: headerParamListEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.4; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3; JAXRS:JAVADOC:6; JAXRS:JAVADOC:12; JAXRS:JAVADOC:12.1;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void headerParamListEntityWithFromStringTest() throws Fault {
+    super.headerParamListEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: headerParamThrowingWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:12.3; JAXRS:SPEC:20; JAXRS:SPEC:20.3;
+   * 
+   * @test_Strategy: Exceptions thrown during construction of parameter values
+   * are treated the same as exceptions thrown during construction of field or
+   * bean property values, see Section 3.2.
+   */
+  @Test
+  public void headerParamThrowingWebApplicationExceptionTest() throws Fault {
+    super.headerParamThrowingWebApplicationExceptionTest();
+  }
+
+  /*
+   * @testName: headerParamThrowingIllegalArgumentExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:12.3; JAXRS:SPEC:20; JAXRS:SPEC:20.3;
+   * 
+   * @test_Strategy: Exceptions thrown during construction of parameter values
+   * are treated the same as exceptions thrown during construction of field or
+   * bean property values, see section 3.2.
+   */
+  @Test
+  public void headerParamThrowingIllegalArgumentExceptionTest() throws Fault {
+    super.headerParamThrowingIllegalArgumentExceptionTest();
+  }
+
+  public void headerFieldParamEntityWithConstructorTest() throws Fault {
+    //do nothing  
+  }
+  public void headerFieldParamEntityWithValueOfTest() throws Fault {
+    //do nothing  
+  }
+  public void headerFieldParamEntityWithFromStringTest() throws Fault {
+    //do nothing  
+  }
+  public void headerFieldParamSetEntityWithFromStringTest() throws Fault {
+    //do nothing  
+  }
+  public void headerFieldParamSortedSetEntityWithFromStringTest() throws Fault {
+    //do nothing  
+  }
+  public void headerFieldParamListEntityWithFromStringTest() throws Fault {
+    //do nothing  
+  }
+  public void headerFieldThrowingWebApplicationExceptionTest() throws Fault {
+    //do nothing  
+  }
+  public void headerFieldThrowingIllegalArgumentExceptionTest() throws Fault {
+    //do nothing  
+  }
+  
+  /**
+   * change the GET request to POST request so that the new resources will
+   * handle it
+   */
+  @Override
+  protected String buildRequest(Request type, String... path) {
+    return super.buildRequest(Request.POST, path);
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/headerparam/locator/LocatorResource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/headerparam/locator/LocatorResource.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.headerparam.locator;
+
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+
+import jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingExceptionGivenByName;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingWebApplicationException;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityWithConstructor;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityWithFromString;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityWithValueOf;
+
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.Path;
+
+@Path("resource")
+public class LocatorResource extends MiddleResource {
+
+  @Path("locator")
+  public MiddleResource locatorHasArguments(
+      @HeaderParam("X-CTSTEST-HEADERTEST-STRINGTEST1") @DefaultValue("default") String stringheader1,
+      @HeaderParam("X-CTSTEST-HEADERTEST-stringtest2") @DefaultValue("default") String stringheader2,
+      @HeaderParam("X-CTSTEST-HEADERTEST-inttest1") int intheader1,
+      @HeaderParam("X-CTSTEST-HEADERTEST-inttest2") int intheader2,
+      @HeaderParam("X-CTSTEST-HEADERTEST-bytetest1") byte byteheader1,
+      @HeaderParam("X-CTSTEST-HEADERTEST-bytetest2") byte byteheader2,
+      @HeaderParam("X-CTSTEST-HEADERTEST-doubletest1") double doubleheader1,
+      @HeaderParam("X-CTSTEST-HEADERTEST-doubletest2") double doubleheader2,
+      @HeaderParam("X-CTSTEST-HEADERTEST-floattest1") float floatheader1,
+      @HeaderParam("X-CTSTEST-HEADERTEST-floattest2") float floatheader2,
+      @HeaderParam("X-CTSTEST-HEADERTEST-shorttest1") short shortheader1,
+      @HeaderParam("X-CTSTEST-HEADERTEST-shorttest2") short shortheader2,
+      @HeaderParam("X-CTSTEST-HEADERTEST-longtest1") long longheader1,
+      @HeaderParam("X-CTSTEST-HEADERTEST-longtest2") long longheader2,
+      @HeaderParam("X-CTSTEST-HEADERTEST-booleantest1") boolean booleanheader1,
+      @HeaderParam("X-CTSTEST-HEADERTEST-booleantest2") boolean booleanheader2,
+      @DefaultValue("HeaderParamTest") @HeaderParam("ParamEntityWithConstructor") ParamEntityWithConstructor paramEntityWithConstructor,
+      @DefaultValue("HeaderParamTest") @HeaderParam("ParamEntityWithFromString") ParamEntityWithFromString paramEntityWithFromString,
+      @DefaultValue("HeaderParamTest") @HeaderParam("ParamEntityWithValueOf") ParamEntityWithValueOf paramEntityWithValueOf,
+      @DefaultValue("HeaderParamTest") @HeaderParam("SetParamEntityWithFromString") Set<ParamEntityWithFromString> setParamEntityWithFromString,
+      @DefaultValue("HeaderParamTest") @HeaderParam("SortedSetParamEntityWithFromString") SortedSet<ParamEntityWithFromString> sortedSetParamEntityWithFromString,
+      @DefaultValue("HeaderParamTest") @HeaderParam("ListParamEntityWithFromString") List<ParamEntityWithFromString> listParamEntityWithFromString,
+      @HeaderParam("ParamEntityThrowingWebApplicationException") ParamEntityThrowingWebApplicationException paramEntityThrowingWebApplicationException,
+      @HeaderParam("ParamEntityThrowingExceptionGivenByName") ParamEntityThrowingExceptionGivenByName paramEntityThrowingExceptionGivenByName) {
+    return new MiddleResource(stringheader1, stringheader2, intheader1,
+        intheader2, byteheader1, byteheader2, doubleheader1, doubleheader2,
+        floatheader1, floatheader2, shortheader1, shortheader2, longheader1,
+        longheader2, booleanheader1, booleanheader2, paramEntityWithConstructor,
+        paramEntityWithFromString, paramEntityWithValueOf,
+        setParamEntityWithFromString, sortedSetParamEntityWithFromString,
+        listParamEntityWithFromString,
+        paramEntityThrowingWebApplicationException,
+        paramEntityThrowingExceptionGivenByName);
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/headerparam/locator/MiddleResource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/headerparam/locator/MiddleResource.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.headerparam.locator;
+
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+
+import jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingExceptionGivenByName;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingWebApplicationException;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityWithConstructor;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityWithFromString;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityWithValueOf;
+import jakarta.ws.rs.tck.ee.rs.headerparam.HeaderParamTest;
+
+import jakarta.ws.rs.POST;
+
+public class MiddleResource extends HeaderParamTest {
+
+  private final String returnValue;
+
+  public MiddleResource() {
+    returnValue = null;
+  }
+
+  protected MiddleResource(String stringheader1, String stringheader2,
+      int intheader1, int intheader2, byte byteheader1, byte byteheader2,
+      double doubleheader1, double doubleheader2, float floatheader1,
+      float floatheader2, short shortheader1, short shortheader2,
+      long longheader1, long longheader2, boolean booleanheader1,
+      boolean booleanheader2,
+      ParamEntityWithConstructor paramEntityWithConstructor,
+      ParamEntityWithFromString paramEntityWithFromString,
+      ParamEntityWithValueOf paramEntityWithValueOf,
+      Set<ParamEntityWithFromString> setParamEntityWithFromString,
+      SortedSet<ParamEntityWithFromString> sortedSetParamEntityWithFromString,
+      List<ParamEntityWithFromString> listParamEntityWithFromString,
+      ParamEntityThrowingWebApplicationException paramEntityThrowingWebApplicationException,
+      ParamEntityThrowingExceptionGivenByName paramEntityThrowingExceptionGivenByName) {
+    returnValue = stringParamHandling(stringheader1, stringheader2, intheader1,
+        intheader2, byteheader1, byteheader2, doubleheader1, doubleheader2,
+        floatheader1, floatheader2, shortheader1, shortheader2, longheader1,
+        longheader2, booleanheader1, booleanheader2, paramEntityWithConstructor,
+        paramEntityWithFromString, paramEntityWithValueOf,
+        setParamEntityWithFromString, sortedSetParamEntityWithFromString,
+        listParamEntityWithFromString,
+        paramEntityThrowingWebApplicationException,
+        paramEntityThrowingExceptionGivenByName);
+  }
+
+  @POST
+  public String returnValue() {
+    return returnValue;
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/headerparam/locator/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/headerparam/locator/TSAppConfig.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.headerparam.locator;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.ws.rs.tck.ee.rs.RuntimeExceptionMapper;
+import jakarta.ws.rs.tck.ee.rs.WebApplicationExceptionMapper;
+
+import jakarta.ws.rs.core.Application;
+
+public class TSAppConfig extends Application {
+
+  public java.util.Set<java.lang.Class<?>> getClasses() {
+    Set<Class<?>> resources = new HashSet<Class<?>>();
+    resources.add(LocatorResource.class);
+    resources.add(RuntimeExceptionMapper.class);
+    resources.add(WebApplicationExceptionMapper.class);
+    return resources;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/headerparam/sub/JAXRSSubClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/headerparam/sub/JAXRSSubClientIT.java
@@ -1,0 +1,466 @@
+/*
+ * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+package jakarta.ws.rs.tck.ee.rs.headerparam.sub;
+
+import java.io.InputStream;
+import java.io.IOException;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JAXRSSubClientIT
+    extends jakarta.ws.rs.tck.ee.rs.headerparam.JAXRSClientIT {
+
+  private static final long serialVersionUID = -7534318281215084279L;
+
+  public JAXRSSubClientIT() {
+    setup();
+    setContextRoot("/jaxrs_ee_rs_headerparam_sub_web/resource/subresource");
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  @Deployment(testable = false, name = "jaxrs_ee_rs_headerparam_sub_deployment")
+  public static WebArchive createDeployment() throws IOException{
+
+    InputStream inStream = JAXRSSubClientIT.class.getClassLoader().getResourceAsStream("jakarta/ws/rs/tck/ee/rs/headerparam/sub/web.xml.template");
+    String webXml = editWebXmlString(inStream);
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_ee_rs_headerparam_sub_web.war");
+    archive.addClasses(TSAppConfig.class, SubResource.class,
+      jakarta.ws.rs.tck.ee.rs.headerparam.HeaderParamTest.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityPrototype.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityWithConstructor.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityWithValueOf.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityWithFromString.class,
+      jakarta.ws.rs.tck.ee.rs.ParamTest.class,
+      jakarta.ws.rs.tck.ee.rs.JaxrsParamClient.CollectionName.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingWebApplicationException.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
+      jakarta.ws.rs.tck.ee.rs.RuntimeExceptionMapper.class,
+      jakarta.ws.rs.tck.ee.rs.WebApplicationExceptionMapper.class
+);
+    archive.setWebXML(new StringAsset(webXml));
+    return archive;
+
+  }
+
+
+
+  /* Run test */
+  /*
+   * @testName: headerParamStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.1; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:JAVADOC:3; JAXRS:JAVADOC:5;
+   * 
+   * @test_Strategy: Client invokes HEAD on root resource at /HeaderParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void headerParamStringTest() throws Fault {
+    super.headerParamStringTest();
+  }
+
+  /*
+   * @testName: headerParamNoQueryTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.1; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:JAVADOC:5;
+   * 
+   * @test_Strategy: Client invokes GET on a resource at /HeaderParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void headerParamNoQueryTest() throws Fault {
+    super.headerParamNoQueryTest();
+  }
+
+  /*
+   * @testName: headerParamIntTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.1; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:JAVADOC:5;
+   * 
+   * @test_Strategy: Client invokes GET on a resource at /HeaderParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void headerParamIntTest() throws Fault {
+    super.headerParamIntTest();
+  }
+
+  /*
+   * @testName: headerParamDoubleTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.1; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:JAVADOC:5;
+   * 
+   * @test_Strategy: Client invokes GET on a resource at /HeaderParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void headerParamDoubleTest() throws Fault {
+    super.headerParamDoubleTest();
+  }
+
+  /*
+   * @testName: headerParamFloatTest
+   *
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.1; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:JAVADOC:5;
+   *
+   * @test_Strategy: Client invokes GET on a resource at /HeaderParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void headerParamFloatTest() throws Fault {
+    super.headerParamFloatTest();
+  }
+
+  /*
+   * @testName: headerParamLongTest
+   *
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.1; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:JAVADOC:5;
+   *
+   * @test_Strategy: Client invokes GET on a sub resource at /HeaderParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void headerParamLongTest() throws Fault {
+    super.headerParamLongTest();
+  }
+
+  /*
+   * @testName: headerParamShortTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.1; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:JAVADOC:5;
+   * 
+   * @test_Strategy: Client invokes GET on a sub resource at /HeaderParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void headerParamShortTest() throws Fault {
+    super.headerParamShortTest();
+  }
+
+  /*
+   * @testName: headerParamByteTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.1; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:JAVADOC:5;
+   * 
+   * @test_Strategy: Client invokes GET on a sub resource at /HeaderParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void headerParamByteTest() throws Fault {
+    super.headerParamByteTest();
+  }
+
+  /*
+   * @testName: headerParamBooleanTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.1; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:JAVADOC:5;
+   * 
+   * @test_Strategy: Client invokes GET on a sub resource at /HeaderParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void headerParamBooleanTest() throws Fault {
+    super.headerParamBooleanTest();
+  }
+
+  /*
+   * @testName: headerParamEntityWithConstructorTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.2; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:JAVADOC:6; JAXRS:JAVADOC:12; JAXRS:JAVADOC:12.1;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void headerParamEntityWithConstructorTest() throws Fault {
+    super.headerParamEntityWithConstructorTest();
+  }
+
+  /*
+   * @testName: headerParamEntityWithValueOfTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.3; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:JAVADOC:6; JAXRS:JAVADOC:12; JAXRS:JAVADOC:12.1;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void headerParamEntityWithValueOfTest() throws Fault {
+    super.headerParamEntityWithValueOfTest();
+  }
+
+  /*
+   * @testName: headerParamEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.3; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:JAVADOC:6; JAXRS:JAVADOC:12; JAXRS:JAVADOC:12.1;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void headerParamEntityWithFromStringTest() throws Fault {
+    super.headerParamEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: headerParamSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.4; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:JAVADOC:6; JAXRS:JAVADOC:12; JAXRS:JAVADOC:12.1;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void headerParamSetEntityWithFromStringTest() throws Fault {
+    super.headerParamSetEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: headerParamSortedSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.4; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:JAVADOC:6; JAXRS:JAVADOC:12; JAXRS:JAVADOC:12.1;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void headerParamSortedSetEntityWithFromStringTest() throws Fault {
+    super.headerParamSortedSetEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: headerParamListEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.4; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:JAVADOC:6; JAXRS:JAVADOC:12; JAXRS:JAVADOC:12.1;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void headerParamListEntityWithFromStringTest() throws Fault {
+    super.headerParamListEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: headerFieldParamEntityWithConstructorTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.2; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:SPEC:4; JAXRS:JAVADOC:6;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void headerFieldParamEntityWithConstructorTest() throws Fault {
+    super.headerFieldParamEntityWithConstructorTest();
+  }
+
+  /*
+   * @testName: headerFieldParamEntityWithValueOfTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.3; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:SPEC:4; JAXRS:JAVADOC:6;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   * 
+   * An implementation is only required to set the annotated field and bean
+   * property values of instances created by the implementation runtime. (Check
+   * the resource with resource locator is injected field properties)
+   */
+  @Test
+  public void headerFieldParamEntityWithValueOfTest() throws Fault {
+    super.headerFieldParamEntityWithValueOfTest();
+  }
+
+  /*
+   * @testName: headerFieldParamEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.3; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:SPEC:4; JAXRS:JAVADOC:6;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   * 
+   * An implementation is only required to set the annotated field and bean
+   * property values of instances created by the implementation runtime. (Check
+   * the resource with resource locator is injected field properties)
+   */
+  @Test
+  public void headerFieldParamEntityWithFromStringTest() throws Fault {
+    super.headerFieldParamEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: headerFieldParamSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.4; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:SPEC:4; JAXRS:JAVADOC:6;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   * 
+   * An implementation is only required to set the annotated field and bean
+   * property values of instances created by the implementation runtime. (Check
+   * the resource with resource locator is injected field properties)
+   */
+  @Test
+  public void headerFieldParamSetEntityWithFromStringTest() throws Fault {
+    super.headerFieldParamSetEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: headerFieldParamSortedSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.4; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:SPEC:4; JAXRS:JAVADOC:6;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   * 
+   * An implementation is only required to set the annotated field and bean
+   * property values of instances created by the implementation runtime. (Check
+   * the resource with resource locator is injected field properties)
+   */
+  @Test
+  public void headerFieldParamSortedSetEntityWithFromStringTest() throws Fault {
+    super.headerFieldParamSortedSetEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: headerFieldParamListEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.5; JAXRS:SPEC:5.4; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:SPEC:4; JAXRS:JAVADOC:6;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   * 
+   * An implementation is only required to set the annotated field and bean
+   * property values of instances created by the implementation runtime. (Check
+   * the resource with resource locator is injected field properties)
+   */
+  @Test
+  public void headerFieldParamListEntityWithFromStringTest() throws Fault {
+    super.headerFieldParamListEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: headerParamThrowingWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:12.3; JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Exceptions thrown during construction of parameter values
+   * are treated the same as exceptions thrown during construction of field or
+   * bean property values, see Section 3.2.
+   */
+  @Test
+  public void headerParamThrowingWebApplicationExceptionTest() throws Fault {
+    super.headerParamThrowingWebApplicationExceptionTest();
+  }
+
+  /*
+   * @testName: headerFieldThrowingWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:8; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:SPEC:4;
+   * 
+   * @test_Strategy: A WebApplicationException thrown during construction of
+   * field or property values using 2 or 3 above is processed directly as
+   * described in section 3.3.4.
+   * 
+   * An implementation is only required to set the annotated field and bean
+   * property values of instances created by the implementation runtime. (Check
+   * the resource with resource locator is injected field properties)
+   */
+  @Test
+  public void headerFieldThrowingWebApplicationExceptionTest() throws Fault {
+    super.headerFieldThrowingWebApplicationExceptionTest();
+  }
+
+  /*
+   * @testName: headerParamThrowingIllegalArgumentExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:12.3; JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Exceptions thrown during construction of parameter values
+   * are treated the same as exceptions thrown during construction of field or
+   * bean property values, see section 3.2.
+   */
+  @Test
+  public void headerParamThrowingIllegalArgumentExceptionTest() throws Fault {
+    super.headerParamThrowingIllegalArgumentExceptionTest();
+  }
+
+  /*
+   * @testName: headerFieldThrowingIllegalArgumentExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:9; JAXRS:SPEC:9.2; JAXRS:SPEC:10; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:SPEC:4;
+   * 
+   * @test_Strategy: Other exceptions thrown during construction of field or
+   * property values using 2 or 3 above are treated as client errors:
+   *
+   * if the field or property is annotated with @HeaderParam or @CookieParam
+   * then an implementation MUST generate a WebApplicationException that wraps
+   * the thrown exception with a client error response (400 status) and no
+   * entity.
+   *
+   * An implementation is only required to set the annotated field and bean
+   * property values of instances created by the implementation runtime. (Check
+   * the resource with resource locator is injected field properties)
+   */
+  @Test
+  public void headerFieldThrowingIllegalArgumentExceptionTest() throws Fault {
+    super.headerFieldThrowingIllegalArgumentExceptionTest();
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/headerparam/sub/SubResource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/headerparam/sub/SubResource.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.headerparam.sub;
+
+import jakarta.ws.rs.tck.ee.rs.headerparam.HeaderParamTest;
+
+import jakarta.ws.rs.Path;
+
+@Path("resource")
+public class SubResource extends HeaderParamTest {
+
+  @Path("subresource")
+  public SubResource subresource() {
+    return this;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/headerparam/sub/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/headerparam/sub/TSAppConfig.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.headerparam.sub;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.ws.rs.tck.ee.rs.RuntimeExceptionMapper;
+import jakarta.ws.rs.tck.ee.rs.WebApplicationExceptionMapper;
+
+import jakarta.ws.rs.core.Application;
+
+public class TSAppConfig extends Application {
+
+  public java.util.Set<java.lang.Class<?>> getClasses() {
+    Set<Class<?>> resources = new HashSet<Class<?>>();
+    resources.add(SubResource.class);
+    resources.add(RuntimeExceptionMapper.class);
+    resources.add(WebApplicationExceptionMapper.class);
+    return resources;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/matrixparam/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/matrixparam/JAXRSClientIT.java
@@ -1,0 +1,515 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+package jakarta.ws.rs.tck.ee.rs.matrixparam;
+
+import jakarta.ws.rs.tck.ee.rs.JaxrsParamClient;
+
+import jakarta.ws.rs.core.Response.Status;
+
+import java.io.InputStream;
+import java.io.IOException;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JAXRSClientIT extends JaxrsParamClient {
+
+  private static final long serialVersionUID = 1L;
+
+  public JAXRSClientIT() {
+    setup();
+    setContextRoot("/jaxrs_ee_rs_matrixparam_web/MatrixParamTest");
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  @Deployment(testable = false, name = "jaxrs_ee_rs_matrixparam_deployment")
+  public static WebArchive createDeployment() throws IOException{
+
+    InputStream inStream = JAXRSClientIT.class.getClassLoader().getResourceAsStream("jakarta/ws/rs/tck/ee/rs/matrixparam/web.xml.template");
+    String webXml = editWebXmlString(inStream);
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_ee_rs_matrixparam_web.war");
+    archive.addClasses(TSAppConfig.class, MatrixParamTest.class,
+      jakarta.ws.rs.tck.ee.rs.matrixparam.MatrixParamTest.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityPrototype.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityWithConstructor.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityWithValueOf.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityWithFromString.class,
+      jakarta.ws.rs.tck.ee.rs.ParamTest.class,
+      jakarta.ws.rs.tck.ee.rs.JaxrsParamClient.CollectionName.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingWebApplicationException.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
+      jakarta.ws.rs.tck.ee.rs.RuntimeExceptionMapper.class,
+      jakarta.ws.rs.tck.ee.rs.WebApplicationExceptionMapper.class
+);
+    archive.setWebXML(new StringAsset(webXml));
+    return archive;
+
+  }
+
+
+
+  /* Run test */
+  /*
+   * @testName: matrixParamStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.1; JAXRS:JAVADOC:7;
+   * 
+   * @test_Strategy: Client invokes GET on root resource at /MatrixParamTest;
+   * Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamStringTest() throws Fault {
+    setProperty(Property.REQUEST, buildRequest("stringtest=cts"));
+    setProperty(Property.SEARCH_STRING, "stringtest=cts");
+    invoke();
+
+    setProperty(Property.REQUEST,
+        buildRequest("stringtest1=cts;stringtest=ri_impl"));
+    setProperty(Property.SEARCH_STRING, "stringtest=ri_impl|stringtest1=cts");
+    invoke();
+  }
+
+  /*
+   * @testName: matrixParamIntTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.1; JAXRS:JAVADOC:7;
+   * 
+   * @test_Strategy: Client invokes GET on a resource at /MatrixParamTest;
+   * Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamIntTest() throws Fault {
+    setProperty(Property.REQUEST, buildRequest("inttest1=2147483647"));
+    setProperty(Property.SEARCH_STRING, "inttest1=2147483647");
+    invoke();
+
+    setProperty(Property.REQUEST,
+        buildRequest("inttest1=2147483647;inttest2=-2147483648"));
+    setProperty(Property.SEARCH_STRING,
+        "inttest1=2147483647|inttest2=-2147483648");
+    invoke();
+
+  }
+
+  /*
+   * @testName: matrixParamDoubleTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.1; JAXRS:JAVADOC:7;
+   * 
+   * @test_Strategy: Client invokes GET on a resource at /MatrixParamTest;
+   * Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamDoubleTest() throws Fault {
+    setProperty(Property.REQUEST, buildRequest("doubletest1=123"));
+    setProperty(Property.SEARCH_STRING, "doubletest1=123.0");
+    invoke();
+
+    setProperty(Property.REQUEST,
+        buildRequest("doubletest1=12.345;doubletest2=34.567"));
+    setProperty(Property.SEARCH_STRING,
+        "doubletest1=12.345|doubletest2=34.567");
+    invoke();
+
+  }
+
+  /*
+   * @testName: matrixParamFloatTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.1; JAXRS:JAVADOC:7;
+   * 
+   * @test_Strategy: Client invokes GET on a resource at /MatrixParamTest;
+   * Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamFloatTest() throws Fault {
+    setProperty(Property.REQUEST, buildRequest("floattest1=123"));
+    setProperty(Property.SEARCH_STRING, "floattest1=123.0");
+    invoke();
+
+    setProperty(Property.REQUEST,
+        buildRequest("floattest1=12.345;floattest2=34.567"));
+    setProperty(Property.SEARCH_STRING, "floattest1=12.345|floattest2=34.567");
+    invoke();
+
+  }
+
+  /*
+   * @testName: matrixParamLongTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.1; JAXRS:JAVADOC:7;
+   * 
+   * @test_Strategy: Client invokes GET on a resource at /MatrixParamTest;
+   * Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamLongTest() throws Fault {
+    setProperty(Property.REQUEST,
+        buildRequest("longtest=-9223372036854775808"));
+    setProperty(Property.SEARCH_STRING, "longtest=-9223372036854775808");
+    invoke();
+
+    setProperty(Property.REQUEST, buildRequest(
+        "longtest1=-9223372036854775808;longtest2=9223372036854775807"));
+    setProperty(Property.SEARCH_STRING,
+        "longtest1=-9223372036854775808|longtest2=9223372036854775807");
+    invoke();
+  }
+
+  /*
+   * @testName: matrixParamShortTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.1; JAXRS:JAVADOC:7;
+   * 
+   * @test_Strategy: Client invokes GET on a resource at /MatrixParamTest;
+   * Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamShortTest() throws Fault {
+    setProperty(Property.REQUEST, buildRequest("shorttest=-32768"));
+    setProperty(Property.SEARCH_STRING, "shorttest=-32768");
+    invoke();
+
+    setProperty(Property.REQUEST,
+        buildRequest("shorttest1=32767;shorttest2=-32768"));
+    setProperty(Property.SEARCH_STRING, "shorttest1=32767|shorttest2=-32768");
+    invoke();
+  }
+
+  /*
+   * @testName: matrixParamByteTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.1; JAXRS:JAVADOC:7;
+   * 
+   * @test_Strategy: Client invokes GET on a resource at /MatrixParamTest;
+   * Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamByteTest() throws Fault {
+    setProperty(Property.REQUEST, buildRequest("bytetest=127"));
+    setProperty(Property.SEARCH_STRING, "bytetest=127");
+    invoke();
+
+    setProperty(Property.REQUEST, buildRequest("bytetest1=123;bytetest2=-128"));
+    setProperty(Property.SEARCH_STRING, "bytetest1=123|bytetest2=-128");
+    invoke();
+  }
+
+  /*
+   * @testName: matrixParamBooleanTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.1; JAXRS:JAVADOC:7;
+   * 
+   * @test_Strategy: Client invokes GET on a resource at /MatrixParamTest;
+   * Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamBooleanTest() throws Fault {
+    setProperty(Property.REQUEST, buildRequest("booleantest=true"));
+    setProperty(Property.SEARCH_STRING, "booleantest=true");
+    invoke();
+
+    setProperty(Property.REQUEST,
+        buildRequest("booleantest1=false;booleantest2=true"));
+    setProperty(Property.SEARCH_STRING, "booleantest1=false|booleantest2=true");
+    invoke();
+  }
+
+  /*
+   * @testName: matrixParamEntityWithConstructorTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.2; JAXRS:JAVADOC:6;
+   * JAXRS:JAVADOC:12; JAXRS:JAVADOC:12.1;
+   * 
+   * @test_Strategy: Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamEntityWithConstructorTest() throws Fault {
+    paramEntityWithConstructorTest();
+  }
+
+  /*
+   * @testName: matrixParamEntityWithValueOfTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.3; JAXRS:JAVADOC:6;
+   * JAXRS:JAVADOC:12; JAXRS:JAVADOC:12.1;
+   * 
+   * @test_Strategy: Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamEntityWithValueOfTest() throws Fault {
+    paramEntityWithValueOfTest();
+  }
+
+  /*
+   * @testName: matrixParamEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.3; JAXRS:JAVADOC:6;
+   * JAXRS:JAVADOC:12; JAXRS:JAVADOC:12.1;
+   * 
+   * @test_Strategy: Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamEntityWithFromStringTest() throws Fault {
+    paramEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: matrixParamSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.4; JAXRS:JAVADOC:6;
+   * 
+   * @test_Strategy: Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamSetEntityWithFromStringTest() throws Fault {
+    paramCollectionEntityWithFromStringTest(CollectionName.SET);
+  }
+
+  /*
+   * @testName: matrixParamSortedSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.4; JAXRS:JAVADOC:6;
+   * JAXRS:JAVADOC:12; JAXRS:JAVADOC:12.1;
+   * 
+   * @test_Strategy: Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamSortedSetEntityWithFromStringTest() throws Fault {
+    paramCollectionEntityWithFromStringTest(CollectionName.SORTED_SET);
+  }
+
+  /*
+   * @testName: matrixParamListEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.4; JAXRS:JAVADOC:6;
+   * JAXRS:JAVADOC:12; JAXRS:JAVADOC:12.1;
+   * 
+   * @test_Strategy: Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamListEntityWithFromStringTest() throws Fault {
+    paramCollectionEntityWithFromStringTest(CollectionName.LIST);
+  }
+
+  /*
+   * @testName: matrixFieldParamEntityWithConstructorTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.2; JAXRS:JAVADOC:6;
+   * 
+   * @test_Strategy: Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixFieldParamEntityWithConstructorTest() throws Fault {
+    fieldEntityWithConstructorTest();
+  }
+
+  /*
+   * @testName: matrixFieldParamEntityWithValueOfTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.3; JAXRS:JAVADOC:6;
+   * 
+   * @test_Strategy: Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixFieldParamEntityWithValueOfTest() throws Fault {
+    fieldEntityWithValueOfTest();
+  }
+
+  /*
+   * @testName: matrixFieldParamEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.3; JAXRS:JAVADOC:6;
+   * 
+   * @test_Strategy: Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixFieldParamEntityWithFromStringTest() throws Fault {
+    fieldEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: matrixFieldParamSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.4; JAXRS:JAVADOC:6;
+   * 
+   * @test_Strategy: Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixFieldParamSetEntityWithFromStringTest() throws Fault {
+    fieldCollectionEntityWithFromStringTest(CollectionName.SET);
+  }
+
+  /*
+   * @testName: matrixFieldParamSortedSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.4; JAXRS:JAVADOC:6;
+   * 
+   * @test_Strategy: Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixFieldParamSortedSetEntityWithFromStringTest() throws Fault {
+    fieldCollectionEntityWithFromStringTest(CollectionName.SORTED_SET);
+  }
+
+  /*
+   * @testName: matrixFieldParamListEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.4; JAXRS:JAVADOC:6;
+   * 
+   * @test_Strategy: Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixFieldParamListEntityWithFromStringTest() throws Fault {
+    fieldCollectionEntityWithFromStringTest(CollectionName.LIST);
+  }
+
+  /*
+   * @testName: matrixParamEntityWithEncodedTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:7; JAXRS:SPEC:12.2;
+   * 
+   * @test_Strategy: Verify that named MatrixParam @Encoded is handled
+   */
+  @Test
+  public void matrixParamEntityWithEncodedTest() throws Fault {
+    super.paramEntityWithEncodedTest();
+  }
+
+  /*
+   * @testName: matrixFieldParamEntityWithEncodedTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:7;
+   * 
+   * @test_Strategy: Verify that named MatrixParam @Encoded is handled
+   */
+  @Test
+  public void matrixFieldParamEntityWithEncodedTest() throws Fault {
+    super.fieldEntityWithEncodedTest();
+  }
+
+  /*
+   * @testName: matrixParamThrowingWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:12.3;
+   * 
+   * @test_Strategy: Exceptions thrown during construction of parameter values
+   * are treated the same as exceptions thrown during construction of field or
+   * bean property values, see Section 3.2.
+   */
+  @Test
+  public void matrixParamThrowingWebApplicationExceptionTest() throws Fault {
+    super.paramThrowingWebApplicationExceptionTest();
+  }
+
+  /*
+   * @testName: matrixFieldThrowingWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:8;
+   * 
+   * @test_Strategy: A WebApplicationException thrown during construction of
+   * field or property values using 2 or 3 above is processed directly as
+   * described in section 3.3.4.
+   */
+  @Test
+  public void matrixFieldThrowingWebApplicationExceptionTest() throws Fault {
+    super.fieldThrowingWebApplicationExceptionTest();
+  }
+
+  /*
+   * @testName: matrixParamThrowingIllegalArgumentExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:12.3;
+   * 
+   * @test_Strategy: Exceptions thrown during construction of parameter values
+   * are treated the same as exceptions thrown during construction of field or
+   * bean property values, see section 3.2.
+   */
+  @Test
+  public void matrixParamThrowingIllegalArgumentExceptionTest() throws Fault {
+    setProperty(Property.UNORDERED_SEARCH_STRING, Status.NOT_FOUND.name());
+    super.paramThrowingIllegalArgumentExceptionTest();
+  }
+
+  /*
+   * @testName: matrixFieldThrowingIllegalArgumentExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:9; JAXRS:SPEC:9.1; JAXRS:SPEC:10;
+   * 
+   * @test_Strategy: Other exceptions thrown during construction of field or
+   * property values using 2 or 3 above are treated as client errors:
+   * 
+   * if the field or property is annotated with @MatrixParam,
+   * 
+   * @QueryParam or @PathParam then an implementation MUST generate a
+   * WebApplicationException that wraps the thrown exception with a not found
+   * response (404 status) and no entity;
+   */
+  @Test
+  public void matrixFieldThrowingIllegalArgumentExceptionTest() throws Fault {
+    setProperty(Property.UNORDERED_SEARCH_STRING, Status.NOT_FOUND.name());
+    super.fieldThrowingIllegalArgumentExceptionTest();
+  }
+
+  @Override
+  protected String buildRequest(String param) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(Request.GET.name()).append(" ").append(_contextRoot);
+    sb.append(";").append(param).append(HTTP11);
+    return sb.toString();
+  }
+
+  @Override
+  protected String getDefaultValueOfParam(String param) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(param).append("=");
+    sb.append(MatrixParamTest.class.getSimpleName());
+    return sb.toString();
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/matrixparam/MatrixParamTest.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/matrixparam/MatrixParamTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.matrixparam;
+
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+
+import jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingExceptionGivenByName;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingWebApplicationException;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityWithConstructor;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityWithFromString;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityWithValueOf;
+import jakarta.ws.rs.tck.ee.rs.ParamTest;
+
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.Encoded;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.MatrixParam;
+import jakarta.ws.rs.Path;
+
+@Path(value = "/MatrixParamTest")
+public class MatrixParamTest extends ParamTest {
+
+  @DefaultValue("MatrixParamTest")
+  @MatrixParam("FieldParamEntityWithConstructor")
+  ParamEntityWithConstructor fieldParamEntityWithConstructor;
+
+  @Encoded
+  @DefaultValue("MatrixParamTest")
+  @MatrixParam("FieldParamEntityWithFromString")
+  ParamEntityWithFromString fieldParamEntityWithFromString;
+
+  @DefaultValue("MatrixParamTest")
+  @MatrixParam("FieldParamEntityWithValueOf")
+  ParamEntityWithValueOf fieldParamEntityWithValueOf;
+
+  @DefaultValue("MatrixParamTest")
+  @MatrixParam("FieldSetParamEntityWithFromString")
+  Set<ParamEntityWithFromString> fieldSetParamEntityWithFromString;
+
+  @DefaultValue("MatrixParamTest")
+  @MatrixParam("FieldSortedSetParamEntityWithFromString")
+  SortedSet<ParamEntityWithFromString> fieldSortedSetParamEntityWithFromString;
+
+  @DefaultValue("MatrixParamTest")
+  @MatrixParam("FieldListParamEntityWithFromString")
+  List<ParamEntityWithFromString> fieldListParamEntityWithFromString;
+
+  @MatrixParam("FieldParamEntityThrowingWebApplicationException")
+  public ParamEntityThrowingWebApplicationException fieldEntityThrowingWebApplicationException;
+
+  @MatrixParam("FieldParamEntityThrowingExceptionGivenByName")
+  public ParamEntityThrowingExceptionGivenByName fieldEntityThrowingExceptionGivenByName;
+
+  @GET
+  public String stringParamHandling(
+      @MatrixParam("stringtest") String stringheader,
+      @MatrixParam("stringtest1") String stringheader1,
+      @MatrixParam("inttest") int intheader,
+      @MatrixParam("inttest1") int intheader1,
+      @MatrixParam("inttest2") int intheader2,
+      @MatrixParam("bytetest") byte byteheader,
+      @MatrixParam("bytetest1") byte byteheader1,
+      @MatrixParam("bytetest2") byte byteheader2,
+      @MatrixParam("doubletest") double doubleheader,
+      @MatrixParam("doubletest1") double doubleheader1,
+      @MatrixParam("doubletest2") double doubleheader2,
+      @MatrixParam("floattest") float floatheader,
+      @MatrixParam("floattest1") float floatheader1,
+      @MatrixParam("floattest2") float floatheader2,
+      @MatrixParam("shorttest") short shortheader,
+      @MatrixParam("shorttest1") short shortheader1,
+      @MatrixParam("shorttest2") short shortheader2,
+      @MatrixParam("longtest") long longheader,
+      @MatrixParam("longtest1") long longheader1,
+      @MatrixParam("longtest2") long longheader2,
+      @MatrixParam("booleantest") boolean booleanheader,
+      @MatrixParam("booleantest1") boolean booleanheader1,
+      @MatrixParam("booleantest2") boolean booleanheader2,
+      @DefaultValue("MatrixParamTest") @MatrixParam("ParamEntityWithConstructor") ParamEntityWithConstructor paramEntityWithConstructor,
+      @Encoded @DefaultValue("MatrixParamTest") @MatrixParam("ParamEntityWithFromString") ParamEntityWithFromString paramEntityWithFromString,
+      @DefaultValue("MatrixParamTest") @MatrixParam("ParamEntityWithValueOf") ParamEntityWithValueOf paramEntityWithValueOf,
+      @DefaultValue("MatrixParamTest") @MatrixParam("SetParamEntityWithFromString") Set<ParamEntityWithFromString> setParamEntityWithFromString,
+      @DefaultValue("MatrixParamTest") @MatrixParam("SortedSetParamEntityWithFromString") SortedSet<ParamEntityWithFromString> sortedSetParamEntityWithFromString,
+      @DefaultValue("MatrixParamTest") @MatrixParam("ListParamEntityWithFromString") List<ParamEntityWithFromString> listParamEntityWithFromString,
+      @MatrixParam("ParamEntityThrowingWebApplicationException") ParamEntityThrowingWebApplicationException paramEntityThrowingWebApplicationException,
+      @MatrixParam("ParamEntityThrowingExceptionGivenByName") ParamEntityThrowingExceptionGivenByName paramEntityThrowingExceptionGivenByName) {
+
+    sb = new StringBuilder();
+
+    sb.append("stringtest=").append(stringheader);
+    sb.append("stringtest1=").append(stringheader1);
+
+    sb.append("inttest=").append(intheader);
+    sb.append("inttest1=").append(intheader1);
+    sb.append("inttest2=").append(intheader2);
+
+    sb.append("doubletest=").append(doubleheader);
+    sb.append("doubletest1=").append(doubleheader1);
+    sb.append("doubletest2=").append(doubleheader2);
+
+    sb.append("floattest=").append(floatheader);
+    sb.append("floattest1=").append(floatheader1);
+    sb.append("floattest2=").append(floatheader2);
+
+    sb.append("longtest=").append(longheader);
+    sb.append("longtest1=").append(longheader1);
+    sb.append("longtest2=").append(longheader2);
+
+    sb.append("shorttest=").append(shortheader);
+    sb.append("shorttest1=").append(shortheader1);
+    sb.append("shorttest2=").append(shortheader2);
+
+    sb.append("bytetest=").append(byteheader);
+    sb.append("bytetest1=").append(byteheader1);
+    sb.append("bytetest2=").append(byteheader2);
+
+    sb.append("booleantest=").append(booleanheader);
+    sb.append("booleantest1=").append(booleanheader1);
+    sb.append("booleantest2=").append(booleanheader2);
+
+    setReturnValues(paramEntityWithConstructor, paramEntityWithFromString,
+        paramEntityWithValueOf, setParamEntityWithFromString,
+        sortedSetParamEntityWithFromString, listParamEntityWithFromString, "");
+
+    setReturnValues(fieldParamEntityWithConstructor,
+        fieldParamEntityWithFromString, fieldParamEntityWithValueOf,
+        fieldSetParamEntityWithFromString,
+        fieldSortedSetParamEntityWithFromString,
+        fieldListParamEntityWithFromString, FIELD);
+
+    return sb.toString();
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/matrixparam/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/matrixparam/TSAppConfig.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.matrixparam;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.ws.rs.tck.ee.rs.RuntimeExceptionMapper;
+import jakarta.ws.rs.tck.ee.rs.WebApplicationExceptionMapper;
+
+import jakarta.ws.rs.core.Application;
+
+/**
+ *
+ * @author diannejiao
+ */
+public class TSAppConfig extends Application {
+
+  public java.util.Set<java.lang.Class<?>> getClasses() {
+    Set<Class<?>> resources = new HashSet<Class<?>>();
+    resources.add(MatrixParamTest.class);
+    resources.add(RuntimeExceptionMapper.class);
+    resources.add(WebApplicationExceptionMapper.class);
+    return resources;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/matrixparam/locator/JAXRSLocatorClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/matrixparam/locator/JAXRSLocatorClientIT.java
@@ -1,0 +1,356 @@
+/*
+ * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.matrixparam.locator;
+
+import java.io.InputStream;
+import java.io.IOException;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JAXRSLocatorClientIT
+    extends jakarta.ws.rs.tck.ee.rs.matrixparam.JAXRSClientIT {
+
+  private static final long serialVersionUID = 1L;
+
+  public JAXRSLocatorClientIT() {
+    setup();
+    setContextRoot("/jaxrs_ee_rs_matrixparam_locator_web/resource/locator");
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  @Deployment(testable = false, name = "jaxrs_ee_rs_matrixparam_locator_deployment")
+  public static WebArchive createDeployment() throws IOException {
+
+    InputStream inStream = JAXRSLocatorClientIT.class.getClassLoader().getResourceAsStream("jakarta/ws/rs/tck/ee/rs/matrixparam/locator/web.xml.template");
+    String webXml = editWebXmlString(inStream);
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_ee_rs_matrixparam_locator_web.war");
+    archive.addClasses(TSAppConfig.class, LocatorResource.class, MiddleResource.class,
+      jakarta.ws.rs.tck.ee.rs.matrixparam.MatrixParamTest.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityPrototype.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityWithConstructor.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityWithValueOf.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityWithFromString.class,
+      jakarta.ws.rs.tck.ee.rs.ParamTest.class,
+      jakarta.ws.rs.tck.ee.rs.JaxrsParamClient.CollectionName.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingWebApplicationException.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
+      jakarta.ws.rs.tck.ee.rs.RuntimeExceptionMapper.class,
+      jakarta.ws.rs.tck.ee.rs.WebApplicationExceptionMapper.class
+    );
+    archive.setWebXML(new StringAsset(webXml));
+    return archive;
+
+  }
+
+
+
+  /* Run test */
+  /*
+   * @testName: matrixParamStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.1; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3; JAXRS:JAVADOC:7;
+   * 
+   * @test_Strategy: Client invokes GET on root resource at /MatrixParamTest;
+   * Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamStringTest() throws Fault {
+    super.matrixParamStringTest();
+  }
+
+  /*
+   * @testName: matrixParamIntTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.1; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3; JAXRS:JAVADOC:7;
+   * 
+   * @test_Strategy: Client invokes GET on a resource at /MatrixParamTest;
+   * Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamIntTest() throws Fault {
+    super.matrixParamIntTest();
+  }
+
+  /*
+   * @testName: matrixParamDoubleTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.1; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3; JAXRS:JAVADOC:7;
+   * 
+   * @test_Strategy: Client invokes GET on a resource at /MatrixParamTest;
+   * Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamDoubleTest() throws Fault {
+    super.matrixParamDoubleTest();
+  }
+
+  /*
+   * @testName: matrixParamFloatTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.1; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3; JAXRS:JAVADOC:7;
+   * 
+   * @test_Strategy: Client invokes GET on a resource at /MatrixParamTest;
+   * Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamFloatTest() throws Fault {
+    super.matrixParamFloatTest();
+  }
+
+  /*
+   * @testName: matrixParamLongTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.1; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3; JAXRS:JAVADOC:7;
+   * 
+   * @test_Strategy: Client invokes GET on a resource at /MatrixParamTest;
+   * Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamLongTest() throws Fault {
+    super.matrixParamLongTest();
+  }
+
+  /*
+   * @testName: matrixParamShortTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.1; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3; JAXRS:JAVADOC:7;
+   * 
+   * @test_Strategy: Client invokes GET on a resource at /MatrixParamTest;
+   * Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamShortTest() throws Fault {
+    super.matrixParamShortTest();
+  }
+
+  /*
+   * @testName: matrixParamByteTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.1; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3; JAXRS:JAVADOC:7;
+   * 
+   * @test_Strategy: Client invokes GET on a resource at /MatrixParamTest;
+   * Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamByteTest() throws Fault {
+    super.matrixParamByteTest();
+  }
+
+  /*
+   * @testName: matrixParamBooleanTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.1; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3; JAXRS:JAVADOC:7;
+   * 
+   * @test_Strategy: Client invokes GET on a resource at /MatrixParamTest;
+   * Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamBooleanTest() throws Fault {
+    super.matrixParamBooleanTest();
+  }
+
+  /*
+   * @testName: matrixParamEntityWithConstructorTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.2; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3; JAXRS:JAVADOC:6; JAXRS:JAVADOC:12; JAXRS:JAVADOC:12.1;
+   * 
+   * @test_Strategy: Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamEntityWithConstructorTest() throws Fault {
+    super.matrixParamEntityWithConstructorTest();
+  }
+
+  /*
+   * @testName: matrixParamEntityWithValueOfTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.3; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3; JAXRS:JAVADOC:6; JAXRS:JAVADOC:12; JAXRS:JAVADOC:12.1;
+   * 
+   * @test_Strategy: Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamEntityWithValueOfTest() throws Fault {
+    super.matrixParamEntityWithValueOfTest();
+  }
+
+  /*
+   * @testName: matrixParamEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.3; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3; JAXRS:JAVADOC:6; JAXRS:JAVADOC:12; JAXRS:JAVADOC:12.1;
+   * 
+   * @test_Strategy: Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamEntityWithFromStringTest() throws Fault {
+    super.matrixParamEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: matrixParamSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.4; JAXRS:JAVADOC:6;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.3;
+   * 
+   * @test_Strategy: Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamSetEntityWithFromStringTest() throws Fault {
+    super.matrixParamSetEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: matrixParamSortedSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.4; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3; JAXRS:JAVADOC:6; JAXRS:JAVADOC:12; JAXRS:JAVADOC:12.1;
+   * 
+   * @test_Strategy: Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamSortedSetEntityWithFromStringTest() throws Fault {
+    super.matrixParamSortedSetEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: matrixParamListEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.4; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3; JAXRS:JAVADOC:6; JAXRS:JAVADOC:12; JAXRS:JAVADOC:12.1;
+   * 
+   * @test_Strategy: Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamListEntityWithFromStringTest() throws Fault {
+    super.matrixParamListEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: matrixParamEntityWithEncodedTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:7; JAXRS:SPEC:12.2;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.3;
+   * 
+   * @test_Strategy: Verify that named MatrixParam @Encoded is handled
+   */
+  @Test
+  public void matrixParamEntityWithEncodedTest() throws Fault {
+    super.matrixParamEntityWithEncodedTest();
+  }
+
+  /*
+   * @testName: matrixParamThrowingWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:12.3; JAXRS:SPEC:20; JAXRS:SPEC:20.3;
+   * 
+   * @test_Strategy: Exceptions thrown during construction of parameter values
+   * are treated the same as exceptions thrown during construction of field or
+   * bean property values, see Section 3.2.
+   */
+  @Test
+  public void matrixParamThrowingWebApplicationExceptionTest() throws Fault {
+    super.matrixParamThrowingWebApplicationExceptionTest();
+  }
+
+  /*
+   * @testName: matrixParamThrowingIllegalArgumentExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:12.3; JAXRS:SPEC:20; JAXRS:SPEC:20.3;
+   * 
+   * @test_Strategy: Exceptions thrown during construction of parameter values
+   * are treated the same as exceptions thrown during construction of field or
+   * bean property values, see section 3.2.
+   */
+  @Test
+  public void matrixParamThrowingIllegalArgumentExceptionTest() throws Fault {
+    super.matrixParamThrowingIllegalArgumentExceptionTest();
+  }
+
+  public void matrixFieldParamEntityWithConstructorTest() throws Fault {
+    //do nothing  
+  }
+  public void matrixFieldParamEntityWithValueOfTest() throws Fault {
+    //do nothing  
+  }
+  public void matrixFieldParamEntityWithFromStringTest() throws Fault {
+    //do nothing  
+  }
+  public void matrixFieldParamSetEntityWithFromStringTest() throws Fault {
+    //do nothing  
+  }
+  public void matrixFieldParamSortedSetEntityWithFromStringTest() throws Fault {
+    //do nothing  
+  }
+  public void matrixFieldParamListEntityWithFromStringTest() throws Fault {
+    //do nothing  
+  }
+  public void matrixFieldThrowingWebApplicationExceptionTest() throws Fault {
+    //do nothing  
+  }
+  public void matrixFieldThrowingIllegalArgumentExceptionTest() throws Fault {
+    //do nothing  
+  }
+  public void matrixFieldParamEntityWithEncodedTest() throws Fault {
+    //do nothing  
+  }
+
+  @Override
+  protected String buildRequest(String param) {
+    return super.buildRequest(param).replace(Request.GET.name(),
+        Request.POST.name());
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/matrixparam/locator/LocatorResource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/matrixparam/locator/LocatorResource.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.matrixparam.locator;
+
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+
+import jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingExceptionGivenByName;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingWebApplicationException;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityWithConstructor;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityWithFromString;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityWithValueOf;
+
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.Encoded;
+import jakarta.ws.rs.MatrixParam;
+import jakarta.ws.rs.Path;
+
+@Path("resource")
+public class LocatorResource extends MiddleResource {
+
+  @Path("locator")
+  public MiddleResource locatorHasArguments(
+      @MatrixParam("stringtest") String stringheader,
+      @MatrixParam("stringtest1") String stringheader1,
+      @MatrixParam("inttest") int intheader,
+      @MatrixParam("inttest1") int intheader1,
+      @MatrixParam("inttest2") int intheader2,
+      @MatrixParam("bytetest") byte byteheader,
+      @MatrixParam("bytetest1") byte byteheader1,
+      @MatrixParam("bytetest2") byte byteheader2,
+      @MatrixParam("doubletest") double doubleheader,
+      @MatrixParam("doubletest1") double doubleheader1,
+      @MatrixParam("doubletest2") double doubleheader2,
+      @MatrixParam("floattest") float floatheader,
+      @MatrixParam("floattest1") float floatheader1,
+      @MatrixParam("floattest2") float floatheader2,
+      @MatrixParam("shorttest") short shortheader,
+      @MatrixParam("shorttest1") short shortheader1,
+      @MatrixParam("shorttest2") short shortheader2,
+      @MatrixParam("longtest") long longheader,
+      @MatrixParam("longtest1") long longheader1,
+      @MatrixParam("longtest2") long longheader2,
+      @MatrixParam("booleantest") boolean booleanheader,
+      @MatrixParam("booleantest1") boolean booleanheader1,
+      @MatrixParam("booleantest2") boolean booleanheader2,
+      @DefaultValue("MatrixParamTest") @MatrixParam("ParamEntityWithConstructor") ParamEntityWithConstructor paramEntityWithConstructor,
+      @Encoded @DefaultValue("MatrixParamTest") @MatrixParam("ParamEntityWithFromString") ParamEntityWithFromString paramEntityWithFromString,
+      @DefaultValue("MatrixParamTest") @MatrixParam("ParamEntityWithValueOf") ParamEntityWithValueOf paramEntityWithValueOf,
+      @DefaultValue("MatrixParamTest") @MatrixParam("SetParamEntityWithFromString") Set<ParamEntityWithFromString> setParamEntityWithFromString,
+      @DefaultValue("MatrixParamTest") @MatrixParam("SortedSetParamEntityWithFromString") SortedSet<ParamEntityWithFromString> sortedSetParamEntityWithFromString,
+      @DefaultValue("MatrixParamTest") @MatrixParam("ListParamEntityWithFromString") List<ParamEntityWithFromString> listParamEntityWithFromString,
+      @MatrixParam("ParamEntityThrowingWebApplicationException") ParamEntityThrowingWebApplicationException paramEntityThrowingWebApplicationException,
+      @MatrixParam("ParamEntityThrowingExceptionGivenByName") ParamEntityThrowingExceptionGivenByName paramEntityThrowingExceptionGivenByName) {
+    return new MiddleResource(stringheader, stringheader1, intheader,
+        intheader1, intheader2, byteheader, byteheader1, byteheader2,
+        doubleheader, doubleheader1, doubleheader2, floatheader, floatheader1,
+        floatheader2, shortheader, shortheader1, shortheader2, longheader,
+        longheader1, longheader2, booleanheader, booleanheader1, booleanheader2,
+        paramEntityWithConstructor, paramEntityWithFromString,
+        paramEntityWithValueOf, setParamEntityWithFromString,
+        sortedSetParamEntityWithFromString, listParamEntityWithFromString,
+        paramEntityThrowingWebApplicationException,
+        paramEntityThrowingExceptionGivenByName);
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/matrixparam/locator/MiddleResource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/matrixparam/locator/MiddleResource.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.matrixparam.locator;
+
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+
+import jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingExceptionGivenByName;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingWebApplicationException;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityWithConstructor;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityWithFromString;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityWithValueOf;
+import jakarta.ws.rs.tck.ee.rs.matrixparam.MatrixParamTest;
+
+import jakarta.ws.rs.POST;
+
+public class MiddleResource extends MatrixParamTest {
+
+  private final String returnValue;
+
+  public MiddleResource() {
+    returnValue = null;
+  }
+
+  protected MiddleResource(String stringheader, String stringheader1,
+      int intheader, int intheader1, int intheader2, byte byteheader,
+      byte byteheader1, byte byteheader2, double doubleheader,
+      double doubleheader1, double doubleheader2, float floatheader,
+      float floatheader1, float floatheader2, short shortheader,
+      short shortheader1, short shortheader2, long longheader, long longheader1,
+      long longheader2, boolean booleanheader, boolean booleanheader1,
+      boolean booleanheader2,
+      ParamEntityWithConstructor paramEntityWithConstructor,
+      ParamEntityWithFromString paramEntityWithFromString,
+      ParamEntityWithValueOf paramEntityWithValueOf,
+      Set<ParamEntityWithFromString> setParamEntityWithFromString,
+      SortedSet<ParamEntityWithFromString> sortedSetParamEntityWithFromString,
+      List<ParamEntityWithFromString> listParamEntityWithFromString,
+      ParamEntityThrowingWebApplicationException paramEntityThrowingWebApplicationException,
+      ParamEntityThrowingExceptionGivenByName paramEntityThrowingExceptionGivenByName) {
+    returnValue = stringParamHandling(stringheader, stringheader1, intheader,
+        intheader1, intheader2, byteheader, byteheader1, byteheader2,
+        doubleheader, doubleheader1, doubleheader2, floatheader, floatheader1,
+        floatheader2, shortheader, shortheader1, shortheader2, longheader,
+        longheader1, longheader2, booleanheader, booleanheader1, booleanheader2,
+        paramEntityWithConstructor, paramEntityWithFromString,
+        paramEntityWithValueOf, setParamEntityWithFromString,
+        sortedSetParamEntityWithFromString, listParamEntityWithFromString,
+        paramEntityThrowingWebApplicationException,
+        paramEntityThrowingExceptionGivenByName);
+  }
+
+  @POST
+  public String returnValue() {
+    return returnValue;
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/matrixparam/locator/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/matrixparam/locator/TSAppConfig.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.matrixparam.locator;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.ws.rs.tck.ee.rs.RuntimeExceptionMapper;
+import jakarta.ws.rs.tck.ee.rs.WebApplicationExceptionMapper;
+
+import jakarta.ws.rs.core.Application;
+
+public class TSAppConfig extends Application {
+
+  public java.util.Set<java.lang.Class<?>> getClasses() {
+    Set<Class<?>> resources = new HashSet<Class<?>>();
+    resources.add(LocatorResource.class);
+    resources.add(RuntimeExceptionMapper.class);
+    resources.add(WebApplicationExceptionMapper.class);
+    return resources;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/matrixparam/sub/JAXRSSubClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/matrixparam/sub/JAXRSSubClientIT.java
@@ -1,0 +1,480 @@
+/*
+ * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.matrixparam.sub;
+
+import java.io.InputStream;
+import java.io.IOException;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JAXRSSubClientIT
+    extends jakarta.ws.rs.tck.ee.rs.matrixparam.JAXRSClientIT {
+
+  private static final long serialVersionUID = 1L;
+
+  public JAXRSSubClientIT() {
+    setup();
+    setContextRoot("/jaxrs_ee_rs_matrixparam_sub_web/resource/subresource");
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  @Deployment(testable = false)
+  public static WebArchive createDeployment() throws IOException{
+
+    InputStream inStream = JAXRSSubClientIT.class.getClassLoader().getResourceAsStream("jakarta/ws/rs/tck/ee/rs/matrixparam/sub/web.xml.template");
+    String webXml = editWebXmlString(inStream);
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_ee_rs_matrixparam_sub_web.war");
+    archive.addClasses(TSAppConfig.class, SubResource.class, 
+    jakarta.ws.rs.tck.ee.rs.matrixparam.MatrixParamTest.class,
+    jakarta.ws.rs.tck.ee.rs.ParamEntityPrototype.class,
+    jakarta.ws.rs.tck.ee.rs.ParamEntityWithConstructor.class,
+    jakarta.ws.rs.tck.ee.rs.ParamEntityWithValueOf.class,
+    jakarta.ws.rs.tck.ee.rs.ParamEntityWithFromString.class,
+    jakarta.ws.rs.tck.ee.rs.ParamTest.class,
+    jakarta.ws.rs.tck.ee.rs.JaxrsParamClient.CollectionName.class,
+    jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingWebApplicationException.class,
+    jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
+    jakarta.ws.rs.tck.ee.rs.RuntimeExceptionMapper.class,
+    jakarta.ws.rs.tck.ee.rs.WebApplicationExceptionMapper.class
+);
+    archive.setWebXML(new StringAsset(webXml));
+    return archive;
+
+  }
+
+
+
+  /* Run test */
+  /*
+   * @testName: matrixParamStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.1; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:JAVADOC:7;
+   * 
+   * @test_Strategy: Client invokes GET on root resource at /MatrixParamTest;
+   * Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamStringTest() throws Fault {
+    super.matrixParamStringTest();
+  }
+
+  /*
+   * @testName: matrixParamIntTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.1; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:JAVADOC:7;
+   * 
+   * @test_Strategy: Client invokes GET on a resource at /MatrixParamTest;
+   * Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamIntTest() throws Fault {
+    super.matrixParamIntTest();
+  }
+
+  /*
+   * @testName: matrixParamDoubleTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.1; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:JAVADOC:7;
+   * 
+   * @test_Strategy: Client invokes GET on a resource at /MatrixParamTest;
+   * Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamDoubleTest() throws Fault {
+    super.matrixParamDoubleTest();
+  }
+
+  /*
+   * @testName: matrixParamFloatTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.1; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:JAVADOC:7;
+   * 
+   * @test_Strategy: Client invokes GET on a resource at /MatrixParamTest;
+   * Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamFloatTest() throws Fault {
+    super.matrixParamFloatTest();
+  }
+
+  /*
+   * @testName: matrixParamLongTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.1; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:JAVADOC:7;
+   * 
+   * @test_Strategy: Client invokes GET on a resource at /MatrixParamTest;
+   * Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamLongTest() throws Fault {
+    super.matrixParamLongTest();
+  }
+
+  /*
+   * @testName: matrixParamShortTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.1; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:JAVADOC:7;
+   * 
+   * @test_Strategy: Client invokes GET on a resource at /MatrixParamTest;
+   * Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamShortTest() throws Fault {
+    super.matrixParamShortTest();
+  }
+
+  /*
+   * @testName: matrixParamByteTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.1; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:JAVADOC:7;
+   * 
+   * @test_Strategy: Client invokes GET on a resource at /MatrixParamTest;
+   * Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamByteTest() throws Fault {
+    super.matrixParamByteTest();
+  }
+
+  /*
+   * @testName: matrixParamBooleanTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.1; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:JAVADOC:7;
+   * 
+   * @test_Strategy: Client invokes GET on a resource at /MatrixParamTest;
+   * Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamBooleanTest() throws Fault {
+    super.matrixParamBooleanTest();
+  }
+
+  /*
+   * @testName: matrixParamEntityWithConstructorTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.2; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:JAVADOC:6; JAXRS:JAVADOC:12; JAXRS:JAVADOC:12.1;
+   * 
+   * @test_Strategy: Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamEntityWithConstructorTest() throws Fault {
+    super.matrixParamEntityWithConstructorTest();
+  }
+
+  /*
+   * @testName: matrixParamEntityWithValueOfTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.3; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:JAVADOC:6; JAXRS:JAVADOC:12; JAXRS:JAVADOC:12.1;
+   * 
+   * @test_Strategy: Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamEntityWithValueOfTest() throws Fault {
+    super.matrixParamEntityWithValueOfTest();
+  }
+
+  /*
+   * @testName: matrixParamEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.3; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:JAVADOC:6; JAXRS:JAVADOC:12; JAXRS:JAVADOC:12.1;
+   * 
+   * @test_Strategy: Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamEntityWithFromStringTest() throws Fault {
+    super.matrixParamEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: matrixParamSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.4; JAXRS:JAVADOC:6;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamSetEntityWithFromStringTest() throws Fault {
+    super.matrixParamSetEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: matrixParamSortedSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.4; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:JAVADOC:6; JAXRS:JAVADOC:12; JAXRS:JAVADOC:12.1;
+   * 
+   * @test_Strategy: Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamSortedSetEntityWithFromStringTest() throws Fault {
+    super.matrixParamSortedSetEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: matrixParamListEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.4; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:JAVADOC:6; JAXRS:JAVADOC:12; JAXRS:JAVADOC:12.1;
+   * 
+   * @test_Strategy: Verify that named MatrixParam is handled properly
+   */
+  @Test
+  public void matrixParamListEntityWithFromStringTest() throws Fault {
+    super.matrixParamListEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: matrixFieldParamEntityWithConstructorTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.2; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:SPEC:4; JAXRS:JAVADOC:6;
+   * 
+   * @test_Strategy: Verify that named MatrixParam is handled properly
+   * 
+   * An implementation is only required to set the annotated field and bean
+   * property values of instances created by the implementation runtime. (Check
+   * the resource with resource locator is injected field properties)
+   */
+  @Test
+  public void matrixFieldParamEntityWithConstructorTest() throws Fault {
+    fieldEntityWithConstructorTest();
+  }
+
+  /*
+   * @testName: matrixFieldParamEntityWithValueOfTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.3; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:SPEC:4; JAXRS:JAVADOC:6;
+   * 
+   * @test_Strategy: Verify that named MatrixParam is handled properly
+   * 
+   * An implementation is only required to set the annotated field and bean
+   * property values of instances created by the implementation runtime. (Check
+   * the resource with resource locator is injected field properties)
+   */
+  @Test
+  public void matrixFieldParamEntityWithValueOfTest() throws Fault {
+    super.matrixFieldParamEntityWithValueOfTest();
+  }
+
+  /*
+   * @testName: matrixFieldParamEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.3; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:SPEC:4; JAXRS:JAVADOC:6;
+   * 
+   * @test_Strategy: Verify that named MatrixParam is handled properly
+   * 
+   * An implementation is only required to set the annotated field and bean
+   * property values of instances created by the implementation runtime. (Check
+   * the resource with resource locator is injected field properties)
+   */
+  @Test
+  public void matrixFieldParamEntityWithFromStringTest() throws Fault {
+    super.matrixFieldParamEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: matrixFieldParamSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.4; JAXRS:JAVADOC:6;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.2; JAXRS:SPEC:4;
+   * 
+   * @test_Strategy: Verify that named MatrixParam is handled properly
+   * 
+   * An implementation is only required to set the annotated field and bean
+   * property values of instances created by the implementation runtime. (Check
+   * the resource with resource locator is injected field properties)
+   */
+  @Test
+  public void matrixFieldParamSetEntityWithFromStringTest() throws Fault {
+    super.matrixFieldParamSetEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: matrixFieldParamSortedSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.4; JAXRS:JAVADOC:6;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.2; JAXRS:SPEC:4;
+   * 
+   * @test_Strategy: Verify that named MatrixParam is handled properly
+   * 
+   * An implementation is only required to set the annotated field and bean
+   * property values of instances created by the implementation runtime. (Check
+   * the resource with resource locator is injected field properties)
+   */
+  @Test
+  public void matrixFieldParamSortedSetEntityWithFromStringTest() throws Fault {
+    super.matrixFieldParamSortedSetEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: matrixFieldParamListEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:5.4; JAXRS:JAVADOC:6;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.2; JAXRS:SPEC:4;
+   * 
+   * @test_Strategy: Verify that named MatrixParam is handled properly
+   * 
+   * An implementation is only required to set the annotated field and bean
+   * property values of instances created by the implementation runtime. (Check
+   * the resource with resource locator is injected field properties)
+   */
+  @Test
+  public void matrixFieldParamListEntityWithFromStringTest() throws Fault {
+    super.matrixFieldParamListEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: matrixParamEntityWithEncodedTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:7; JAXRS:SPEC:12.2;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Verify that named MatrixParam @Encoded is handled
+   */
+  @Test
+  public void matrixParamEntityWithEncodedTest() throws Fault {
+    super.matrixParamEntityWithEncodedTest();
+  }
+
+  /*
+   * @testName: matrixFieldParamEntityWithEncodedTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:7; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Verify that named MatrixParam @Encoded is handled
+   */
+  @Test
+  public void matrixFieldParamEntityWithEncodedTest() throws Fault {
+    super.matrixFieldParamEntityWithEncodedTest();
+  }
+
+  /*
+   * @testName: matrixParamThrowingWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:12.3; JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Exceptions thrown during construction of parameter values
+   * are treated the same as exceptions thrown during construction of field or
+   * bean property values, see Section 3.2.
+   */
+  @Test
+  public void matrixParamThrowingWebApplicationExceptionTest() throws Fault {
+    super.matrixParamThrowingWebApplicationExceptionTest();
+  }
+
+  /*
+   * @testName: matrixFieldThrowingWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:8; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:SPEC:4;
+   * 
+   * @test_Strategy: A WebApplicationException thrown during construction of
+   * field or property values using 2 or 3 above is processed directly as
+   * described in section 3.3.4.
+   * 
+   * An implementation is only required to set the annotated field and bean
+   * property values of instances created by the implementation runtime. (Check
+   * the resource with resource locator is injected field properties)
+   */
+  @Test
+  public void matrixFieldThrowingWebApplicationExceptionTest() throws Fault {
+    super.matrixFieldThrowingWebApplicationExceptionTest();
+  }
+
+  /*
+   * @testName: matrixParamThrowingIllegalArgumentExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:12.3; JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Exceptions thrown during construction of parameter values
+   * are treated the same as exceptions thrown during construction of field or
+   * bean property values, see section 3.2.
+   */
+  @Test
+  public void matrixParamThrowingIllegalArgumentExceptionTest() throws Fault {
+    super.matrixParamThrowingIllegalArgumentExceptionTest();
+  }
+
+  /*
+   * @testName: matrixFieldThrowingIllegalArgumentExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:9; JAXRS:SPEC:9.1; JAXRS:SPEC:10; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:SPEC:4;
+   * 
+   * @test_Strategy: Other exceptions thrown during construction of field or
+   * property values using 2 or 3 above are treated as client errors:
+   * 
+   * if the field or property is annotated with @MatrixParam,
+   * 
+   * @QueryParam or @PathParam then an implementation MUST generate a
+   * WebApplicationException that wraps the thrown exception with a not found
+   * response (404 status) and no entity;
+   *
+   * An implementation is only required to set the annotated field and bean
+   * property values of instances created by the implementation runtime. (Check
+   * the resource with resource locator is injected field properties)
+   */
+  @Test
+  public void matrixFieldThrowingIllegalArgumentExceptionTest() throws Fault {
+    super.matrixFieldThrowingIllegalArgumentExceptionTest();
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/matrixparam/sub/SubResource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/matrixparam/sub/SubResource.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.matrixparam.sub;
+
+import jakarta.ws.rs.tck.ee.rs.matrixparam.MatrixParamTest;
+
+import jakarta.ws.rs.Path;
+
+@Path("resource")
+public class SubResource extends MatrixParamTest {
+  @Path("subresource")
+  public SubResource subresource() {
+    return this;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/matrixparam/sub/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/matrixparam/sub/TSAppConfig.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.matrixparam.sub;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.ws.rs.tck.ee.rs.RuntimeExceptionMapper;
+import jakarta.ws.rs.tck.ee.rs.WebApplicationExceptionMapper;
+
+import jakarta.ws.rs.core.Application;
+
+public class TSAppConfig extends Application {
+
+  public java.util.Set<java.lang.Class<?>> getClasses() {
+    Set<Class<?>> resources = new HashSet<Class<?>>();
+    resources.add(SubResource.class);
+    resources.add(RuntimeExceptionMapper.class);
+    resources.add(WebApplicationExceptionMapper.class);
+    return resources;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/options/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/options/JAXRSClientIT.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.options;
+
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+
+import jakarta.ws.rs.core.Response.Status;
+
+import java.io.InputStream;
+import java.io.IOException;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JAXRSClientIT extends JAXRSCommonClient {
+  private static final long serialVersionUID = 1L;
+
+  public JAXRSClientIT() {
+    setup();
+    setContextRoot("/jaxrs_ee_rs_options_web/Options");
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  @Deployment(testable = false)
+  public static WebArchive createDeployment() throws IOException{
+
+    InputStream inStream = JAXRSClientIT.class.getClassLoader().getResourceAsStream("jakarta/ws/rs/tck/ee/rs/options/web.xml.template");
+    String webXml = editWebXmlString(inStream);
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_ee_rs_options_web.war");
+    archive.addClasses(TSAppConfig.class, Resource.class);
+    archive.setWebXML(new StringAsset(webXml));
+    return archive;
+
+  }
+
+
+
+  /* Run test */
+  /*
+   * @testName: optionsTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:18; JAXRS:SPEC:18.1;
+   * 
+   * @test_Strategy: Call a method annotated with a request method designator
+   * for OPTIONS
+   */
+  @Test
+  public void optionsTest() throws Fault {
+    setProperty(REQUEST, buildRequest("OPTIONS", "options"));
+    setProperty(STATUS_CODE, getStatusCode(Status.ACCEPTED));
+    invoke();
+  }
+
+  /*
+   * @testName: autoResponseTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:18; JAXRS:SPEC:18.2;
+   * 
+   * @test_Strategy: Generate an automatic response using the metadata provided
+   * by the JAX-RS annotations on the matching class and its methods.
+   */
+  @Test
+  public void autoResponseTest() throws Fault {
+    setProperty(REQUEST, buildRequest("OPTIONS", "get"));
+    setProperty(STATUS_CODE, "!" + getStatusCode(Status.NOT_FOUND));
+    invoke();
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/options/Resource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/options/Resource.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.options;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.OPTIONS;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+
+@Path("Options")
+public class Resource {
+
+  @OPTIONS
+  @Path("options")
+  public Response options() {
+    return Response.status(Status.ACCEPTED).build();
+  }
+
+  @GET
+  @Path("get")
+  public Response get() {
+    return Response.status(Status.CONFLICT).build();
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/options/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/options/TSAppConfig.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.options;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.ws.rs.core.Application;
+
+public class TSAppConfig extends Application {
+
+  public java.util.Set<java.lang.Class<?>> getClasses() {
+    Set<Class<?>> resources = new HashSet<Class<?>>();
+    resources.add(Resource.class);
+    return resources;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/pathparam/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/pathparam/JAXRSClientIT.java
@@ -1,0 +1,460 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.pathparam;
+
+import jakarta.ws.rs.tck.ee.rs.JaxrsParamClient;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response.Status;
+
+import java.io.InputStream;
+import java.io.IOException;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JAXRSClientIT extends JaxrsParamClient {
+
+  private static final long serialVersionUID = 1L;
+
+  public JAXRSClientIT() {
+    setup();
+    setContextRoot("/jaxrs_ee_rs_pathparam_web/PathParamTest");
+    useDefaultValue = false;
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  @Deployment(testable = false)
+  public static WebArchive createDeployment() throws IOException{
+
+    InputStream inStream = JAXRSClientIT.class.getClassLoader().getResourceAsStream("jakarta/ws/rs/tck/ee/rs/pathparam/web.xml.template");
+    String webXml = editWebXmlString(inStream);
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_ee_rs_pathparam_web.war");
+    archive.addClasses(TSAppConfig.class, PathParamTest.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityPrototype.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityWithConstructor.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityWithValueOf.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityWithFromString.class,
+      jakarta.ws.rs.tck.ee.rs.ParamTest.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingWebApplicationException.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
+      jakarta.ws.rs.tck.ee.rs.RuntimeExceptionMapper.class,
+      jakarta.ws.rs.tck.ee.rs.WebApplicationExceptionMapper.class
+    );
+    archive.setWebXML(new StringAsset(webXml));
+    return archive;
+
+  }
+
+
+
+  /* Run test */
+  /*
+   * @testName: test1
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:JAVADOC:9;
+   * 
+   * @test_Strategy: Client invokes Request.GET on root resource at
+   * /PathParamTest; Verify that right Method is invoked while using PathParam
+   * with primitive type String.
+   */
+  @Test
+  public void test1() throws Fault {
+    setProperty(Property.REQUEST_HEADERS,
+        buildAccept(MediaType.TEXT_HTML_TYPE));
+    setProperty(Property.REQUEST, buildRequest(Request.GET, "a"));
+    setProperty(Property.SEARCH_STRING, "single=a");
+    invoke();
+  }
+
+  /*
+   * @testName: test2
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:JAVADOC:9; JAXRS:JAVADOC:114;
+   * 
+   * @test_Strategy: Client invokes Request.GET on root resource at
+   * /PathParamTest; Verify that right Method is invoked while using PathParam
+   * primitive type String and PathSegment.
+   */
+  @Test
+  public void test2() throws Fault {
+    setProperty(Property.REQUEST, buildRequest(Request.GET, "a/b"));
+    setProperty(Property.SEARCH_STRING, "double=ab");
+    invoke();
+  }
+
+  /*
+   * @testName: test3
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:JAVADOC:9; JAXRS:JAVADOC:114;
+   * 
+   * @test_Strategy: Client invokes Request.GET on root resource at
+   * /PathParamTest; Verify that right Method is invoked while using PathParam
+   * primitive type int, float and PathSegment.
+   */
+  @Test
+  public void test3() throws Fault {
+    setProperty(Property.REQUEST,
+        buildRequest(Request.GET, "2147483647/b/12.345"));
+    setProperty(Property.SEARCH_STRING, "triple=2147483647b12.345");
+    invoke();
+
+    setProperty(Property.REQUEST,
+        buildRequest(Request.GET, "-2147483648/b/123.0"));
+    setProperty(Property.SEARCH_STRING, "triple=-2147483648b123.0");
+    invoke();
+  }
+
+  /*
+   * @testName: test4
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:JAVADOC:9; JAXRS:JAVADOC:114;
+   * 
+   * @test_Strategy: Client invokes Request.GET on root resource at
+   * /PathParamTest; Verify that right Method is invoked using PathParam
+   * primitive type double, boolean, byte, and PathSegment.
+   */
+  @Test
+  public void test4() throws Fault {
+    setProperty(Property.REQUEST,
+        buildRequest(Request.GET, "123.1/true/127/tmp"));
+    setProperty(Property.SEARCH_STRING, "quard=123.1true127tmp");
+    invoke();
+
+    setProperty(Property.REQUEST,
+        buildRequest(Request.GET, "345/false/-128/xyz"));
+    setProperty(Property.SEARCH_STRING, "quard=345.0false-128xyz");
+    invoke();
+  }
+
+  /*
+   * @testName: test5
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:JAVADOC:9; JAXRS:JAVADOC:114;
+   * 
+   * @test_Strategy: Client invokes Request.GET on root resource at
+   * /PathParamTest; Verify that right Method is invoked using PathParam
+   * primitive type long, String, short, boolean and PathSegment.
+   */
+  @Test
+  public void test5() throws Fault {
+    setProperty(Property.REQUEST,
+        buildRequest(Request.GET, "-9223372036854775808/b/32767/true/abc"));
+    setProperty(Property.SEARCH_STRING,
+        "penta=-9223372036854775808b32767trueabc");
+    invoke();
+
+    setProperty(Property.REQUEST,
+        buildRequest(Request.GET, "9223372036854775807/b/-32768/false/xyz"));
+    setProperty(Property.SEARCH_STRING,
+        "penta=9223372036854775807b-32768falsexyz");
+    invoke();
+  }
+
+  /*
+   * @testName: test6
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:JAVADOC:9;
+   * 
+   * @test_Strategy: Client invokes Request.GET on root resource at
+   * /PathParamTest; Verify that right Method is invoked using PathParam
+   * primitive type List<String>.
+   */
+  @Test
+  public void test6() throws Fault {
+    String[] headers = { "list=abcdef", "list=fedcba" };
+
+    for (String header : headers) {
+      setProperty(Property.REQUEST_HEADERS, "Accept: text/plain");
+      setProperty(Property.REQUEST, buildRequest(Request.GET, "a/b/c/d/e/f"));
+      setProperty(Property.SEARCH_STRING, header);
+      try {
+        invoke();
+        return;
+      } catch (Exception ex) {
+        TestUtil
+            .logTrace("Header " + header + " didnt work out, try another one");
+      }
+    }
+    throw new Fault("If you get to here means test failed.");
+  }
+
+  /*
+   * @testName: test7
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:JAVADOC:9;JAXRS:JAVADOC:113;
+   * JAXRS:JAVADOC:114;
+   * 
+   * @test_Strategy: Client invokes Request.GET on root resource at
+   * /PathParamTest with Matrix parameter; Verify that right Method is invoked
+   * using PathParam PathSegment.
+   */
+  @Test
+  public void test7() throws Fault {
+    String[] headers = { "matrix=/a;boolean1=false;boolean2=true",
+        "matrix=/a;boolean2=true;boolean1=false" };
+    for (String header : headers) {
+      setProperty(Property.REQUEST_HEADERS, "Accept:text/plain");
+      setProperty(Property.REQUEST,
+          buildRequest(Request.GET, "matrix/a;boolean1=false;boolean2=true"));
+      setProperty(Property.SEARCH_STRING, header);
+      try {
+        invoke();
+        return;
+      } catch (Exception ex) {
+        TestUtil
+            .logTrace("Header " + header + " didnt work out, try another one");
+      }
+    }
+    throw new Fault("If you get to here means test failed.");
+  }
+
+  /*
+   * @testName: pathParamEntityWithConstructorTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:SPEC:5.2; JAXRS:SPEC:12;
+   * 
+   * @test_Strategy: Verify that named PathParam is handled properly
+   */
+  @Test
+  public void pathParamEntityWithConstructorTest() throws Fault {
+    super.paramEntityWithConstructorTest();
+  }
+
+  /*
+   * @testName: pathParamEntityWithValueOfTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:SPEC:5.3; JAXRS:SPEC:12;
+   * 
+   * @test_Strategy: Verify that named PathParam is handled properly
+   */
+  @Test
+  public void pathParamEntityWithValueOfTest() throws Fault {
+    super.paramEntityWithValueOfTest();
+  }
+
+  /*
+   * @testName: pathParamEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:SPEC:5.3; JAXRS:SPEC:12;
+   * 
+   * @test_Strategy: Verify that named PathParam is handled properly
+   */
+  @Test
+  public void pathParamEntityWithFromStringTest() throws Fault {
+    searchEqualsEncoded = true;
+    super.paramEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: pathParamSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:SPEC:5.4; JAXRS:SPEC:12;
+   * 
+   * @test_Strategy: Verify that named PathParam is handled properly
+   */
+  @Test
+  public void pathParamSetEntityWithFromStringTest() throws Fault {
+    super.paramCollectionEntityWithFromStringTest(CollectionName.SET);
+  }
+
+  /*
+   * @testName: pathParamSortedSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:SPEC:5.4; JAXRS:SPEC:12;
+   * 
+   * @test_Strategy: Verify that named PathParam is handled properly
+   */
+  @Test
+  public void pathParamSortedSetEntityWithFromStringTest() throws Fault {
+    super.paramCollectionEntityWithFromStringTest(CollectionName.SORTED_SET);
+  }
+
+  /*
+   * @testName: pathParamListEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:SPEC:5.4; JAXRS:SPEC:12;
+   * 
+   * @test_Strategy: Verify that named PathParam is handled properly
+   */
+  @Test
+  public void pathParamListEntityWithFromStringTest() throws Fault {
+    super.paramCollectionEntityWithFromStringTest(CollectionName.LIST);
+  }
+
+  /*
+   * pathFieldParamEntityWithConstructorTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:SPEC:5.2;
+   * 
+   * @test_Strategy: Verify that named PathParam is handled properly
+   */
+  public void pathFieldParamEntityWithConstructorTest() throws Fault {
+    super.fieldEntityWithConstructorTest();
+  }
+
+  /*
+   * pathFieldParamEntityWithValueOfTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:SPEC:5.3;
+   * 
+   * @test_Strategy: Verify that named PathParam is handled properly
+   */
+  public void pathFieldParamEntityWithValueOfTest() throws Fault {
+    super.fieldEntityWithValueOfTest();
+  }
+
+  /*
+   * pathFieldParamEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:SPEC:5.3;
+   * 
+   * @test_Strategy: Verify that named PathParam is handled properly
+   */
+  public void pathFieldParamEntityWithFromStringTest() throws Fault {
+    super.fieldEntityWithFromStringTest();
+  }
+
+  /*
+   * pathFieldParamSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:SPEC:5.4;
+   * 
+   * @test_Strategy: Verify that named PathParam is handled properly
+   */
+  public void pathFieldParamSetEntityWithFromStringTest() throws Fault {
+    super.fieldCollectionEntityWithFromStringTest(CollectionName.SET);
+  }
+
+  /*
+   * pathFieldParamSortedSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:SPEC:5.4;
+   * 
+   * @test_Strategy: Verify that named PathParam is handled properly
+   */
+  public void pathFieldParamSortedSetEntityWithFromStringTest() throws Fault {
+    super.fieldCollectionEntityWithFromStringTest(CollectionName.SORTED_SET);
+  }
+
+  /*
+   * pathFieldParamListEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:SPEC:5.4;
+   * 
+   * @test_Strategy: Verify that named PathParam is handled properly
+   */
+  public void pathFieldParamListEntityWithFromStringTest() throws Fault {
+    super.fieldCollectionEntityWithFromStringTest(CollectionName.LIST);
+  }
+
+  /*
+   * @testName: pathParamEntityWithEncodedTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:SPEC:7;
+   * 
+   * @test_Strategy: Verify that named PathParam @Encoded is handled
+   */
+  @Test
+  public void pathParamEntityWithEncodedTest() throws Fault {
+    searchEqualsEncoded = true;
+    super.paramEntityWithEncodedTest();
+  }
+
+  /*
+   * @testName: pathParamThrowingWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:8;
+   * 
+   * @test_Strategy: A WebApplicationException thrown during construction of
+   * field or property values using 2 or 3 above is processed directly as
+   * described in section 3.3.4.
+   */
+  @Test
+  public void pathParamThrowingWebApplicationExceptionTest() throws Fault {
+    super.paramThrowingWebApplicationExceptionTest();
+  }
+
+  /*
+   * @testName: pathParamThrowingIllegalArgumentExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:9; JAXRS:SPEC:9.1; JAXRS:SPEC:10;
+   * 
+   * @test_Strategy: Other exceptions thrown during construction of field or
+   * property values using 2 or 3 above are treated as client errors:
+   * 
+   * if the field or property is annotated with @MatrixParam,
+   * 
+   * @QueryParam or @PathParam then an implementation MUST generate a
+   * WebApplicationException that wraps the thrown exception with a not found
+   * response (404 status) and no entity;
+   */
+  @Test
+  public void pathParamThrowingIllegalArgumentExceptionTest() throws Fault {
+    setProperty(Property.UNORDERED_SEARCH_STRING, Status.NOT_FOUND.name());
+    super.paramThrowingIllegalArgumentExceptionTest();
+  }
+
+  @Override
+  protected String buildRequest(String param) {
+    setProperty(Property.REQUEST_HEADERS,
+        buildAccept(MediaType.TEXT_PLAIN_TYPE));
+
+    StringBuilder sb = new StringBuilder();
+    sb.append(Request.GET.name()).append(" ").append(_contextRoot);
+    sb.append(SL).append(segmentFromParam(param)).append(SL);
+    sb.append(param.replace("=", "%3d")).append(SL);
+    return sb.append(HTTP11).toString();
+  }
+
+  @Override
+  protected String getDefaultValueOfParam(String param) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(param).append("=");
+    sb.append(PathParamTest.class.getSimpleName());
+    return sb.toString();
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/pathparam/PathParamTest.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/pathparam/PathParamTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.pathparam;
+
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+
+import jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingExceptionGivenByName;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingWebApplicationException;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityWithConstructor;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityWithFromString;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityWithValueOf;
+
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.Encoded;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.PathSegment;
+
+@Path(value = "/PathParamTest")
+public class PathParamTest {
+  @Produces(MediaType.TEXT_HTML)
+  @GET
+  @Path("/{id}")
+  public String single(@PathParam("id") String id) {
+    return "single=" + id;
+  }
+
+  @Produces(MediaType.TEXT_HTML)
+  @GET
+  @Path("/{id}/{id1}")
+  public String two(@PathParam("id") String id,
+      @PathParam("id1") PathSegment id1) {
+    return "double=" + id + id1.getPath();
+  }
+
+  @GET
+  @Path("/{id}/{id1}/{id2}")
+  public String triple(@PathParam("id") int id,
+      @PathParam("id1") PathSegment id1, @PathParam("id2") float id2) {
+    return "triple=" + id + id1.getPath() + id2;
+  }
+
+  @GET
+  @Path("/{id}/{id1}/{id2}/{id3}")
+  public String quard(@PathParam("id") double id, @PathParam("id1") boolean id1,
+      @PathParam("id2") byte id2, @PathParam("id3") PathSegment id3) {
+    return "quard=" + id + id1 + id2 + id3.getPath();
+  }
+
+  @GET
+  @Path("/{id}/{id1}/{id2}/{id3}/{id4}")
+  public String penta(@PathParam("id") long id, @PathParam("id1") String id1,
+      @PathParam("id2") short id2, @PathParam("id3") boolean id3,
+      @PathParam("id4") PathSegment id4) {
+    return "penta=" + id + id1 + id2 + id3 + id4.getPath();
+  }
+
+  @Produces(MediaType.TEXT_PLAIN)
+  @GET
+  @Path("/{id}/{id}/{id}/{id}/{id}/{id}")
+  public String list(@PathParam("id") List<String> id) {
+    StringBuffer sb = new StringBuffer();
+    sb.append("list=");
+    for (String tmp : id) {
+      sb.append(tmp);
+    }
+    return sb.toString();
+  }
+
+  @Produces(MediaType.TEXT_PLAIN)
+  @GET
+  @Path("/matrix/{id}")
+  public String matrixparamtest(@PathParam("id") PathSegment id) {
+    StringBuffer sb = new StringBuffer();
+    sb.append("matrix=");
+
+    sb.append("/" + id.getPath());
+    MultivaluedMap<String, String> matrix = id.getMatrixParameters();
+    Set<String> keys = matrix.keySet();
+    for (Object key : keys) {
+      sb.append(";" + key.toString() + "=" + matrix.getFirst(key.toString()));
+
+    }
+    return sb.toString();
+  }
+
+  @Produces(MediaType.TEXT_PLAIN)
+  @GET
+  @Path("/ParamEntityWithConstructor/{id}")
+  public String paramEntityWithConstructorTest(
+      @DefaultValue("PathParamTest") @PathParam("id") ParamEntityWithConstructor paramEntityWithConstructor) {
+    return paramEntityWithConstructor.getValue();
+  }
+
+  @Produces(MediaType.TEXT_PLAIN)
+  @GET
+  @Path("/ParamEntityWithFromString/{id}")
+  public String paramEntityWithFromStringTest(
+      @Encoded @DefaultValue("PathParamTest") @PathParam("id") ParamEntityWithFromString paramEntityWithFromString) {
+    return paramEntityWithFromString.getValue();
+  }
+
+  @Produces(MediaType.TEXT_PLAIN)
+  @GET
+  @Path("/ParamEntityWithValueOf/{id}")
+  public String paramEntityWithValueOfTest(
+      @DefaultValue("PathParamTest") @PathParam("id") ParamEntityWithValueOf paramEntityWithValueOf) {
+    return paramEntityWithValueOf.getValue();
+  }
+
+  @Produces(MediaType.TEXT_PLAIN)
+  @GET
+  @Path("/SetParamEntityWithFromString/{id}")
+  public String setParamEntityWithFromStringTest(
+      @DefaultValue("PathParamTest") @PathParam("id") Set<ParamEntityWithFromString> setParamEntityWithFromString) {
+    return setParamEntityWithFromString.iterator().next().getValue();
+  }
+
+  @Produces(MediaType.TEXT_PLAIN)
+  @GET
+  @Path("/SortedSetParamEntityWithFromString/{id}")
+  public String sortedSetParamEntityWithFromStringTest(
+      @DefaultValue("PathParamTest") @PathParam("id") SortedSet<ParamEntityWithFromString> sortedSetParamEntityWithFromString) {
+    return sortedSetParamEntityWithFromString.iterator().next().getValue();
+  }
+
+  @Produces(MediaType.TEXT_PLAIN)
+  @GET
+  @Path("/ListParamEntityWithFromString/{id}")
+  public String listParamEntityWithFromStringTest(
+      @DefaultValue("PathParamTest") @PathParam("id") List<ParamEntityWithFromString> listParamEntityWithFromString) {
+    return listParamEntityWithFromString.iterator().next().getValue();
+  }
+
+  @Produces(MediaType.TEXT_PLAIN)
+  @GET
+  @Path("/ParamEntityThrowingWebApplicationException/{id}")
+  public String paramEntityThrowingWebApplicationException(
+      @PathParam("id") ParamEntityThrowingWebApplicationException paramEntityThrowingWebApplicationException) {
+    return "";
+  }
+
+  @Produces(MediaType.TEXT_PLAIN)
+  @GET
+  @Path("/ParamEntityThrowingExceptionGivenByName/{id}")
+  public String paramEntityThrowingExceptionGivenByName(
+      @PathParam("id") ParamEntityThrowingExceptionGivenByName paramEntityThrowingExceptionGivenByName) {
+    return "";
+  }
+
+  @DefaultValue("PathParamTest")
+  @PathParam("FieldParamEntityWithConstructor")
+  ParamEntityWithConstructor fieldParamEntityWithConstructor;
+
+  @Produces(MediaType.TEXT_PLAIN)
+  @GET
+  @Path("/FieldParamEntityWithConstructor/{FieldParamEntityWithConstructor}")
+  public String fieldEntityWithConstructorTest() {
+    return fieldParamEntityWithConstructor.getValue();
+  }
+
+  @DefaultValue("PathParamTest")
+  @PathParam("FieldParamEntityWithFromString")
+  ParamEntityWithFromString fieldParamEntityWithFromString;
+
+  @Produces(MediaType.TEXT_PLAIN)
+  @GET
+  @Path("/FieldParamEntityWithFromString/{FieldParamEntityWithFromString}")
+  public String fieldEntityWithFromStringTest() {
+    return fieldParamEntityWithFromString.getValue();
+  }
+
+  @DefaultValue("PathParamTest")
+  @PathParam("FieldParamEntityWithValueOf")
+  ParamEntityWithValueOf fieldParamEntityWithValueOf;
+
+  @Produces(MediaType.TEXT_PLAIN)
+  @GET
+  @Path("/FieldParamEntityWithValueOf/{FieldParamEntityWithValueOf}")
+  public String fieldEntityWithValueOfTest() {
+    return fieldParamEntityWithValueOf.getValue();
+  }
+
+  @DefaultValue("PathParamTest")
+  @PathParam("FieldSetParamEntityWithFromString")
+  Set<ParamEntityWithFromString> fieldSetParamEntityWithFromString;
+
+  @Produces(MediaType.TEXT_PLAIN)
+  @GET
+  @Path("/FieldSetParamEntityWithFromString/{FieldSetParamEntityWithFromString}")
+  public String fieldSetParamEntityWithFromStringTest() {
+    return fieldSetParamEntityWithFromString.iterator().next().getValue();
+  }
+
+  @DefaultValue("PathParamTest")
+  @PathParam("FieldSortedSetParamEntityWithFromString")
+  SortedSet<ParamEntityWithFromString> fieldSortedSetParamEntityWithFromString;
+
+  @Produces(MediaType.TEXT_PLAIN)
+  @GET
+  @Path("/FieldSortedSetParamEntityWithFromString/{fieldSortedSetParamEntityWithFromString}")
+  public String fieldSortedSetParamEntityWithFromStringTest() {
+    return fieldSortedSetParamEntityWithFromString.iterator().next().getValue();
+  }
+
+  @DefaultValue("PathParamTest")
+  @PathParam("FieldListParamEntityWithFromString")
+  List<ParamEntityWithFromString> fieldListParamEntityWithFromString;
+
+  @Produces(MediaType.TEXT_PLAIN)
+  @GET
+  @Path("/FieldListParamEntityWithFromString/{FieldListParamEntityWithFromString}")
+  public String fieldListParamEntityWithFromStringTest() {
+    return fieldListParamEntityWithFromString.iterator().next().getValue();
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/pathparam/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/pathparam/TSAppConfig.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.pathparam;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.ws.rs.tck.ee.rs.RuntimeExceptionMapper;
+import jakarta.ws.rs.tck.ee.rs.WebApplicationExceptionMapper;
+
+import jakarta.ws.rs.core.Application;
+
+/**
+ *
+ * @author diannejiao
+ */
+public class TSAppConfig extends Application {
+
+  public java.util.Set<java.lang.Class<?>> getClasses() {
+    Set<Class<?>> resources = new HashSet<Class<?>>();
+    resources.add(PathParamTest.class);
+    resources.add(RuntimeExceptionMapper.class);
+    resources.add(WebApplicationExceptionMapper.class);
+    return resources;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/pathparam/locator/JAXRSLocatorClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/pathparam/locator/JAXRSLocatorClientIT.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.pathparam.locator;
+
+import java.io.InputStream;
+import java.io.IOException;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JAXRSLocatorClientIT
+    extends jakarta.ws.rs.tck.ee.rs.pathparam.JAXRSClientIT {
+
+  private static final long serialVersionUID = 1L;
+
+  public JAXRSLocatorClientIT() {
+    setup();
+    setContextRoot("/jaxrs_ee_rs_pathparam_locator_web/resource/locator");
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  @Deployment(testable = false, name = "jaxrs_ee_rs_pathparam_locator_deployment")
+  public static WebArchive createDeployment() throws IOException{
+
+    InputStream inStream = JAXRSLocatorClientIT.class.getClassLoader().getResourceAsStream("jakarta/ws/rs/tck/ee/rs/pathparam/locator/web.xml.template");
+    String webXml = editWebXmlString(inStream);
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_ee_rs_pathparam_locator_web.war");
+    archive.addClasses(TSAppConfig.class, LocatorResource.class, MiddleResource.class, PathSegmentImpl.class,
+      jakarta.ws.rs.tck.ee.rs.pathparam.PathParamTest.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityPrototype.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityWithConstructor.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityWithValueOf.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityWithFromString.class,
+      jakarta.ws.rs.tck.ee.rs.ParamTest.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingWebApplicationException.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
+      jakarta.ws.rs.tck.ee.rs.RuntimeExceptionMapper.class,
+      jakarta.ws.rs.tck.ee.rs.WebApplicationExceptionMapper.class
+    );
+    archive.setWebXML(new StringAsset(webXml));
+    return archive;
+
+  }
+
+
+
+  /* Run test */
+  /*
+   * @testName: test1
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:JAVADOC:9; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3;
+   * 
+   * @test_Strategy: Client invokes GET on root resource at /PathParamTest;
+   * Verify that right Method is invoked while using PathParam with primitive
+   * type String.
+   */
+  @Test
+  public void test1() throws Fault {
+    super.test1();
+  }
+
+  /*
+   * @testName: test2
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:JAVADOC:9; JAXRS:JAVADOC:114;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.3;
+   * 
+   * @test_Strategy: Client invokes GET on root resource at /PathParamTest;
+   * Verify that right Method is invoked while using PathParam primitive type
+   * String and PathSegment.
+   */
+  @Test
+  public void test2() throws Fault {
+    super.test2();
+  }
+
+  /*
+   * @testName: test3
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:JAVADOC:9; JAXRS:JAVADOC:114;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.3;
+   * 
+   * @test_Strategy: Client invokes GET on root resource at /PathParamTest;
+   * Verify that right Method is invoked while using PathParam primitive type
+   * int, float and PathSegment.
+   */
+  @Test
+  public void test3() throws Fault {
+    super.test3();
+  }
+
+  /*
+   * @testName: test4
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:JAVADOC:9; JAXRS:JAVADOC:114;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.3;
+   * 
+   * @test_Strategy: Client invokes GET on root resource at /PathParamTest;
+   * Verify that right Method is invoked using PathParam primitive type double,
+   * boolean, byte, and PathSegment.
+   */
+  @Test
+  public void test4() throws Fault {
+    super.test4();
+  }
+
+  /*
+   * @testName: test5
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:JAVADOC:9; JAXRS:JAVADOC:114;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.3;
+   * 
+   * @test_Strategy: Client invokes GET on root resource at /PathParamTest;
+   * Verify that right Method is invoked using PathParam primitive type long,
+   * String, short, boolean and PathSegment.
+   */
+  @Test
+  public void test5() throws Fault {
+    super.test5();
+  }
+
+  /*
+   * @testName: test6
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:JAVADOC:9; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3;
+   * 
+   * @test_Strategy: Client invokes GET on root resource at /PathParamTest;
+   * Verify that right Method is invoked using PathParam primitive type
+   * List<String>.
+   */
+  @Test
+  public void test6() throws Fault {
+    super.test6();
+  }
+
+  /*
+   * @testName: pathParamEntityWithConstructorTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:SPEC:5.2; JAXRS:SPEC:12;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.3;
+   * 
+   * @test_Strategy: Verify that named Param is handled properly
+   */
+  @Test
+  public void pathParamEntityWithConstructorTest() throws Fault {
+    super.paramEntityWithConstructorTest();
+  }
+
+  /*
+   * @testName: pathParamEntityWithValueOfTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:SPEC:5.3; JAXRS:SPEC:12;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.3;
+   * 
+   * @test_Strategy: Verify that named Param is handled properly
+   */
+  @Test
+  public void pathParamEntityWithValueOfTest() throws Fault {
+    super.pathParamEntityWithValueOfTest();
+  }
+
+  /*
+   * @testName: pathParamEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:SPEC:5.3; JAXRS:SPEC:12;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.3;
+   * 
+   * @test_Strategy: Verify that named Param is handled properly
+   */
+  @Test
+  public void pathParamEntityWithFromStringTest() throws Fault {
+    _contextRoot += "encoded";
+    super.pathParamEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: pathParamSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:SPEC:5.4; JAXRS:SPEC:12;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.3;
+   * 
+   * @test_Strategy: Verify that named PathParam is handled properly
+   */
+  @Test
+  public void pathParamSetEntityWithFromStringTest() throws Fault {
+    super.pathParamSetEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: pathParamListEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:SPEC:5.4; JAXRS:SPEC:12;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.3;
+   * 
+   * @test_Strategy: Verify that named PathParam is handled properly
+   */
+  @Test
+  public void pathParamListEntityWithFromStringTest() throws Fault {
+    super.pathParamListEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: pathParamThrowingWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:8; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3;
+   * 
+   * @test_Strategy: A WebApplicationException thrown during construction of
+   * field or property values using 2 or 3 above is processed directly as
+   * described in section 3.3.4.
+   */
+  @Test
+  public void pathParamThrowingWebApplicationExceptionTest() throws Fault {
+    super.pathParamThrowingWebApplicationExceptionTest();
+  }
+
+  /*
+   * @testName: pathParamThrowingIllegalArgumentExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:9; JAXRS:SPEC:9.1; JAXRS:SPEC:10; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.3;
+   * 
+   * @test_Strategy: Other exceptions thrown during construction of field or
+   * property values using 2 or 3 above are treated as client errors:
+   * 
+   * if the field or property is annotated with @MatrixParam,
+   * 
+   * @QueryParam or @PathParam then an implementation MUST generate a
+   * WebApplicationException that wraps the thrown exception with a not found
+   * response (404 status) and no entity;
+   */
+  @Test
+  public void pathParamThrowingIllegalArgumentExceptionTest() throws Fault {
+    super.pathParamThrowingIllegalArgumentExceptionTest();
+  }
+
+  public void test7() throws Fault {
+    //do nothing  
+  }
+  public void pathParamSortedSetEntityWithFromStringTest() throws Fault {
+    //do nothing  
+  }
+  public void pathFieldParamEntityWithConstructorTest() throws Fault {
+    //do nothing  
+  }
+  public void pathFieldParamEntityWithValueOfTest() throws Fault {
+    //do nothing  
+  }
+  public void pathFieldParamEntityWithFromStringTest() throws Fault {
+    //do nothing  
+  }
+  public void pathFieldParamSetEntityWithFromStringTest() throws Fault {
+    //do nothing  
+  }
+  public void pathFieldParamSortedSetEntityWithFromStringTest() throws Fault {
+    //do nothing  
+  }
+  public void pathFieldParamListEntityWithFromStringTest() throws Fault {
+    //do nothing  
+  }
+  public void pathParamEntityWithEncodedTest() throws Fault {
+    //do nothing  
+  }
+  
+
+  @Override
+  protected String buildRequest(Request type, String... path) {
+    return super.buildRequest(Request.POST, path);
+  }
+
+  @Override
+  protected String buildRequest(String param) {
+    return super.buildRequest(param).replace(Request.GET.name(),
+        Request.POST.name());
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/pathparam/locator/LocatorResource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/pathparam/locator/LocatorResource.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.pathparam.locator;
+
+import jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingExceptionGivenByName;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingWebApplicationException;
+
+import jakarta.ws.rs.Encoded;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+
+@Path("resource")
+public class LocatorResource extends MiddleResource {
+
+  @Path("locator/{id1}")
+  public MiddleResource locatorHasArguments(@PathParam("id1") String id1) {
+    return new MiddleResource(id1);
+  }
+
+  @Path("locator/{id1}/{id2}")
+  public MiddleResource locatorHasArguments(@PathParam("id1") String id1,
+      @PathParam("id2") String id2) {
+    return new MiddleResource(id1, id2);
+  }
+
+  @Path("locatorencoded/{id1}/{id2}")
+  public MiddleResource locatorHasEncodedArguments(@PathParam("id1") String id1,
+      @Encoded @PathParam("id2") String id2) {
+    return new MiddleResource(id1, id2);
+  }
+
+  @Path("locator/{id1}/{id2}/{id3}")
+  public MiddleResource locatorHasArguments(@PathParam("id1") String id1,
+      @PathParam("id2") String id2, @PathParam("id3") String id3) {
+    return new MiddleResource(id1, id2, id3);
+  }
+
+  @Path("locator/{id1}/{id2}/{id3}/{id4}")
+  public MiddleResource locatorHasArguments(@PathParam("id1") String id1,
+      @PathParam("id2") String id2, @PathParam("id3") String id3,
+      @PathParam("id4") String id4) {
+    return new MiddleResource(id1, id2, id3, id4);
+  }
+
+  @Path("locator/{id1}/{id2}/{id3}/{id4}/{id5}")
+  public MiddleResource locatorHasArguments(@PathParam("id1") String id1,
+      @PathParam("id2") String id2, @PathParam("id3") String id3,
+      @PathParam("id4") String id4, @PathParam("id5") String id5) {
+    return new MiddleResource(id1, id2, id3, id4, id5);
+  }
+
+  @Path("locator/{id1}/{id2}/{id3}/{id4}/{id5}/{id6}")
+  public MiddleResource locatorHasArguments(@PathParam("id1") String id1,
+      @PathParam("id2") String id2, @PathParam("id3") String id3,
+      @PathParam("id4") String id4, @PathParam("id5") String id5,
+      @PathParam("id6") String id6) {
+    return new MiddleResource(id1, id2, id3, id4, id5, id6);
+  }
+
+  @Path("/locator/ParamEntityThrowingWebApplicationException/{id}")
+  public MiddleResource locatorHasArguments(
+      @PathParam("id") ParamEntityThrowingWebApplicationException paramEntityThrowingWebApplicationException) {
+    return null;
+  }
+
+  @Path("/locator/ParamEntityThrowingExceptionGivenByName/{id}")
+  public MiddleResource locatorHasArguments(
+      @PathParam("id") ParamEntityThrowingExceptionGivenByName paramEntityThrowingExceptionGivenByName) {
+    return null;
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/pathparam/locator/MiddleResource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/pathparam/locator/MiddleResource.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.pathparam.locator;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import jakarta.ws.rs.tck.ee.rs.ParamEntityWithConstructor;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityWithFromString;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityWithValueOf;
+import jakarta.ws.rs.tck.ee.rs.pathparam.PathParamTest;
+
+import jakarta.ws.rs.POST;
+
+public class MiddleResource extends PathParamTest {
+
+  private final String returnValue;
+
+  public MiddleResource() {
+    returnValue = null;
+  }
+
+  protected MiddleResource(String id) {
+    returnValue = single(id);
+  }
+
+  protected MiddleResource(String id1, String id2) {
+    if ("ParamEntityWithConstructor".equals(id1))
+      returnValue = paramEntityWithConstructorTest(
+          new ParamEntityWithConstructor(id2));
+    else if ("ParamEntityWithFromString".equals(id1))
+      returnValue = paramEntityWithFromStringTest(
+          ParamEntityWithFromString.fromString(id2));
+    else if ("ParamEntityWithValueOf".equals(id1))
+      returnValue = paramEntityWithValueOfTest(
+          ParamEntityWithValueOf.valueOf(id2));
+    else if ("SetParamEntityWithFromString".equals(id1)) {
+      returnValue = setParamEntityWithFromStringTest(
+          Collections.singleton(ParamEntityWithFromString.fromString(id2)));
+    } else if ("ListParamEntityWithFromString".equals(id1)) {
+      returnValue = listParamEntityWithFromStringTest(
+          Collections.singletonList(ParamEntityWithFromString.fromString(id2)));
+    } else
+      returnValue = two(id1, new PathSegmentImpl(id2));
+  }
+
+  protected MiddleResource(String id1, String id2, String id3) {
+    returnValue = triple(Integer.parseInt(id1), new PathSegmentImpl(id2),
+        Float.parseFloat(id3));
+  }
+
+  protected MiddleResource(String id1, String id2, String id3, String id4) {
+    returnValue = quard(Double.parseDouble(id1), Boolean.parseBoolean(id2),
+        Byte.parseByte(id3), new PathSegmentImpl(id4));
+  }
+
+  protected MiddleResource(String id1, String id2, String id3, String id4,
+      String id5) {
+    returnValue = penta(Long.parseLong(id1), id2, Short.parseShort(id3),
+        Boolean.parseBoolean(id4), new PathSegmentImpl(id5));
+  }
+
+  protected MiddleResource(String id1, String id2, String id3, String id4,
+      String id5, String id6) {
+    List<String> list = Arrays.asList(id1, id2, id3, id4, id5, id6);
+    returnValue = list(list);
+  }
+
+  @POST
+  public String returnValue() {
+    return returnValue;
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/pathparam/locator/PathSegmentImpl.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/pathparam/locator/PathSegmentImpl.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.pathparam.locator;
+
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.PathSegment;
+
+public class PathSegmentImpl implements PathSegment {
+
+  public PathSegmentImpl(String id) {
+    super();
+    this.id = id;
+  }
+
+  private String id;
+
+  @Override
+  public MultivaluedMap<String, String> getMatrixParameters() {
+    return null;
+  }
+
+  @Override
+  public String getPath() {
+    return id;
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/pathparam/locator/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/pathparam/locator/TSAppConfig.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.pathparam.locator;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.ws.rs.tck.ee.rs.RuntimeExceptionMapper;
+import jakarta.ws.rs.tck.ee.rs.WebApplicationExceptionMapper;
+
+import jakarta.ws.rs.core.Application;
+
+public class TSAppConfig extends Application {
+
+  public java.util.Set<java.lang.Class<?>> getClasses() {
+    Set<Class<?>> resources = new HashSet<Class<?>>();
+    resources.add(LocatorResource.class);
+    resources.add(RuntimeExceptionMapper.class);
+    resources.add(WebApplicationExceptionMapper.class);
+    return resources;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/pathparam/sub/JAXRSSubClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/pathparam/sub/JAXRSSubClientIT.java
@@ -1,0 +1,417 @@
+/*
+ * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.pathparam.sub;
+
+import java.io.InputStream;
+import java.io.IOException;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JAXRSSubClientIT
+    extends jakarta.ws.rs.tck.ee.rs.pathparam.JAXRSClientIT {
+
+  private static final long serialVersionUID = 1L;
+
+  public JAXRSSubClientIT() {
+    setup();
+    setContextRoot("/jaxrs_ee_rs_pathparam_sub_web/resource/subresource");
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  @Deployment(testable = false, name = "jaxrs_ee_rs_pathparam_sub_deployment")
+  public static WebArchive createDeployment() throws IOException{
+
+    InputStream inStream = JAXRSSubClientIT.class.getClassLoader().getResourceAsStream("jakarta/ws/rs/tck/ee/rs/pathparam/sub/web.xml.template");
+    String webXml = editWebXmlString(inStream);
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_ee_rs_pathparam_sub_web.war");
+    archive.addClasses(TSAppConfig.class, SubResource.class,
+      jakarta.ws.rs.tck.ee.rs.pathparam.PathParamTest.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityPrototype.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityWithConstructor.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityWithValueOf.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityWithFromString.class,
+      jakarta.ws.rs.tck.ee.rs.ParamTest.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingWebApplicationException.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
+      jakarta.ws.rs.tck.ee.rs.RuntimeExceptionMapper.class,
+      jakarta.ws.rs.tck.ee.rs.WebApplicationExceptionMapper.class
+    );
+    archive.setWebXML(new StringAsset(webXml));
+    return archive;
+
+  }
+
+
+
+  /* Run test */
+  /*
+   * @testName: test1
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:JAVADOC:9; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Client invokes GET on root resource at /PathParamTest;
+   * Verify that right Method is invoked while using PathParam with primitive
+   * type String.
+   */
+  @Test
+  public void test1() throws Fault {
+    super.test1();
+  }
+
+  /*
+   * @testName: test2
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:JAVADOC:9; JAXRS:JAVADOC:114;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Client invokes GET on root resource at /PathParamTest;
+   * Verify that right Method is invoked while using PathParam primitive type
+   * String and PathSegment.
+   */
+  @Test
+  public void test2() throws Fault {
+    super.test2();
+  }
+
+  /*
+   * @testName: test3
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:JAVADOC:9; JAXRS:JAVADOC:114;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Client invokes GET on root resource at /PathParamTest;
+   * Verify that right Method is invoked while using PathParam primitive type
+   * int, float and PathSegment.
+   */
+  @Test
+  public void test3() throws Fault {
+    super.test3();
+  }
+
+  /*
+   * @testName: test4
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:JAVADOC:9; JAXRS:JAVADOC:114;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Client invokes GET on root resource at /PathParamTest;
+   * Verify that right Method is invoked using PathParam primitive type double,
+   * boolean, byte, and PathSegment.
+   */
+  @Test
+  public void test4() throws Fault {
+    super.test4();
+  }
+
+  /*
+   * @testName: test5
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:JAVADOC:9; JAXRS:JAVADOC:114;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Client invokes GET on root resource at /PathParamTest;
+   * Verify that right Method is invoked using PathParam primitive type long,
+   * String, short, boolean and PathSegment.
+   */
+  @Test
+  public void test5() throws Fault {
+    super.test5();
+  }
+
+  /*
+   * @testName: test6
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:JAVADOC:9; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Client invokes GET on root resource at /PathParamTest;
+   * Verify that right Method is invoked using PathParam primitive type
+   * List<String>.
+   */
+  @Test
+  public void test6() throws Fault {
+    super.test6();
+  }
+
+  /*
+   * @testName: test7
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:JAVADOC:9;JAXRS:JAVADOC:113;
+   * JAXRS:JAVADOC:114; JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Client invokes GET on root resource at /PathParamTest with
+   * Matrix parameter; Verify that right Method is invoked using PathParam
+   * PathSegment.
+   */
+  @Test
+  public void test7() throws Fault {
+    super.test7();
+  }
+
+  /*
+   * @testName: pathParamEntityWithConstructorTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:SPEC:5.2; JAXRS:SPEC:12;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void pathParamEntityWithConstructorTest() throws Fault {
+    super.paramEntityWithConstructorTest();
+  }
+
+  /*
+   * @testName: pathParamEntityWithValueOfTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:SPEC:5.3; JAXRS:SPEC:12;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void pathParamEntityWithValueOfTest() throws Fault {
+    super.pathParamEntityWithValueOfTest();
+  }
+
+  /*
+   * @testName: pathParamEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:SPEC:5.3; JAXRS:SPEC:12;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void pathParamEntityWithFromStringTest() throws Fault {
+    super.pathParamEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: pathParamSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:SPEC:5.4; JAXRS:SPEC:12;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void pathParamSetEntityWithFromStringTest() throws Fault {
+    super.pathParamSetEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: pathParamSortedSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:SPEC:5.4; JAXRS:SPEC:12;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void pathParamSortedSetEntityWithFromStringTest() throws Fault {
+    super.pathParamSortedSetEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: pathParamListEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:SPEC:5.4; JAXRS:SPEC:12;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void pathParamListEntityWithFromStringTest() throws Fault {
+    super.pathParamListEntityWithFromStringTest();
+  }
+
+  /*
+   * pathFieldParamEntityWithConstructorTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:SPEC:5.2; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:SPEC:4;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   * 
+   * An implementation is only required to set the annotated field and bean
+   * property values of instances created by the implementation runtime. (Check
+   * the resource with resource locator is injected field properties)
+   */
+  public void pathFieldParamEntityWithConstructorTest() throws Fault {
+    super.pathFieldParamEntityWithConstructorTest();
+  }
+
+  /*
+   * pathFieldParamEntityWithValueOfTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:SPEC:5.3; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:SPEC:4;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   *
+   * An implementation is only required to set the annotated field and bean
+   * property values of instances created by the implementation runtime. (Check
+   * the resource with resource locator is injected field properties)
+   */
+  public void pathFieldParamEntityWithValueOfTest() throws Fault {
+    super.fieldEntityWithValueOfTest();
+  }
+
+  /*
+   * pathFieldParamEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:SPEC:5.3; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:SPEC:4;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   *
+   * An implementation is only required to set the annotated field and bean
+   * property values of instances created by the implementation runtime. (Check
+   * the resource with resource locator is injected field properties)
+   */
+  public void pathFieldParamEntityWithFromStringTest() throws Fault {
+    super.fieldEntityWithFromStringTest();
+  }
+
+  /*
+   * pathFieldParamSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:SPEC:5.4; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:SPEC:4;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   *
+   * An implementation is only required to set the annotated field and bean
+   * property values of instances created by the implementation runtime. (Check
+   * the resource with resource locator is injected field properties)
+   */
+  public void pathFieldParamSetEntityWithFromStringTest() throws Fault {
+    super.fieldCollectionEntityWithFromStringTest(CollectionName.SET);
+  }
+
+  /*
+   * pathFieldParamSortedSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:SPEC:5.4; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:SPEC:4;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   *
+   * An implementation is only required to set the annotated field and bean
+   * property values of instances created by the implementation runtime. (Check
+   * the resource with resource locator is injected field properties)
+   */
+  public void pathFieldParamSortedSetEntityWithFromStringTest() throws Fault {
+    super.fieldCollectionEntityWithFromStringTest(CollectionName.SORTED_SET);
+  }
+
+  /*
+   * pathFieldParamListEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:SPEC:5.4; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:SPEC:4;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   *
+   * An implementation is only required to set the annotated field and bean
+   * property values of instances created by the implementation runtime. (Check
+   * the resource with resource locator is injected field properties)
+   */
+  public void pathFieldParamListEntityWithFromStringTest() throws Fault {
+    super.fieldCollectionEntityWithFromStringTest(CollectionName.LIST);
+  }
+
+  /*
+   * @testName: pathParamEntityWithEncodedTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.3; JAXRS:SPEC:7; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Verify that named PathParam @Encoded is handled
+   */
+  @Test
+  public void pathParamEntityWithEncodedTest() throws Fault {
+    super.pathParamEntityWithEncodedTest();
+  }
+
+  /*
+   * @testName: pathParamThrowingWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.1; JAXRS:SPEC:8; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: A WebApplicationException thrown during construction of
+   * field or property values using 2 or 3 above is processed directly as
+   * described in section 3.3.4.
+   */
+  @Test
+  public void pathParamThrowingWebApplicationExceptionTest() throws Fault {
+    super.pathParamThrowingWebApplicationExceptionTest();
+  }
+
+  /*
+   * @testName: pathParamThrowingIllegalArgumentExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:9; JAXRS:SPEC:9.1; JAXRS:SPEC:10; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Other exceptions thrown during construction of field or
+   * property values using 2 or 3 above are treated as client errors:
+   * 
+   * if the field or property is annotated with @MatrixParam,
+   * 
+   * @QueryParam or @PathParam then an implementation MUST generate a
+   * WebApplicationException that wraps the thrown exception with a not found
+   * response (404 status) and no entity;
+   */
+  @Test
+  public void pathParamThrowingIllegalArgumentExceptionTest() throws Fault {
+    super.pathParamThrowingIllegalArgumentExceptionTest();
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/pathparam/sub/SubResource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/pathparam/sub/SubResource.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.pathparam.sub;
+
+import jakarta.ws.rs.tck.ee.rs.pathparam.PathParamTest;
+
+import jakarta.ws.rs.Path;
+
+@Path("resource")
+public class SubResource extends PathParamTest {
+
+  @Path("subresource")
+  public SubResource subresorce() {
+    return this;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/pathparam/sub/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/pathparam/sub/TSAppConfig.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.pathparam.sub;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.ws.rs.tck.ee.rs.RuntimeExceptionMapper;
+import jakarta.ws.rs.tck.ee.rs.WebApplicationExceptionMapper;
+
+import jakarta.ws.rs.core.Application;
+
+public class TSAppConfig extends Application {
+
+  public java.util.Set<java.lang.Class<?>> getClasses() {
+    Set<Class<?>> resources = new HashSet<Class<?>>();
+    resources.add(SubResource.class);
+    resources.add(RuntimeExceptionMapper.class);
+    resources.add(WebApplicationExceptionMapper.class);
+    return resources;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/produceconsume/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/produceconsume/JAXRSClientIT.java
@@ -1,0 +1,445 @@
+/*
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.produceconsume;
+
+import jakarta.ws.rs.tck.common.JAXRSCommonClient;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response.Status;
+
+import java.io.InputStream;
+import java.io.IOException;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JAXRSClientIT extends JAXRSCommonClient {
+
+  private static final long serialVersionUID = 3927081991341346347L;
+
+  public JAXRSClientIT() {
+    setup();
+    setContextRoot("/jaxrs_ee_rs_produceconsume_web/resource");
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  @Deployment(testable = false)
+  public static WebArchive createDeployment() throws IOException{
+
+    InputStream inStream = JAXRSClientIT.class.getClassLoader().getResourceAsStream("jakarta/ws/rs/tck/ee/rs/produceconsume/web.xml.template");
+    String webXml = editWebXmlString(inStream);
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_ee_rs_produceconsume_web.war");
+    archive.addClasses(TSAppConfig.class, Resource.class);
+    archive.setWebXML(new StringAsset(webXml));
+    return archive;
+
+  }
+
+
+
+  /* Run test */
+  /*
+   * @testName: anyPlainTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:21; JAXRS:SPEC:26.6; JAXRS:SPEC:25.8;
+   * 
+   * @test_Strategy: An implementation MUST NOT invoke a method whose effective
+   * value of @Produces does not match the request Accept header. test accept
+   *//*
+      * @produces text/plain
+      */
+  @Test
+  public void anyPlainTest() throws Fault {
+    setProperty(Property.REQUEST, buildRequest(Request.GET, "plain"));
+    setProperty(Property.SEARCH_STRING, MediaType.TEXT_PLAIN);
+    invoke();
+  }
+
+  /*
+   * @testName: anyWidgetsxmlTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:21; JAXRS:SPEC:26.6; JAXRS:SPEC:25.8;
+   * 
+   * @test_Strategy: An implementation MUST NOT invoke a method whose effective
+   * value of @Produces does not match the request Accept header. test accept
+   *//*
+      * @produces text/plain
+      */
+  @Test
+  public void anyWidgetsxmlTest() throws Fault {
+    setProperty(Property.REQUEST, buildRequest(Request.GET, "widgetsxml"));
+    setProperty(Property.SEARCH_STRING, Resource.WIDGETS_XML);
+    invoke();
+  }
+
+  /*
+   * @testName: anyUnknownTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:21; JAXRS:SPEC:26.6; JAXRS:SPEC:25.8;
+   * 
+   * @test_Strategy: An implementation MUST NOT invoke a method whose effective
+   * value of @Produces does not match the request Accept header. test accept
+   *//*
+      * @produces unknown/unknown
+      */
+  @Test
+  public void anyUnknownTest() throws Fault {
+    setProperty(Property.REQUEST, buildRequest(Request.GET, "unknown"));
+    setProperty(Property.SEARCH_STRING, Resource.UNKNOWN);
+    invoke();
+  }
+
+  /*
+   * @testName: widgetsXmlAnyTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:21; JAXRS:SPEC:25.8; JAXRS:JAVADOC:10;
+   * 
+   * @test_Strategy: An implementation MUST NOT invoke a method whose effective
+   * value of @Produces does not match the request Accept header. test accept
+   * text/plain @produces *.*
+   */
+  @Test
+  public void widgetsXmlAnyTest() throws Fault {
+    setProperty(Property.REQUEST_HEADERS, "Accept: " + Resource.WIDGETS_XML);
+    setProperty(Property.REQUEST, buildRequest(Request.GET, "any"));
+    setProperty(Property.SEARCH_STRING, MediaType.WILDCARD);
+    invoke();
+  }
+
+  /*
+   * @testName: plainAnyTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:21; JAXRS:SPEC:25.8; JAXRS:JAVADOC:10;
+   * 
+   * @test_Strategy: An implementation MUST NOT invoke a method whose effective
+   * value of @Produces does not match the request Accept header. test accept
+   * text/plain @produces *.*
+   */
+  @Test
+  public void plainAnyTest() throws Fault {
+    setProperty(Property.REQUEST_HEADERS,
+        buildAccept(MediaType.TEXT_PLAIN_TYPE));
+    setProperty(Property.REQUEST, buildRequest(Request.GET, "any"));
+    setProperty(Property.SEARCH_STRING, MediaType.WILDCARD);
+    invoke();
+  }
+
+  /*
+   * @testName: unknownAnyTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:21; JAXRS:SPEC:25.8; JAXRS:JAVADOC:10;
+   * 
+   * @test_Strategy: An implementation MUST NOT invoke a method whose effective
+   * value of @Produces does not match the request Accept header. test accept
+   * unknown/unknown @produces *.*
+   */
+  @Test
+  public void unknownAnyTest() throws Fault {
+    setProperty(Property.REQUEST_HEADERS, "Accept: " + Resource.UNKNOWN);
+    setProperty(Property.REQUEST, buildRequest(Request.GET, "any"));
+    setProperty(Property.SEARCH_STRING, MediaType.WILDCARD);
+    invoke();
+  }
+
+  /*
+   * @testName: htmlPlainTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:21; JAXRS:SPEC:26.7; JAXRS:JAVADOC:10;
+   * 
+   * @test_Strategy: An implementation MUST NOT invoke a method whose effective
+   * value of @Produces does not match the request Accept header. test accept
+   * text/plain @produces text/html
+   */
+  @Test
+  public void htmlPlainTest() throws Fault {
+    setProperty(Property.REQUEST_HEADERS,
+        buildAccept(MediaType.TEXT_HTML_TYPE));
+    setProperty(Property.REQUEST, buildRequest(Request.GET, "plain"));
+    setProperty(Property.STATUS_CODE, getStatusCode(Status.NOT_ACCEPTABLE));
+    invoke();
+  }
+
+  /*
+   * @testName: htmlUnknownTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:21; JAXRS:SPEC:26.7; JAXRS:JAVADOC:10;
+   * 
+   * @test_Strategy: An implementation MUST NOT invoke a method whose effective
+   * value of @Produces does not match the request Accept header. test accept
+   * text/plain @produces unknown/unknown
+   */
+  @Test
+  public void htmlUnknownTest() throws Fault {
+    setProperty(Property.REQUEST_HEADERS,
+        buildAccept(MediaType.TEXT_HTML_TYPE));
+    setProperty(Property.REQUEST, buildRequest(Request.GET, "plain"));
+    setProperty(Property.STATUS_CODE, getStatusCode(Status.NOT_ACCEPTABLE));
+    invoke();
+  }
+
+  /*
+   * @testName: plainPlusProducePlainTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:22; JAXRS:SPEC:25.8; JAXRS:JAVADOC:1;
+   * JAXRS:JAVADOC:10;
+   * 
+   * @test_Strategy: An implementation MUST NOT invoke a method whose effective
+   * value of @Consumes does not match the request Accept header. accept
+   * text/plain @Consumes text/plain+xml
+   */
+  @Test
+  public void plainPlusProducePlainTest() throws Fault {
+    setProperty(Property.REQUEST_HEADERS,
+        buildAccept(MediaType.TEXT_PLAIN_TYPE));
+    setProperty(Property.REQUEST_HEADERS,
+        buildContentType(MediaType.TEXT_PLAIN_TYPE));
+    setProperty(Property.REQUEST, buildRequest(Request.POST, "plus"));
+    setProperty(Property.SEARCH_STRING, MediaType.TEXT_PLAIN);
+    invoke();
+  }
+
+  /*
+   * @testName: plainPlusProduceXmlTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:22; JAXRS:SPEC:25.8; JAXRS:JAVADOC:1;
+   * JAXRS:JAVADOC:10;
+   * 
+   * @test_Strategy: An implementation MUST NOT invoke a method whose effective
+   * value of @Consumes does not match the request Accept header. accept
+   * text/plain @Consumes text/plain+xml
+   */
+  @Test
+  public void plainPlusProduceXmlTest() throws Fault {
+    setProperty(Property.REQUEST_HEADERS, buildAccept(MediaType.TEXT_XML_TYPE));
+    setProperty(Property.REQUEST_HEADERS,
+        buildContentType(MediaType.TEXT_XML_TYPE));
+    setProperty(Property.REQUEST, buildRequest(Request.POST, "plus"));
+    setProperty(Property.SEARCH_STRING, MediaType.TEXT_XML);
+    invoke();
+  }
+
+  // ----------------------------------------------------------------------
+  /*
+   * @testName: anyPlainConsumesTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:22; JAXRS:SPEC:25.7;
+   * 
+   * @test_Strategy: An implementation MUST NOT invoke a method whose effective
+   * value of @Consumes does not match the request Content-Type header. test
+   * content-type
+   *//*
+      * @Consumes text/plain
+      */
+  @Test
+  public void anyPlainConsumesTest() throws Fault {
+    setProperty(Property.REQUEST, buildRequest(Request.POST, "plain"));
+    setProperty(Property.SEARCH_STRING, MediaType.TEXT_PLAIN);
+    invoke();
+  }
+
+  /*
+   * @testName: anyWidgetsxmlConsumesTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:22; JAXRS:SPEC:25.7;
+   * 
+   * @test_Strategy: An implementation MUST NOT invoke a method whose effective
+   * value of @Consumes does not match the request Content-Type header. test
+   * content-type
+   *//*
+      * @Consumes text/plain
+      */
+  @Test
+  public void anyWidgetsxmlConsumesTest() throws Fault {
+    setProperty(Property.REQUEST, buildRequest(Request.POST, "widgetsxml"));
+    setProperty(Property.SEARCH_STRING, Resource.WIDGETS_XML);
+    invoke();
+  }
+
+  /*
+   * @testName: anyUnknownConsumesTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:22; JAXRS:SPEC:25.7
+   * 
+   * @test_Strategy: An implementation MUST NOT invoke a method whose effective
+   * value of @Consumes does not match the request Content-Type header. test
+   * content-type
+   *//*
+      * @Consumes unknown/unknown
+      */
+  @Test
+  public void anyUnknownConsumesTest() throws Fault {
+    setProperty(Property.REQUEST, buildRequest(Request.POST, "unknown"));
+    setProperty(Property.SEARCH_STRING, Resource.UNKNOWN);
+    invoke();
+  }
+
+  /*
+   * @testName: widgetsXmlAnyConsumesTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:22; JAXRS:SPEC:25.7; JAXRS:JAVADOC:1;
+   * 
+   * @test_Strategy: An implementation MUST NOT invoke a method whose effective
+   * value of @Consumes does not match the request Content-Type header. test
+   * content-type text/plain @Consumes *.*
+   */
+  @Test
+  public void widgetsXmlAnyConsumesTest() throws Fault {
+    setProperty(Property.REQUEST_HEADERS,
+        "Content-Type: " + Resource.WIDGETS_XML);
+    setProperty(Property.REQUEST, buildRequest(Request.POST, "any"));
+    setProperty(Property.SEARCH_STRING, MediaType.WILDCARD);
+    invoke();
+  }
+
+  /*
+   * @testName: plainAnyConsumesTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:22; JAXRS:SPEC:25.7; JAXRS:JAVADOC:1;
+   * 
+   * @test_Strategy: An implementation MUST NOT invoke a method whose effective
+   * value of @Consumes does not match the request Content-Type header. test
+   * content-type text/plain @Consumes *.*
+   */
+  @Test
+  public void plainAnyConsumesTest() throws Fault {
+    setProperty(Property.REQUEST_HEADERS,
+        buildContentType(MediaType.TEXT_PLAIN_TYPE));
+    setProperty(Property.REQUEST, buildRequest(Request.POST, "any"));
+    setProperty(Property.SEARCH_STRING, MediaType.WILDCARD);
+    invoke();
+  }
+
+  /*
+   * @testName: unknownAnyConsumesTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:22; JAXRS:SPEC:25.7; JAXRS:JAVADOC:1;
+   * 
+   * @test_Strategy: An implementation MUST NOT invoke a method whose effective
+   * value of @Consumes does not match the request Content-Type header. test
+   * content-type unknown/unknown @Consumes *.*
+   */
+  @Test
+  public void unknownAnyConsumesTest() throws Fault {
+    setProperty(Property.REQUEST_HEADERS, "Content-type: " + Resource.UNKNOWN);
+    setProperty(Property.REQUEST, buildRequest(Request.POST, "any"));
+    setProperty(Property.SEARCH_STRING, MediaType.WILDCARD);
+    invoke();
+  }
+
+  /*
+   * @testName: htmlPlainConsumesTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:22; JAXRS:JAVADOC:1;
+   * 
+   * @test_Strategy: An implementation MUST NOT invoke a method whose effective
+   * value of @Consumes does not match the request Content-Type header. test
+   * content-type text/html @Consumes text/plain
+   */
+  @Test
+  public void htmlPlainConsumesTest() throws Fault {
+    setProperty(Property.REQUEST_HEADERS,
+        buildContentType(MediaType.TEXT_HTML_TYPE));
+    setProperty(Property.REQUEST, buildRequest(Request.POST, "plain"));
+    setProperty(Property.STATUS_CODE,
+        getStatusCode(Status.UNSUPPORTED_MEDIA_TYPE));
+    invoke();
+  }
+
+  /*
+   * @testName: htmlUnknownConsumesTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:22; JAXRS:JAVADOC:1;
+   * 
+   * @test_Strategy: An implementation MUST NOT invoke a method whose effective
+   * value of @Consumes does not match the request Content-Type header. test
+   * content-type text/html @Consumes text/plain
+   */
+  @Test
+  public void htmlUnknownConsumesTest() throws Fault {
+    setProperty(Property.REQUEST_HEADERS,
+        buildContentType(MediaType.TEXT_HTML_TYPE));
+    setProperty(Property.REQUEST, buildRequest(Request.POST, "plain"));
+    setProperty(Property.STATUS_CODE,
+        getStatusCode(Status.UNSUPPORTED_MEDIA_TYPE));
+    invoke();
+  }
+
+  /*
+   * @testName: plainPlusConsumePlainTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:22; JAXRS:SPEC:25.7; JAXRS:JAVADOC:1;
+   * 
+   * @test_Strategy: An implementation MUST NOT invoke a method whose effective
+   * value of @Consumes does not match the request Content-Type header.
+   * content-type text/plain @Consumes text/plain+xml
+   */
+  @Test
+  public void plainPlusConsumePlainTest() throws Fault {
+    setProperty(Property.REQUEST_HEADERS,
+        buildContentType(MediaType.TEXT_PLAIN_TYPE));
+    setProperty(Property.REQUEST, buildRequest(Request.POST, "plus"));
+    setProperty(Property.SEARCH_STRING, MediaType.TEXT_PLAIN);
+    invoke();
+  }
+
+  /*
+   * @testName: plainPlusConsumeXmlTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:22; JAXRS:SPEC:25.7; JAXRS:JAVADOC:1;
+   * 
+   * @test_Strategy: An implementation MUST NOT invoke a method whose effective
+   * value of @Consumes does not match the request Content-Type header.
+   * content-type text/plain @Consumes text/plain+xml
+   */
+  @Test
+  public void plainPlusConsumeXmlTest() throws Fault {
+    setProperty(Property.REQUEST_HEADERS,
+        buildContentType(MediaType.TEXT_XML_TYPE));
+    setProperty(Property.REQUEST, buildRequest(Request.POST, "plus"));
+    setProperty(Property.SEARCH_STRING, MediaType.TEXT_XML);
+    invoke();
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/produceconsume/Resource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/produceconsume/Resource.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.produceconsume;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("resource")
+public class Resource {
+
+  public static final String WIDGETS_XML = "application/widgets+xml";
+
+  public static final String UNKNOWN = "unknown/unknown";
+
+  @GET
+  @Path("plain")
+  @Produces(MediaType.TEXT_PLAIN)
+  public String pPlain() {
+    return MediaType.TEXT_PLAIN;
+  }
+
+  @GET
+  @Path("html")
+  @Produces(MediaType.TEXT_HTML)
+  public String pHtml() {
+    return MediaType.TEXT_HTML;
+  }
+
+  @GET
+  @Path("widgetsxml")
+  @Produces(WIDGETS_XML)
+  public String pWidgetxml() {
+    return WIDGETS_XML;
+  }
+
+  @GET
+  @Path("unknown")
+  @Produces(UNKNOWN)
+  public String pUnknown() {
+    return UNKNOWN;
+  }
+
+  @GET
+  @Path("any")
+  @Produces(MediaType.WILDCARD)
+  public String pAny() {
+    return MediaType.WILDCARD;
+  }
+
+  @POST
+  @Path("plain")
+  @Consumes(MediaType.TEXT_PLAIN)
+  public String cPlain() {
+    return MediaType.TEXT_PLAIN;
+  }
+
+  @POST
+  @Path("html")
+  @Consumes(MediaType.TEXT_HTML)
+  public String cHtml() {
+    return MediaType.TEXT_HTML;
+  }
+
+  @POST
+  @Path("widgetsxml")
+  @Consumes(WIDGETS_XML)
+  public String cWidgetxml() {
+    return WIDGETS_XML;
+  }
+
+  @POST
+  @Path("unknown")
+  @Consumes(UNKNOWN)
+  public String cUnknown() {
+    return UNKNOWN;
+  }
+
+  @POST
+  @Path("any")
+  @Consumes(MediaType.WILDCARD)
+  public String cAny() {
+    return MediaType.WILDCARD;
+  }
+
+  @POST
+  @Path("plus")
+  @Produces(MediaType.TEXT_PLAIN + "," + MediaType.TEXT_XML)
+  @Consumes(MediaType.TEXT_PLAIN + "," + MediaType.TEXT_XML)
+  public String plus(@Context HttpHeaders headers) {
+    return headers.getMediaType() == null ? "null"
+        : headers.getMediaType().toString();
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/produceconsume/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/produceconsume/TSAppConfig.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.produceconsume;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.ws.rs.core.Application;
+
+public class TSAppConfig extends Application {
+
+  public java.util.Set<java.lang.Class<?>> getClasses() {
+    Set<Class<?>> resources = new HashSet<Class<?>>();
+    resources.add(Resource.class);
+    return resources;
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/put/HttpMethodPutTest.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/put/HttpMethodPutTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.put;
+
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+
+@Path(value = "/PutTest")
+
+public class HttpMethodPutTest {
+
+  static String html_content = "<html>"
+      + "<head><title>CTS-get text/html</title></head>"
+      + "<body>CTS-put text/html</body></html>";
+
+  @PUT
+  @Produces(value = "text/plain")
+  public String getPlain() {
+    return "CTS-put text/plain";
+  }
+
+  @PUT
+  @Produces(value = "text/html")
+  public String getHtml() {
+    return html_content;
+  }
+
+  @PUT
+  @Path(value = "/sub")
+  @Produces(value = "text/html")
+  public String getSub() {
+    return html_content;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/put/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/put/JAXRSClientIT.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.put;
+
+import jakarta.ws.rs.tck.common.client.JaxrsCommonClient;
+
+import java.io.InputStream;
+import java.io.IOException;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+
+@ExtendWith(ArquillianExtension.class)
+public class JAXRSClientIT extends JaxrsCommonClient {
+
+  private static final long serialVersionUID = -71817508809693264L;
+
+  public JAXRSClientIT() {
+    setup();
+    setContextRoot("/jaxrs_ee_rs_put_web");
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  @Deployment(testable = false)
+  public static WebArchive createDeployment() throws IOException{
+
+    InputStream inStream = JAXRSClientIT.class.getClassLoader().getResourceAsStream("jakarta/ws/rs/tck/ee/rs/put/web.xml.template");
+    String webXml = editWebXmlString(inStream);
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_ee_rs_put_web.war");
+    archive.addClasses(TSAppConfig.class, HttpMethodPutTest.class);
+    archive.setWebXML(new StringAsset(webXml));
+    return archive;
+
+  }
+
+
+
+  /*
+   * @class.setup_props: webServerHost; webServerPort; ts_home;
+   */
+  /* Run test */
+  /*
+   * @testName: putTest1
+   * 
+   * @assertion_ids: JAXRS:SPEC:20.1; JAXRS:JAVADOC:6; JAXRS:JAVADOC:8;
+   * JAXRS:JAVADOC:10;
+   * 
+   * @test_Strategy: Client invokes PUT on root resource at /PutTest; Verify
+   * that right Method is invoked.
+   */
+  @Test
+  public void putTest1() throws Fault {
+    setProperty(Property.REQUEST_HEADERS, "Accept:text/plain");
+    setProperty(Property.CONTENT, "dummy");
+    setProperty(Property.REQUEST, buildRequest(Request.PUT, "PutTest"));
+    setProperty(Property.SEARCH_STRING, "CTS-put text/plain");
+    invoke();
+  }
+
+  /*
+   * @testName: putTest2
+   * 
+   * @assertion_ids: JAXRS:SPEC:20.1; JAXRS:JAVADOC:6; JAXRS:JAVADOC:8;
+   * JAXRS:JAVADOC:10;
+   * 
+   * @test_Strategy: Client invokes PUT on root resource at /PutTest; Verify
+   * that right Method is invoked.
+   */
+  @Test
+  public void putTest2() throws Fault {
+    setProperty(Property.CONTENT, "dummy");
+    setProperty(Property.REQUEST_HEADERS, "Accept:text/html");
+    setProperty(Property.REQUEST, buildRequest(Request.PUT, "PutTest"));
+    setProperty(Property.SEARCH_STRING, "CTS-put text/html");
+    invoke();
+  }
+
+  /*
+   * @testName: putSubTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:20.1; JAXRS:JAVADOC:6; JAXRS:JAVADOC:8;
+   * JAXRS:JAVADOC:10;
+   * 
+   * @test_Strategy: Client invokes PUT on a sub resource at /PutTest/sub;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void putSubTest() throws Fault {
+    setProperty(Property.CONTENT, "dummy");
+    setProperty(Property.REQUEST, buildRequest(Request.PUT, "PutTest/sub"));
+    setProperty(Property.SEARCH_STRING, "CTS-put text/html");
+    invoke();
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/put/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/put/TSAppConfig.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.put;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.ws.rs.core.Application;
+
+/**
+ *
+ * @author diannejiao
+ */
+public class TSAppConfig extends Application {
+
+  public java.util.Set<java.lang.Class<?>> getClasses() {
+    Set<Class<?>> resources = new HashSet<Class<?>>();
+    resources.add(HttpMethodPutTest.class);
+    return resources;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/queryparam/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/queryparam/JAXRSClientIT.java
@@ -1,0 +1,624 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+package jakarta.ws.rs.tck.ee.rs.queryparam;
+
+import jakarta.ws.rs.tck.ee.rs.JaxrsParamClient;
+
+import jakarta.ws.rs.core.Response.Status;
+
+import java.io.InputStream;
+import java.io.IOException;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JAXRSClientIT extends JaxrsParamClient {
+
+  private static final long serialVersionUID = 1L;
+
+  public JAXRSClientIT() {
+    setup();
+    setContextRoot("/jaxrs_ee_rs_queryparam_web/QueryParamTest");
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  @Deployment(testable = false)
+  public static WebArchive createDeployment() throws IOException{
+
+    InputStream inStream = JAXRSClientIT.class.getClassLoader().getResourceAsStream("jakarta/ws/rs/tck/ee/rs/queryparam/web.xml.template");
+    String webXml = editWebXmlString(inStream);
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_ee_rs_queryparam_web.war");
+    archive.addClasses(TSAppConfig.class, QueryParamTest.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityPrototype.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityWithConstructor.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityWithValueOf.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityWithFromString.class,
+      jakarta.ws.rs.tck.ee.rs.ParamTest.class,
+      jakarta.ws.rs.tck.ee.rs.JaxrsParamClient.CollectionName.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingWebApplicationException.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
+      jakarta.ws.rs.tck.ee.rs.RuntimeExceptionMapper.class,
+      jakarta.ws.rs.tck.ee.rs.WebApplicationExceptionMapper.class
+    );
+    archive.setWebXML(new StringAsset(webXml));
+    return archive;
+
+  }
+
+
+
+  /* Run test */
+  /*
+   * @testName: queryParamStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.1; JAXRS:SPEC:12.1;
+   * JAXRS:JAVADOC:11; JAXRS:JAVADOC:3; JAXRS:JAVADOC:21; JAXRS:JAVADOC:22;
+   * 
+   * @test_Strategy: Client invokes HEAD on root resource at /QueryParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void queryParamStringTest() throws Fault {
+    setProperty(Property.REQUEST, buildRequest("stringtest=cts"));
+    setProperty(Property.SEARCH_STRING, "stringtest=cts");
+    invoke();
+
+    setProperty(Property.REQUEST,
+        buildRequest("stringtest=cts1&stringtest=cts2"));
+    setProperty(Property.SEARCH_STRING, "stringtest=cts1");
+    invoke();
+
+    setProperty(Property.REQUEST,
+        buildRequest("stringtest1=cts&stringtest2=ri_impl"));
+    setProperty(Property.SEARCH_STRING,
+        "stringtest=abc|stringtest1=cts|stringtest2=ri_impl");
+    invoke();
+
+    setProperty(Property.REQUEST,
+        buildRequest("stringtest1=cts&stringtest2=ri_impl&stringtest1=newone"));
+    setProperty(Property.SEARCH_STRING,
+        "stringtest=abc|stringtest1=cts|stringtest2=ri_impl");
+    invoke();
+  }
+
+  /*
+   * @testName: queryParamNoQueryTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.1; JAXRS:SPEC:14;
+   * JAXRS:JAVADOC:11; JAXRS:JAVADOC:3; JAXRS:JAVADOC:21; JAXRS:JAVADOC:22;
+   * 
+   * @test_Strategy: Client invokes HEAD on a sub resource at /QueryParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void queryParamNoQueryTest() throws Fault {
+    setProperty(Property.REQUEST_HEADERS, "Accept: text/plain");
+    setProperty(Property.REQUEST, buildRequest(""));
+    setProperty(Property.SEARCH_STRING, "stringtest=abc|No QueryParam");
+    invoke();
+  }
+
+  /*
+   * @testName: queryParamIntTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.1; JAXRS:JAVADOC:11;
+   * JAXRS:JAVADOC:3; JAXRS:JAVADOC:21; JAXRS:JAVADOC:22;
+   * 
+   * @test_Strategy: Client invokes HEAD on a sub resource at /QueryParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void queryParamIntTest() throws Fault {
+    setProperty(Property.REQUEST, buildRequest("inttest1=2147483647"));
+    setProperty(Property.SEARCH_STRING, "inttest1=2147483647");
+    invoke();
+
+    setProperty(Property.REQUEST,
+        buildRequest("inttest=-2147483648&inttest=2147483647"));
+    setProperty(Property.SEARCH_STRING, "inttest=-2147483648");
+    invoke();
+
+    setProperty(Property.REQUEST,
+        buildRequest("inttest1=2147483647&inttest2=-2147483648"));
+    setProperty(Property.SEARCH_STRING,
+        "inttest1=2147483647|inttest2=-2147483648");
+    invoke();
+
+    setProperty(Property.REQUEST,
+        buildRequest("inttest1=-2147483648&inttest2=2147483647&inttest1=1234"));
+    setProperty(Property.SEARCH_STRING,
+        "inttest1=-2147483648|inttest2=2147483647");
+    invoke();
+  }
+
+  /*
+   * @testName: queryParamDoubleTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.1; JAXRS:JAVADOC:11;
+   * JAXRS:JAVADOC:3; JAXRS:JAVADOC:21; JAXRS:JAVADOC:22;
+   * 
+   * @test_Strategy: Client invokes HEAD on a sub resource at /QueryParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void queryParamDoubleTest() throws Fault {
+    setProperty(Property.REQUEST, buildRequest("doubletest1=123"));
+    setProperty(Property.SEARCH_STRING, "doubletest1=123.0");
+    invoke();
+
+    setProperty(Property.REQUEST,
+        buildRequest("doubletest=123.1&doubletest=345"));
+    setProperty(Property.SEARCH_STRING, "doubletest=123.1");
+    invoke();
+
+    setProperty(Property.REQUEST,
+        buildRequest("doubletest1=12.345&doubletest2=34.567"));
+    setProperty(Property.SEARCH_STRING,
+        "doubletest1=12.345|doubletest2=34.567");
+    invoke();
+
+    setProperty(Property.REQUEST, buildRequest(
+        "doubletest1=23.456&doubletest2=0.56789&doubletest1=1.234"));
+    setProperty(Property.SEARCH_STRING,
+        "doubletest1=23.456|doubletest2=0.56789");
+    invoke();
+  }
+
+  /*
+   * @testName: queryParamFloatTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.1; JAXRS:JAVADOC:11;
+   * JAXRS:JAVADOC:3; JAXRS:JAVADOC:21; JAXRS:JAVADOC:22;
+   *
+   * @test_Strategy: Client invokes HEAD on a sub resource at /QueryParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void queryParamFloatTest() throws Fault {
+    setProperty(Property.REQUEST, buildRequest("floattest1=123"));
+    setProperty(Property.SEARCH_STRING, "floattest1=123.0");
+    invoke();
+
+    setProperty(Property.REQUEST,
+        buildRequest("floattest=123.1&floattest=345"));
+    setProperty(Property.SEARCH_STRING, "floattest=123.1");
+    invoke();
+
+    setProperty(Property.REQUEST,
+        buildRequest("floattest1=12.345&floattest2=34.567"));
+    setProperty(Property.SEARCH_STRING, "floattest1=12.345|floattest2=34.567");
+    invoke();
+
+    setProperty(Property.REQUEST,
+        buildRequest("floattest1=23.456&floattest2=0.56789&floattest1=1.234"));
+    setProperty(Property.SEARCH_STRING, "floattest1=23.456|floattest2=0.56789");
+    invoke();
+  }
+
+  /*
+   * @testName: queryParamLongTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.1; JAXRS:JAVADOC:11;
+   * JAXRS:JAVADOC:3; JAXRS:JAVADOC:21; JAXRS:JAVADOC:22;
+   * 
+   * @test_Strategy: Client invokes GET on a sub resource at /QueryParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void queryParamLongTest() throws Fault {
+    setProperty(Property.REQUEST,
+        buildRequest("longtest=-9223372036854775808"));
+    setProperty(Property.SEARCH_STRING, "longtest=-9223372036854775808");
+    invoke();
+
+    setProperty(Property.REQUEST, buildRequest(
+        "longtest=9223372036854775807&longtest=-9223372036854775808"));
+    setProperty(Property.SEARCH_STRING, "longtest=9223372036854775807");
+    invoke();
+
+    setProperty(Property.REQUEST, buildRequest(
+        "longtest1=-9223372036854775808&longtest2=9223372036854775807"));
+    setProperty(Property.SEARCH_STRING,
+        "longtest1=-9223372036854775808|longtest2=9223372036854775807");
+    invoke();
+
+    setProperty(Property.REQUEST, buildRequest(
+        "longtest1=-9223372036854775808&longtest2=9223372036854775807&longtest1=1234"));
+    setProperty(Property.SEARCH_STRING,
+        "longtest1=-9223372036854775808|longtest2=9223372036854775807");
+    invoke();
+  }
+
+  /*
+   * @testName: queryParamShortTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.1; JAXRS:JAVADOC:11;
+   * JAXRS:JAVADOC:3; JAXRS:JAVADOC:21; JAXRS:JAVADOC:22;
+   * 
+   * @test_Strategy: Client invokes GET on a sub resource at /QueryParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void queryParamShortTest() throws Fault {
+    setProperty(Property.REQUEST, buildRequest("shorttest=-32768"));
+    setProperty(Property.SEARCH_STRING, "shorttest=-32768");
+    invoke();
+
+    setProperty(Property.REQUEST,
+        buildRequest("shorttest=32767&shorttest=-32768"));
+    setProperty(Property.SEARCH_STRING, "shorttest=32767");
+    invoke();
+
+    setProperty(Property.REQUEST,
+        buildRequest("shorttest1=32767&shorttest2=-32768"));
+    setProperty(Property.SEARCH_STRING, "shorttest1=32767|shorttest2=-32768");
+    invoke();
+
+    setProperty(Property.REQUEST,
+        buildRequest("shorttest1=32767&shorttest2=-32768&shorttest1=1234"));
+    setProperty(Property.SEARCH_STRING, "shorttest1=32767|shorttest2=-32768");
+    invoke();
+  }
+
+  /*
+   * @testName: queryParamByteTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.1; JAXRS:JAVADOC:11;
+   * JAXRS:JAVADOC:3; JAXRS:JAVADOC:21; JAXRS:JAVADOC:22;
+   * 
+   * @test_Strategy: Client invokes GET on a sub resource at /QueryParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void queryParamByteTest() throws Fault {
+    setProperty(Property.REQUEST, buildRequest("bytetest=127"));
+    setProperty(Property.SEARCH_STRING, "bytetest=127");
+    invoke();
+
+    setProperty(Property.REQUEST, buildRequest("bytetest=-128&bytetest=26"));
+    setProperty(Property.SEARCH_STRING, "bytetest=-128");
+    invoke();
+
+    setProperty(Property.REQUEST, buildRequest("bytetest1=123&bytetest2=-128"));
+    setProperty(Property.SEARCH_STRING, "bytetest1=123|bytetest2=-128");
+    invoke();
+
+    setProperty(Property.REQUEST,
+        buildRequest("bytetest1=0&bytetest2=-128&bytetest1=127"));
+    setProperty(Property.SEARCH_STRING, "bytetest2=-128");
+    setProperty(Property.UNEXPECTED_RESPONSE_MATCH, "bytetest1");
+    invoke();
+  }
+
+  /*
+   * @testName: queryParamBooleanTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.1; JAXRS:JAVADOC:11;
+   * JAXRS:JAVADOC:3; JAXRS:JAVADOC:21; JAXRS:JAVADOC:22;
+   * 
+   * @test_Strategy: Client invokes GET on a sub resource at /QueryParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void queryParamBooleanTest() throws Fault {
+    setProperty(Property.REQUEST, buildRequest("booleantest=true"));
+    setProperty(Property.SEARCH_STRING, "booleantest=true");
+    invoke();
+
+    setProperty(Property.REQUEST,
+        buildRequest("booleantest=true&booleantest=false"));
+    setProperty(Property.SEARCH_STRING, "booleantest=true");
+    invoke();
+
+    setProperty(Property.REQUEST,
+        buildRequest("booleantest1=false&booleantest2=true"));
+    setProperty(Property.SEARCH_STRING, "booleantest2=true");
+    invoke();
+
+    setProperty(Property.REQUEST,
+        buildRequest("booleantest1=true&booleantest2=false&booleantest1=true"));
+    setProperty(Property.SEARCH_STRING, "booleantest1=true");
+    invoke();
+  }
+
+  /*
+   * @testName: queryParamEntityWithConstructorTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.2; JAXRS:SPEC:12;
+   * JAXRS:SPEC:12.1;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void queryParamEntityWithConstructorTest() throws Fault {
+    super.paramEntityWithConstructorTest();
+  }
+
+  /*
+   * @testName: queryParamEntityWithValueOfTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.3; JAXRS:SPEC:12;
+   * JAXRS:SPEC:12.1;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void queryParamEntityWithValueOfTest() throws Fault {
+    super.paramEntityWithValueOfTest();
+  }
+
+  /*
+   * @testName: queryParamEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.3; JAXRS:SPEC:12;
+   * JAXRS:SPEC:12.1;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void queryParamEntityWithFromStringTest() throws Fault {
+    super.paramEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: queryParamSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.4; JAXRS:SPEC:12;
+   * JAXRS:SPEC:12.1;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void queryParamSetEntityWithFromStringTest() throws Fault {
+    super.paramCollectionEntityWithFromStringTest(CollectionName.SET);
+  }
+
+  /*
+   * @testName: queryParamSortedSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.4; JAXRS:SPEC:12;
+   * JAXRS:SPEC:12.1;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void queryParamSortedSetEntityWithFromStringTest() throws Fault {
+    super.paramCollectionEntityWithFromStringTest(CollectionName.SORTED_SET);
+  }
+
+  /*
+   * @testName: queryParamListEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.4; JAXRS:SPEC:12;
+   * JAXRS:SPEC:12.1;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void queryParamListEntityWithFromStringTest() throws Fault {
+    super.paramCollectionEntityWithFromStringTest(CollectionName.LIST);
+  }
+
+  /*
+   * @testName: queryFieldParamEntityWithConstructorTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.2; JAXRS:SPEC:6;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void queryFieldParamEntityWithConstructorTest() throws Fault {
+    super.fieldEntityWithConstructorTest();
+  }
+
+  /*
+   * @testName: queryFieldParamEntityWithValueOfTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.3; JAXRS:SPEC:6;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void queryFieldParamEntityWithValueOfTest() throws Fault {
+    super.fieldEntityWithValueOfTest();
+  }
+
+  /*
+   * @testName: queryFieldParamEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.3; JAXRS:SPEC:6;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void queryFieldParamEntityWithFromStringTest() throws Fault {
+    super.fieldEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: queryFieldParamSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.4; JAXRS:SPEC:6;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void queryFieldParamSetEntityWithFromStringTest() throws Fault {
+    super.fieldCollectionEntityWithFromStringTest(CollectionName.SET);
+  }
+
+  /*
+   * @testName: queryFieldParamSortedSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.4; JAXRS:SPEC:6;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void queryFieldParamSortedSetEntityWithFromStringTest() throws Fault {
+    super.fieldCollectionEntityWithFromStringTest(CollectionName.SORTED_SET);
+  }
+
+  /*
+   * @testName: queryFieldParamListEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.4; JAXRS:SPEC:6;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void queryFieldParamListEntityWithFromStringTest() throws Fault {
+    super.fieldCollectionEntityWithFromStringTest(CollectionName.LIST);
+  }
+
+  /*
+   * @testName: queryParamEntityWithEncodedTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:7; JAXRS:SPEC:12;
+   * JAXRS:SPEC:12.2;
+   * 
+   * @test_Strategy: Verify that named QueryParam @Encoded is handled
+   */
+  @Test
+  public void queryParamEntityWithEncodedTest() throws Fault {
+    super.paramEntityWithEncodedTest();
+  }
+
+  /*
+   * @testName: queryFieldParamEntityWithEncodedTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:7;
+   * 
+   * @test_Strategy: Verify that named QueryParam @Encoded is handled
+   */
+  @Test
+  public void queryFieldParamEntityWithEncodedTest() throws Fault {
+    super.fieldEntityWithEncodedTest();
+  }
+
+  /*
+   * @testName: queryParamThrowingWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:12.3;
+   * 
+   * @test_Strategy: Exceptions thrown during construction of parameter values
+   * are treated the same as exceptions thrown during construction of field or
+   * bean property values, see Section 3.2.
+   */
+  @Test
+  public void queryParamThrowingWebApplicationExceptionTest() throws Fault {
+    super.paramThrowingWebApplicationExceptionTest();
+  }
+
+  /*
+   * @testName: queryFieldThrowingWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:8;
+   * 
+   * @test_Strategy: A WebApplicationException thrown during construction of
+   * field or property values using 2 or 3 above is processed directly as
+   * described in section 3.3.4.
+   */
+  @Test
+  public void queryFieldThrowingWebApplicationExceptionTest() throws Fault {
+    super.fieldThrowingWebApplicationExceptionTest();
+  }
+
+  /*
+   * @testName: queryParamThrowingIllegalArgumentExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:12.3;
+   * 
+   * @test_Strategy: Exceptions thrown during construction of parameter values
+   * are treated the same as exceptions thrown during construction of field or
+   * bean property values, see section 3.2.
+   */
+  @Test
+  public void queryParamThrowingIllegalArgumentExceptionTest() throws Fault {
+    setProperty(Property.UNORDERED_SEARCH_STRING, Status.NOT_FOUND.name());
+    super.paramThrowingIllegalArgumentExceptionTest();
+  }
+
+  /*
+   * @testName: queryFieldThrowingIllegalArgumentExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:9; JAXRS:SPEC:9.1; JAXRS:SPEC:10;
+   * 
+   * @test_Strategy: Other exceptions thrown during construction of field or
+   * property values using 2 or 3 above are treated as client errors:
+   * 
+   * if the field or property is annotated with @MatrixParam,
+   * 
+   * @QueryParam or @PathParam then an implementation MUST generate a
+   * WebApplicationException that wraps the thrown exception with a not found
+   * response (404 status) and no entity;
+   */
+  @Test
+  public void queryFieldThrowingIllegalArgumentExceptionTest() throws Fault {
+    setProperty(Property.UNORDERED_SEARCH_STRING, Status.NOT_FOUND.name());
+    super.fieldThrowingIllegalArgumentExceptionTest();
+  }
+
+  @Override
+  protected String buildRequest(String param) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(GET).append(_contextRoot).append("?");
+    sb.append(param).append(HTTP11);
+    return sb.toString();
+  }
+
+  @Override
+  protected String getDefaultValueOfParam(String param) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(param).append("=");
+    sb.append(QueryParamTest.class.getSimpleName());
+    return sb.toString();
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/queryparam/QueryParamTest.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/queryparam/QueryParamTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.queryparam;
+
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+
+import jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingExceptionGivenByName;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingWebApplicationException;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityWithConstructor;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityWithFromString;
+import jakarta.ws.rs.tck.ee.rs.ParamEntityWithValueOf;
+import jakarta.ws.rs.tck.ee.rs.ParamTest;
+
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.Encoded;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+
+@Path(value = "/QueryParamTest")
+public class QueryParamTest extends ParamTest {
+
+  @DefaultValue("QueryParamTest")
+  @QueryParam("FieldParamEntityWithConstructor")
+  ParamEntityWithConstructor fieldParamEntityWithConstructor;
+
+  @Encoded
+  @DefaultValue("QueryParamTest")
+  @QueryParam("FieldParamEntityWithFromString")
+  ParamEntityWithFromString fieldParamEntityWithFromString;
+
+  @DefaultValue("QueryParamTest")
+  @QueryParam("FieldParamEntityWithValueOf")
+  ParamEntityWithValueOf fieldParamEntityWithValueOf;
+
+  @DefaultValue("QueryParamTest")
+  @QueryParam("FieldSetParamEntityWithFromString")
+  Set<ParamEntityWithFromString> fieldSetParamEntityWithFromString;
+
+  @DefaultValue("QueryParamTest")
+  @QueryParam("FieldSortedSetParamEntityWithFromString")
+  SortedSet<ParamEntityWithFromString> fieldSortedSetParamEntityWithFromString;
+
+  @DefaultValue("QueryParamTest")
+  @QueryParam("FieldListParamEntityWithFromString")
+  List<ParamEntityWithFromString> fieldListParamEntityWithFromString;
+
+  @QueryParam("FieldParamEntityThrowingWebApplicationException")
+  public ParamEntityThrowingWebApplicationException fieldEntityThrowingWebApplicationException;
+
+  @QueryParam("FieldParamEntityThrowingExceptionGivenByName")
+  public ParamEntityThrowingExceptionGivenByName fieldEntityThrowingExceptionGivenByName;
+
+  @GET
+  @Produces("text/plain")
+  public String stringParamHandling(
+      @QueryParam("stringtest") @DefaultValue("abc") String stringheader,
+      @QueryParam("stringtest1") @DefaultValue("default") String stringheader1,
+      @QueryParam("stringtest2") @DefaultValue("default") String stringheader2,
+      @QueryParam("inttest") int intheader,
+      @QueryParam("inttest1") int intheader1,
+      @QueryParam("inttest2") int intheader2,
+      @QueryParam("bytetest") byte byteheader,
+      @QueryParam("bytetest1") byte byteheader1,
+      @QueryParam("bytetest2") byte byteheader2,
+      @QueryParam("doubletest") double doubleheader,
+      @QueryParam("doubletest1") double doubleheader1,
+      @QueryParam("doubletest2") double doubleheader2,
+      @QueryParam("floattest") float floatheader,
+      @QueryParam("floattest1") float floatheader1,
+      @QueryParam("floattest2") float floatheader2,
+      @QueryParam("shorttest") short shortheader,
+      @QueryParam("shorttest1") short shortheader1,
+      @QueryParam("shorttest2") short shortheader2,
+      @QueryParam("longtest") long longheader,
+      @QueryParam("longtest1") long longheader1,
+      @QueryParam("longtest2") long longheader2,
+      @QueryParam("booleantest") boolean booleanheader,
+      @QueryParam("booleantest1") boolean booleanheader1,
+      @QueryParam("booleantest2") boolean booleanheader2,
+      @DefaultValue("QueryParamTest") @QueryParam("ParamEntityWithConstructor") ParamEntityWithConstructor paramEntityWithConstructor,
+      @Encoded @DefaultValue("QueryParamTest") @QueryParam("ParamEntityWithFromString") ParamEntityWithFromString paramEntityWithFromString,
+      @DefaultValue("QueryParamTest") @QueryParam("ParamEntityWithValueOf") ParamEntityWithValueOf paramEntityWithValueOf,
+      @DefaultValue("QueryParamTest") @QueryParam("SetParamEntityWithFromString") Set<ParamEntityWithFromString> setParamEntityWithFromString,
+      @DefaultValue("QueryParamTest") @QueryParam("SortedSetParamEntityWithFromString") SortedSet<ParamEntityWithFromString> sortedSetParamEntityWithFromString,
+      @DefaultValue("QueryParamTest") @QueryParam("ListParamEntityWithFromString") List<ParamEntityWithFromString> listParamEntityWithFromString,
+      @QueryParam("ParamEntityThrowingWebApplicationException") ParamEntityThrowingWebApplicationException paramEntityThrowingWebApplicationException,
+      @QueryParam("ParamEntityThrowingExceptionGivenByName") ParamEntityThrowingExceptionGivenByName paramEntityThrowingExceptionGivenByName) {
+
+    noparam = true;
+
+    sb = new StringBuilder();
+    if (stringheader == "" || stringheader == null
+        || !stringheader.equals("abc"))
+      noparam = false;
+    sb.append("stringtest=").append(stringheader);
+
+    if (stringheader1 == "" || stringheader1 == null
+        || !stringheader1.equals("default"))
+      noparam = false;
+    sb.append("stringtest1=").append(stringheader1);
+
+    if (stringheader2 == "" || stringheader2 == null
+        || !stringheader2.equals("default"))
+      noparam = false;
+    sb.append("stringtest2=").append(stringheader2);
+
+    appendNonNullSetNoParam("inttest", intheader);
+    appendNonNullSetNoParam("inttest1", intheader1);
+    appendNonNullSetNoParam("inttest2", intheader2);
+    appendNonNullSetNoParam("doubletest", doubleheader);
+    appendNonNullSetNoParam("doubletest1", doubleheader1);
+    appendNonNullSetNoParam("doubletest2", doubleheader2);
+    appendNonNullSetNoParam("floattest", floatheader);
+    appendNonNullSetNoParam("floattest1", floatheader1);
+    appendNonNullSetNoParam("floattest2", floatheader2);
+    appendNonNullSetNoParam("longtest", longheader);
+    appendNonNullSetNoParam("longtest1", longheader1);
+    appendNonNullSetNoParam("longtest2", longheader2);
+    appendNonNullSetNoParam("shorttest", shortheader);
+    appendNonNullSetNoParam("shorttest1", shortheader1);
+    appendNonNullSetNoParam("shorttest2", shortheader2);
+    appendNonNullSetNoParam("bytetest", byteheader);
+    appendNonNullSetNoParam("bytetest1", byteheader1);
+    appendNonNullSetNoParam("bytetest2", byteheader2);
+    appendTrueSetNoParam("booleantest", booleanheader);
+    appendTrueSetNoParam("booleantest1", booleanheader1);
+    appendTrueSetNoParam("booleantest2", booleanheader2);
+
+    setReturnValues(paramEntityWithConstructor, paramEntityWithFromString,
+        paramEntityWithValueOf, setParamEntityWithFromString,
+        sortedSetParamEntityWithFromString, listParamEntityWithFromString, "");
+
+    setReturnValues(fieldParamEntityWithConstructor,
+        fieldParamEntityWithFromString, fieldParamEntityWithValueOf,
+        fieldSetParamEntityWithFromString,
+        fieldSortedSetParamEntityWithFromString,
+        fieldListParamEntityWithFromString, FIELD);
+
+    if (noparam)
+      sb.append("No QueryParam");
+    return sb.toString();
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/queryparam/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/queryparam/TSAppConfig.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.queryparam;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.ws.rs.tck.ee.rs.RuntimeExceptionMapper;
+import jakarta.ws.rs.tck.ee.rs.WebApplicationExceptionMapper;
+
+import jakarta.ws.rs.core.Application;
+
+/**
+ *
+ * @author diannejiao
+ */
+public class TSAppConfig extends Application {
+
+  public java.util.Set<java.lang.Class<?>> getClasses() {
+    Set<Class<?>> resources = new HashSet<Class<?>>();
+    resources.add(QueryParamTest.class);
+    resources.add(RuntimeExceptionMapper.class);
+    resources.add(WebApplicationExceptionMapper.class);
+    return resources;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/queryparam/sub/JAXRSSubClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/queryparam/sub/JAXRSSubClientIT.java
@@ -1,0 +1,510 @@
+/*
+ * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+package jakarta.ws.rs.tck.ee.rs.queryparam.sub;
+
+import java.io.InputStream;
+import java.io.IOException;
+import jakarta.ws.rs.tck.lib.util.TestUtil;
+
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JAXRSSubClientIT
+    extends jakarta.ws.rs.tck.ee.rs.queryparam.JAXRSClientIT {
+
+  private static final long serialVersionUID = 1L;
+
+  public JAXRSSubClientIT() {
+    setup();
+    setContextRoot("/jaxrs_ee_rs_queryparam_sub_web/resource/subresource");
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    TestUtil.logMsg("STARTING TEST : "+testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    TestUtil.logMsg("FINISHED TEST : "+testInfo.getDisplayName());
+  }
+
+  @Deployment(testable = false, name = "jaxrs_ee_rs_queryparam_sub_deployment")
+  public static WebArchive createDeployment() throws IOException{
+
+    InputStream inStream = JAXRSSubClientIT.class.getClassLoader().getResourceAsStream("jakarta/ws/rs/tck/ee/rs/queryparam/sub/web.xml.template");
+    String webXml = editWebXmlString(inStream);
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_ee_rs_queryparam_sub_web.war");
+    archive.addClasses(TSAppConfig.class, SubResource.class,
+      jakarta.ws.rs.tck.ee.rs.queryparam.QueryParamTest.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityPrototype.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityWithConstructor.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityWithValueOf.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityWithFromString.class,
+      jakarta.ws.rs.tck.ee.rs.ParamTest.class,
+      jakarta.ws.rs.tck.ee.rs.JaxrsParamClient.CollectionName.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingWebApplicationException.class,
+      jakarta.ws.rs.tck.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
+      jakarta.ws.rs.tck.ee.rs.RuntimeExceptionMapper.class,
+      jakarta.ws.rs.tck.ee.rs.WebApplicationExceptionMapper.class
+    );
+    archive.setWebXML(new StringAsset(webXml));
+    return archive;
+
+  }
+
+
+
+  /* Run test */
+  /*
+   * @testName: queryParamStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.1; JAXRS:SPEC:12.1;
+   * JAXRS:JAVADOC:11; JAXRS:JAVADOC:3; JAXRS:JAVADOC:21; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:JAVADOC:22;
+   * 
+   * @test_Strategy: Client invokes HEAD on root resource at /QueryParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void queryParamStringTest() throws Fault {
+    super.queryParamStringTest();
+  }
+
+  /*
+   * @testName: queryParamNoQueryTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.1; JAXRS:SPEC:14;
+   * JAXRS:JAVADOC:11; JAXRS:JAVADOC:3; JAXRS:JAVADOC:21; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:JAVADOC:22;
+   * 
+   * @test_Strategy: Client invokes HEAD on a sub resource at /QueryParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void queryParamNoQueryTest() throws Fault {
+    super.queryParamNoQueryTest();
+  }
+
+  /*
+   * @testName: queryParamIntTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.1; JAXRS:JAVADOC:11;
+   * JAXRS:JAVADOC:3; JAXRS:JAVADOC:21; JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * JAXRS:JAVADOC:22;
+   * 
+   * @test_Strategy: Client invokes HEAD on a sub resource at /QueryParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void queryParamIntTest() throws Fault {
+    super.queryParamIntTest();
+  }
+
+  /*
+   * @testName: queryParamDoubleTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.1; JAXRS:JAVADOC:11;
+   * JAXRS:JAVADOC:3; JAXRS:JAVADOC:21; JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * JAXRS:JAVADOC:22;
+   * 
+   * @test_Strategy: Client invokes HEAD on a sub resource at /QueryParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void queryParamDoubleTest() throws Fault {
+    super.queryParamDoubleTest();
+  }
+
+  /*
+   * @testName: queryParamFloatTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.1; JAXRS:JAVADOC:11;
+   * JAXRS:JAVADOC:3; JAXRS:JAVADOC:21; JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * JAXRS:JAVADOC:22;
+   *
+   * @test_Strategy: Client invokes HEAD on a sub resource at /QueryParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void queryParamFloatTest() throws Fault {
+    super.queryParamFloatTest();
+  }
+
+  /*
+   * @testName: queryParamLongTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.1; JAXRS:JAVADOC:11;
+   * JAXRS:JAVADOC:3; JAXRS:JAVADOC:21; JAXRS:JAVADOC:22; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Client invokes GET on a sub resource at /QueryParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void queryParamLongTest() throws Fault {
+    super.queryParamLongTest();
+  }
+
+  /*
+   * @testName: queryParamShortTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.1; JAXRS:JAVADOC:11;
+   * JAXRS:JAVADOC:3; JAXRS:JAVADOC:21; JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * JAXRS:JAVADOC:22;
+   * 
+   * @test_Strategy: Client invokes GET on a sub resource at /QueryParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void queryParamShortTest() throws Fault {
+    super.queryParamShortTest();
+  }
+
+  /*
+   * @testName: queryParamByteTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.1; JAXRS:JAVADOC:11;
+   * JAXRS:JAVADOC:3; JAXRS:JAVADOC:21; JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * JAXRS:JAVADOC:22;
+   * 
+   * @test_Strategy: Client invokes GET on a sub resource at /QueryParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void queryParamByteTest() throws Fault {
+    super.queryParamByteTest();
+  }
+
+  /*
+   * @testName: queryParamBooleanTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.1; JAXRS:JAVADOC:11;
+   * JAXRS:JAVADOC:3; JAXRS:JAVADOC:21; JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * JAXRS:JAVADOC:22;
+   * 
+   * @test_Strategy: Client invokes GET on a sub resource at /QueryParamTest;
+   * Verify that right Method is invoked.
+   */
+  @Test
+  public void queryParamBooleanTest() throws Fault {
+    super.queryParamBooleanTest();
+  }
+
+  /*
+   * @testName: queryParamEntityWithConstructorTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.2; JAXRS:SPEC:12;
+   * JAXRS:SPEC:12.1; JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void queryParamEntityWithConstructorTest() throws Fault {
+    super.queryParamEntityWithConstructorTest();
+  }
+
+  /*
+   * @testName: queryParamEntityWithValueOfTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.3; JAXRS:SPEC:12;
+   * JAXRS:SPEC:12.1; JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void queryParamEntityWithValueOfTest() throws Fault {
+    super.queryParamEntityWithValueOfTest();
+  }
+
+  /*
+   * @testName: queryParamEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.3; JAXRS:SPEC:12;
+   * JAXRS:SPEC:12.1; JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void queryParamEntityWithFromStringTest() throws Fault {
+    super.queryParamEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: queryParamSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.4; JAXRS:SPEC:12;
+   * JAXRS:SPEC:12.1; JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void queryParamSetEntityWithFromStringTest() throws Fault {
+    super.queryParamSetEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: queryParamSortedSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.4; JAXRS:SPEC:12;
+   * JAXRS:SPEC:12.1; JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void queryParamSortedSetEntityWithFromStringTest() throws Fault {
+    super.queryParamSortedSetEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: queryParamListEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.4; JAXRS:SPEC:12;
+   * JAXRS:SPEC:12.1; JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void queryParamListEntityWithFromStringTest() throws Fault {
+    super.queryParamListEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: queryFieldParamEntityWithConstructorTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.2; JAXRS:SPEC:6;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.2; JAXRS:SPEC:4;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   * 
+   * An implementation is only required to set the annotated field and bean
+   * property values of instances created by the implementation runtime. (Check
+   * the resource with resource locator is injected field properties)
+   */
+  @Test
+  public void queryFieldParamEntityWithConstructorTest() throws Fault {
+    super.queryFieldParamEntityWithConstructorTest();
+  }
+
+  /*
+   * @testName: queryFieldParamEntityWithValueOfTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.3; JAXRS:SPEC:6;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.2; JAXRS:SPEC:4;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   * 
+   * An implementation is only required to set the annotated field and bean
+   * property values of instances created by the implementation runtime. (Check
+   * the resource with resource locator is injected field properties)
+   */
+  @Test
+  public void queryFieldParamEntityWithValueOfTest() throws Fault {
+    super.queryFieldParamEntityWithValueOfTest();
+  }
+
+  /*
+   * @testName: queryFieldParamEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.3; JAXRS:SPEC:6;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.2; JAXRS:SPEC:4;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   * 
+   * An implementation is only required to set the annotated field and bean
+   * property values of instances created by the implementation runtime. (Check
+   * the resource with resource locator is injected field properties)
+   */
+  @Test
+  public void queryFieldParamEntityWithFromStringTest() throws Fault {
+    super.queryFieldParamEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: queryFieldParamSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.4; JAXRS:SPEC:6;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.2; JAXRS:SPEC:4;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   */
+  @Test
+  public void queryFieldParamSetEntityWithFromStringTest() throws Fault {
+    super.queryFieldParamSetEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: queryFieldParamSortedSetEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.4; JAXRS:SPEC:6;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.2; JAXRS:SPEC:4;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   * 
+   * An implementation is only required to set the annotated field and bean
+   * property values of instances created by the implementation runtime. (Check
+   * the resource with resource locator is injected field properties)
+   */
+  @Test
+  public void queryFieldParamSortedSetEntityWithFromStringTest() throws Fault {
+    super.queryFieldParamSortedSetEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: queryFieldParamListEntityWithFromStringTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:5.4; JAXRS:SPEC:6;
+   * JAXRS:SPEC:20; JAXRS:SPEC:20.2; JAXRS:SPEC:4;
+   * 
+   * @test_Strategy: Verify that named QueryParam is handled properly
+   * 
+   * An implementation is only required to set the annotated field and bean
+   * property values of instances created by the implementation runtime. (Check
+   * the resource with resource locator is injected field properties)
+   */
+  @Test
+  public void queryFieldParamListEntityWithFromStringTest() throws Fault {
+    super.queryFieldParamListEntityWithFromStringTest();
+  }
+
+  /*
+   * @testName: queryParamEntityWithEncodedTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:7; JAXRS:SPEC:12;
+   * JAXRS:SPEC:12.2; JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Verify that named QueryParam @Encoded is handled
+   */
+  @Test
+  public void queryParamEntityWithEncodedTest() throws Fault {
+    super.queryParamEntityWithEncodedTest();
+  }
+
+  /*
+   * @testName: queryFieldParamEntityWithEncodedTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:7; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:SPEC:4;
+   * 
+   * @test_Strategy: Verify that named QueryParam @Encoded is handled
+   * 
+   * An implementation is only required to set the annotated field and bean
+   * property values of instances created by the implementation runtime. (Check
+   * the resource with resource locator is injected field properties)
+   */
+  @Test
+  public void queryFieldParamEntityWithEncodedTest() throws Fault {
+    super.queryFieldParamEntityWithEncodedTest();
+  }
+
+  /*
+   * @testName: queryParamThrowingWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:12.3; JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Exceptions thrown during construction of parameter values
+   * are treated the same as exceptions thrown during construction of field or
+   * bean property values, see Section 3.2.
+   */
+  @Test
+  public void queryParamThrowingWebApplicationExceptionTest() throws Fault {
+    super.queryParamThrowingWebApplicationExceptionTest();
+  }
+
+  /*
+   * @testName: queryFieldThrowingWebApplicationExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:3.2; JAXRS:SPEC:8; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:SPEC:4;
+   * 
+   * @test_Strategy: A WebApplicationException thrown during construction of
+   * field or property values using 2 or 3 above is processed directly as
+   * described in section 3.3.4.
+   * 
+   * An implementation is only required to set the annotated field and bean
+   * property values of instances created by the implementation runtime. (Check
+   * the resource with resource locator is injected field properties)
+   */
+  @Test
+  public void queryFieldThrowingWebApplicationExceptionTest() throws Fault {
+    super.queryFieldThrowingWebApplicationExceptionTest();
+  }
+
+  /*
+   * @testName: queryParamThrowingIllegalArgumentExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:12.3; JAXRS:SPEC:20; JAXRS:SPEC:20.2;
+   * 
+   * @test_Strategy: Exceptions thrown during construction of parameter values
+   * are treated the same as exceptions thrown during construction of field or
+   * bean property values, see section 3.2.
+   * 
+   * An implementation is only required to set the annotated field and bean
+   * property values of instances created by the implementation runtime. (Check
+   * the resource with resource locator is injected field properties)
+   */
+  @Test
+  public void queryParamThrowingIllegalArgumentExceptionTest() throws Fault {
+    super.queryParamThrowingIllegalArgumentExceptionTest();
+  }
+
+  /*
+   * @testName: queryFieldThrowingIllegalArgumentExceptionTest
+   * 
+   * @assertion_ids: JAXRS:SPEC:9; JAXRS:SPEC:9.1; JAXRS:SPEC:20;
+   * JAXRS:SPEC:20.2; JAXRS:SPEC:4; JAXRS:SPEC:10;
+   * 
+   * @test_Strategy: Other exceptions thrown during construction of field or
+   * property values using 2 or 3 above are treated as client errors:
+   * 
+   * if the field or property is annotated with @MatrixParam,
+   * 
+   * @QueryParam or @PathParam then an implementation MUST generate a
+   * WebApplicationException that wraps the thrown exception with a not found
+   * response (404 status) and no entity;
+   *
+   * An implementation is only required to set the annotated field and bean
+   * property values of instances created by the implementation runtime. (Check
+   * the resource with resource locator is injected field properties)
+   */
+  @Test
+  public void queryFieldThrowingIllegalArgumentExceptionTest() throws Fault {
+    super.queryFieldThrowingIllegalArgumentExceptionTest();
+  }
+
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/queryparam/sub/SubResource.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/queryparam/sub/SubResource.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.queryparam.sub;
+
+import jakarta.ws.rs.tck.ee.rs.queryparam.QueryParamTest;
+
+import jakarta.ws.rs.Path;
+
+@Path("resource")
+public class SubResource extends QueryParamTest {
+
+  @Path("subresource")
+  public SubResource subresource() {
+    return this;
+  }
+}

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/queryparam/sub/TSAppConfig.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/ee/rs/queryparam/sub/TSAppConfig.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.ws.rs.tck.ee.rs.queryparam.sub;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.ws.rs.tck.ee.rs.RuntimeExceptionMapper;
+import jakarta.ws.rs.tck.ee.rs.WebApplicationExceptionMapper;
+
+import jakarta.ws.rs.core.Application;
+
+public class TSAppConfig extends Application {
+
+  public java.util.Set<java.lang.Class<?>> getClasses() {
+    Set<Class<?>> resources = new HashSet<Class<?>>();
+    resources.add(SubResource.class);
+    resources.add(RuntimeExceptionMapper.class);
+    resources.add(WebApplicationExceptionMapper.class);
+    return resources;
+  }
+}

--- a/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/formparam/locator/web.xml.template
+++ b/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/formparam/locator/web.xml.template
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+    <servlet>
+        <servlet-name>CTSJAX-RSFORMPARAM_LOCATOR</servlet-name>
+        <servlet-class>servlet_adaptor</servlet-class>
+        <init-param>
+            <param-name>jakarta.ws.rs.Application</param-name>
+            <param-value>jakarta.ws.rs.tck.ee.rs.formparam.locator.TSAppConfig</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>CTSJAX-RSFORMPARAM_LOCATOR</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+    <session-config>
+        <session-timeout>30</session-timeout>
+    </session-config>
+</web-app>

--- a/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/formparam/sub/web.xml.template
+++ b/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/formparam/sub/web.xml.template
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+    <servlet>
+        <servlet-name>CTSJAX-RSFORMPARAM_SUB</servlet-name>
+        <servlet-class>servlet_adaptor</servlet-class>
+        <init-param>
+            <param-name>jakarta.ws.rs.Application</param-name>
+            <param-value>jakarta.ws.rs.tck.ee.rs.formparam.sub.TSAppConfig</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>CTSJAX-RSFORMPARAM_SUB</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+    <session-config>
+        <session-timeout>30</session-timeout>
+    </session-config>
+</web-app>

--- a/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/formparam/web.xml.template
+++ b/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/formparam/web.xml.template
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+    <servlet>
+        <servlet-name>CTSJAX-RSFORMPARAM</servlet-name>
+        <servlet-class>servlet_adaptor</servlet-class>
+        <init-param>
+            <param-name>jakarta.ws.rs.Application</param-name>
+            <param-value>jakarta.ws.rs.tck.ee.rs.formparam.TSAppConfig</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>CTSJAX-RSFORMPARAM</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+    <session-config>
+        <session-timeout>30</session-timeout>
+    </session-config>
+</web-app>

--- a/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/get/web.xml.template
+++ b/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/get/web.xml.template
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+    <servlet>
+        <servlet-name>CTSJAX-RSGET</servlet-name>
+        <servlet-class>servlet_adaptor</servlet-class>
+        <init-param>
+            <param-name>jakarta.ws.rs.Application</param-name>
+            <param-value>jakarta.ws.rs.tck.ee.rs.get.TSAppConfig</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>CTSJAX-RSGET</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+    <session-config>
+        <session-timeout>30</session-timeout>
+    </session-config>
+</web-app>

--- a/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/head/web.xml.template
+++ b/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/head/web.xml.template
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+    <servlet>
+        <servlet-name>CTSJAX-RSHEAD</servlet-name>
+        <servlet-class>servlet_adaptor</servlet-class>
+        <init-param>
+            <param-name>jakarta.ws.rs.Application</param-name>
+            <param-value>jakarta.ws.rs.tck.ee.rs.head.TSAppConfig</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>CTSJAX-RSHEAD</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+    <session-config>
+        <session-timeout>30</session-timeout>
+    </session-config>
+</web-app>

--- a/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/headerparam/locator/web.xml.template
+++ b/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/headerparam/locator/web.xml.template
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+    <servlet>
+        <servlet-name>CTSJAX-RSHeaderParam_locator</servlet-name>
+        <servlet-class>servlet_adaptor</servlet-class>
+        <init-param>
+            <param-name>jakarta.ws.rs.Application</param-name>
+            <param-value>jakarta.ws.rs.tck.ee.rs.headerparam.locator.TSAppConfig</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>CTSJAX-RSHeaderParam_locator</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+    <session-config>
+        <session-timeout>30</session-timeout>
+    </session-config>
+</web-app>

--- a/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/headerparam/sub/web.xml.template
+++ b/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/headerparam/sub/web.xml.template
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+    <servlet>
+        <servlet-name>CTSJAX-RSHeaderParam_Sub</servlet-name>
+        <servlet-class>servlet_adaptor</servlet-class>
+        <init-param>
+            <param-name>jakarta.ws.rs.Application</param-name>
+            <param-value>jakarta.ws.rs.tck.ee.rs.headerparam.sub.TSAppConfig</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>CTSJAX-RSHeaderParam_Sub</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+    <session-config>
+        <session-timeout>30</session-timeout>
+    </session-config>
+</web-app>

--- a/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/headerparam/web.xml.template
+++ b/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/headerparam/web.xml.template
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+    <servlet>
+        <servlet-name>CTSJAX-RSHeaderParam</servlet-name>
+        <servlet-class>servlet_adaptor</servlet-class>
+        <init-param>
+            <param-name>jakarta.ws.rs.Application</param-name>
+            <param-value>jakarta.ws.rs.tck.ee.rs.headerparam.TSAppConfig</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>CTSJAX-RSHeaderParam</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+    <session-config>
+        <session-timeout>30</session-timeout>
+    </session-config>
+</web-app>

--- a/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/matrixparam/locator/web.xml.template
+++ b/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/matrixparam/locator/web.xml.template
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+    <servlet>
+        <servlet-name>CTSJAX-RSMATRIXPARAM_LOCATOR</servlet-name>
+        <servlet-class>servlet_adaptor</servlet-class>
+        <init-param>
+            <param-name>jakarta.ws.rs.Application</param-name>
+            <param-value>jakarta.ws.rs.tck.ee.rs.matrixparam.locator.TSAppConfig</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>CTSJAX-RSMATRIXPARAM_LOCATOR</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+    <session-config>
+        <session-timeout>30</session-timeout>
+    </session-config>
+</web-app>

--- a/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/matrixparam/sub/web.xml.template
+++ b/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/matrixparam/sub/web.xml.template
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+    <servlet>
+        <servlet-name>CTSJAX-RSMATRIXPARAM_Sub</servlet-name>
+        <servlet-class>servlet_adaptor</servlet-class>
+        <init-param>
+            <param-name>jakarta.ws.rs.Application</param-name>
+            <param-value>jakarta.ws.rs.tck.ee.rs.matrixparam.sub.TSAppConfig</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>CTSJAX-RSMATRIXPARAM_Sub</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+    <session-config>
+        <session-timeout>30</session-timeout>
+    </session-config>
+</web-app>

--- a/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/matrixparam/web.xml.template
+++ b/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/matrixparam/web.xml.template
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+    <servlet>
+        <servlet-name>CTSJAX-RSMATRIXPARAM</servlet-name>
+        <servlet-class>servlet_adaptor</servlet-class>
+        <init-param>
+            <param-name>jakarta.ws.rs.Application</param-name>
+            <param-value>jakarta.ws.rs.tck.ee.rs.matrixparam.TSAppConfig</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>CTSJAX-RSMATRIXPARAM</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+    <session-config>
+        <session-timeout>30</session-timeout>
+    </session-config>
+</web-app>

--- a/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/options/web.xml.template
+++ b/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/options/web.xml.template
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+    <servlet>
+        <servlet-name>CTSJAX-RSHEAD</servlet-name>
+        <servlet-class>servlet_adaptor</servlet-class>
+        <init-param>
+            <param-name>jakarta.ws.rs.Application</param-name>
+            <param-value>jakarta.ws.rs.tck.ee.rs.options.TSAppConfig</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>CTSJAX-RSHEAD</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+    <session-config>
+        <session-timeout>30</session-timeout>
+    </session-config>
+</web-app>

--- a/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/pathparam/locator/web.xml.template
+++ b/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/pathparam/locator/web.xml.template
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+    <servlet>
+        <servlet-name>CTSJAX-RSPATHPARAM_LOCATOR</servlet-name>
+        <servlet-class>servlet_adaptor</servlet-class>
+        <init-param>
+            <param-name>jakarta.ws.rs.Application</param-name>
+            <param-value>jakarta.ws.rs.tck.ee.rs.pathparam.locator.TSAppConfig</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>CTSJAX-RSPATHPARAM_LOCATOR</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+    <session-config>
+        <session-timeout>30</session-timeout>
+    </session-config>
+</web-app>

--- a/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/pathparam/sub/web.xml.template
+++ b/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/pathparam/sub/web.xml.template
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+    <servlet>
+        <servlet-name>CTSJAX-RSPATHPARAM_Sub</servlet-name>
+        <servlet-class>servlet_adaptor</servlet-class>
+        <init-param>
+            <param-name>jakarta.ws.rs.Application</param-name>
+            <param-value>jakarta.ws.rs.tck.ee.rs.pathparam.sub.TSAppConfig</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>CTSJAX-RSPATHPARAM_Sub</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+    <session-config>
+        <session-timeout>30</session-timeout>
+    </session-config>
+</web-app>

--- a/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/pathparam/web.xml.template
+++ b/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/pathparam/web.xml.template
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+    <servlet>
+        <servlet-name>CTSJAX-RSPATHPARAM</servlet-name>
+        <servlet-class>servlet_adaptor</servlet-class>
+        <init-param>
+            <param-name>jakarta.ws.rs.Application</param-name>
+            <param-value>jakarta.ws.rs.tck.ee.rs.pathparam.TSAppConfig</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>CTSJAX-RSPATHPARAM</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+    <session-config>
+        <session-timeout>30</session-timeout>
+    </session-config>
+</web-app>

--- a/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/produceconsume/web.xml.template
+++ b/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/produceconsume/web.xml.template
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+    <servlet>
+        <servlet-name>CTS_JAXRS_PRODUCE_CONSUME</servlet-name>
+        <servlet-class>servlet_adaptor</servlet-class>
+        <init-param>
+            <param-name>jakarta.ws.rs.Application</param-name>
+            <param-value>jakarta.ws.rs.tck.ee.rs.produceconsume.TSAppConfig</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>CTS_JAXRS_PRODUCE_CONSUME</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+    <session-config>
+        <session-timeout>30</session-timeout>
+    </session-config>
+</web-app>

--- a/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/put/web.xml.template
+++ b/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/put/web.xml.template
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+    <servlet>
+        <servlet-name>CTSJAX-RSPut</servlet-name>
+        <servlet-class>servlet_adaptor</servlet-class>
+        <init-param>
+            <param-name>jakarta.ws.rs.Application</param-name>
+            <param-value>jakarta.ws.rs.tck.ee.rs.put.TSAppConfig</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>CTSJAX-RSPut</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+    <session-config>
+        <session-timeout>30</session-timeout>
+    </session-config>
+</web-app>

--- a/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/queryparam/sub/web.xml.template
+++ b/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/queryparam/sub/web.xml.template
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+    <servlet>
+        <servlet-name>CTSJAX-RSQueryParam_Sub</servlet-name>
+        <servlet-class>servlet_adaptor</servlet-class>
+        <init-param>
+            <param-name>jakarta.ws.rs.Application</param-name>
+            <param-value>jakarta.ws.rs.tck.ee.rs.queryparam.sub.TSAppConfig</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>CTSJAX-RSQueryParam_Sub</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+    <session-config>
+        <session-timeout>30</session-timeout>
+    </session-config>
+</web-app>

--- a/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/queryparam/web.xml.template
+++ b/jaxrs-tck/src/main/resources/jakarta/ws/rs/tck/ee/rs/queryparam/web.xml.template
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+    <servlet>
+        <servlet-name>CTSJAX-RSQueryParam</servlet-name>
+        <servlet-class>servlet_adaptor</servlet-class>
+        <init-param>
+            <param-name>jakarta.ws.rs.Application</param-name>
+            <param-value>jakarta.ws.rs.tck.ee.rs.queryparam.TSAppConfig</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>CTSJAX-RSQueryParam</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+    <session-config>
+        <session-timeout>30</session-timeout>
+    </session-config>
+</web-app>


### PR DESCRIPTION
This is to migrate the last set of tests from jakartaee-tck jaxrs/ee/rs/ folder 

To test the changes :

export JAVA_HOME=<JDK11_HOME>
export M2_HOME=<MAVEN_HOME>
export PATH=$M2_HOME/bin:$JAVA_HOME/bin:$PATH

jaxrs-tck/
mvn clean install

jersey-tck/
mvn clean verify -Parq-glassfish-managed -Dit.test=jakarta.ws.rs.tck.ee.rs.**

The tests migrated :
jakartaee-tck/src/com/sun/ts/tests/jaxrs/ee/rs/formparam
jakartaee-tck/src/com/sun/ts/tests/jaxrs/ee/rs/get
jakartaee-tck/src/com/sun/ts/tests/jaxrs/ee/rs/head
jakartaee-tck/src/com/sun/ts/tests/jaxrs/ee/rs/headerparam
jakartaee-tck/src/com/sun/ts/tests/jaxrs/ee/rs/matrixparam
jakartaee-tck/src/com/sun/ts/tests/jaxrs/ee/rs/options
jakartaee-tck/src/com/sun/ts/tests/jaxrs/ee/rs/pathparam
jakartaee-tck/src/com/sun/ts/tests/jaxrs/ee/rs/produceconsume
jakartaee-tck/src/com/sun/ts/tests/jaxrs/ee/rs/put
jakartaee-tck/src/com/sun/ts/tests/jaxrs/ee/rs/queryparam

All tests should pass.

This PR will be ready for review post merging of #1031

Signed-off-by: alwin-joseph <alwin.joseph@oracle.com>