### PR TITLE
Reverts changes introduced by PR 972

### DIFF
--- a/jaxrs-spec/src/main/asciidoc/chapters/resources/_declaring_method_capabilities.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/resources/_declaring_method_capabilities.adoc
@@ -67,14 +67,21 @@ using the `WidgetProvider` class (see <<entity_providers>> for
 more information on `MessageBodyReader`).
 
 An implementation MUST NOT invoke a method whose effective value of
-`@Produces` does not match the request `Accept` header.
+`@Produces` does not match the request `Accept` header.
 If no `Accept` header is present in the request, it is assumed that
 the client accepts any media type or `\*/*`.
 
 An implementation MUST NOT invoke a method whose effective value of
-`@Consumes` does not match the request `Content-Type` header.
-If no `Content-Type` header is present in the request, the default
-media type is assumed to be `application/octet-stream`.
+`@Consumes` does not match the request `Content-Type` header,
+with the exception of requests in which the `Content-Type` header is
+absent. In those cases, the content type shall
+be treated as the wildcard `\*/*` for matching
+purposesfootnote:[Given that content types do not include wildcards,
+this is an exceptional condition for the purpose of simplifying the
+matching algorithm.]. This rule
+enables inheritance of class-level `@Consumes` annotations on `@GET`
+resource methods that are typically matched by requests without a
+`Content-Type` header.
 
 [[selecting_from_multiple_media_types]]
 ==== Selecting from multiple media types

--- a/jaxrs-spec/src/main/asciidoc/chapters/resources/_mapping_requests_to_java_methods.adoc
+++ b/jaxrs-spec/src/main/asciidoc/chapters/resources/_mapping_requests_to_java_methods.adoc
@@ -214,10 +214,7 @@ For convenience, we defined latexmath:[$p \ge {\perp}$] for every media
 type latexmath:[$p$].
 +
 Given these definitions, we can now sort latexmath:[$M$] in descending
-order based on latexmath:[$\ge$] as followsfootnote:[If the request content type
-is missing, it is assumed to be `application/octet-stream`. If any of the other
-types or sets of types here are unspecified, then
-latexmath:[$\mbox{*/*}$] and latexmath:[$\mbox{\{*/*\}}$] are assumed.]:
+order based on latexmath:[$\ge$] as follows:
 +
 --
 * Let latexmath:[$t$] be the request content type and latexmath:[$C_M$]


### PR DESCRIPTION
Forcing the default content type of application/octet-stream is problematic in practice. It breaks the common use case of inheriting class-level `@Consumes` annotations on `@GET` methods. Text now also clarifies that specific matching case. See discussion in Issue #970. 

Requesting fast track.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>