### PR TITLE
Fixed pom parent-child relationship 

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -16,7 +16,6 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>jakarta.ws.rs-examples</artifactId>
-    <version>3.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Jakarta RESTful WS Examples</name>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -15,11 +15,16 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>jakarta.ws.rs</groupId>
     <artifactId>jakarta.ws.rs-examples</artifactId>
     <version>3.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Jakarta RESTful WS Examples</name>
+
+    <parent>
+        <groupId>jakarta.ws.rs</groupId>
+        <artifactId>all</artifactId>
+        <version>3.1-SNAPSHOT</version>
+    </parent>
 
     <url>https://github.com/jax-rs/api</url>
 

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -20,20 +20,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.eclipse.ee4j</groupId>
-        <artifactId>project</artifactId>
-        <version>1.0.7</version>
-        <relativePath/>
-    </parent>
-
-    <groupId>jakarta.ws.rs</groupId>
     <artifactId>jakarta.ws.rs-api</artifactId>
     <version>3.1-SNAPSHOT</version>
-
     <packaging>bundle</packaging>
     <name>Jakarta RESTful WS API</name>
     <description>Jakarta RESTful Web Services</description>
+
+    <parent>
+        <groupId>jakarta.ws.rs</groupId>
+        <artifactId>all</artifactId>
+        <version>3.1-SNAPSHOT</version>
+    </parent>
 
     <url>https://github.com/eclipse-ee4j/jaxrs-api</url>
 

--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -21,7 +21,6 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>jakarta.ws.rs-api</artifactId>
-    <version>3.1-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>Jakarta RESTful WS API</name>
     <description>Jakarta RESTful Web Services</description>

--- a/jaxrs-spec/pom.xml
+++ b/jaxrs-spec/pom.xml
@@ -16,13 +16,20 @@
     SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>jakarta.ws.rs</groupId>
+
     <artifactId>jakarta.ws.rs-spec</artifactId>
     <version>3.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Jakarta RESTful WS Specification</name>
+
+    <parent>
+        <groupId>jakarta.ws.rs</groupId>
+        <artifactId>all</artifactId>
+        <version>3.1-SNAPSHOT</version>
+    </parent>
 
     <properties>
         <site.output.dir>${project.build.directory}/staging</site.output.dir>
@@ -91,18 +98,18 @@
                         <configuration>
                             <backend>xhtml</backend>
                             <attributes>
-				<imagesdir>images</imagesdir>
+                                <imagesdir>images</imagesdir>
                                 <revnumber>${project.version}</revnumber>
                                 <revremark>${status}</revremark>
                                 <revdate>${revisiondate}</revdate>
                                 <doctype>book</doctype>
                                 <status>${status}</status>
-                                <data-uri />
+                                <data-uri/>
                                 <icons>font</icons>
                                 <toc>left</toc>
                                 <icons>font</icons>
                                 <sectanchors>true</sectanchors>
-                                <idprefix />
+                                <idprefix/>
                                 <idseparator>-</idseparator>
                                 <docinfo1>true</docinfo1>
                             </attributes>
@@ -117,7 +124,7 @@
                         <configuration>
                             <backend>pdf</backend>
                             <attributes>
-				<imagesdir>images</imagesdir>
+                                <imagesdir>images</imagesdir>
                                 <pdf-stylesdir>${project.basedir}/src/theme</pdf-stylesdir>
                                 <pdf-style>jakartaee</pdf-style>
                                 <revnumber>${project.version}</revnumber>
@@ -125,13 +132,13 @@
                                 <revdate>${revisiondate}</revdate>
                                 <doctype>book</doctype>
                                 <status>${status}</status>
-                                <data-uri />
+                                <data-uri/>
                                 <icons>font</icons>
-                                <pagenums />
-                                <toc />
+                                <pagenums/>
+                                <toc/>
                                 <icons>font</icons>
                                 <sectanchors>true</sectanchors>
-                                <idprefix />
+                                <idprefix/>
                                 <idseparator>-</idseparator>
                                 <docinfo1>true</docinfo1>
                                 <embedAssets>true</embedAssets>

--- a/jaxrs-spec/pom.xml
+++ b/jaxrs-spec/pom.xml
@@ -21,7 +21,6 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>jakarta.ws.rs-spec</artifactId>
-    <version>3.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Jakarta RESTful WS Specification</name>
 

--- a/jaxrs-tck/pom.xml
+++ b/jaxrs-tck/pom.xml
@@ -22,7 +22,6 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>jakarta.ws.rs-tck</artifactId>
-    <version>3.1-SNAPSHOT</version>
 
     <parent>
         <groupId>jakarta.ws.rs</groupId>

--- a/jaxrs-tck/pom.xml
+++ b/jaxrs-tck/pom.xml
@@ -21,9 +21,14 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>jakarta.ws.rs</groupId>
     <artifactId>jakarta.ws.rs-tck</artifactId>
     <version>3.1-SNAPSHOT</version>
+
+    <parent>
+        <groupId>jakarta.ws.rs</groupId>
+        <artifactId>all</artifactId>
+        <version>3.1-SNAPSHOT</version>
+    </parent>
 
     <name>Jakarta RESTful WS TCK</name>
     <description>Technology Compatibility Kit for Jakarta RESTful Web Services</description>
@@ -165,7 +170,6 @@
             <version>5.0.0</version>
             <scope>provided</scope>
         </dependency>
-
 
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,13 @@
     <packaging>pom</packaging>
     <name>Jakarta RESTful WS Project</name>
 
+    <parent>
+        <groupId>org.eclipse.ee4j</groupId>
+        <artifactId>project</artifactId>
+        <version>1.0.7</version>
+        <relativePath/>
+    </parent>
+
     <modules>
         <module>jaxrs-api</module>
         <module>jaxrs-spec</module>


### PR DESCRIPTION
Fixed pom parent-child relationship to make sure deploy works on Jenkins nightly builds. Nightly builds have been failing for a while due to misconfiguration problems. See https://ci.eclipse.org/jaxrs/job/Nightly%20Build/job/master/

Some minor re-formatting too. Fast track.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>