### PR TITLE
Moved distribution management to main pom

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,6 @@ pipeline {
 			when {
 				anyOf {
 					branch 'master'
-                                        branch 'release-prep2'
 				}
 			}
 			steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,7 @@ pipeline {
 			when {
 				anyOf {
 					branch 'master'
+                                        branch 'release-prep2'
 				}
 			}
 			steps {

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -283,20 +283,6 @@
             <artifactId>microprofile-config-api</artifactId>
             <version>${microprofile.config.version}</version>
         </dependency>
-
     </dependencies>
 
-    <distributionManagement>
-        <repository>
-            <id>repo.eclipse.org</id>
-            <name>JAX-RS API Repository - Releases</name>
-            <url>https://repo.eclipse.org/content/repositories/jax-rs-api-releases/</url>
-        </repository>
-
-        <snapshotRepository>
-            <id>repo.eclipse.org</id>
-            <name>JAX-RS API Repository - Snapshots</name>
-            <url>https://repo.eclipse.org/content/repositories/jax-rs-api-snapshots/</url>
-        </snapshotRepository>
-    </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,27 @@
         <relativePath/>
     </parent>
 
+    <distributionManagement>
+        <snapshotRepository>
+            <id>repo.eclipse.org</id>
+            <name>JAX-RS API Repository - Snapshots</name>
+            <url>https://repo.eclipse.org/content/repositories/jax-rs-api-snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <profiles>
+        <profile>
+            <id>release-eclipse</id>
+            <distributionManagement>
+                <repository>
+                    <id>repo.eclipse.org</id>
+                    <name>JAX-RS API Repository - Releases</name>
+                    <url>https://repo.eclipse.org/content/repositories/jax-rs-api-releases/</url>
+                </repository>
+            </distributionManagement>
+        </profile>
+    </profiles>
+
     <modules>
         <module>jaxrs-api</module>
         <module>jaxrs-spec</module>


### PR DESCRIPTION
Moved distribution management for Eclipse's content repos to main pom. Protected release repo using a profile to avoid accidental pushes.