### PR TITLE
Adopt OpenJDK now is Eclipse Temurin

### DIFF
--- a/.github/workflows/maven-package.yml
+++ b/.github/workflows/maven-package.yml
@@ -18,6 +18,6 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: '11'
-        distribution: 'adopt'
+        distribution: 'temurin'
     - name: Build with Maven
       run: mvn -B package --file pom.xml


### PR DESCRIPTION
Adopt OpenJDK is called Eclipse Temurin since a while. There will be no new JDKs published with the adopt label, but only with the temurin label. So our builds should use Temurin instead of Adopt now. 

**As these are no API changes, this is a fast-track review period of just one day as per our [committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**