### PR TITLE
Ensure resourceconstructor test includes beans.xml

### DIFF
--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/common/JAXRSCommonClient.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/common/JAXRSCommonClient.java
@@ -533,15 +533,19 @@ public abstract class JAXRSCommonClient {
     return sb.toString();
   }
 
-  public static String editWebXmlString(InputStream inStream) throws IOException{
+  public static String toString(InputStream inStream) throws IOException{
     String line;
-    String webXmlTemplate = "";
+    String str = "";
     try (BufferedReader bufReader = new BufferedReader(new InputStreamReader(inStream, StandardCharsets.UTF_8))) {
       while ((line = bufReader.readLine()) != null) {
-        webXmlTemplate = webXmlTemplate + line + System.lineSeparator();
+        str = str + line + System.lineSeparator();
       }
+      return str;
     }
-    
+  }
+  
+  public static String editWebXmlString(InputStream inStream) throws IOException{
+    String webXmlTemplate = toString(inStream);
     String webXml = webXmlTemplate.replaceAll("servlet_adaptor", servletAdaptor);
     return webXml;
   }

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/common/JAXRSCommonClient.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/common/JAXRSCommonClient.java
@@ -21,7 +21,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Enumeration;
 import java.util.Hashtable;
-import java.util.Properties;
+import java.util.stream.Collectors;
 import java.nio.charset.StandardCharsets;
 
 
@@ -49,7 +49,7 @@ import jakarta.ws.rs.core.Response;
  */
 //public abstract class JAXRSCommonClient extends ServiceEETest {
 public abstract class JAXRSCommonClient {
-
+  @SuppressWarnings("unused")
   private static final long serialVersionUID = 1L;
 
   /**
@@ -534,20 +534,13 @@ public abstract class JAXRSCommonClient {
   }
 
   public static String toString(InputStream inStream) throws IOException{
-    String line;
-    String str = "";
     try (BufferedReader bufReader = new BufferedReader(new InputStreamReader(inStream, StandardCharsets.UTF_8))) {
-      while ((line = bufReader.readLine()) != null) {
-        str = str + line + System.lineSeparator();
-      }
-      return str;
+      return bufReader.lines().collect(Collectors.joining(System.lineSeparator()));
     }
   }
-  
+
   public static String editWebXmlString(InputStream inStream) throws IOException{
-    String webXmlTemplate = toString(inStream);
-    String webXml = webXmlTemplate.replaceAll("servlet_adaptor", servletAdaptor);
-    return webXml;
+    return toString(inStream).replaceAll("servlet_adaptor", servletAdaptor);
   }
 
   /**

--- a/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/spec/resourceconstructor/JAXRSClientIT.java
+++ b/jaxrs-tck/src/main/java/jakarta/ws/rs/tck/spec/resourceconstructor/JAXRSClientIT.java
@@ -55,8 +55,11 @@ public class JAXRSClientIT extends JaxrsCommonClient {
   public static WebArchive createDeployment() throws IOException{
     InputStream inStream = JAXRSClientIT.class.getClassLoader().getResourceAsStream("jakarta/ws/rs/tck/spec/resourceconstructor/web.xml.template");
     String webXml = editWebXmlString(inStream);
+    inStream = JAXRSClientIT.class.getClassLoader().getResourceAsStream("jakarta/ws/rs/tck/spec/resourceconstructor/beans.xml");
+    String beansXml = toString(inStream);
     WebArchive archive = ShrinkWrap.create(WebArchive.class, "jaxrs_spec_resourceconstructor_web.war");
     archive.addClasses(TSAppConfig.class, Resource.class, CookieResource.class, HeaderResource.class, MatrixResource.class, PathResource.class, QueryResource.class);
+    archive.addAsWebInfResource(new StringAsset(beansXml), "beans.xml");
     archive.setWebXML(new StringAsset(webXml));
     return archive;
   }


### PR DESCRIPTION
This change adds the beans.xml file to the deployed WAR for the `resourceconstructor` test.  The beans.xml was added as part of challenge issue #938, but from my testing it was not added to the WAR file.  This change fixes that.

Since this only fixes a bug in a TCK test and makes no changes to spec or API, I'd like to request fast-track.