### PR TITLE
Fixed: jersey-tck fails on JRE 17 due to Unsafe class

### DIFF
--- a/jersey-tck/pom.xml
+++ b/jersey-tck/pom.xml
@@ -32,7 +32,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <jersey.version>3.0.0</jersey.version>
-        <glassfish.container.version>6.1.0</glassfish.container.version>
+        <glassfish.container.version>6.2.3</glassfish.container.version>
         <jakarta.platform.version>9.1.0</jakarta.platform.version>
         <junit.jupiter.version>5.7.2</junit.jupiter.version>
         <jakarta.rest.version>3.1.0</jakarta.rest.version>


### PR DESCRIPTION
`mvn --file jersey-tck/pom.xml verify` fails on JRE 17.

The reason is that it uses GlassFish 6.1.0, which is not compatible with JRE 17 (uses `Unsafe` class).

The solution is to replace it by GlassFish 6.2.3.

**As these are no API changes, this is a fast-track review period of just one day as per our [committer rules](https://github.com/eclipse-ee4j/jaxrs-api/wiki/Committer-Conventions#minimum-length-of-review-period-before-merge--close-of-prs-and-closing-of-issues).**