### PR TITLE
Building for Java 11+ only as recommended by Jakarta EE 10 Release Plan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ dist: trusty
 language: java
 
 jdk:
-  - oraclejdk8
   - oraclejdk11
-  - openjdk8
   - openjdk11
   - openjdk16
   - openjdk17

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -25,6 +25,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>11</maven.compiler.release>
         <microprofile.config.version>3.0-RC1</microprofile.config.version>
     </properties>
 
@@ -74,10 +75,6 @@
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.1</version>
-                    <configuration>
-                        <source>1.8</source>
-                        <target>1.8</target>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -31,7 +31,6 @@
     <artifactId>jakarta.ws.rs-api</artifactId>
     <version>3.1-SNAPSHOT</version>
 
-
     <packaging>bundle</packaging>
     <name>Jakarta RESTful WS API</name>
     <description>Jakarta RESTful Web Services</description>
@@ -93,172 +92,6 @@
             <properties>
                 <skip.release.tests>true</skip.release.tests>
             </properties>
-        </profile>
-        <profile>
-            <id>jdk11+</id>
-            <activation>
-                <jdk>[11,)</jdk>
-            </activation>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <artifactId>maven-compiler-plugin</artifactId>
-                            <version>${maven.compiler.plugin.version}</version>
-                            <executions>
-                                <execution>
-                                    <id>default-compile</id>
-                                    <configuration>
-                                        <!-- compile everything to ensure module-info contains right entries -->
-                                        <source>9</source>
-                                        <target>9</target>
-                                    </configuration>
-                                </execution>
-                                <execution>
-                                    <id>base-compile</id>
-                                    <goals>
-                                        <goal>compile</goal>
-                                    </goals>
-                                    <!-- recompile everything for target VM except the module-info.java -->
-                                    <configuration>
-                                        <excludes>
-                                            <exclude>module-info.java</exclude>
-                                        </excludes>
-                                        <source>${java.version}</source>
-                                        <target>${java.version}</target>
-                                    </configuration>
-                                </execution>
-                            </executions>
-                            <configuration>
-                                <source>${java.version}</source>
-                                <target>${java.version}</target>
-                            </configuration>
-                        </plugin>
-                        <plugin>
-                            <artifactId>maven-surefire-plugin</artifactId>
-                            <configuration>
-                                <argLine>--add-modules jakarta.xml.bind</argLine>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
-        <profile>
-            <id>jdk9-jdk10</id>
-            <activation>
-                <jdk>[9,11)</jdk>
-            </activation>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <artifactId>maven-compiler-plugin</artifactId>
-                            <version>${maven.compiler.plugin.version}</version>
-                            <executions>
-                                <execution>
-                                    <id>default-compile</id>
-                                    <configuration>
-                                        <!-- compile everything to ensure module-info contains right entries -->
-                                        <release>9</release>
-                                    </configuration>
-                                </execution>
-                                <execution>
-                                    <id>base-compile</id>
-                                    <goals>
-                                        <goal>compile</goal>
-                                    </goals>
-                                    <!-- recompile everything for target VM except the module-info.java -->
-                                    <configuration>
-                                        <excludes>
-                                            <exclude>module-info.java</exclude>
-                                        </excludes>
-                                        <source>${java.version}</source>
-                                        <target>${java.version}</target>
-                                    </configuration>
-                                </execution>
-                            </executions>
-                            <configuration>
-                                <source>${java.version}</source>
-                                <target>${java.version}</target>
-                            </configuration>
-                        </plugin>
-                        <plugin>
-                            <artifactId>maven-surefire-plugin</artifactId>
-                            <configuration>
-                                <argLine>--add-modules jakarta.xml.bind</argLine>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
-        <profile>
-            <id>jdk8-</id>
-            <activation>
-                <jdk>(,9)</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <!-- TODO: overriding parent pom (profile jvnet-release) - we should find nicer way -->
-                        <!-- 1.8- javadoc cannot handle module-info -->
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>${maven.javadoc.plugin.version}</version>
-                        <configuration combine.self="override">
-                            <doctitle>${apidocs.title}</doctitle>
-                            <bottom>
-                                <![CDATA[<p align="left">Copyright &#169; 2018, 2020 Eclipse Foundation.<br>Use is subject to <a href="{@docRoot}/resources/EFSL.html" target="_top">license terms</a>.]]>
-                            </bottom>
-                            <docfilessubdirs>true</docfilessubdirs>
-                            <!--javaApiLinks>
-                                <property>
-                                    <name>api_1.3</name>
-                                    <value>http://download.oracle.com/javase/1.3/docs/api/</value>
-                                </property>
-                                <property>
-                                    <name>api_1.4</name>
-                                    <value>http://download.oracle.com/javase/1.4.2/docs/api/</value>
-                                </property>
-                                <property>
-                                    <name>api_1.5</name>
-                                    <value>http://download.oracle.com/javase/1.5.0/docs/api/</value>
-                                </property>
-                                <property>
-                                    <name>api_1.6</name>
-                                    <value>http://download.oracle.com/javase/6/docs/api/</value>
-                                </property>
-                            </javaApiLinks-->
-                            <sourceFileExcludes>
-                                <fileExclude>module-info.java</fileExclude>
-                            </sourceFileExcludes>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <artifactId>maven-compiler-plugin</artifactId>
-                            <version>${maven.compiler.plugin.version}</version>
-                            <configuration>
-                                <source>${java.version}</source>
-                                <target>${java.version}</target>
-                                <excludes>
-                                    <exclude>module-info.java</exclude>
-                                </excludes>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
         </profile>
     </profiles>
 
@@ -462,6 +295,12 @@
                         <ignoreYear>false</ignoreYear>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                        <argLine>--add-modules jakarta.xml.bind</argLine>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -544,10 +383,11 @@
 
     <properties>
         <apidocs.title>Jakarta RESTful Web Services ${spec.version} API Specification ${spec.version.revision}</apidocs.title>
-        <java.version>1.8</java.version>
+        <java.version>11</java.version>
 
         <maven.bundle.plugin.version>5.1.2</maven.bundle.plugin.version>
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
+        <maven.compiler.release>${java.version}</maven.compiler.release>
         <maven.javadoc.plugin.version>3.3.0</maven.javadoc.plugin.version>
 
         <api.package>jakarta.ws.rs</api.package>


### PR DESCRIPTION
The [Jakarta EE 10 Release Plan](https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee10/JakartaEE10ReleasePlan) recommends that the *minimum* supported Java SE version is 11, so it makes no sense to stay on SE 8 and keep a complex set of POM profiles for JDK 8...10.

**As these are no API changes, this is a fast-track review period of just one day as per our [committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**