### PR TITLE
mvn verify instead of package --file pom.xml

### DIFF
--- a/.github/workflows/maven-package.yml
+++ b/.github/workflows/maven-package.yml
@@ -20,4 +20,4 @@ jobs:
         java-version: '11'
         distribution: 'adopt'
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -B verify


### PR DESCRIPTION
This PR replaces the custom configuration "package --file pom.xml" by the usual "verify" configuration which is more stereotypical in Maven projects, which allows to run integration tests, and aligns Github Actions with what we had in Travis CI.

**As these are no API changes, this is a fast-track review period of just one day as per our [committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**