### PR TITLE
Add status code 308 Permanent Redirect

### DIFF
--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/Response.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/Response.java
@@ -1223,6 +1223,13 @@ public abstract class Response implements AutoCloseable {
          */
         TEMPORARY_REDIRECT(307, "Temporary Redirect"),
         /**
+         * 308 Permanent Redirect, see <a href="https://tools.ietf.org/html/rfc7538">RFC 7538:
+         * The Hypertext Transfer Protocol Status Code 308 (Permanent Redirect)</a>.
+         *
+         * @since 3.1
+         */
+        PERMANENT_REDIRECT(308, "Permanent Redirect"),
+        /**
          * 400 Bad Request, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1">HTTP/1.1
          * documentation</a>.
          */


### PR DESCRIPTION
This adds the status code _[308 Permanent Redirect](https://tools.ietf.org/html/rfc7538)_ as discussed in #993.

One possible application would be if part of an API has been permanently moved to another URI.