### PR TITLE
Add default value for parameter binding annotations ( rest-issue-#579)

### DIFF
--- a/examples/src/main/java/jaxrs/examples/params/OptionalParamNameExample.java
+++ b/examples/src/main/java/jaxrs/examples/params/OptionalParamNameExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/examples/src/main/java/jaxrs/examples/params/OptionalParamNameExample.java
+++ b/examples/src/main/java/jaxrs/examples/params/OptionalParamNameExample.java
@@ -29,7 +29,7 @@ import jakarta.ws.rs.QueryParam;
 /**
  * Examples demonstrating optional parameter names in Jakarta REST annotations.
  * 
- * <p>Starting with Jakarta REST 4.0, parameter binding annotations support optional
+ * <p>Starting with Jakarta REST 5.0, parameter binding annotations support optional
  * parameter names. When the annotation value is omitted, the parameter name is
  * inferred from the annotated element.</p>
  * 
@@ -39,9 +39,8 @@ import jakarta.ws.rs.QueryParam;
  * without this flag.</p>
  * 
  * <h4>Maven Configuration:</h4>
- * <pre>{@code
+ * {@snippet :
  * <plugin>
- *     <groupId>org.apache.maven.plugins</groupId>
  *     <artifactId>maven-compiler-plugin</artifactId>
  *     <configuration>
  *         <compilerArgs>
@@ -49,9 +48,7 @@ import jakarta.ws.rs.QueryParam;
  *         </compilerArgs>
  *     </configuration>
  * </plugin>
- * }</pre>
- * 
- * @see <a href="https://github.com/jakartaee/rest/issues/579">Issue #579</a>
+ * }
  */
 @Path("examples")
 public class OptionalParamNameExample {
@@ -60,15 +57,15 @@ public class OptionalParamNameExample {
      * Example 1: Path parameters with optional names.
      * 
      * <p><strong>Before (explicit names required):</strong></p>
-     * <pre>{@code
-     * public String hello(@PathParam("name") String name, 
-     *                    @PathParam("surname") String surname)
-     * }</pre>
-     * 
+     * {@snippet :
+     * public String hello(@PathParam("name") String name,
+     *                     @PathParam("surname") String surname)
+     * }
+     *
      * <p><strong>After (optional names):</strong></p>
-     * <pre>{@code
+     * {@snippet :
      * public String hello(@PathParam String name, @PathParam String surname)
-     * }</pre>
+     * }
      */
     @GET
     @Path("hello/{name}/{surname}")
@@ -102,9 +99,9 @@ public class OptionalParamNameExample {
      */
     @GET
     @Path("matrix/{path}")
-    public String matrix(@PathParam String path, 
-                        @MatrixParam String color,
-                        @MatrixParam String size) {
+    public String matrix(@PathParam String path,
+                         @MatrixParam String color,
+                         @MatrixParam String size) {
         return "Path: " + path + ", Color: " + color + ", Size: " + size;
     }
 
@@ -135,8 +132,8 @@ public class OptionalParamNameExample {
     @GET
     @Path("mixed/{id}")
     public String mixed(@PathParam String id,
-                       @QueryParam("q") String query,
-                       @HeaderParam String userAgent) {
+                        @QueryParam("q") String query,
+                        @HeaderParam String userAgent) {
         return "ID: " + id + ", Query: " + query + ", User-Agent: " + userAgent;
     }
 
@@ -163,10 +160,9 @@ public class OptionalParamNameExample {
     @GET
     @Path("profile/{userId}")
     public String profile(@PathParam String userId,
-                         @QueryParam String tab,
-                         @QueryParam String section,
-                         @HeaderParam String accept) {
-        return String.format("User: %s, Tab: %s, Section: %s, Accept: %s",
-                           userId, tab, section, accept);
+                          @QueryParam String tab,
+                          @QueryParam String section,
+                          @HeaderParam String accept) {
+        return "User: %s, Tab: %s, Section: %s, Accept: %s".formatted(userId, tab, section, accept);
     }
 }

--- a/examples/src/main/java/jaxrs/examples/params/OptionalParamNameExample.java
+++ b/examples/src/main/java/jaxrs/examples/params/OptionalParamNameExample.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jaxrs.examples.params;
+
+import jakarta.ws.rs.CookieParam;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.MatrixParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
+
+/**
+ * Examples demonstrating optional parameter names in Jakarta REST annotations.
+ * 
+ * <p>Starting with Jakarta REST 4.0, parameter binding annotations support optional
+ * parameter names. When the annotation value is omitted, the parameter name is
+ * inferred from the annotated element.</p>
+ * 
+ * <h3>Compiler Configuration Required</h3>
+ * <p>For method parameters, the {@code -parameters} compiler flag must be enabled
+ * to preserve parameter names in bytecode. Field and property injection always works
+ * without this flag.</p>
+ * 
+ * <h4>Maven Configuration:</h4>
+ * <pre>{@code
+ * <plugin>
+ *     <groupId>org.apache.maven.plugins</groupId>
+ *     <artifactId>maven-compiler-plugin</artifactId>
+ *     <configuration>
+ *         <compilerArgs>
+ *             <arg>-parameters</arg>
+ *         </compilerArgs>
+ *     </configuration>
+ * </plugin>
+ * }</pre>
+ * 
+ * @see <a href="https://github.com/jakartaee/rest/issues/579">Issue #579</a>
+ */
+@Path("examples")
+public class OptionalParamNameExample {
+
+    /**
+     * Example 1: Path parameters with optional names.
+     * 
+     * <p><strong>Before (explicit names required):</strong></p>
+     * <pre>{@code
+     * public String hello(@PathParam("name") String name, 
+     *                    @PathParam("surname") String surname)
+     * }</pre>
+     * 
+     * <p><strong>After (optional names):</strong></p>
+     * <pre>{@code
+     * public String hello(@PathParam String name, @PathParam String surname)
+     * }</pre>
+     */
+    @GET
+    @Path("hello/{name}/{surname}")
+    public String hello(@PathParam String name, @PathParam String surname) {
+        return "Hello, " + name + " " + surname;
+    }
+
+    /**
+     * Example 2: Query parameters with optional names.
+     * The parameter names 'query' and 'filter' are inferred from method parameters.
+     */
+    @GET
+    @Path("search")
+    public String search(@QueryParam String query, @QueryParam String filter) {
+        return "Searching for: " + query + " with filter: " + filter;
+    }
+
+    /**
+     * Example 3: Header parameters with optional names.
+     * The parameter name 'authorization' is inferred from the method parameter.
+     */
+    @GET
+    @Path("secure")
+    public String secure(@HeaderParam String authorization) {
+        return "Authorization: " + authorization;
+    }
+
+    /**
+     * Example 4: Matrix parameters with optional names.
+     * Matrix parameters are semicolon-separated in the path.
+     */
+    @GET
+    @Path("matrix/{path}")
+    public String matrix(@PathParam String path, 
+                        @MatrixParam String color,
+                        @MatrixParam String size) {
+        return "Path: " + path + ", Color: " + color + ", Size: " + size;
+    }
+
+    /**
+     * Example 5: Cookie parameters with optional names.
+     * The parameter name 'sessionId' is inferred from the method parameter.
+     */
+    @GET
+    @Path("session")
+    public String session(@CookieParam String sessionId) {
+        return "Session ID: " + sessionId;
+    }
+
+    /**
+     * Example 6: Form parameters with optional names.
+     * Used with application/x-www-form-urlencoded content type.
+     */
+    @POST
+    @Path("login")
+    public String login(@FormParam String username, @FormParam String password) {
+        return "Login attempt for user: " + username;
+    }
+
+    /**
+     * Example 7: Mixed usage - combining explicit and inferred names.
+     * This demonstrates backward compatibility.
+     */
+    @GET
+    @Path("mixed/{id}")
+    public String mixed(@PathParam String id,
+                       @QueryParam("q") String query,
+                       @HeaderParam String userAgent) {
+        return "ID: " + id + ", Query: " + query + ", User-Agent: " + userAgent;
+    }
+
+    /**
+     * Example 8: Field injection with optional names.
+     * Field injection always works without the -parameters compiler flag.
+     */
+    @PathParam
+    private String userId;
+
+    @QueryParam
+    private String page;
+
+    @GET
+    @Path("user")
+    public String getUser() {
+        return "User ID: " + userId + ", Page: " + page;
+    }
+
+    /**
+     * Example 9: Multiple parameters of the same type.
+     * Each parameter name is inferred independently.
+     */
+    @GET
+    @Path("profile/{userId}")
+    public String profile(@PathParam String userId,
+                         @QueryParam String tab,
+                         @QueryParam String section,
+                         @HeaderParam String accept) {
+        return String.format("User: %s, Tab: %s, Section: %s, Accept: %s",
+                           userId, tab, section, accept);
+    }
+}

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/CookieParam.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/CookieParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2026 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -65,7 +65,7 @@ public @interface CookieParam {
      * If the value is not specified (empty string), the name of the annotated element (parameter, field, or property)
      * will be used as the parameter name. This requires that parameter names are preserved in the bytecode, which can be
      * enabled using the {@code -parameters} compiler flag in Java 8+. If parameter names are not available at runtime
-     * and no explicit value is provided, implementations MUST throw a deployment-time exception with a clear error message
+     * and no explicit value is provided, implementations MUST throw an exception during initialization with a clear error message
      * indicating that either an explicit parameter name must be provided or the {@code -parameters} compiler flag must be enabled.
      * </p>
      *

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/CookieParam.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/CookieParam.java
@@ -61,7 +61,15 @@ public @interface CookieParam {
      * Defines the name of the HTTP cookie whose value will be used to initialize the value of the annotated method
      * argument, class field or bean property.
      *
-     * @return HTTP cookie name.
+     * <p>
+     * If the value is not specified (empty string), the name of the annotated element (parameter, field, or property)
+     * will be used as the parameter name. This requires that parameter names are preserved in the bytecode, which can be
+     * enabled using the {@code -parameters} compiler flag in Java 8+. If parameter names are not available at runtime
+     * and no explicit value is provided, implementations MUST throw a deployment-time exception with a clear error message
+     * indicating that either an explicit parameter name must be provided or the {@code -parameters} compiler flag must be enabled.
+     * </p>
+     *
+     * @return HTTP cookie name, or an empty string to use the annotated element's name.
      */
-    String value();
+    String value() default "";
 }

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/CookieParam.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/CookieParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -69,7 +69,7 @@ public @interface CookieParam {
      * indicating that either an explicit parameter name must be provided or the {@code -parameters} compiler flag must be enabled.
      * </p>
      *
-     * @return HTTP cookie name, or an empty string to use the annotated element's name.
+     * @return HTTP cookie name, or an empty string indicating that the annotated element's name should be used.
      */
     String value() default "";
 }

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/FormParam.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/FormParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -82,7 +82,7 @@ public @interface FormParam {
      * indicating that either an explicit parameter name must be provided or the {@code -parameters} compiler flag must be enabled.
      * </p>
      *
-     * @return form parameter name, or an empty string to use the annotated element's name.
+     * @return form parameter name, or an empty string indicating that the annotated element's name should be used.
      */
     String value() default "";
 }

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/FormParam.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/FormParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2026 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -78,7 +78,7 @@ public @interface FormParam {
      * If the value is not specified (empty string), the name of the annotated element (parameter, field, or property)
      * will be used as the parameter name. This requires that parameter names are preserved in the bytecode, which can be
      * enabled using the {@code -parameters} compiler flag in Java 8+. If parameter names are not available at runtime
-     * and no explicit value is provided, implementations MUST throw a deployment-time exception with a clear error message
+     * and no explicit value is provided, implementations MUST throw an exception during initialization with a clear error message
      * indicating that either an explicit parameter name must be provided or the {@code -parameters} compiler flag must be enabled.
      * </p>
      *

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/FormParam.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/FormParam.java
@@ -74,7 +74,15 @@ public @interface FormParam {
      * and will instead be treated as literal text. E.g. if the parameter name is "a b" then the value of the annotation is
      * "a b", <i>not</i> "a+b" or "a%20b".
      *
-     * @return form parameter name.
+     * <p>
+     * If the value is not specified (empty string), the name of the annotated element (parameter, field, or property)
+     * will be used as the parameter name. This requires that parameter names are preserved in the bytecode, which can be
+     * enabled using the {@code -parameters} compiler flag in Java 8+. If parameter names are not available at runtime
+     * and no explicit value is provided, implementations MUST throw a deployment-time exception with a clear error message
+     * indicating that either an explicit parameter name must be provided or the {@code -parameters} compiler flag must be enabled.
+     * </p>
+     *
+     * @return form parameter name, or an empty string to use the annotated element's name.
      */
-    String value();
+    String value() default "";
 }

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/HeaderParam.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/HeaderParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -72,7 +72,7 @@ public @interface HeaderParam {
      * indicating that either an explicit parameter name must be provided or the {@code -parameters} compiler flag must be enabled.
      * </p>
      *
-     * @return HTTP header name, or an empty string to use the annotated element's name.
+     * @return HTTP header name, or an empty string indicating that the annotated element's name should be used.
      */
     String value() default "";
 }

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/HeaderParam.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/HeaderParam.java
@@ -64,7 +64,15 @@ public @interface HeaderParam {
      * Defines the name of the HTTP header whose value will be used to initialize the value of the annotated method
      * argument, class field or bean property. Case insensitive.
      *
-     * @return HTTP header name.
+     * <p>
+     * If the value is not specified (empty string), the name of the annotated element (parameter, field, or property)
+     * will be used as the parameter name. This requires that parameter names are preserved in the bytecode, which can be
+     * enabled using the {@code -parameters} compiler flag in Java 8+. If parameter names are not available at runtime
+     * and no explicit value is provided, implementations MUST throw a deployment-time exception with a clear error message
+     * indicating that either an explicit parameter name must be provided or the {@code -parameters} compiler flag must be enabled.
+     * </p>
+     *
+     * @return HTTP header name, or an empty string to use the annotated element's name.
      */
-    String value();
+    String value() default "";
 }

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/HeaderParam.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/HeaderParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2026 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -68,7 +68,7 @@ public @interface HeaderParam {
      * If the value is not specified (empty string), the name of the annotated element (parameter, field, or property)
      * will be used as the parameter name. This requires that parameter names are preserved in the bytecode, which can be
      * enabled using the {@code -parameters} compiler flag in Java 8+. If parameter names are not available at runtime
-     * and no explicit value is provided, implementations MUST throw a deployment-time exception with a clear error message
+     * and no explicit value is provided, implementations MUST throw an exception during initialization with a clear error message
      * indicating that either an explicit parameter name must be provided or the {@code -parameters} compiler flag must be enabled.
      * </p>
      *

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/MatrixParam.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/MatrixParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2026 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -78,7 +78,7 @@ public @interface MatrixParam {
      * If the value is not specified (empty string), the name of the annotated element (parameter, field, or property)
      * will be used as the parameter name. This requires that parameter names are preserved in the bytecode, which can be
      * enabled using the {@code -parameters} compiler flag in Java 8+. If parameter names are not available at runtime
-     * and no explicit value is provided, implementations MUST throw a deployment-time exception with a clear error message
+     * and no explicit value is provided, implementations MUST throw an exception during initialization with a clear error message
      * indicating that either an explicit parameter name must be provided or the {@code -parameters} compiler flag must be enabled.
      * </p>
      *

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/MatrixParam.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/MatrixParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -82,7 +82,7 @@ public @interface MatrixParam {
      * indicating that either an explicit parameter name must be provided or the {@code -parameters} compiler flag must be enabled.
      * </p>
      *
-     * @return URI matrix parameter name, or an empty string to use the annotated element's name.
+     * @return URI matrix parameter name, or an empty string indicating that the annotated element's name should be used.
      */
     String value() default "";
 }

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/MatrixParam.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/MatrixParam.java
@@ -74,7 +74,15 @@ public @interface MatrixParam {
      * the value will not be decoded and will instead be treated as literal text. E.g. if the parameter name is "a b" then
      * the value of the annotation is "a b", <i>not</i> "a+b" or "a%20b".
      *
-     * @return URI matrix parameter name.
+     * <p>
+     * If the value is not specified (empty string), the name of the annotated element (parameter, field, or property)
+     * will be used as the parameter name. This requires that parameter names are preserved in the bytecode, which can be
+     * enabled using the {@code -parameters} compiler flag in Java 8+. If parameter names are not available at runtime
+     * and no explicit value is provided, implementations MUST throw a deployment-time exception with a clear error message
+     * indicating that either an explicit parameter name must be provided or the {@code -parameters} compiler flag must be enabled.
+     * </p>
+     *
+     * @return URI matrix parameter name, or an empty string to use the annotated element's name.
      */
-    String value();
+    String value() default "";
 }

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/PathParam.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/PathParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -87,7 +87,7 @@ public @interface PathParam {
      * indicating that either an explicit parameter name must be provided or the {@code -parameters} compiler flag must be enabled.
      * </p>
      *
-     * @return resource URI template parameter name, or an empty string to use the annotated element's name.
+     * @return resource URI template parameter name, or an empty string indicating that the annotated element's name should be used.
      */
     String value() default "";
 }

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/PathParam.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/PathParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2026 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -83,7 +83,7 @@ public @interface PathParam {
      * If the value is not specified (empty string), the name of the annotated element (parameter, field, or property)
      * will be used as the parameter name. This requires that parameter names are preserved in the bytecode, which can be
      * enabled using the {@code -parameters} compiler flag in Java 8+. If parameter names are not available at runtime
-     * and no explicit value is provided, implementations MUST throw a deployment-time exception with a clear error message
+     * and no explicit value is provided, implementations MUST throw an exception during initialization with a clear error message
      * indicating that either an explicit parameter name must be provided or the {@code -parameters} compiler flag must be enabled.
      * </p>
      *

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/PathParam.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/PathParam.java
@@ -77,8 +77,17 @@ public @interface PathParam {
      * <p>
      * E.g. a class annotated with: {@code @Path("widgets/{id}")} can have methods annotated whose arguments are annotated
      * with {@code @PathParam("id")}.
+     * </p>
      *
-     * @return resource URI template parameter name.
+     * <p>
+     * If the value is not specified (empty string), the name of the annotated element (parameter, field, or property)
+     * will be used as the parameter name. This requires that parameter names are preserved in the bytecode, which can be
+     * enabled using the {@code -parameters} compiler flag in Java 8+. If parameter names are not available at runtime
+     * and no explicit value is provided, implementations MUST throw a deployment-time exception with a clear error message
+     * indicating that either an explicit parameter name must be provided or the {@code -parameters} compiler flag must be enabled.
+     * </p>
+     *
+     * @return resource URI template parameter name, or an empty string to use the annotated element's name.
      */
-    String value();
+    String value() default "";
 }

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/QueryParam.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/QueryParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -76,7 +76,7 @@ public @interface QueryParam {
      * indicating that either an explicit parameter name must be provided or the {@code -parameters} compiler flag must be enabled.
      * </p>
      *
-     * @return HTTP query parameter name, or an empty string to use the annotated element's name.
+     * @return HTTP query parameter name, or an empty string indicating that the annotated element's name should be used.
      */
     String value() default "";
 }

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/QueryParam.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/QueryParam.java
@@ -68,7 +68,15 @@ public @interface QueryParam {
      * the value will not be decoded and will instead be treated as literal text. E.g. if the parameter name is "a b" then
      * the value of the annotation is "a b", <i>not</i> "a+b" or "a%20b".
      *
-     * @return HTTP query parameter name.
+     * <p>
+     * If the value is not specified (empty string), the name of the annotated element (parameter, field, or property)
+     * will be used as the parameter name. This requires that parameter names are preserved in the bytecode, which can be
+     * enabled using the {@code -parameters} compiler flag in Java 8+. If parameter names are not available at runtime
+     * and no explicit value is provided, implementations MUST throw a deployment-time exception with a clear error message
+     * indicating that either an explicit parameter name must be provided or the {@code -parameters} compiler flag must be enabled.
+     * </p>
+     *
+     * @return HTTP query parameter name, or an empty string to use the annotated element's name.
      */
-    String value();
+    String value() default "";
 }

--- a/jaxrs-api/src/main/java/jakarta/ws/rs/QueryParam.java
+++ b/jaxrs-api/src/main/java/jakarta/ws/rs/QueryParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2026 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -72,7 +72,7 @@ public @interface QueryParam {
      * If the value is not specified (empty string), the name of the annotated element (parameter, field, or property)
      * will be used as the parameter name. This requires that parameter names are preserved in the bytecode, which can be
      * enabled using the {@code -parameters} compiler flag in Java 8+. If parameter names are not available at runtime
-     * and no explicit value is provided, implementations MUST throw a deployment-time exception with a clear error message
+     * and no explicit value is provided, implementations MUST throw an exception during initialization with a clear error message
      * indicating that either an explicit parameter name must be provided or the {@code -parameters} compiler flag must be enabled.
      * </p>
      *

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/api/rs/params/defaultnames/DefaultParamNamesIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/api/rs/params/defaultnames/DefaultParamNamesIT.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.ws.rs.api.rs.params.defaultnames;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import ee.jakarta.tck.ws.rs.common.JAXRSCommonClient;
+import ee.jakarta.tck.ws.rs.lib.util.TestUtil;
+import jakarta.ws.rs.core.Response;
+
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */
+/**
+ * Tests for optional parameter names in Jakarta REST parameter binding annotations.
+ * Verifies that @PathParam, @QueryParam, @MatrixParam, @FormParam, @HeaderParam,
+ * and @CookieParam can infer parameter names when no explicit value is provided.
+ * 
+ * @see <a href="https://github.com/jakartaee/rest/issues/579">Issue #579</a>
+ */
+public class DefaultParamNamesIT extends JAXRSCommonClient {
+
+    private static final long serialVersionUID = 1L;
+
+    @BeforeEach
+    void logStartTest(TestInfo testInfo) {
+        TestUtil.logMsg("STARTING TEST : " + testInfo.getDisplayName());
+    }
+
+    @AfterEach
+    void logFinishTest(TestInfo testInfo) {
+        TestUtil.logMsg("FINISHED TEST : " + testInfo.getDisplayName());
+    }
+
+    /*
+     * @testName: pathParamDefaultNameTest
+     * 
+     * @assertion_ids: JAXRS:SPEC:XXX;
+     * 
+     * @test_Strategy: Verify that @PathParam without an explicit value uses the
+     * parameter name from the method signature when the -parameters compiler flag
+     * is enabled.
+     */
+    @Test
+    public void pathParamDefaultNameTest() throws Fault {
+        setProperty(Property.REQUEST, buildRequest(Request.GET, "resource/path/john/doe"));
+        setProperty(Property.SEARCH_STRING, "john doe");
+        invoke();
+    }
+
+    /*
+     * @testName: queryParamDefaultNameTest
+     * 
+     * @assertion_ids: JAXRS:SPEC:XXX;
+     * 
+     * @test_Strategy: Verify that @QueryParam without an explicit value uses the
+     * parameter name from the method signature when the -parameters compiler flag
+     * is enabled.
+     */
+    @Test
+    public void queryParamDefaultNameTest() throws Fault {
+        setProperty(Property.REQUEST, buildRequest(Request.GET, "resource/query?search=test&filter=active"));
+        setProperty(Property.SEARCH_STRING, "search=test filter=active");
+        invoke();
+    }
+
+    /*
+     * @testName: headerParamDefaultNameTest
+     * 
+     * @assertion_ids: JAXRS:SPEC:XXX;
+     * 
+     * @test_Strategy: Verify that @HeaderParam without an explicit value uses the
+     * parameter name from the method signature when the -parameters compiler flag
+     * is enabled.
+     */
+    @Test
+    public void headerParamDefaultNameTest() throws Fault {
+        setProperty(Property.REQUEST, buildRequest(Request.GET, "resource/header"));
+        setProperty(Property.REQUEST_HEADERS, "Authorization: Bearer token123");
+        setProperty(Property.SEARCH_STRING, "Bearer token123");
+        invoke();
+    }
+
+    /*
+     * @testName: matrixParamDefaultNameTest
+     * 
+     * @assertion_ids: JAXRS:SPEC:XXX;
+     * 
+     * @test_Strategy: Verify that @MatrixParam without an explicit value uses the
+     * parameter name from the method signature when the -parameters compiler flag
+     * is enabled.
+     */
+    @Test
+    public void matrixParamDefaultNameTest() throws Fault {
+        setProperty(Property.REQUEST, buildRequest(Request.GET, "resource/matrix/item;color=red;size=large"));
+        setProperty(Property.SEARCH_STRING, "color=red size=large");
+        invoke();
+    }
+
+    /*
+     * @testName: cookieParamDefaultNameTest
+     * 
+     * @assertion_ids: JAXRS:SPEC:XXX;
+     * 
+     * @test_Strategy: Verify that @CookieParam without an explicit value uses the
+     * parameter name from the method signature when the -parameters compiler flag
+     * is enabled.
+     */
+    @Test
+    public void cookieParamDefaultNameTest() throws Fault {
+        setProperty(Property.REQUEST, buildRequest(Request.GET, "resource/cookie"));
+        setProperty(Property.REQUEST_HEADERS, "Cookie: sessionId=abc123");
+        setProperty(Property.SEARCH_STRING, "abc123");
+        invoke();
+    }
+
+    /*
+     * @testName: formParamDefaultNameTest
+     * 
+     * @assertion_ids: JAXRS:SPEC:XXX;
+     * 
+     * @test_Strategy: Verify that @FormParam without an explicit value uses the
+     * parameter name from the method signature when the -parameters compiler flag
+     * is enabled.
+     */
+    @Test
+    public void formParamDefaultNameTest() throws Fault {
+        setProperty(Property.REQUEST, buildRequest(Request.POST, "resource/form"));
+        setProperty(Property.REQUEST_HEADERS, "Content-Type: application/x-www-form-urlencoded");
+        setProperty(Property.CONTENT, "username=john&password=secret");
+        setProperty(Property.SEARCH_STRING, "username=john password=secret");
+        invoke();
+    }
+
+    /*
+     * @testName: mixedParamDefaultNameTest
+     * 
+     * @assertion_ids: JAXRS:SPEC:XXX;
+     * 
+     * @test_Strategy: Verify that a mix of explicit and inferred parameter names
+     * works correctly, demonstrating backward compatibility.
+     */
+    @Test
+    public void mixedParamDefaultNameTest() throws Fault {
+        setProperty(Property.REQUEST, buildRequest(Request.GET, "resource/mixed/123?page=1"));
+        setProperty(Property.REQUEST_HEADERS, "User-Agent: TestClient/1.0");
+        setProperty(Property.SEARCH_STRING, "id=123 page=1 userAgent=TestClient/1.0");
+        invoke();
+    }
+
+    /*
+     * @testName: fieldInjectionDefaultNameTest
+     * 
+     * @assertion_ids: JAXRS:SPEC:XXX;
+     * 
+     * @test_Strategy: Verify that field injection with default parameter names
+     * works without the -parameters compiler flag, as field names are always
+     * available at runtime.
+     */
+    @Test
+    public void fieldInjectionDefaultNameTest() throws Fault {
+        setProperty(Property.REQUEST, buildRequest(Request.GET, "resource/field?userId=user123&page=5"));
+        setProperty(Property.SEARCH_STRING, "userId=user123 page=5");
+        invoke();
+    }
+
+    /*
+     * @testName: allParamTypesDefaultNameTest
+     * 
+     * @assertion_ids: JAXRS:SPEC:XXX;
+     * 
+     * @test_Strategy: Verify that all six parameter binding annotations work
+     * together with default parameter names in a single resource method.
+     */
+    @Test
+    public void allParamTypesDefaultNameTest() throws Fault {
+        setProperty(Property.REQUEST, buildRequest(Request.POST, "resource/all/item123;color=blue?filter=active"));
+        setProperty(Property.REQUEST_HEADERS, 
+            "Authorization: Bearer token456\r\n" +
+            "Cookie: sessionId=xyz789\r\n" +
+            "Content-Type: application/x-www-form-urlencoded");
+        setProperty(Property.CONTENT, "username=alice&action=update");
+        setProperty(Property.SEARCH_STRING, 
+            "pathId=item123 color=blue filter=active " +
+            "authorization=Bearer token456 sessionId=xyz789 " +
+            "username=alice action=update");
+        invoke();
+    }
+}

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/api/rs/params/defaultnames/DefaultParamNamesIT.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/api/rs/params/defaultnames/DefaultParamNamesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/api/rs/params/defaultnames/DefaultParamNamesResource.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/api/rs/params/defaultnames/DefaultParamNamesResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/api/rs/params/defaultnames/DefaultParamNamesResource.java
+++ b/jaxrs-tck/src/main/java/ee/jakarta/tck/ws/rs/api/rs/params/defaultnames/DefaultParamNamesResource.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.ws.rs.api.rs.params.defaultnames;
+
+import jakarta.ws.rs.CookieParam;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.MatrixParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
+
+/**
+ * Test resource for verifying optional parameter names in Jakarta REST annotations.
+ * This resource demonstrates that parameter binding annotations can infer parameter
+ * names when no explicit value is provided.
+ * 
+ * <p><strong>Important:</strong> This resource must be compiled with the
+ * {@code -parameters} compiler flag to preserve method parameter names in bytecode.</p>
+ */
+@Path("resource")
+public class DefaultParamNamesResource {
+
+    /**
+     * Tests @PathParam with inferred parameter names.
+     * Path: /resource/path/{name}/{surname}
+     */
+    @GET
+    @Path("path/{name}/{surname}")
+    public String testPathParam(@PathParam String name, @PathParam String surname) {
+        return name + " " + surname;
+    }
+
+    /**
+     * Tests @QueryParam with inferred parameter names.
+     * Path: /resource/query?search=value&filter=value
+     */
+    @GET
+    @Path("query")
+    public String testQueryParam(@QueryParam String search, @QueryParam String filter) {
+        return "search=" + search + " filter=" + filter;
+    }
+
+    /**
+     * Tests @HeaderParam with inferred parameter name.
+     * Expects Authorization header.
+     */
+    @GET
+    @Path("header")
+    public String testHeaderParam(@HeaderParam String authorization) {
+        return authorization;
+    }
+
+    /**
+     * Tests @MatrixParam with inferred parameter names.
+     * Path: /resource/matrix/{path};color=value;size=value
+     */
+    @GET
+    @Path("matrix/{path}")
+    public String testMatrixParam(@PathParam String path,
+                                  @MatrixParam String color,
+                                  @MatrixParam String size) {
+        return "color=" + color + " size=" + size;
+    }
+
+    /**
+     * Tests @CookieParam with inferred parameter name.
+     * Expects sessionId cookie.
+     */
+    @GET
+    @Path("cookie")
+    public String testCookieParam(@CookieParam String sessionId) {
+        return sessionId;
+    }
+
+    /**
+     * Tests @FormParam with inferred parameter names.
+     * Expects application/x-www-form-urlencoded with username and password.
+     */
+    @POST
+    @Path("form")
+    public String testFormParam(@FormParam String username, @FormParam String password) {
+        return "username=" + username + " password=" + password;
+    }
+
+    /**
+     * Tests mixed usage of explicit and inferred parameter names.
+     * Demonstrates backward compatibility.
+     * Path: /resource/mixed/{id}?page=value
+     * Expects User-Agent header.
+     */
+    @GET
+    @Path("mixed/{id}")
+    public String testMixedParams(@PathParam String id,
+                                  @QueryParam("page") String page,
+                                  @HeaderParam String userAgent) {
+        return "id=" + id + " page=" + page + " userAgent=" + userAgent;
+    }
+
+    /**
+     * Field injection with inferred parameter names.
+     * Field names are always available at runtime, so -parameters flag is not required.
+     */
+    @QueryParam
+    private String userId;
+
+    @QueryParam
+    private String page;
+
+    /**
+     * Tests field injection with inferred parameter names.
+     * Path: /resource/field?userId=value&page=value
+     */
+    @GET
+    @Path("field")
+    public String testFieldInjection() {
+        return "userId=" + userId + " page=" + page;
+    }
+
+    /**
+     * Tests all six parameter binding annotations together.
+     * Path: /resource/all/{pathId};color=value?filter=value
+     * Expects Authorization header, sessionId cookie, and form data.
+     */
+    @POST
+    @Path("all/{pathId}")
+    public String testAllParamTypes(@PathParam String pathId,
+                                    @MatrixParam String color,
+                                    @QueryParam String filter,
+                                    @HeaderParam String authorization,
+                                    @CookieParam String sessionId,
+                                    @FormParam String username,
+                                    @FormParam String action) {
+        return "pathId=" + pathId + " " +
+               "color=" + color + " " +
+               "filter=" + filter + " " +
+               "authorization=" + authorization + " " +
+               "sessionId=" + sessionId + " " +
+               "username=" + username + " " +
+               "action=" + action;
+    }
+}


### PR DESCRIPTION
This PR is a proposed implementation for #579: It allows to simply write `@PathParam` without the need to specify the parameter name.