### PR TITLE
[#979] Fixed JavaDoc Warnings

### DIFF
--- a/jaxrs-api/src/main/java/jakarta/ws/rs/client/ResponseProcessingException.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/client/ResponseProcessingException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -31,6 +31,9 @@ public class ResponseProcessingException extends ProcessingException {
 
     private static final long serialVersionUID = -4923161617935731839L;
 
+    /**
+     * The response instance for which the processing failed.
+     */
     private final Response response;
 
     /**

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/Cookie.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/Cookie.java
@@ -260,6 +260,11 @@ public class Cookie {
      */
     public static class Builder extends AbstractCookieBuilder<Builder> {
 
+        /**
+         * Create a new instance.
+         *
+         * @param name the name of the cookie.
+         */
         public Builder(String name) {
             super(name);
         }

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/PathSegment.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/PathSegment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -32,7 +32,6 @@ public interface PathSegment {
 
     /**
      * Get the path segment.
-     * <p>
      *
      * @return the path segment
      */

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/sse/SseEventSource.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/sse/SseEventSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -141,6 +141,13 @@ public interface SseEventSource extends AutoCloseable {
             }
         }
 
+        /**
+         * Set the SSE streaming endpoint.
+         *
+         * @param endpoint SSE streaming endpoint. Must not be {@code null}.
+         * @return updated event source builder instance.
+         * @throws NullPointerException in case the supplied web target is {@code null}.
+         */
         protected abstract Builder target(WebTarget endpoint);
 
         /**

--- a/jaxrs-api/src/main/java/module-info.java
+++ b/jaxrs-api/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -14,6 +14,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
+/**
+ * Defines the Jakarta RESTful Web Services API
+ */
 module jakarta.ws.rs {
 
     requires static jakarta.xml.bind;


### PR DESCRIPTION
This PR fixes warnings in the JAX-RS API's JavaDocs.