### PR TITLE
Add status code 423 Locked

### DIFF
--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/Response.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/Response.java
@@ -1344,6 +1344,13 @@ public abstract class Response implements AutoCloseable {
          */
         EXPECTATION_FAILED(417, "Expectation Failed"),
         /**
+         * 423 Locked, see <a href="https://datatracker.ietf.org/doc/html/rfc4918#section-9.8.5">RFC 4918: HTTP Extensions
+         * for Web Distributed Authoring and Versioning</a>.
+         *
+         * @since 3.2
+         */
+        LOCKED(423, "LOCKED"),
+        /**
          * 428 Precondition required, see <a href="https://tools.ietf.org/html/rfc6585#section-3">RFC 6585: Additional HTTP
          * Status Codes</a>.
          *

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/core/Response.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/core/Response.java
@@ -1344,10 +1344,10 @@ public abstract class Response implements AutoCloseable {
          */
         EXPECTATION_FAILED(417, "Expectation Failed"),
         /**
-         * 423 Locked, see <a href="https://datatracker.ietf.org/doc/html/rfc4918#section-9.8.5">RFC 4918: HTTP Extensions
+         * 423 Locked, see <a href="https://datatracker.ietf.org/doc/html/rfc4918#section-11.3">RFC 4918: HTTP Extensions
          * for Web Distributed Authoring and Versioning</a>.
          *
-         * @since 3.2
+         * @since 5.0
          */
         LOCKED(423, "LOCKED"),
         /**


### PR DESCRIPTION
This adds the Locked status code for cases where the requested REST resource has been locked.
For example, if a resource is being updated and we need to lock it while the update is in progress.