### PR TITLE
Add status code 300 Multiple Choices

### DIFF
--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/Response.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/Response.java
@@ -1190,6 +1190,13 @@ public abstract class Response implements AutoCloseable {
          */
         PARTIAL_CONTENT(206, "Partial Content"),
         /**
+         * 300 Multiple Choices, see <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-6.4.1">HTTP/1.1:
+         * Semantics and Content</a>.
+         *
+         * @since 3.1
+         */
+        MULTIPLE_CHOICES(300, "Multiple Choices"),
+        /**
          * 301 Moved Permanently, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.2">HTTP/1.1
          * documentation</a>.
          */


### PR DESCRIPTION
This adds the status code _[300 Multiple Choices](https://tools.ietf.org/html/rfc7231#section-6.4.1)_ as discussed in #993.

I could see reactive content negotiation being used in a REST service, be it about language, media type or something else. This is why I think we should include this.