### PR TITLE
separate modules into profiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,12 +47,30 @@
                 </repository>
             </distributionManagement>
         </profile>
+        <profile>
+            <id>dependentModules</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>jaxrs.all.build</name>
+                </property>
+            </activation>
+            <modules>
+                <module>jaxrs-api</module>
+                <module>jaxrs-tck</module>
+                <module>examples</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>dependentSpecification</id>
+            <activation>
+                <property>
+                    <name>jaxrs.all.build</name>
+                </property>
+            </activation>
+            <modules>
+                <module>jaxrs-spec</module>
+            </modules>
+        </profile>
     </profiles>
-
-    <modules>
-        <module>jaxrs-api</module>
-        <module>jaxrs-spec</module>
-        <module>jaxrs-tck</module>
-        <module>examples</module>
-    </modules>
 </project>


### PR DESCRIPTION
The purpose of the PR is to separate modules in the parent pom into profiles, which is good for releases to the maven staging/central. 

The issue is that when releasing API (from the jaxrs-api module) the parent pom shall be published into staging/central as well. 

So, when the forward approach is applied (the project is being built from its root folder) all modules are being compiled. But when it comes to releasing where only particular modules are being released related parent pom becomes invalid from the point of modules view. 

In the PR there are 2 profiles with 3 and 1 modules respectively. The module with 3 profiles contains references to API, TCK, and examples. And the module with one module relates to the spec which is never being published to staging/central. 

Thus when the project is being compiled from its root folder using ``mvn clean install`` the project is being assembled with 3 modules> API, TCK, and examples. 

In order to assemble the project with the spec included, the build shall be called in the following way: ``mvn clean install -Djaxrs.all.build``. 

Separation of the spec module into an inactive profile guarantees that the parent pom is valid in the maven central without the spec module. 


Signed-off-by: Maxim Nesen <maxim.nesen@oracle.com>