### PR TITLE
Fix the TCK name mismatch in jersey-tck/

### DIFF
--- a/jersey-tck/pom.xml
+++ b/jersey-tck/pom.xml
@@ -36,6 +36,7 @@
         <jakarta.platform.version>9.1.0</jakarta.platform.version>
         <junit.jupiter.version>5.7.2</junit.jupiter.version>
         <jakarta.rest.version>3.1.0</jakarta.rest.version>
+        <tck.artifactId>jakarta-restful-ws-tck</tck.artifactId>
     </properties>
 
     <dependencyManagement>
@@ -85,7 +86,7 @@
 
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
-            <artifactId>jakarta.ws.rs-tck</artifactId>
+            <artifactId>${tck.artifactId}</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
@@ -448,7 +449,7 @@
                             <goal>verify</goal>
                         </goals>
                         <configuration>
-                            <dependenciesToScan>jakarta.ws.rs:jakarta.ws.rs-tck</dependenciesToScan>
+                            <dependenciesToScan>jakarta.ws.rs:${tck.artifactId}</dependenciesToScan>
                             <systemPropertyVariables>
                                 <GLASSFISH_HOME>${project.build.directory}/glassfish6</GLASSFISH_HOME>
                                 <servlet_adaptor>org.glassfish.jersey.servlet.ServletContainer</servlet_adaptor>


### PR DESCRIPTION
Requesting fast-track review for this one as it changes neither the api nor the spec.